### PR TITLE
Instrumentation.AWS - Changed project dependency to package reference

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog - OpenTelemetry.Contrib.Instrumentation.AWS
+
+## 1.0.1 [2021-Feb-24]
+
+This is the first release for the `OpenTelemetry.Contrib.Instrumentation.AWS`
+project.
+
+For more details, please refer to the
+[README](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Contrib.Instrumentation.AWS/README.md)

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/OpenTelemetry.Contrib.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/OpenTelemetry.Contrib.Instrumentation.AWS.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\OpenTelemetry.Contrib.Extensions.AWSXRay\OpenTelemetry.Contrib.Extensions.AWSXRay.csproj" />
+    <PackageReference Include="OpenTelemetry.Contrib.Extensions.AWSXRay" Version="1.0.1" />
     <PackageReference Include="AWSSDK.Core" Version="3.5.1.24" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When referencing the source code of `Extensions.AWSXRay`, the [MinVer](https://github.com/adamralph/minver#how-it-works) will try to infer the version number for `Extensions.AWSXRay`, and causes stable version of `Instrumentation.AWS` to depend on a pre-release version of `1.0.2-alpha` for `Extensions.AWSXRay`, which is in conflict with what we wanted as `1.0.1`. Changing the project reference to package reference will resolve this.