### PR TITLE
Add ActivitySourceAdapter to AddAzureInstrumentation

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.Azure/AzureClientsInstrumentation.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Azure/AzureClientsInstrumentation.cs
@@ -17,6 +17,7 @@
 using System;
 using OpenTelemetry.Contrib.Instrumentation.Azure.Implementation;
 using OpenTelemetry.Instrumentation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Contrib.Instrumentation.Azure
 {
@@ -34,10 +35,13 @@ namespace OpenTelemetry.Contrib.Instrumentation.Azure
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureClientsInstrumentation"/> class.
         /// </summary>
-        public AzureClientsInstrumentation()
+        /// <param name="activitySource">
+        /// ActivitySource adapter instance.
+        /// </param>
+        public AzureClientsInstrumentation(ActivitySourceAdapter activitySource)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
-                name => new AzureSdkDiagnosticListener(name),
+                name => new AzureSdkDiagnosticListener(name, activitySource),
                 listener => listener.Name.StartsWith("Azure."),
                 null);
             this.diagnosticSourceSubscriber.Subscribe();

--- a/src/OpenTelemetry.Contrib.Instrumentation.Azure/AzurePipelineInstrumentation.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Azure/AzurePipelineInstrumentation.cs
@@ -17,6 +17,7 @@
 using System;
 using OpenTelemetry.Contrib.Instrumentation.Azure.Implementation;
 using OpenTelemetry.Instrumentation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Contrib.Instrumentation.Azure
 {
@@ -34,9 +35,12 @@ namespace OpenTelemetry.Contrib.Instrumentation.Azure
         /// <summary>
         /// Initializes a new instance of the <see cref="AzurePipelineInstrumentation"/> class.
         /// </summary>
-        public AzurePipelineInstrumentation()
+        /// <param name="activitySource">
+        /// ActivitySource adapter instance.
+        /// </param>
+        public AzurePipelineInstrumentation(ActivitySourceAdapter activitySource)
         {
-            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new AzureSdkDiagnosticListener("Azure.Pipeline"), null);
+            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new AzureSdkDiagnosticListener("Azure.Pipeline", activitySource), null);
             this.diagnosticSourceSubscriber.Subscribe();
         }
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.Azure/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Azure/TracerProviderBuilderExtensions.cs
@@ -37,8 +37,8 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.AddInstrumentation((activitySource) => new AzureClientsInstrumentation());
-            builder.AddInstrumentation((activitySource) => new AzurePipelineInstrumentation());
+            builder.AddInstrumentation((activitySource) => new AzureClientsInstrumentation(activitySource));
+            builder.AddInstrumentation((activitySource) => new AzurePipelineInstrumentation(activitySource));
             return builder;
         }
     }


### PR DESCRIPTION
Current implementation does not collect data. Modified the code to use `ActivitySourceAdapter`.

Now, we could collect traces using below instrumentation code.

```csharp

using var tracerProvider = Sdk.CreateTracerProviderBuilder()
.AddAzureInstrumentation()
.AddConsoleExporter(opt => opt.DisplayAsJson = true)
.Build();

```