### PR TITLE
Adjust MassTransit to the semantic conventions

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/DisplayNameHelper.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/DisplayNameHelper.cs
@@ -43,6 +43,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
 
         private static string ConvertConsumeOperationToDisplayName(string consumerType) => $"{consumerType} process";
 
-        private static string ConvertHandleOperationToDisplayName(string peerAddress) => $"{peerAddress} consume";
+        private static string ConvertHandleOperationToDisplayName(string peerAddress) => $"{peerAddress} process";
     }
 }

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/DisplayNameHelper.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/DisplayNameHelper.cs
@@ -37,12 +37,12 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
         public static string GetHandleOperationDisplayName(string peerAddress) =>
             HandleOperationDisplayNameCache.GetOrAdd(peerAddress, ConvertHandleOperationToDisplayName);
 
-        private static string ConvertSendOperationToDisplayName(string peerAddress) => $"SEND {peerAddress}";
+        private static string ConvertSendOperationToDisplayName(string peerAddress) => $"{peerAddress} send";
 
-        private static string ConvertReceiveOperationToDisplayName(string peerAddress) => $"RECV {peerAddress}";
+        private static string ConvertReceiveOperationToDisplayName(string peerAddress) => $"{peerAddress} consume";
 
-        private static string ConvertConsumeOperationToDisplayName(string consumerType) => $"CONSUME {consumerType}";
+        private static string ConvertConsumeOperationToDisplayName(string consumerType) => $"{consumerType} process";
 
-        private static string ConvertHandleOperationToDisplayName(string peerAddress) => $"HANDLE {peerAddress}";
+        private static string ConvertHandleOperationToDisplayName(string peerAddress) => $"{peerAddress} consume";
     }
 }

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
@@ -90,24 +90,15 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
         {
             if (activity.OperationName == OperationName.Transport.Send)
             {
-                activity.DisplayName = DisplayNameHelper.GetSendOperationDisplayName(this.GetTag(activity.Tags, TagName.PeerAddress));
-
                 this.ProcessHostInfo(activity);
 
                 this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
                 this.RenameTag(activity, TagName.ConversationId, SemanticConventions.AttributeMessagingConversationId);
 
-                activity.SetTag(TagName.SpanKind, null);
-                activity.SetTag(TagName.PeerAddress, null);
-                activity.SetTag(TagName.PeerHost, null);
-                activity.SetTag(TagName.PeerService, null);
-
                 activity.SetTag(TagName.SourceAddress, null);
             }
             else if (activity.OperationName == OperationName.Transport.Receive)
             {
-                activity.DisplayName = DisplayNameHelper.GetReceiveOperationDisplayName(this.GetTag(activity.Tags, TagName.PeerAddress));
-
                 this.ProcessHostInfo(activity);
 
                 this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
@@ -115,15 +106,22 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
 
                 activity.SetTag(TagName.MessageId, null);
 
-                activity.SetTag(TagName.SpanKind, null);
-                activity.SetTag(TagName.PeerAddress, null);
-                activity.SetTag(TagName.PeerHost, null);
-                activity.SetTag(TagName.PeerService, null);
-
                 activity.SetTag(TagName.MessageTypes, null);
                 activity.SetTag(TagName.SourceAddress, null);
                 activity.SetTag(TagName.SourceHostMachine, null);
             }
+            else if (activity.OperationName == OperationName.Consumer.Consume)
+            {
+                this.RenameTag(activity, TagName.ConsumerType, SemanticConventions.AttributeMessagingMassTransitConsumerType);
+            }
+            else if (activity.OperationName == OperationName.Consumer.Handle)
+            {
+            }
+
+            activity.SetTag(TagName.SpanKind, null);
+            activity.SetTag(TagName.PeerService, null);
+            activity.SetTag(TagName.PeerAddress, null);
+            activity.SetTag(TagName.PeerHost, null);
         }
 
         private void ProcessHostInfo(Activity activity)

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
@@ -95,6 +95,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
                 this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
                 this.RenameTag(activity, TagName.ConversationId, SemanticConventions.AttributeMessagingConversationId);
                 this.RenameTag(activity, TagName.InitiatorId, SemanticConventions.AttributeMessagingMassTransitInitiatorId);
+                this.RenameTag(activity, TagName.CorrelationId, SemanticConventions.AttributeMessagingMassTransitCorrelationId);
 
                 activity.SetTag(TagName.SourceAddress, null);
             }
@@ -105,6 +106,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
                 this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
                 this.RenameTag(activity, TagName.ConversationId, SemanticConventions.AttributeMessagingConversationId);
                 this.RenameTag(activity, TagName.InitiatorId, SemanticConventions.AttributeMessagingMassTransitInitiatorId);
+                this.RenameTag(activity, TagName.CorrelationId, SemanticConventions.AttributeMessagingMassTransitCorrelationId);
 
                 activity.SetTag(TagName.MessageId, null);
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
@@ -94,6 +94,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
 
                 this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
                 this.RenameTag(activity, TagName.ConversationId, SemanticConventions.AttributeMessagingConversationId);
+                this.RenameTag(activity, TagName.InitiatorId, SemanticConventions.AttributeMessagingMassTransitInitiatorId);
 
                 activity.SetTag(TagName.SourceAddress, null);
             }
@@ -103,6 +104,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
 
                 this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
                 this.RenameTag(activity, TagName.ConversationId, SemanticConventions.AttributeMessagingConversationId);
+                this.RenameTag(activity, TagName.InitiatorId, SemanticConventions.AttributeMessagingMassTransitInitiatorId);
 
                 activity.SetTag(TagName.MessageId, null);
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -53,6 +54,11 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
                 return;
             }
 
+            if (activity.IsAllDataRequested)
+            {
+                this.TransformMassTransitTags(activity);
+            }
+
             this.activitySource.Stop(activity);
         }
 
@@ -80,10 +86,82 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
             };
         }
 
+        private void TransformMassTransitTags(Activity activity)
+        {
+            if (activity.OperationName == OperationName.Transport.Send)
+            {
+                activity.DisplayName = DisplayNameHelper.GetSendOperationDisplayName(this.GetTag(activity.Tags, TagName.PeerAddress));
+
+                this.ProcessHostInfo(activity);
+
+                this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
+                this.RenameTag(activity, TagName.ConversationId, SemanticConventions.AttributeMessagingConversationId);
+
+                activity.SetTag(TagName.SpanKind, null);
+                activity.SetTag(TagName.PeerAddress, null);
+                activity.SetTag(TagName.PeerHost, null);
+                activity.SetTag(TagName.PeerService, null);
+
+                activity.SetTag(TagName.SourceAddress, null);
+            }
+            else if (activity.OperationName == OperationName.Transport.Receive)
+            {
+                activity.DisplayName = DisplayNameHelper.GetReceiveOperationDisplayName(this.GetTag(activity.Tags, TagName.PeerAddress));
+
+                this.ProcessHostInfo(activity);
+
+                this.RenameTag(activity, TagName.MessageId, SemanticConventions.AttributeMessagingMessageId);
+                this.RenameTag(activity, TagName.ConversationId, SemanticConventions.AttributeMessagingConversationId);
+
+                activity.SetTag(TagName.MessageId, null);
+
+                activity.SetTag(TagName.SpanKind, null);
+                activity.SetTag(TagName.PeerAddress, null);
+                activity.SetTag(TagName.PeerHost, null);
+                activity.SetTag(TagName.PeerService, null);
+
+                activity.SetTag(TagName.MessageTypes, null);
+                activity.SetTag(TagName.SourceAddress, null);
+                activity.SetTag(TagName.SourceHostMachine, null);
+            }
+        }
+
+        private void ProcessHostInfo(Activity activity)
+        {
+            if (Uri.TryCreate(activity.GetTagValue(TagName.DestinationAddress).ToString(), UriKind.Absolute, out var destinationAddress))
+            {
+                activity.SetTag(SemanticConventions.AttributeMessagingSystem, destinationAddress.Scheme);
+                activity.SetTag(SemanticConventions.AttributeMessagingDestination, destinationAddress.LocalPath);
+
+                var uriHostNameType = Uri.CheckHostName(destinationAddress.Host);
+                if (uriHostNameType == UriHostNameType.IPv4 || uriHostNameType == UriHostNameType.IPv6)
+                {
+                    activity.SetTag(SemanticConventions.AttributeNetPeerIp, destinationAddress.Host);
+                }
+                else
+                {
+                    activity.SetTag(SemanticConventions.AttributeNetPeerName, destinationAddress.Host);
+                }
+
+                if (destinationAddress.Port > 0)
+                {
+                    activity.SetTag(SemanticConventions.AttributeNetPeerPort, destinationAddress.Port);
+                }
+
+                activity.SetTag(TagName.DestinationAddress, null);
+            }
+        }
+
         private string GetTag(IEnumerable<KeyValuePair<string, string>> tags, string tagName)
         {
             var tag = tags.SingleOrDefault(kv => kv.Key == tagName);
             return tag.Value;
+        }
+
+        private void RenameTag(Activity activity, string oldTagName, string newTagName)
+        {
+            activity.SetTag(newTagName, activity.GetTagValue(oldTagName));
+            activity.SetTag(oldTagName, null);
         }
     }
 }

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
@@ -72,8 +72,8 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
         {
             return activity.OperationName switch
             {
-                OperationName.Transport.Send => ActivityKind.Client,
-                OperationName.Transport.Receive => ActivityKind.Internal,
+                OperationName.Transport.Send => ActivityKind.Producer,
+                OperationName.Transport.Receive => ActivityKind.Consumer,
                 OperationName.Consumer.Consume => ActivityKind.Consumer,
                 OperationName.Consumer.Handle => ActivityKind.Consumer,
                 _ => activity.Kind,

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
@@ -80,8 +80,8 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
             {
                 OperationName.Transport.Send => ActivityKind.Producer,
                 OperationName.Transport.Receive => ActivityKind.Consumer,
-                OperationName.Consumer.Consume => ActivityKind.Consumer,
-                OperationName.Consumer.Handle => ActivityKind.Consumer,
+                OperationName.Consumer.Consume => ActivityKind.Internal,
+                OperationName.Consumer.Handle => ActivityKind.Internal,
                 _ => activity.Kind,
             };
         }

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/SemanticConventions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/SemanticConventions.cs
@@ -41,5 +41,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
 
         public const string AttributeMessagingMassTransitInitiatorId = "messaging.masstransit.initiator_id";
         public const string AttributeMessagingMassTransitCorrelationId = "messaging.masstransit.correlation_id";
+        public const string AttributeMessagingMassTransitConsumerType = "messaging.masstransit.consumer_type";
     }
 }

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/SemanticConventions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/SemanticConventions.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="SemanticConventions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
+{
+    internal class SemanticConventions
+    {
+        public const string AttributeNetTransport = "net.transport";
+        public const string AttributeNetPeerIp = "net.peer.ip";
+        public const string AttributeNetPeerPort = "net.peer.port";
+        public const string AttributeNetPeerName = "net.peer.name";
+        public const string AttributeNetHostIp = "net.host.ip";
+        public const string AttributeNetHostPort = "net.host.port";
+        public const string AttributeNetHostName = "net.host.name";
+
+        public const string AttributeMessagingSystem = "messaging.system";
+        public const string AttributeMessagingDestination = "messaging.destination";
+        public const string AttributeMessagingDestinationKind = "messaging.destination_kind";
+        public const string AttributeMessagingTempDestination = "messaging.temp_destination";
+        public const string AttributeMessagingProtocol = "messaging.protocol";
+        public const string AttributeMessagingProtocolVersion = "messaging.protocol_version";
+        public const string AttributeMessagingUrl = "messaging.url";
+        public const string AttributeMessagingMessageId = "messaging.message_id";
+        public const string AttributeMessagingConversationId = "messaging.conversation_id";
+        public const string AttributeMessagingPayloadSize = "messaging.message_payload_size_bytes";
+        public const string AttributeMessagingPayloadCompressedSize = "messaging.message_payload_compressed_size_bytes";
+        public const string AttributeMessagingOperation = "messaging.operation";
+
+        public const string AttributeMessagingMassTransitInitiatorId = "messaging.masstransit.initiator_id";
+        public const string AttributeMessagingMassTransitCorrelationId = "messaging.masstransit.correlation_id";
+    }
+}

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/TagName.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/TagName.cs
@@ -18,7 +18,22 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
 {
     internal class TagName
     {
+        public const string SpanKind = "span.kind";
+
         public const string PeerAddress = "peer.address";
+        public const string PeerHost = "peer.host";
+        public const string PeerService = "peer.service";
+
+        public const string MessageId = "message-id";
+        public const string ConversationId = "conversation-id";
+        public const string CorrelationId = "correlation-id";
+        public const string InitiatorId = "initiator-id";
+
         public const string ConsumerType = "consumer-type";
+        public const string MessageTypes = "message-types";
+
+        public const string DestinationAddress = "destination-address";
+        public const string SourceAddress = "source-address";
+        public const string InputAddress = "input-address";
     }
 }

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/TagName.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/TagName.cs
@@ -23,6 +23,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
         public const string PeerAddress = "peer.address";
         public const string PeerHost = "peer.host";
         public const string PeerService = "peer.service";
+        public const string SourceHostMachine = "source-host-machine";
 
         public const string MessageId = "message-id";
         public const string ConversationId = "conversation-id";

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
 
-                Assert.Equal("SEND /input_queue", actualActivity.DisplayName);
+                Assert.Equal("/input_queue send", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Producer, actualActivity.Kind);
                 Assert.Equal("loopback", actualActivity.GetTagValue(SemanticConventions.AttributeMessagingSystem)?.ToString());
 
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
 
-                Assert.Equal("RECV /input_queue", actualActivity.DisplayName);
+                Assert.Equal("/input_queue consume", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
                 Assert.Equal("loopback", actualActivity.GetTagValue(SemanticConventions.AttributeMessagingSystem)?.ToString());
 
@@ -169,7 +169,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
 
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
-                Assert.Equal("CONSUME OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.DisplayName);
+                Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer process", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
                 Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.GetTagValue(SemanticConventions.AttributeMessagingMassTransitConsumerType)?.ToString());
 
@@ -212,7 +212,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
 
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
-                Assert.Equal("HANDLE TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.DisplayName);
+                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests consume", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
 
                 Assert.Null(actualActivity.GetTagValue(TagName.SpanKind));

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using MassTransit.Testing;
 using Moq;
+using OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -59,14 +60,14 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("SEND /input_queue", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Producer.ToString().ToLowerInvariant(), actualActivity.GetTagValue("span.kind").ToString());
-                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue("message-id").ToString());
-                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue("conversation-id").ToString());
-                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue("destination-address").ToString());
-                Assert.Equal(expectedMessageContext.SourceAddress.ToString(), actualActivity.GetTagValue("source-address").ToString());
-                Assert.Equal("/input_queue", actualActivity.GetTagValue("peer.address").ToString());
-                Assert.Equal("localhost", actualActivity.GetTagValue("peer.host").ToString());
-                Assert.Equal("Send", actualActivity.GetTagValue("peer.service").ToString());
+                Assert.Equal(SpanKind.Producer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
+                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
+                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.DestinationAddress).ToString());
+                Assert.Equal(expectedMessageContext.SourceAddress.ToString(), actualActivity.GetTagValue(TagName.SourceAddress).ToString());
+                Assert.Equal("/input_queue", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
+                Assert.Equal("localhost", actualActivity.GetTagValue(TagName.PeerHost).ToString());
+                Assert.Equal("Send", actualActivity.GetTagValue(TagName.PeerService).ToString());
             }
         }
 
@@ -102,17 +103,17 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("RECV /input_queue", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue("span.kind").ToString());
-                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue("message-id").ToString());
-                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue("conversation-id").ToString());
-                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue("input-address").ToString());
-                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue("destination-address").ToString());
-                Assert.Equal(expectedMessageContext.SourceAddress.ToString(), actualActivity.GetTagValue("source-address").ToString());
+                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
+                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
+                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.InputAddress).ToString());
+                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.DestinationAddress).ToString());
+                Assert.Equal(expectedMessageContext.SourceAddress.ToString(), actualActivity.GetTagValue(TagName.SourceAddress).ToString());
                 Assert.NotNull(actualActivity.GetTagValue("source-host-machine").ToString());
-                Assert.NotNull(actualActivity.GetTagValue("message-types").ToString());
-                Assert.Equal("/input_queue", actualActivity.GetTagValue("peer.address").ToString());
-                Assert.Equal("localhost", actualActivity.GetTagValue("peer.host").ToString());
-                Assert.Equal("Receive", actualActivity.GetTagValue("peer.service").ToString());
+                Assert.NotNull(actualActivity.GetTagValue(TagName.MessageTypes).ToString());
+                Assert.Equal("/input_queue", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
+                Assert.Equal("localhost", actualActivity.GetTagValue(TagName.PeerHost).ToString());
+                Assert.Equal("Receive", actualActivity.GetTagValue(TagName.PeerService).ToString());
             }
         }
 
@@ -148,11 +149,11 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("CONSUME OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue("span.kind").ToString());
-                Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.GetTagValue("consumer-type").ToString());
-                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue("peer.address").ToString());
-                Assert.NotNull(actualActivity.GetTagValue("peer.host").ToString());
-                Assert.Equal("Consumer", actualActivity.GetTagValue("peer.service").ToString());
+                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.GetTagValue(TagName.ConsumerType).ToString());
+                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
+                Assert.NotNull(actualActivity.GetTagValue(TagName.PeerHost).ToString());
+                Assert.Equal("Consumer", actualActivity.GetTagValue(TagName.PeerService).ToString());
             }
         }
 
@@ -188,10 +189,10 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("HANDLE TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue("span.kind").ToString());
-                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue("peer.address").ToString());
-                Assert.NotNull(actualActivity.GetTagValue("peer.host").ToString());
-                Assert.Equal("Handler", actualActivity.GetTagValue("peer.service").ToString());
+                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
+                Assert.NotNull(actualActivity.GetTagValue(TagName.PeerHost).ToString());
+                Assert.Equal("Handler", actualActivity.GetTagValue(TagName.PeerService).ToString());
             }
         }
 

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("SEND /input_queue", actualActivity.DisplayName);
-                Assert.Equal(ActivityKind.Client, actualActivity.Kind);
+                Assert.Equal(ActivityKind.Producer, actualActivity.Kind);
                 Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
                 Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
                 Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.DestinationAddress).ToString());
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("RECV /input_queue", actualActivity.DisplayName);
-                Assert.Equal(ActivityKind.Internal, actualActivity.Kind);
+                Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
                 Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
                 Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
                 Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.InputAddress).ToString());

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -170,7 +170,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer process", actualActivity.DisplayName);
-                Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
+                Assert.Equal(ActivityKind.Internal, actualActivity.Kind);
                 Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.GetTagValue(SemanticConventions.AttributeMessagingMassTransitConsumerType)?.ToString());
 
                 Assert.Null(actualActivity.GetTagValue(TagName.SpanKind));
@@ -212,8 +212,8 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
 
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
-                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests consume", actualActivity.DisplayName);
-                Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
+                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests process", actualActivity.DisplayName);
+                Assert.Equal(ActivityKind.Internal, actualActivity.Kind);
 
                 Assert.Null(actualActivity.GetTagValue(TagName.SpanKind));
                 Assert.Null(actualActivity.GetTagValue(TagName.PeerService));

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -171,10 +171,13 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("CONSUME OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
-                Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.GetTagValue(TagName.ConsumerType).ToString());
-                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
-                Assert.NotNull(actualActivity.GetTagValue(TagName.PeerHost).ToString());
-                Assert.Equal("Consumer", actualActivity.GetTagValue(TagName.PeerService).ToString());
+                Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.GetTagValue(SemanticConventions.AttributeMessagingMassTransitConsumerType)?.ToString());
+
+                Assert.Null(actualActivity.GetTagValue(TagName.SpanKind));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerService));
+
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerAddress));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerHost));
             }
         }
 
@@ -211,9 +214,12 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("HANDLE TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
-                Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
-                Assert.NotNull(actualActivity.GetTagValue(TagName.PeerHost).ToString());
-                Assert.Equal("Handler", actualActivity.GetTagValue(TagName.PeerService).ToString());
+
+                Assert.Null(actualActivity.GetTagValue(TagName.SpanKind));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerService));
+
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerAddress));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerHost));
             }
         }
 

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -59,15 +59,26 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
 
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
+
                 Assert.Equal("SEND /input_queue", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Producer, actualActivity.Kind);
-                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
-                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
-                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.DestinationAddress).ToString());
-                Assert.Equal(expectedMessageContext.SourceAddress.ToString(), actualActivity.GetTagValue(TagName.SourceAddress).ToString());
-                Assert.Equal("/input_queue", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
-                Assert.Equal("localhost", actualActivity.GetTagValue(TagName.PeerHost).ToString());
-                Assert.Equal("Send", actualActivity.GetTagValue(TagName.PeerService).ToString());
+                Assert.Equal("loopback", actualActivity.GetTagValue(SemanticConventions.AttributeMessagingSystem)?.ToString());
+
+                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(SemanticConventions.AttributeMessagingMessageId)?.ToString());
+                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(SemanticConventions.AttributeMessagingConversationId)?.ToString());
+                Assert.Equal(expectedMessageContext.DestinationAddress.AbsolutePath, actualActivity.GetTagValue(SemanticConventions.AttributeMessagingDestination)?.ToString());
+                Assert.Equal(expectedMessageContext.DestinationAddress.Host, actualActivity.GetTagValue(SemanticConventions.AttributeNetPeerName)?.ToString());
+
+                Assert.Null(actualActivity.GetTagValue(TagName.MessageId));
+                Assert.Null(actualActivity.GetTagValue(TagName.ConversationId));
+                Assert.Null(actualActivity.GetTagValue(TagName.DestinationAddress));
+
+                Assert.Null(actualActivity.GetTagValue(TagName.SpanKind));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerService));
+
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerAddress));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerHost));
+                Assert.Null(actualActivity.GetTagValue(TagName.SourceAddress));
             }
         }
 
@@ -102,18 +113,28 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
 
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
+
                 Assert.Equal("RECV /input_queue", actualActivity.DisplayName);
                 Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
-                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
-                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
-                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.InputAddress).ToString());
-                Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.DestinationAddress).ToString());
-                Assert.Equal(expectedMessageContext.SourceAddress.ToString(), actualActivity.GetTagValue(TagName.SourceAddress).ToString());
-                Assert.NotNull(actualActivity.GetTagValue("source-host-machine").ToString());
-                Assert.NotNull(actualActivity.GetTagValue(TagName.MessageTypes).ToString());
-                Assert.Equal("/input_queue", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
-                Assert.Equal("localhost", actualActivity.GetTagValue(TagName.PeerHost).ToString());
-                Assert.Equal("Receive", actualActivity.GetTagValue(TagName.PeerService).ToString());
+                Assert.Equal("loopback", actualActivity.GetTagValue(SemanticConventions.AttributeMessagingSystem)?.ToString());
+
+                Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(SemanticConventions.AttributeMessagingMessageId)?.ToString());
+                Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(SemanticConventions.AttributeMessagingConversationId)?.ToString());
+                Assert.Equal(expectedMessageContext.DestinationAddress.AbsolutePath, actualActivity.GetTagValue(SemanticConventions.AttributeMessagingDestination)?.ToString());
+                Assert.Equal(expectedMessageContext.DestinationAddress.Host, actualActivity.GetTagValue(SemanticConventions.AttributeNetPeerName)?.ToString());
+
+                Assert.Null(actualActivity.GetTagValue(TagName.MessageId));
+                Assert.Null(actualActivity.GetTagValue(TagName.ConversationId));
+                Assert.Null(actualActivity.GetTagValue(TagName.DestinationAddress));
+
+                Assert.Null(actualActivity.GetTagValue(TagName.SpanKind));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerService));
+
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerAddress));
+                Assert.Null(actualActivity.GetTagValue(TagName.PeerHost));
+                Assert.Null(actualActivity.GetTagValue(TagName.MessageTypes));
+                Assert.Null(actualActivity.GetTagValue(TagName.SourceAddress));
+                Assert.Null(actualActivity.GetTagValue(TagName.SourceHostMachine));
             }
         }
 

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("SEND /input_queue", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Producer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal(ActivityKind.Client, actualActivity.Kind);
                 Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
                 Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
                 Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.DestinationAddress).ToString());
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("RECV /input_queue", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal(ActivityKind.Internal, actualActivity.Kind);
                 Assert.Equal(expectedMessageContext.MessageId.ToString(), actualActivity.GetTagValue(TagName.MessageId).ToString());
                 Assert.Equal(expectedMessageContext.ConversationId.ToString(), actualActivity.GetTagValue(TagName.ConversationId).ToString());
                 Assert.Equal(expectedMessageContext.DestinationAddress.ToString(), actualActivity.GetTagValue(TagName.InputAddress).ToString());
@@ -149,7 +149,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("CONSUME OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
                 Assert.Equal("OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests.TestConsumer", actualActivity.GetTagValue(TagName.ConsumerType).ToString());
                 Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
                 Assert.NotNull(actualActivity.GetTagValue(TagName.PeerHost).ToString());
@@ -189,7 +189,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                 Assert.NotNull(actualActivity);
                 Assert.NotNull(expectedMessageContext);
                 Assert.Equal("HANDLE TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.DisplayName);
-                Assert.Equal(SpanKind.Consumer.ToString().ToLowerInvariant(), actualActivity.GetTagValue(TagName.SpanKind).ToString());
+                Assert.Equal(ActivityKind.Consumer, actualActivity.Kind);
                 Assert.Equal("TestMessage/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests", actualActivity.GetTagValue(TagName.PeerAddress).ToString());
                 Assert.NotNull(actualActivity.GetTagValue(TagName.PeerHost).ToString());
                 Assert.Equal("Handler", actualActivity.GetTagValue(TagName.PeerService).ToString());


### PR DESCRIPTION
Partially resolves #47

Fixed
- Span names do not match the spec (partially)
- Default tag names do not match the spec
- A lot of redundant tags
- Incorrect `span.kind`
- `net.peer.*` tags are not populated correctly
- The instrumentation produces an incorrect `peer.service` tag