### PR TITLE
Add Prashant as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Maintainers
 * [Cijo Thomas](https://github.com/cijothomas), Microsoft
 * [Mike Goldsmith](https://github.com/MikeGoldsmith), Honeycomb
 * [Mikel Blanchard](https://github.com/CodeBlanch), CoStar Group
+* [Prashant Srivastava](https://github.com/srprash), AWS
 * [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Google
 
 *Find more about the maintainer role in [community


### PR DESCRIPTION
As we are kick starting contrib repo, it'd be okay to waive the typical requirement of being an approver for 1 month, before being maintainer.