### PR TITLE
Individual component versioning through tag prefixes

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-    
+
   <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!=''">
     <PropertyGroup>
       <RevisionNumber>0</RevisionNumber>
@@ -42,7 +42,7 @@
       <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</FileVersion>
     </PropertyGroup>
   </Target>
-  
+
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -32,17 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
-  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!=''">
-    <PropertyGroup>
-      <RevisionNumber>0</RevisionNumber>
-      <RevisionNumber Condition="$(MinVerVersion.Split(`.`).Length) == 4">$(MinVerVersion.Split(`.`)[3])</RevisionNumber>
-      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>
-      <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</Version>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</FileVersion>
-    </PropertyGroup>
-  </Target>
-
+  
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -32,6 +32,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+    
+  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!=''">
+    <PropertyGroup>
+      <RevisionNumber>0</RevisionNumber>
+      <RevisionNumber Condition="$(MinVerVersion.Split(`.`).Length) == 4">$(MinVerVersion.Split(`.`)[3])</RevisionNumber>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>
+      <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</Version>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</FileVersion>
+    </PropertyGroup>
+  </Target>
   
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
@@ -10,5 +10,8 @@
     <PackageReference Include="Google.Cloud.Trace.V2" Version="2.0.0" />
     <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
   </ItemGroup>
-
+    
+  <PropertyGroup>
+    <MinVerTagPrefix>Exporter.Stackdriver-</MinVerTagPrefix>
+  </PropertyGroup>
 </Project>

--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
@@ -3,15 +3,11 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Stackdriver .NET Exporter for OpenTelemetry.</Description>
     <PackageTags>$(PackageTags);Stackdriver;Google;GCP;distributed-tracing</PackageTags>
+    <MinVerTagPrefix>Exporter.Stackdriver-</MinVerTagPrefix>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Monitoring.V3" Version="2.1.0" />
     <PackageReference Include="Google.Cloud.Trace.V2" Version="2.0.0" />
     <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
   </ItemGroup>
-    
-  <PropertyGroup>
-    <MinVerTagPrefix>Exporter.Stackdriver-</MinVerTagPrefix>
-  </PropertyGroup>
 </Project>

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
@@ -13,13 +13,4 @@
     <MinVerTagPrefix>Extensions.AWSXRay-</MinVerTagPrefix>
   </PropertyGroup>
     
-  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!=''">
-    <PropertyGroup>
-      <RevisionNumber>0</RevisionNumber>
-      <RevisionNumber Condition="$(MinVerVersion.Split(`.`).Length) == 4">$(MinVerVersion.Split(`.`)[3])</RevisionNumber>
-      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>
-      <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</Version>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</FileVersion>
-    </PropertyGroup>
-  </Target>
 </Project>

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
@@ -1,16 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS X-Ray.</Description>
+    <MinVerTagPrefix>Extensions.AWSXRay-</MinVerTagPrefix>
   </PropertyGroup>
-  
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.0.0-rc2" />
   </ItemGroup>
-  
-  <PropertyGroup>
-    <MinVerTagPrefix>Extensions.AWSXRay-</MinVerTagPrefix>
-  </PropertyGroup>
-    
 </Project>

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
@@ -4,7 +4,22 @@
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS X-Ray.</Description>
   </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.0.0-rc2" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <MinVerTagPrefix>Extensions.AWSXRay-</MinVerTagPrefix>
+  </PropertyGroup>
+    
+  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!=''">
+    <PropertyGroup>
+      <RevisionNumber>0</RevisionNumber>
+      <RevisionNumber Condition="$(MinVerVersion.Split(`.`).Length) == 4">$(MinVerVersion.Split(`.`)[3])</RevisionNumber>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>
+      <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</Version>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</FileVersion>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.csproj
@@ -1,18 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>Elasticsearch instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
+    <MinVerTagPrefix>Instrumentation.ElasticsearchClient-</MinVerTagPrefix>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
   </ItemGroup>
-    
-  <PropertyGroup>
-    <MinVerTagPrefix>Instrumentation.ElasticsearchClient-</MinVerTagPrefix>
-  </PropertyGroup>
-
 </Project>

--- a/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.csproj
@@ -10,5 +10,9 @@
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
   </ItemGroup>
+    
+  <PropertyGroup>
+    <MinVerTagPrefix>Instrumentation.ElasticsearchClient-</MinVerTagPrefix>
+  </PropertyGroup>
 
 </Project>

--- a/src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft.EntityFrameworkCore instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
+    <MinVerTagPrefix>Instrumentation.EntityFrameworkCore-</MinVerTagPrefix>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
   </ItemGroup>
-
 </Project>

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/OpenTelemetry.Contrib.Instrumentation.MassTransit.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/OpenTelemetry.Contrib.Instrumentation.MassTransit.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>OpenTelemetry instrumentation for MassTransit</Description>
     <PackageTags>$(PackageTags);distributed-tracing;MassTransit</PackageTags>
+    <MinVerTagPrefix>Instrumentation.MassTransit-</MinVerTagPrefix>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
MinVer provides a feature to [version multiple projects in a single repo independently](https://github.com/adamralph/minver#can-i-version-multiple-projects-in-a-single-repo-independently) by defining a tag prefix for each project. I believe we can leverage this feature by defining specific tag prefix for each project and then creating a tag with `<projectPrefix>-<version>` when we want to do a release for the project.

For example, if the project name is `OpenTelemetry.Contrib.Extensions.AWSXRay`, the tag prefix will be `Extensions.AWSXRay-` and the tag name will be `Extensions.AWSXRay-1.0.0-rc2`. 

Any new project added to the repo must define the `<MinVerTagPrefix>` in its `csproj` file.

I checked the [naming requirements](https://git-scm.com/docs/git-tag#Documentation/git-tag.txt-lttagnamegt) for a git tag name but didn't find a restriction on the length. Please call out here if you know of any such limit.