### PR TITLE
Update root activity's sampling decision when using ActivitySource.StartActivity()

### DIFF
--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
@@ -186,7 +186,8 @@ var currentActivity = Activity.Current;
 currentActivity.SetTag("key", "val");
 ```
 
-#### Note:
+#### Note
+
 * When using AWS X-Ray as your tracing backend, you can control whether
 attributes are uploaded as annotations or metadata by configuring the
 AWS OTel Collector's indexed keys.

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
@@ -1,39 +1,53 @@
 # Tracing with AWS Distro for OpenTelemetry .Net SDK
 
-If you want to send the traces to AWS X-Ray, you can do so by using AWS Distro with the OpenTelemetry SDK.
+If you want to send the traces to AWS X-Ray, you can do so
+by using AWS Distro with the OpenTelemetry SDK.
 
 ## Getting Started
 
-In order to instrument your .Net application for tracing, start by downloading the OpenTelemetry nuget package
+In order to instrument your .Net application for tracing,
+start by downloading the OpenTelemetry nuget package
 
-```
+```shell
 dotnet add package OpenTelemetry
 ```
 
-By default, the OpenTelemetry SDK generates traces with W3C random ID which X-Ray backend doesn't support yet. You need to install the `OpenTelemetry.Contrib.Extensions.AWSXRay` to be able to use the `AWSXRayIdGenerator` which generates X-Ray compatible trace IDs. If you plan to call an AWS service or another application instrumented with AWS X-Ray SDK, you'll need to use the `AWSXRayPropagator` as well.
+By default, the OpenTelemetry SDK generates traces with
+W3C random ID which X-Ray backend doesn't support yet.
+You need to install the `OpenTelemetry.Contrib.Extensions.AWSXRay`
+to be able to use the `AWSXRayIdGenerator` which generates X-Ray
+compatible trace IDs. If you plan to call an AWS service or
+another application instrumented with AWS X-Ray SDK, you'll
+need to use the `AWSXRayPropagator` as well.
 
-```
+```shell
 dotnet add package OpenTelemetry.Contrib.Extensions.AWSXRay
 ```
 
 ### Note
 
-* You'll also need to have the [AWS Distro for OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter) running to export traces to X-Ray.
+* You'll also need to have the AWS Distro for OpenTelemetry
+Collector running to export traces to X-Ray.
 
 ### Instrumenting .Net applications
 
 #### ASP.Net Core
 
-Start by downloading the ASP.Net Core and OTLP exporter instrumentation packages
+Start by downloading the ASP.Net Core and OTLP exporter instrumentation
+packages
 
-```
+```shell
 dotnet add package OpenTelemetry.Instrumentation.AspNetCore
 dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
 ```
 
-Next, in your application's **Startup.cs** add the instrumentation and the OTLP exporter as services in the `ConfigureServices` method. Make sure to call `AddXRayTraceId()` in the **beginning** when building `TracerProviderBuilder`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+Next, in your application's **Startup.cs** add the instrumentation
+and the OTLP exporter as services in the `ConfigureServices` method.
+Make sure to call `AddXRayTraceId()` in the **beginning** when
+building `TracerProviderBuilder`. If you want to trace AWS services,
+make sure to configure `AWSXRayPropagator`.
 
-```
+```csharp
 using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
 using OpenTelemetry.Trace;
 
@@ -43,22 +57,24 @@ public void ConfigureServices(IServiceCollection services)
         .AddXRayTraceId() // for generating AWS X-Ray compliant trace IDs
         .AddAspNetCoreInstrumentation()
         .AddOtlpExporter());
-    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
+    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator());
 }
 ```
 
-By default the OTLP exporter sends data to an OpenTelemetry collector at **localhost:55681**
+By default the OTLP exporter sends data to an OpenTelemetry
+collector at **localhost:55681**
 
 #### ASP.Net
 
 Download the ASP.Net and OTLP exporter instrumentation packages
 
-```
+```shell
 dotnet add package OpenTelemetry.Instrumentation.AspNet
 dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
 ```
 
-The ASP.Net instrumentation requires [modification](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/src/OpenTelemetry.Instrumentation.AspNet/README.md#step-2-modify-webconfig) to Web.config to add a HttpModule to your web server.
+The ASP.Net instrumentation requires modification to Web.config to add
+a HttpModule to your web server.
 
 ```xml
 <system.webServer>
@@ -71,9 +87,12 @@ The ASP.Net instrumentation requires [modification](https://github.com/open-tele
 </system.webServer>
 ```
 
-Now all you need to do is enable the instrumentation for the application startup. This is done in the **Global.asax.cs** as shown below. Make sure to call `AddXRayTraceId()` in the **beginning** when building `TracerProviderBuilder`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+Now all you need to do is enable the instrumentation for the application startup.
+This is done in the **Global.asax.cs** as shown below. Make sure to call
+`AddXRayTraceId()` in the **beginning** when building `TracerProviderBuilder`.
+If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
 
-```
+```csharp
 using OpenTelemetry;
 using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
 using OpenTelemetry.Trace;
@@ -88,7 +107,7 @@ public class WebApiApplication : HttpApplication
             .AddAspNetInstrumentation()
             .AddOtlpExporter()
             .Build();
-        Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
+        Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator());
     }
 
     protected void Application_End()
@@ -100,33 +119,43 @@ public class WebApiApplication : HttpApplication
 
 #### Console
 
-Make sure to call `AddXRayTraceIdWithSampler()` in the **beginning** when building `TracerProviderBuilder`. You'll need to pass the sampler you're using in your application. If you're using the default sampler, just pass `new ParentBasedSampler(new AlwaysOnSampler())`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+Make sure to call `AddXRayTraceIdWithSampler()` in the **beginning**
+when building `TracerProviderBuilder`. You'll need to pass the sampler
+you're using in your application. If you're using the default sampler,
+just pass `new ParentBasedSampler(new AlwaysOnSampler())`.
+If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
 
-```
+```csharp
 using OpenTelemetry;
 using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
 using OpenTelemetry.Trace;
 
 var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddXRayTraceIdWithSampler(your_sampler) // for generating AWS X-Ray compliant trace IDs
-                .AddOtlpExporter()
-                .Build();
-Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
+    // generating AWS X-Ray compliant trace IDs
+    .AddXRayTraceIdWithSampler(your_sampler)
+    .AddOtlpExporter()
+    .Build();
+
+// configure AWSXRayPropagator
+Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator());
 ```
 
 ### Instrumenting AWS SDK
 
-For tracing downstream call to AWS services from your .Net application, you will need three components: the `AWSXRayIdGenerator`, the `AWSXRayPropagator`, and the AWS client instrumentation.
+For tracing downstream call to AWS services from your .Net application,
+you will need three components: the `AWSXRayIdGenerator`,
+the `AWSXRayPropagator`, and the AWS client instrumentation.
 
- Download the `OpenTelemetry.Contrib.Extensions.AWSXRay` package:
+Download the `OpenTelemetry.Contrib.Extensions.AWSXRay` package:
 
-```
+```shell
 dotnet add package OpenTelemetry.Contrib.Extensions.AWSXRay
 ```
 
-Add the `AWSXRayIdGenerator`, `AWSXRayPropagator` and `AWSInstrumentation` to your application. The below example is for an ASP.Net Core application.
+Add the `AWSXRayIdGenerator`, `AWSXRayPropagator` and `AWSInstrumentation`
+to your application. The below example is for an ASP.Net Core application.
 
-```
+```csharp
 using OpenTelemetry;
 using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
 using OpenTelemetry.Trace;
@@ -135,25 +164,33 @@ public void ConfigureServices(IServiceCollection services)
 {
     services.AddControllers();
     services.AddOpenTelemetryTracing((builder) => builder
-        .AddXRayTraceId() // for generating AWS X-Ray compliant trace IDs
-        .AddAWSInstrumentation() // for tracing calls to AWS services via AWS SDK for .Net
+        // for generating AWS X-Ray compliant trace IDs
+        .AddXRayTraceId()
+        // for tracing calls to AWS services via AWS SDK for .Net
+        .AddAWSInstrumentation()
         .AddAspNetCoreInstrumentation()
         .AddOtlpExporter());
-    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
+
+    // configure AWSXRayPropagator
+    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator());
 }
 ```
 
 ### Adding Custom Attributes
 
-You can add custom attributes to an `Activity` by calling `SetTag` method on the current activity.
+You can add custom attributes to an `Activity` by calling
+`SetTag` method on the current activity.
 
-```
+```csharp
 var currentActivity = Activity.Current;
 currentActivity.SetTag("key", "val");
 ```
 
 #### Note:
-* When using AWS X-Ray as your tracing backend, you can control whether attributes are uploaded as annotations or metadata by configuring the AWS OTel Collector's indexed [keys](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter#exporter-configuration). By default, all attributes will be metadata.
+* When using AWS X-Ray as your tracing backend, you can control whether
+attributes are uploaded as annotations or metadata by configuring the
+AWS OTel Collector's indexed keys.
+By default, all attributes will be metadata.
 
 ## References
 

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
@@ -186,9 +186,7 @@ var currentActivity = Activity.Current;
 currentActivity.SetTag("key", "val");
 ```
 
-#### Note
-
-* When using AWS X-Ray as your tracing backend, you can control whether
+When using AWS X-Ray as your tracing backend, you can control whether
 attributes are uploaded as annotations or metadata by configuring the
 AWS OTel Collector's indexed keys.
 By default, all attributes will be metadata.

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
@@ -1,0 +1,161 @@
+# Tracing with AWS Distro for OpenTelemetry .Net SDK
+
+If you want to send the traces to AWS X-Ray, you can do so by using AWS Distro with the OpenTelemetry SDK.
+
+## Getting Started
+
+In order to instrument your .Net application for tracing, start by downloading the OpenTelemetry nuget package
+
+```
+dotnet add package OpenTelemetry
+```
+
+By default, the OpenTelemetry SDK generates traces with W3C random ID which X-Ray backend doesn’t support yet. You need to install the `OpenTelemetry.Contrib.Extensions.AWSXRay` to be able to use the `AWSXRayIdGenerator` which generates X-Ray compatible trace IDs. If you plan to call an AWS service or another application instrumented with AWS X-Ray SDK, you’ll need to use the `AWSXRayPropagator` as well.
+
+```
+dotnet add package OpenTelemetry.Contrib.Extensions.AWSXRay
+```
+
+### Note
+
+* You’ll also need to have the [AWS Distro for OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter) running to export traces to X-Ray.
+
+### Instrumenting .Net applications
+
+#### ASP.Net Core
+
+Start by downloading the ASP.Net Core and OTLP exporter instrumentation packages
+
+```
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+Next, in your application’s **Startup.cs** add the instrumentation and the OTLP exporter as services in the `ConfigureServices` method. Make sure to call `AddXRayTraceId()` in the **beginning** when building `TracerProviderBuilder`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+
+```
+using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
+using OpenTelemetry.Trace;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddOpenTelemetryTracing((builder) => builder
+        .AddXRayTraceId() // for generating AWS X-Ray compliant trace IDs
+        .AddAspNetCoreInstrumentation()
+        .AddOtlpExporter());
+    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()            
+}
+```
+
+By default the OTLP exporter sends data to an OpenTelemetry collector at **localhost:55681**
+
+#### ASP.Net
+
+Download the ASP.Net and OTLP exporter instrumentation packages
+
+```
+dotnet add package OpenTelemetry.Instrumentation.AspNet
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+The ASP.Net instrumentation requires [modification](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/src/OpenTelemetry.Instrumentation.AspNet/README.md#step-2-modify-webconfig) to Web.config to add a HttpModule to your web server.
+
+```xml
+<system.webServer>
+    <modules>
+    <add name="TelemetryCorrelationHttpModule"
+    type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule,
+    Microsoft.AspNet.TelemetryCorrelation"
+    preCondition="integratedMode,managedHandler" />
+    </modules>
+</system.webServer>
+```
+
+Now all you need to do is enable the instrumentation for the application startup. This is done in the **Global.asax.cs** as shown below. Make sure to call `AddXRayTraceId()` in the **beginning** when building `TracerProviderBuilder`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+
+```
+using OpenTelemetry;
+using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
+using OpenTelemetry.Trace;
+
+public class WebApiApplication : HttpApplication
+{
+    private TracerProvider tracerProvider;
+    protected void Application_Start()
+    {
+        this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddXRayTraceId() // for generating AWS X-Ray compliant trace IDs
+            .AddAspNetInstrumentation()
+            .AddOtlpExporter()
+            .Build();
+        Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()            
+    }
+    
+    protected void Application_End()
+    {
+        this.tracerProvider?.Dispose();
+    }
+}
+```
+
+#### Console
+
+Make sure to call `AddXRayTraceIdWithSampler()` in the **beginning** when building `TracerProviderBuilder`. You’ll need to pass the sampler you’re using in your application. If you’re using the default sampler, just pass `new ParentBasedSampler(new AlwaysOnSampler())`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+
+```
+using OpenTelemetry;
+using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
+using OpenTelemetry.Trace;
+
+var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddXRayTraceIdWithSampler(your_sampler) // for generating AWS X-Ray compliant trace IDs
+                .AddOtlpExporter()
+                .Build();
+Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()
+```
+
+### Instrumenting AWS SDK
+
+For tracing downstream call to AWS services from your .Net application, you will need three components: the `AWSXRayIdGenerator`, the `AWSXRayPropagator`, and the AWS client instrumentation. 
+
+ Download the OpenTelemetry.Contrib.Instrumentation.AWS package:
+
+```
+dotnet add package OpenTelemetry.Contrib.Extensions.AWSXRay
+```
+
+Add the `AWSXRayIdGenerator`, `AWSXRayPropagator` and `AWSInstrumentation` to your application. The below example is for an ASP.Net Core application.
+
+```
+using OpenTelemetry;
+using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
+using OpenTelemetry.Trace;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddControllers();
+    services.AddOpenTelemetryTracing((builder) => builder
+        .AddXRayTraceId() // for generating AWS X-Ray compliant trace IDs
+        .AddAWSInstrumentation() // for tracing calls to AWS services via AWS SDK for .Net
+        .AddAspNetCoreInstrumentation()
+        .AddOtlpExporter());   
+    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()            
+}
+```
+
+### Adding Custom Attributes
+
+You can add custom attributes to an `Activity` by calling `SetTag` method on the current activity.
+
+```
+var currentActivity = Activity.Current;
+currentActivity.SetTag("key", "val");
+```
+
+#### Note:
+* When using AWS X-Ray as your tracing backend, you can control whether attributes are uploaded as annotations or metadata by configuring the AWS OTel Collector’s indexed [keys](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter#exporter-configuration). By default, all attributes will be metadata.
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)
+* [AWS Distro for OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter)

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/README.md
@@ -10,7 +10,7 @@ In order to instrument your .Net application for tracing, start by downloading t
 dotnet add package OpenTelemetry
 ```
 
-By default, the OpenTelemetry SDK generates traces with W3C random ID which X-Ray backend doesn’t support yet. You need to install the `OpenTelemetry.Contrib.Extensions.AWSXRay` to be able to use the `AWSXRayIdGenerator` which generates X-Ray compatible trace IDs. If you plan to call an AWS service or another application instrumented with AWS X-Ray SDK, you’ll need to use the `AWSXRayPropagator` as well.
+By default, the OpenTelemetry SDK generates traces with W3C random ID which X-Ray backend doesn't support yet. You need to install the `OpenTelemetry.Contrib.Extensions.AWSXRay` to be able to use the `AWSXRayIdGenerator` which generates X-Ray compatible trace IDs. If you plan to call an AWS service or another application instrumented with AWS X-Ray SDK, you'll need to use the `AWSXRayPropagator` as well.
 
 ```
 dotnet add package OpenTelemetry.Contrib.Extensions.AWSXRay
@@ -18,7 +18,7 @@ dotnet add package OpenTelemetry.Contrib.Extensions.AWSXRay
 
 ### Note
 
-* You’ll also need to have the [AWS Distro for OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter) running to export traces to X-Ray.
+* You'll also need to have the [AWS Distro for OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter) running to export traces to X-Ray.
 
 ### Instrumenting .Net applications
 
@@ -31,7 +31,7 @@ dotnet add package OpenTelemetry.Instrumentation.AspNetCore
 dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
 ```
 
-Next, in your application’s **Startup.cs** add the instrumentation and the OTLP exporter as services in the `ConfigureServices` method. Make sure to call `AddXRayTraceId()` in the **beginning** when building `TracerProviderBuilder`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+Next, in your application's **Startup.cs** add the instrumentation and the OTLP exporter as services in the `ConfigureServices` method. Make sure to call `AddXRayTraceId()` in the **beginning** when building `TracerProviderBuilder`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
 
 ```
 using OpenTelemetry.Contrib.Extensions.AWSXRay.Trace;
@@ -43,7 +43,7 @@ public void ConfigureServices(IServiceCollection services)
         .AddXRayTraceId() // for generating AWS X-Ray compliant trace IDs
         .AddAspNetCoreInstrumentation()
         .AddOtlpExporter());
-    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()            
+    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
 }
 ```
 
@@ -88,9 +88,9 @@ public class WebApiApplication : HttpApplication
             .AddAspNetInstrumentation()
             .AddOtlpExporter()
             .Build();
-        Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()            
+        Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
     }
-    
+
     protected void Application_End()
     {
         this.tracerProvider?.Dispose();
@@ -100,7 +100,7 @@ public class WebApiApplication : HttpApplication
 
 #### Console
 
-Make sure to call `AddXRayTraceIdWithSampler()` in the **beginning** when building `TracerProviderBuilder`. You’ll need to pass the sampler you’re using in your application. If you’re using the default sampler, just pass `new ParentBasedSampler(new AlwaysOnSampler())`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
+Make sure to call `AddXRayTraceIdWithSampler()` in the **beginning** when building `TracerProviderBuilder`. You'll need to pass the sampler you're using in your application. If you're using the default sampler, just pass `new ParentBasedSampler(new AlwaysOnSampler())`. If you want to trace AWS services, make sure to configure `AWSXRayPropagator`.
 
 ```
 using OpenTelemetry;
@@ -111,14 +111,14 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddXRayTraceIdWithSampler(your_sampler) // for generating AWS X-Ray compliant trace IDs
                 .AddOtlpExporter()
                 .Build();
-Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()
+Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
 ```
 
 ### Instrumenting AWS SDK
 
-For tracing downstream call to AWS services from your .Net application, you will need three components: the `AWSXRayIdGenerator`, the `AWSXRayPropagator`, and the AWS client instrumentation. 
+For tracing downstream call to AWS services from your .Net application, you will need three components: the `AWSXRayIdGenerator`, the `AWSXRayPropagator`, and the AWS client instrumentation.
 
- Download the OpenTelemetry.Contrib.Instrumentation.AWS package:
+ Download the `OpenTelemetry.Contrib.Extensions.AWSXRay` package:
 
 ```
 dotnet add package OpenTelemetry.Contrib.Extensions.AWSXRay
@@ -138,8 +138,8 @@ public void ConfigureServices(IServiceCollection services)
         .AddXRayTraceId() // for generating AWS X-Ray compliant trace IDs
         .AddAWSInstrumentation() // for tracing calls to AWS services via AWS SDK for .Net
         .AddAspNetCoreInstrumentation()
-        .AddOtlpExporter());   
-    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator()            
+        .AddOtlpExporter());
+    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator()); // configure AWSXRayPropagator
 }
 ```
 
@@ -153,7 +153,7 @@ currentActivity.SetTag("key", "val");
 ```
 
 #### Note:
-* When using AWS X-Ray as your tracing backend, you can control whether attributes are uploaded as annotations or metadata by configuring the AWS OTel Collector’s indexed [keys](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter#exporter-configuration). By default, all attributes will be metadata.
+* When using AWS X-Ray as your tracing backend, you can control whether attributes are uploaded as annotations or metadata by configuring the AWS OTel Collector's indexed [keys](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/awsxrayexporter#exporter-configuration). By default, all attributes will be metadata.
 
 ## References
 

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/TracerProviderBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/>.</returns>
-        public static TracerProviderBuilder AddXRayActivityTraceIdGenerator(this TracerProviderBuilder builder)
+        public static TracerProviderBuilder AddXRayTraceId(this TracerProviderBuilder builder)
         {
             if (builder == null)
             {
@@ -37,6 +37,24 @@ namespace OpenTelemetry.Trace
             }
 
             AWSXRayIdGenerator.ReplaceTraceId();
+            return builder;
+        }
+
+        /// <summary>
+        /// 1. Replace the trace id of root activity.
+        /// 2. Update the sampling decision for root activity when it's created through ActivitySource.StartActivity().
+        /// </summary>
+        /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+        /// <param name="sampler"><see cref="Sampler"/> being used.</param>
+        /// <returns>The instance of <see cref="TracerProviderBuilder"/>.</returns>
+        public static TracerProviderBuilder AddXRayTraceIdWithSampler(this TracerProviderBuilder builder, Sampler sampler)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            AWSXRayIdGenerator.ReplaceTraceId(sampler);
             return builder;
         }
     }

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/TestAWSXRayIdGenerator.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/TestAWSXRayIdGenerator.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Diagnostics;
-using Moq;
 using OpenTelemetry.Trace;
 using Xunit;
 

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/TestAWSXRayIdGenerator.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/TestAWSXRayIdGenerator.cs
@@ -16,10 +16,11 @@
 
 using System;
 using System.Diagnostics;
+using Moq;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Contrib.Extensions.AWSRay.Tests
+namespace OpenTelemetry.Contrib.Extensions.AWSXRay.Tests
 {
     public class TestAWSXRayIdGenerator
     {
@@ -31,7 +32,7 @@ namespace OpenTelemetry.Contrib.Extensions.AWSRay.Tests
             var originalParentSpanId = activity.ParentSpanId;
             var originalTraceFlag = activity.ActivityTraceFlags;
 
-            using (Sdk.CreateTracerProviderBuilder().AddXRayActivityTraceIdGenerator().Build())
+            using (Sdk.CreateTracerProviderBuilder().AddXRayTraceId().Build())
             {
                 activity.Start();
 
@@ -43,14 +44,14 @@ namespace OpenTelemetry.Contrib.Extensions.AWSRay.Tests
         }
 
         [Fact]
-        public void TestGenerateTraceIdForNonRootNodeSampled()
+        public void TestGenerateTraceIdForNonRootNode()
         {
             var activity = new Activity("Test");
             var traceId = ActivityTraceId.CreateFromString("12345678901234567890123456789012".AsSpan());
             var parentId = ActivitySpanId.CreateFromString("1234567890123456".AsSpan());
             activity.SetParentId(traceId, parentId, ActivityTraceFlags.Recorded);
 
-            using (Sdk.CreateTracerProviderBuilder().AddXRayActivityTraceIdGenerator().Build())
+            using (Sdk.CreateTracerProviderBuilder().AddXRayTraceId().Build())
             {
                 activity.Start();
 
@@ -68,13 +69,51 @@ namespace OpenTelemetry.Contrib.Extensions.AWSRay.Tests
             var parentId = ActivitySpanId.CreateFromString("1234567890123456".AsSpan());
             activity.SetParentId(traceId, parentId, ActivityTraceFlags.None);
 
-            using (Sdk.CreateTracerProviderBuilder().AddXRayActivityTraceIdGenerator().Build())
+            using (Sdk.CreateTracerProviderBuilder().AddXRayTraceId().Build())
             {
                 activity.Start();
 
                 Assert.Equal("12345678901234567890123456789012", activity.TraceId.ToHexString());
                 Assert.Equal("1234567890123456", activity.ParentSpanId.ToHexString());
                 Assert.Equal(ActivityTraceFlags.None, activity.ActivityTraceFlags);
+            }
+        }
+
+        [Fact]
+        public void TestGenerateTraceIdForRootNodeUsingActivitySourceWithTraceIdBasedSamplerOn()
+        {
+            using (Sdk.CreateTracerProviderBuilder()
+                .AddXRayTraceIdWithSampler(new TraceIdRatioBasedSampler(1.0))
+                .AddSource("TestTraceIdBasedSamplerOn")
+                .SetSampler(new TraceIdRatioBasedSampler(1.0))
+                .Build())
+            {
+                using (var activitySource = new ActivitySource("TestTraceIdBasedSamplerOn"))
+                {
+                    using (var activity = activitySource.StartActivity("RootActivity", ActivityKind.Internal))
+                    {
+                        Assert.True(activity.ActivityTraceFlags == ActivityTraceFlags.Recorded);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void TestGenerateTraceIdForRootNodeUsingActivitySourceWithTraceIdBasedSamplerOff()
+        {
+            using (Sdk.CreateTracerProviderBuilder()
+                .AddXRayTraceIdWithSampler(new TraceIdRatioBasedSampler(0.0))
+                .AddSource("TestTraceIdBasedSamplerOff")
+                .SetSampler(new TraceIdRatioBasedSampler(0.0))
+                .Build())
+            {
+                using (var activitySource = new ActivitySource("TestTraceIdBasedSamplerOff"))
+                {
+                    using (var activity = activitySource.StartActivity("RootActivity", ActivityKind.Internal))
+                    {
+                        Assert.True(activity.ActivityTraceFlags == ActivityTraceFlags.None);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
When using `ActivitySource.StartActivity()` to create root activity, the sampling decision is decided [before](https://github.com/dotnet/runtime/blob/ae9da6432360728c77ab10b1ef0c414d1a9ee287/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs#L207) invoking `ActivityListener`s. If user is using traceid-dependent sampler, root activity's sampling decision needs to be updated as well while replacing trace id. Here, we provide a new API called `AddXRayTraceIdWithSampler` to override the trace id and update sampling decision for this case.