### PR TITLE
Added AWS X-Ray trace id generator and propagator.

### DIFF
--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -77,6 +77,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Contrib.Instr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore.Tests", "test\OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests\OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore.Tests.csproj", "{899E506C-8525-4471-8C6D-5A9FA6B8517B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Contrib.Extensions.AWSXRay", "src\OpenTelemetry.Contrib.Extensions.AWSXRay\OpenTelemetry.Contrib.Extensions.AWSXRay.csproj", "{D8C9AD2A-5C6A-46F5-A216-3D67E6C0FA94}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Contrib.Extensions.AWSXRay.Tests", "test\OpenTelemetry.Contrib.Extensions.AWSXRay.Tests\OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj", "{9CE513AC-CFC5-4DD1-9F16-8719EDCE9BF9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -119,6 +123,14 @@ Global
 		{899E506C-8525-4471-8C6D-5A9FA6B8517B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{899E506C-8525-4471-8C6D-5A9FA6B8517B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{899E506C-8525-4471-8C6D-5A9FA6B8517B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8C9AD2A-5C6A-46F5-A216-3D67E6C0FA94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8C9AD2A-5C6A-46F5-A216-3D67E6C0FA94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8C9AD2A-5C6A-46F5-A216-3D67E6C0FA94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8C9AD2A-5C6A-46F5-A216-3D67E6C0FA94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CE513AC-CFC5-4DD1-9F16-8719EDCE9BF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CE513AC-CFC5-4DD1-9F16-8719EDCE9BF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CE513AC-CFC5-4DD1-9F16-8719EDCE9BF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CE513AC-CFC5-4DD1-9F16-8719EDCE9BF9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -136,6 +148,8 @@ Global
 		{5F10395B-DF38-438A-B5DB-5F6449184F67} = {22DF5DC0-1290-4E83-A9D8-6BB7DE3B3E63}
 		{BC839E07-108A-4184-B1F9-EF28A1E81088} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 		{899E506C-8525-4471-8C6D-5A9FA6B8517B} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
+		{D8C9AD2A-5C6A-46F5-A216-3D67E6C0FA94} = {22DF5DC0-1290-4E83-A9D8-6BB7DE3B3E63}
+		{9CE513AC-CFC5-4DD1-9F16-8719EDCE9BF9} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayEventSource.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayEventSource.cs
@@ -1,0 +1,69 @@
+﻿// <copyright file="AWSXRayEventSource.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Threading;
+
+namespace OpenTelemetry.Contrib.Extensions.AWSXRay
+{
+    [EventSource(Name = "OpenTelemetry-AWS-XRay")]
+    internal class AWSXRayEventSource : EventSource
+    {
+        public static AWSXRayEventSource Log = new AWSXRayEventSource();
+
+        [NonEvent]
+        public void ActivityContextExtractException(string format, Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
+            {
+                this.FailedToExtractActivityContext(format, ToInvariantString(ex));
+            }
+        }
+
+        [Event(1, Message = "Failed to extract activity context in format: '{0}', context: '{1}'.", Level = EventLevel.Warning)]
+        public void FailedToExtractActivityContext(string format, string exception)
+        {
+            this.WriteEvent(1, format, exception);
+        }
+
+        [Event(2, Message = "Failed to inject activity context in format: '{0}', context: '{1}'.", Level = EventLevel.Warning)]
+        public void FailedToInjectActivityContext(string format, string error)
+        {
+            this.WriteEvent(2, format, error);
+        }
+
+        /// <summary>
+        /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
+        /// appropriate for diagnostics tracing.
+        /// </summary>
+        private static string ToInvariantString(Exception exception)
+        {
+            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+                return exception.ToString();
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayIdGenerator.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayIdGenerator.cs
@@ -1,0 +1,135 @@
+﻿// <copyright file="AWSXRayIdGenerator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+
+namespace OpenTelemetry.Contrib.Extensions.AWSXRay
+{
+    /// <summary>
+    /// Generate AWS X-Ray compatible trace id and replace the trace id of root activity.
+    /// See https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids.
+    /// </summary>
+    public static class AWSXRayIdGenerator
+    {
+        private const int RandomNumberHexDigits = 24;
+
+        private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+        private const long MicrosecondPerSecond = TimeSpan.TicksPerSecond / TicksPerMicrosecond;
+
+        private static readonly DateTime EpochStart = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly long UnixEpochMicroseconds = EpochStart.Ticks / TicksPerMicrosecond;
+        private static readonly Random Global = new Random();
+        private static readonly ThreadLocal<Random> Local = new ThreadLocal<Random>(() =>
+        {
+            int seed;
+            lock (Global)
+            {
+                seed = Global.Next();
+            }
+
+            return new Random(seed);
+        });
+
+        internal static void ReplaceTraceId()
+        {
+            var awsXRayActivityListener = new ActivityListener
+            {
+                ActivityStarted = (activity) =>
+                {
+                    if (string.IsNullOrEmpty(activity.ParentId))
+                    {
+                        var awsXRayTraceId = GenerateAWSXRayCompatiableTraceId();
+
+                        activity.SetParentId(awsXRayTraceId, default, activity.ActivityTraceFlags);
+                    }
+                },
+
+                ShouldListenTo = (_) => true,
+            };
+
+            ActivitySource.AddActivityListener(awsXRayActivityListener);
+        }
+
+        internal static ActivityTraceId GenerateAWSXRayCompatiableTraceId()
+        {
+            var epoch = (int)DateTime.UtcNow.ToUnixTimeSeconds(); // first 8 digit as time stamp
+
+            var randomNumber = GenerateHexNumber(RandomNumberHexDigits); // remaining 24 random digit
+
+            var newTraceId = string.Concat(epoch.ToString("x", CultureInfo.InvariantCulture), randomNumber);
+
+            return ActivityTraceId.CreateFromString(newTraceId.AsSpan());
+        }
+
+        /// <summary>
+        /// Convert a given time to Unix time which is the number of seconds since 1st January 1970, 00:00:00 UTC.
+        /// </summary>
+        /// <param name="date">.Net representation of time.</param>
+        /// <returns>The number of seconds elapsed since 1970-01-01 00:00:00 UTC. The value is expressed in whole and fractional seconds with resolution of microsecond.</returns>
+        private static decimal ToUnixTimeSeconds(this DateTime date)
+        {
+            long microseconds = date.Ticks / TicksPerMicrosecond;
+            long microsecondsSinceEpoch = microseconds - UnixEpochMicroseconds;
+            return (decimal)microsecondsSinceEpoch / MicrosecondPerSecond;
+        }
+
+        /// <summary>
+        /// Generate a random 24-digit hex number.
+        /// </summary>
+        /// <param name="digits">Digits of the hex number.</param>
+        /// <returns>The generated hex number.</returns>
+        private static string GenerateHexNumber(int digits)
+        {
+            if (digits < 0)
+            {
+                throw new ArgumentException("Length can't be a negative number.", "digits");
+            }
+
+            byte[] bytes = new byte[digits / 2];
+            NextBytes(bytes);
+            string hexNumber = string.Concat(bytes.Select(x => x.ToString("x2", CultureInfo.InvariantCulture)).ToArray());
+            if (digits % 2 != 0)
+            {
+                hexNumber += Next(16).ToString("x", CultureInfo.InvariantCulture);
+            }
+
+            return hexNumber;
+        }
+
+        /// <summary>
+        /// Fills the elements of a specified array of bytes with random numbers.
+        /// </summary>
+        /// <param name="buffer">An array of bytes to contain random numbers.</param>
+        private static void NextBytes(byte[] buffer)
+        {
+            Local.Value.NextBytes(buffer);
+        }
+
+        /// <summary>
+        /// Returns a non-negative random integer that is less than the specified maximum.
+        /// </summary>
+        /// <param name="maxValue">Max value of the random integer.</param>
+        /// <returns>A 32-bit signed integer that is greater than or equal to 0, and less than maxValue.</returns>
+        private static int Next(int maxValue)
+        {
+            return Local.Value.Next(maxValue);
+        }
+    }
+}

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED
+[assembly: InternalsVisibleTo("OpenTelemetry.Contrib.Extensions.AWSXRay.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]
+#else
+[assembly: InternalsVisibleTo("OpenTelemetry.Contrib.Extensions.AWSXRay.Tests")]
+#endif

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <Description>OpenTelemetry extensions for AWS X-Ray.</Description>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Trace/AWSXRayPropagator.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Trace/AWSXRayPropagator.cs
@@ -1,0 +1,315 @@
+﻿// <copyright file="AWSXRayPropagator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using OpenTelemetry.Context.Propagation;
+
+namespace OpenTelemetry.Contrib.Extensions.AWSXRay.Trace
+{
+    /// <summary>
+    /// Propagator for AWS X-Ray. See https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader.
+    /// </summary>
+    public class AWSXRayPropagator : IPropagator
+    {
+        private const string AWSXRayTraceHeaderKey = "X-Amzn-Trace-Id";
+        private const char KeyValueDelimiter = '=';
+        private const char TraceHeaderDelimiter = ';';
+
+        private const string RootKey = "Root";
+        private const string Version = "1";
+        private const int RandomNumberHexDigits = 24;
+        private const int EpochHexDigits = 8;
+        private const int TotalLength = 35;
+        private const char TraceIdDelimiter = '-';
+        private const int TraceIdDelimiterFirstIndex = 1;
+        private const int TraceIdDelimiterSecondIndex = 10;
+
+        private const string ParentKey = "Parent";
+        private const int ParentIdHexDigits = 16;
+
+        private const string SampledKey = "Sampled";
+        private const char SampledValue = '1';
+        private const char NotSampledValue = '0';
+
+        /// <inheritdoc/>
+        public ISet<string> Fields => new HashSet<string>() { AWSXRayTraceHeaderKey };
+
+        /// <inheritdoc/>
+        public PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        {
+            if (context.ActivityContext.IsValid())
+            {
+                return context;
+            }
+
+            if (carrier == null)
+            {
+                AWSXRayEventSource.Log.FailedToExtractActivityContext(nameof(AWSXRayPropagator), "null carrier");
+                return context;
+            }
+
+            if (getter == null)
+            {
+                AWSXRayEventSource.Log.FailedToExtractActivityContext(nameof(AWSXRayPropagator), "null getter");
+                return context;
+            }
+
+            try
+            {
+                var parentTraceHeader = getter(carrier, AWSXRayTraceHeaderKey);
+
+                if (parentTraceHeader == null || parentTraceHeader.Count() != 1)
+                {
+                    return context;
+                }
+
+                var parentHeader = parentTraceHeader.First();
+
+                if (!TryParseXRayTraceHeader(parentHeader, out var newActivityContext))
+                {
+                    return context;
+                }
+
+                return new PropagationContext(newActivityContext, context.Baggage);
+            }
+            catch (Exception ex)
+            {
+                AWSXRayEventSource.Log.ActivityContextExtractException(nameof(AWSXRayPropagator), ex);
+            }
+
+            return context;
+        }
+
+        /// <inheritdoc/>
+        public void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+            if (context.ActivityContext.TraceId == default || context.ActivityContext.SpanId == default)
+            {
+                AWSXRayEventSource.Log.FailedToInjectActivityContext(nameof(AWSXRayPropagator), "Invalid context");
+                return;
+            }
+
+            if (carrier == null)
+            {
+                AWSXRayEventSource.Log.FailedToInjectActivityContext(nameof(AWSXRayPropagator), "null carrier");
+                return;
+            }
+
+            if (setter == null)
+            {
+                AWSXRayEventSource.Log.FailedToInjectActivityContext(nameof(AWSXRayPropagator), "null setter");
+                return;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(RootKey);
+            sb.Append(KeyValueDelimiter);
+            sb.Append(ToXRayTraceIdFormat(context.ActivityContext.TraceId.ToHexString()));
+            sb.Append(TraceHeaderDelimiter);
+            sb.Append(ParentKey);
+            sb.Append(KeyValueDelimiter);
+            sb.Append(context.ActivityContext.SpanId.ToHexString());
+            sb.Append(TraceHeaderDelimiter);
+            sb.Append(SampledKey);
+            sb.Append(KeyValueDelimiter);
+            sb.Append((context.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0 ? SampledValue : NotSampledValue);
+
+            setter(carrier, AWSXRayTraceHeaderKey, sb.ToString());
+        }
+
+        internal static bool TryParseXRayTraceHeader(string rawHeader, out ActivityContext activityContext)
+        {
+            // from https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
+            // rawHeader format: Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1
+
+            activityContext = default;
+            ReadOnlySpan<char> traceId = default;
+            ReadOnlySpan<char> parentId = default;
+            char traceOptions = default;
+
+            if (string.IsNullOrEmpty(rawHeader))
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> header = rawHeader.AsSpan();
+            while (header.Length > 0)
+            {
+                int delimiterIndex = header.IndexOf(TraceHeaderDelimiter);
+                ReadOnlySpan<char> part;
+                if (delimiterIndex >= 0)
+                {
+                    part = header.Slice(0, delimiterIndex);
+                    header = header.Slice(delimiterIndex + 1);
+                }
+                else
+                {
+                    part = header.Slice(0);
+                    header = header.Slice(header.Length);
+                }
+
+                ReadOnlySpan<char> trimmedPart = part.Trim();
+                int equalsIndex = trimmedPart.IndexOf(KeyValueDelimiter);
+                if (equalsIndex < 0)
+                {
+                    return false;
+                }
+
+                ReadOnlySpan<char> value = trimmedPart.Slice(equalsIndex + 1);
+                if (trimmedPart.StartsWith(RootKey.AsSpan()))
+                {
+                    if (!TryParseOTFormatTraceId(value, out var otFormatTraceId))
+                    {
+                        return false;
+                    }
+
+                    traceId = otFormatTraceId;
+                }
+                else if (trimmedPart.StartsWith(ParentKey.AsSpan()))
+                {
+                    if (!IsParentIdValid(value))
+                    {
+                        return false;
+                    }
+
+                    parentId = value;
+                }
+                else if (trimmedPart.StartsWith(SampledKey.AsSpan()))
+                {
+                    if (!TryParseSampleDecision(value, out var sampleDecision))
+                    {
+                        return false;
+                    }
+
+                    traceOptions = sampleDecision;
+                }
+            }
+
+            if (traceId == default || parentId == default || traceOptions == default)
+            {
+                return false;
+            }
+
+            var activityTraceId = ActivityTraceId.CreateFromString(traceId);
+            var activityParentId = ActivitySpanId.CreateFromString(parentId);
+            var activityTraceOptions = traceOptions == SampledValue ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None;
+
+            activityContext = new ActivityContext(activityTraceId, activityParentId, activityTraceOptions, isRemote: true);
+
+            return true;
+        }
+
+        internal static bool TryParseOTFormatTraceId(ReadOnlySpan<char> traceId, out ReadOnlySpan<char> otFormatTraceId)
+        {
+            otFormatTraceId = default;
+
+            if (traceId.IsEmpty || traceId.IsWhiteSpace())
+            {
+                return false;
+            }
+
+            if (traceId.Length != TotalLength)
+            {
+                return false;
+            }
+
+            if (!traceId.StartsWith(Version.AsSpan()))
+            {
+                return false;
+            }
+
+            if (traceId[TraceIdDelimiterFirstIndex] != TraceIdDelimiter || traceId[TraceIdDelimiterSecondIndex] != TraceIdDelimiter)
+            {
+                return false;
+            }
+
+            var timestamp = traceId.Slice(TraceIdDelimiterFirstIndex + 1, EpochHexDigits);
+            var randomNumber = traceId.Slice(TraceIdDelimiterSecondIndex + 1);
+            if (timestamp.Length != EpochHexDigits || randomNumber.Length != RandomNumberHexDigits)
+            {
+                return false;
+            }
+
+            var timestampString = timestamp.ToString();
+            var randomNumberString = randomNumber.ToString();
+            if (!int.TryParse(timestampString, NumberStyles.HexNumber, null, out _))
+            {
+                return false;
+            }
+
+            if (!BigInteger.TryParse(randomNumberString, NumberStyles.HexNumber, null, out _))
+            {
+                return false;
+            }
+
+            otFormatTraceId = (timestampString + randomNumberString).AsSpan();
+
+            return true;
+        }
+
+        internal static bool IsParentIdValid(ReadOnlySpan<char> parentId)
+        {
+            if (parentId.IsEmpty || parentId.IsWhiteSpace())
+            {
+                return false;
+            }
+
+            return parentId.Length == ParentIdHexDigits && long.TryParse(parentId.ToString(), NumberStyles.HexNumber, null, out _);
+        }
+
+        internal static bool TryParseSampleDecision(ReadOnlySpan<char> sampleDecision, out char result)
+        {
+            result = default;
+
+            if (sampleDecision.IsEmpty || sampleDecision.IsWhiteSpace())
+            {
+                return false;
+            }
+
+            if (!char.TryParse(sampleDecision.ToString(), out var tempChar))
+            {
+                return false;
+            }
+
+            if (tempChar != SampledValue && tempChar != NotSampledValue)
+            {
+                return false;
+            }
+
+            result = tempChar;
+
+            return true;
+        }
+
+        internal static string ToXRayTraceIdFormat(string traceId)
+        {
+            var sb = new StringBuilder();
+            sb.Append(Version);
+            sb.Append(TraceIdDelimiter);
+            sb.Append(traceId.Substring(0, EpochHexDigits));
+            sb.Append(TraceIdDelimiter);
+            sb.Append(traceId.Substring(EpochHexDigits));
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using OpenTelemetry.Contrib.Extensions.AWSXRay;
+
+namespace OpenTelemetry.Trace
+{
+    /// <summary>
+    /// Extension method to generate AWS X-Ray compatible trace id and replace the trace id of root activity.
+    /// </summary>
+    public static class TracerProviderBuilderExtensions
+    {
+        /// <summary>
+        /// Replace the trace id of root activity.
+        /// </summary>
+        /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+        /// <returns>The instance of <see cref="TracerProviderBuilder"/>.</returns>
+        public static TracerProviderBuilder AddXRayActivityTraceIdGenerator(this TracerProviderBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            AWSXRayIdGenerator.ReplaceTraceId();
+            return builder;
+        }
+    }
+}

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Unit test project for AWS X-Ray for OpenTelemetry</Description>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net452</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
+    <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetXUnitCliVer)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Extensions.AWSXRay\OpenTelemetry.Contrib.Extensions.AWSXRay.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/TestAWSXRayIdGenerator.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/TestAWSXRayIdGenerator.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="TestAWSXRayIdGenerator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Contrib.Extensions.AWSRay.Tests
+{
+    public class TestAWSXRayIdGenerator
+    {
+        [Fact]
+        public void TestGenerateTraceIdForRootNode()
+        {
+            var activity = new Activity("Test");
+            var originalTraceId = activity.TraceId;
+            var originalParentSpanId = activity.ParentSpanId;
+            var originalTraceFlag = activity.ActivityTraceFlags;
+
+            using (Sdk.CreateTracerProviderBuilder().AddXRayActivityTraceIdGenerator().Build())
+            {
+                activity.Start();
+
+                Assert.NotEqual(originalTraceId, activity.TraceId);
+                Assert.NotEqual(originalParentSpanId, activity.ParentSpanId);
+                Assert.Equal("0000000000000000", activity.ParentSpanId.ToHexString());
+                Assert.Equal(originalTraceFlag, activity.ActivityTraceFlags);
+            }
+        }
+
+        [Fact]
+        public void TestGenerateTraceIdForNonRootNodeSampled()
+        {
+            var activity = new Activity("Test");
+            var traceId = ActivityTraceId.CreateFromString("12345678901234567890123456789012".AsSpan());
+            var parentId = ActivitySpanId.CreateFromString("1234567890123456".AsSpan());
+            activity.SetParentId(traceId, parentId, ActivityTraceFlags.Recorded);
+
+            using (Sdk.CreateTracerProviderBuilder().AddXRayActivityTraceIdGenerator().Build())
+            {
+                activity.Start();
+
+                Assert.Equal("12345678901234567890123456789012", activity.TraceId.ToHexString());
+                Assert.Equal("1234567890123456", activity.ParentSpanId.ToHexString());
+                Assert.Equal(ActivityTraceFlags.Recorded, activity.ActivityTraceFlags);
+            }
+        }
+
+        [Fact]
+        public void TestGenerateTraceIdForNonRootNodeNotSampled()
+        {
+            var activity = new Activity("Test");
+            var traceId = ActivityTraceId.CreateFromString("12345678901234567890123456789012".AsSpan());
+            var parentId = ActivitySpanId.CreateFromString("1234567890123456".AsSpan());
+            activity.SetParentId(traceId, parentId, ActivityTraceFlags.None);
+
+            using (Sdk.CreateTracerProviderBuilder().AddXRayActivityTraceIdGenerator().Build())
+            {
+                activity.Start();
+
+                Assert.Equal("12345678901234567890123456789012", activity.TraceId.ToHexString());
+                Assert.Equal("1234567890123456", activity.ParentSpanId.ToHexString());
+                Assert.Equal(ActivityTraceFlags.None, activity.ActivityTraceFlags);
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Trace/TestAWSXRayPropagator.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Trace/TestAWSXRayPropagator.cs
@@ -1,0 +1,226 @@
+﻿// <copyright file="TestAWSXRayPropagator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Contrib.Extensions.AWSXRay.Tests
+{
+    public class TestAWSXRayPropagator
+    {
+        private const string AWSXRayTraceHeaderKey = "X-Amzn-Trace-Id";
+        private const string TraceId = "5759e988bd862e3fe1be46a994272793";
+        private const string ParentId = "53995c3f42cd8ad8";
+
+        private static readonly string[] Empty = new string[0];
+        private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
+        {
+            if (headers.TryGetValue(name, out var value))
+            {
+                return new[] { value };
+            }
+
+            return Empty;
+        };
+
+        private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
+        {
+            carrier[name] = value;
+        };
+
+        private readonly AWSXRayPropagator awsXRayPropagator = new AWSXRayPropagator();
+
+        [Fact]
+        public void TestInjectTraceHeader()
+        {
+            var carrier = new Dictionary<string, string>();
+            var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+            var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+            var traceFlags = ActivityTraceFlags.Recorded;
+            var activityContext = new ActivityContext(traceId, parentId, traceFlags);
+            this.awsXRayPropagator.Inject(new PropagationContext(activityContext, default), carrier, Setter);
+
+            Assert.True(carrier.ContainsKey(AWSXRayTraceHeaderKey));
+            Assert.Equal("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1", carrier[AWSXRayTraceHeaderKey]);
+        }
+
+        [Fact]
+        public void TestInjectTraceHeaderNotSampled()
+        {
+            var carrier = new Dictionary<string, string>();
+            var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+            var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+            var traceFlags = ActivityTraceFlags.None;
+            var activityContext = new ActivityContext(traceId, parentId, traceFlags);
+            this.awsXRayPropagator.Inject(new PropagationContext(activityContext, default), carrier, Setter);
+
+            Assert.True(carrier.ContainsKey(AWSXRayTraceHeaderKey));
+            Assert.Equal("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0", carrier[AWSXRayTraceHeaderKey]);
+        }
+
+        [Fact]
+        public void TestExtractTraceHeader()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1" },
+            };
+            var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+            var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+            var traceFlags = ActivityTraceFlags.Recorded;
+            var activityContext = new ActivityContext(traceId, parentId, traceFlags, isRemote: true);
+
+            Assert.Equal(new PropagationContext(activityContext, default), this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderNotSampled()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0" },
+            };
+            var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+            var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+            var traceFlags = ActivityTraceFlags.None;
+            var activityContext = new ActivityContext(traceId, parentId, traceFlags, isRemote: true);
+
+            Assert.Equal(new PropagationContext(activityContext, default), this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderDifferentOrder()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Sampled=1;Parent=53995c3f42cd8ad8;Root=1-5759e988-bd862e3fe1be46a994272793" },
+            };
+            var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+            var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+            var traceFlags = ActivityTraceFlags.Recorded;
+            var activityContext = new ActivityContext(traceId, parentId, traceFlags, isRemote: true);
+
+            Assert.Equal(new PropagationContext(activityContext, default), this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithEmptyValue()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, string.Empty },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithoutParentId()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1" },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithoutSampleDecision()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8" },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithInvalidTraceId()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=15759e988bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1" },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithInvalidParentId()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=123;Sampled=1" },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithInvalidSampleDecision()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=" },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithInvalidSampleDecisionValue()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=3" },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithInvalidSampleDecisionLength()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=123" },
+            };
+
+            Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+
+        [Fact]
+        public void TestExtractTraceHeaderWithAdditionalField()
+        {
+            var carrier = new Dictionary<string, string>()
+            {
+                { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;Foo=Bar" },
+            };
+            var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+            var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+            var traceFlags = ActivityTraceFlags.Recorded;
+            var activityContext = new ActivityContext(traceId, parentId, traceFlags, isRemote: true);
+
+            Assert.Equal(new PropagationContext(activityContext, default), this.awsXRayPropagator.Extract(default, carrier, Getter));
+        }
+    }
+}


### PR DESCRIPTION
As suggested by https://github.com/open-telemetry/opentelemetry-specification/issues/1047#issuecomment-703748553, moving AWS X-Ray trace id generator and propagator from main repo to contrib repo.

Id generator PR: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1268
Propagator PR: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1300