### PR TITLE
Fix project name for test step

### DIFF
--- a/.github/workflows/package-Exporter.Stackdriver.yml
+++ b/.github/workflows/package-Exporter.Stackdriver.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests
+      run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Exporter.Stackdriver.yml
+++ b/.github/workflows/package-Exporter.Stackdriver.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/${{env.PROJECT}}
+      run: dotnet test test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Extensions.AWSXRay.yml
+++ b/.github/workflows/package-Extensions.AWSXRay.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/${{env.PROJECT}}
+      run: dotnet test test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Extensions.AWSXRay.yml
+++ b/.github/workflows/package-Extensions.AWSXRay.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests
+      run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Instrumentation.Elasticsearch.yml
+++ b/.github/workflows/package-Instrumentation.Elasticsearch.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/OpenTelemetry.Contrib.Instrumentation.Elasticsearch.Tests
+      run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Instrumentation.Elasticsearch.yml
+++ b/.github/workflows/package-Instrumentation.Elasticsearch.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/${{env.PROJECT}}
+      run: dotnet test test/OpenTelemetry.Contrib.Instrumentation.Elasticsearch.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
+++ b/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/${{env.PROJECT}}
+      run: dotnet test test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
+++ b/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests
+      run: dotnet test test/${{env.PROJECT}}Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Instrumentation.MassTransit.yml
+++ b/.github/workflows/package-Instrumentation.MassTransit.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
+      run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build

--- a/.github/workflows/package-Instrumentation.MassTransit.yml
+++ b/.github/workflows/package-Instrumentation.MassTransit.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/${{env.PROJECT}}
+      run: dotnet test test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build


### PR DESCRIPTION
I missed to notice that the tests for the projects have `.Tests` suffixed to them and isn't the exact name as their source projects. So this PR aims to fix the test step in the workflows by explicitly calling the test projects rather than using the `PROJECT` variable.
I could have generalized this too but for some reason the EntityFrameworkCore project doesn't exactly follow the `.Tests` convention rather has the `Tests`  suffix. Maybe we can fix it later for the sake of consistency in the repo.