### PR TITLE
Project code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,19 +2,16 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @open-telemetry/dotnet-approvers
+* @open-telemetry/dotnet-contrib-approvers
 
-src/OpenTelemetry.Contrib.Exporter.Stackdriver/                             @open-telemetry/dotnet-approvers
-test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests/                      @open-telemetry/dotnet-approvers
+src/OpenTelemetry.Contrib.Exporter.Stackdriver/                             @open-telemetry/dotnet-contrib-approvers
+src/OpenTelemetry.Contrib.Extensions.AWSXRay/                               @open-telemetry/dotnet-contrib-approvers @srprash @lupengamzn
+src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/                    @open-telemetry/dotnet-contrib-approvers
+src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/              @open-telemetry/dotnet-contrib-approvers
+src/OpenTelemetry.Contrib.Instrumentation.MassTransit/                      @open-telemetry/dotnet-contrib-approvers
 
-src/OpenTelemetry.Contrib.Extensions.AWSXRay/                               @open-telemetry/dotnet-approvers @srprash @lupengamzn
-test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/                        @open-telemetry/dotnet-approvers @srprash @lupengamzn
-
-src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/                    @open-telemetry/dotnet-approvers
-test/OpenTelemetry.Contrib.Instrumentation.Elasticsearch.Tests/             @open-telemetry/dotnet-approvers
-
-src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/              @open-telemetry/dotnet-approvers
-test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests/        @open-telemetry/dotnet-approvers
-
-src/OpenTelemetry.Contrib.Instrumentation.MassTransit/                      @open-telemetry/dotnet-approvers
-test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/               @open-telemetry/dotnet-approvers
+test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests/                      @open-telemetry/dotnet-contrib-approvers
+test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/                        @open-telemetry/dotnet-contrib-approvers @srprash @lupengamzn
+test/OpenTelemetry.Contrib.Instrumentation.Elasticsearch.Tests/             @open-telemetry/dotnet-contrib-approvers
+test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests/        @open-telemetry/dotnet-contrib-approvers
+test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/               @open-telemetry/dotnet-contrib-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,18 @@
 
 # For anything not explicitly taken by someone else:
 * @open-telemetry/dotnet-approvers
+
+src/OpenTelemetry.Contrib.Exporter.Stackdriver/                             @open-telemetry/dotnet-approvers
+test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests/                      @open-telemetry/dotnet-approvers
+
+src/OpenTelemetry.Contrib.Extensions.AWSXRay/                               @open-telemetry/dotnet-approvers @srprash @lupengamzn
+test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/                        @open-telemetry/dotnet-approvers @srprash @lupengamzn
+
+src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/                    @open-telemetry/dotnet-approvers
+test/OpenTelemetry.Contrib.Instrumentation.Elasticsearch.Tests/             @open-telemetry/dotnet-approvers
+
+src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/              @open-telemetry/dotnet-approvers
+test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests/        @open-telemetry/dotnet-approvers
+
+src/OpenTelemetry.Contrib.Instrumentation.MassTransit/                      @open-telemetry/dotnet-approvers
+test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/               @open-telemetry/dotnet-approvers


### PR DESCRIPTION
Issue: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/67

Adding code owners for the separate components of the contrib repo. Right now, all the code defaults to the @open-telemetry/dotnet-approvers group and I intend to keep it as such until we get specific approvers for each project. 
For the AWS code, I'm adding myself and @lupengamzn to be the code owners. Please feel free to discuss if you feel otherwise.

One thing to note is that any code owner added in this file will also need to have write permissions for the repo to actually let them be the code owners in a true sense.