### PR TITLE
Misc cleanup for contrib

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,129 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+# All files 
+[*] 
+indent_style = space 
+# Code files 
+[*.{cs,csx,vb,vbx}] 
+indent_size = 4 
+insert_final_newline = true 
+trim_trailing_whitespace = true 
+charset = utf-8-bom 
+# maintain DOS/Windows style line endings in md files
+[*.md]
+end_of_line = crlf
+############################### 
+# .NET Coding Conventions     # 
+############################### 
+[*.{cs,vb}] 
+# Organize usings 
+dotnet_sort_system_directives_first = true 
+# this. preferences 
+dotnet_style_qualification_for_field = true:suggestion 
+dotnet_style_qualification_for_property = true:suggestion 
+dotnet_style_qualification_for_method = true:suggestion 
+dotnet_style_qualification_for_event = true:suggestion 
+# Language keywords vs BCL types preferences 
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent 
+dotnet_style_predefined_type_for_member_access = true:silent 
+# Parentheses preferences 
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent 
+# Modifier preferences 
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent 
+dotnet_style_readonly_field = true:suggestion 
+# Expression-level preferences 
+dotnet_style_object_initializer = true:suggestion 
+dotnet_style_collection_initializer = true:suggestion 
+dotnet_style_explicit_tuple_names = true:suggestion 
+dotnet_style_null_propagation = true:suggestion 
+dotnet_style_coalesce_expression = true:suggestion 
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent 
+dotnet_prefer_inferred_tuple_names = true:suggestion 
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion 
+dotnet_style_prefer_auto_properties = true:silent 
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent 
+dotnet_style_prefer_conditional_expression_over_return = true:silent 
+############################### 
+# Naming Conventions          # 
+############################### 
+# Style Definitions 
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case 
+# Use PascalCase for constant fields   
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style 
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field 
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = * 
+dotnet_naming_symbols.constant_fields.required_modifiers          = const 
+############################### 
+# C# Coding Conventions       # 
+############################### 
+[*.cs] 
+# var preferences 
+csharp_style_var_for_built_in_types = true:silent 
+csharp_style_var_when_type_is_apparent = true:silent 
+csharp_style_var_elsewhere = true:silent 
+# Expression-bodied members 
+csharp_style_expression_bodied_methods = false:silent 
+csharp_style_expression_bodied_constructors = false:silent 
+csharp_style_expression_bodied_operators = false:silent 
+csharp_style_expression_bodied_properties = true:silent 
+csharp_style_expression_bodied_indexers = true:silent 
+csharp_style_expression_bodied_accessors = true:silent 
+# Pattern matching preferences 
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion 
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion 
+# Null-checking preferences 
+csharp_style_throw_expression = true:suggestion 
+csharp_style_conditional_delegate_call = true:suggestion 
+# Modifier preferences 
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion 
+# Expression-level preferences 
+csharp_prefer_braces = true:silent 
+csharp_style_deconstructed_variable_declaration = true:suggestion 
+csharp_prefer_simple_default_expression = true:suggestion 
+csharp_style_pattern_local_over_anonymous_function = true:suggestion 
+csharp_style_inlined_variable_declaration = true:suggestion 
+############################### 
+# C# Formatting Rules         # 
+############################### 
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+csharp_new_line_before_else = true 
+csharp_new_line_before_catch = true 
+csharp_new_line_before_finally = true 
+csharp_new_line_before_members_in_object_initializers = true 
+csharp_new_line_before_members_in_anonymous_types = true 
+csharp_new_line_between_query_expression_clauses = true 
+# Indentation preferences 
+csharp_indent_case_contents = true 
+csharp_indent_switch_labels = true 
+csharp_indent_labels = flush_left 
+# Space preferences 
+csharp_space_after_cast = false 
+csharp_space_after_keywords_in_control_flow_statements = true 
+csharp_space_between_method_call_parameter_list_parentheses = false 
+csharp_space_between_method_declaration_parameter_list_parentheses = false 
+csharp_space_between_parentheses = false 
+csharp_space_before_colon_in_inheritance_clause = true 
+csharp_space_after_colon_in_inheritance_clause = true 
+csharp_space_around_binary_operators = before_and_after 
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false 
+csharp_space_between_method_call_name_and_opening_parenthesis = false 
+csharp_space_between_method_call_empty_parameter_list_parentheses = false 
+# Wrapping preferences 
+csharp_preserve_single_line_statements = true 
+csharp_preserve_single_line_blocks = true 
+############################### 
+# VB Coding Conventions       # 
+############################### 
+[*.vb] 
+# Modifier preferences 
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion 
+[obj/**.cs]
+generated_code = true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,5 @@
-#####################################################
-#
-# List of approvers for OpenTelemetry .NET SDK
-#
-#####################################################
-#
-# Learn about membership in OpenTelemetry community:
-#  https://github.com/open-telemetry/community/blob/master/community-membership.md
-# 
-#
-# Learn about CODEOWNERS file format: 
-#  https://help.github.com/en/articles/about-code-owners
-#
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
 
-* @SergeyKanzhelev @lmolkova @discostu105 @bruno-garcia @MikeGoldsmith @cijothomas
+# For anything not explicitly taken by someone else:
+* @open-telemetry/dotnet-approvers

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -15,15 +15,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Instrumentati
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution items", "{07AA0F83-22F6-4B8C-921D-029D3384CB17}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		NuGet.config = NuGet.config
 		opentelemetry-dotnet-contrib.proj = opentelemetry-dotnet-contrib.proj
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{1A06E14B-DD2F-4536-9D2E-F708C0C43555}"
 	ProjectSection(SolutionItems) = preProject
 		.github\codecov.yml = .github\codecov.yml
+		CODEOWNERS = CODEOWNERS
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{43CAFE52-F329-4431-87DA-7FEE1454D9A9}"


### PR DESCRIPTION
* Switched CODEOWNERS to use the @open-telemetry/dotnet-approvers group instead of a list. Same file from the main repo.
* Added .editorconfig from the main repo.
* Added some files to the solution that were missing.