### PR TITLE
Fix test project name in AWS instrumentation

### DIFF
--- a/.github/workflows/package-Instrumentation.AWS.yml
+++ b/.github/workflows/package-Instrumentation.AWS.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/${{env.PROJECT}}
+      run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build


### PR DESCRIPTION
Sorry I missed this one before merging in the whole PR. Doing the same fix as done for the rest of the workflows in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/73