### PR TITLE
Remove X-Ray specific documentation from README

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/README.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/README.md
@@ -18,14 +18,9 @@ public void ConfigureServices(IServiceCollection services)
 {
     services.AddControllers();
     services.AddOpenTelemetryTracing((builder) => builder
-        // for generating AWS X-Ray compliant trace IDs
-        .AddXRayTraceId()
         // for tracing calls to AWS services via AWS SDK for .Net
         .AddAWSInstrumentation()
         .AddAspNetCoreInstrumentation()
         .AddOtlpExporter());
-
-    // configure AWSXRayPropagator
-    Sdk.SetDefaultTextMapPropagator(new AWSXRayPropagator());
 }
 ```


### PR DESCRIPTION
Setting the trace ID is only for X-Ray users, but this instrumentation is unrelated to X-Ray.

And it's almost never a good idea to set the global propagator to just the xray propagator, at least it should be both w3c and xray. But as the instrumentation is directly using xray propagation (nice), it's not necessary anyways.