### PR TITLE
Support Json Credentials for Stackdriver

### DIFF
--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Monitoring.V3" Version="2.1.0" />
     <PackageReference Include="Google.Cloud.Trace.V2" Version="2.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="0.7.0-beta.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.0.1" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/StackdriverTraceExporter.cs
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/StackdriverTraceExporter.cs
@@ -36,6 +36,7 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver
         private readonly Google.Api.Gax.ResourceNames.ProjectName googleCloudProjectId;
         private readonly TraceServiceSettings traceServiceSettings;
         private readonly TraceServiceClient traceServiceClient;
+        private readonly string jsonCredentials;
 
         static StackdriverTraceExporter()
         {
@@ -63,8 +64,10 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver
         /// Initializes a new instance of the <see cref="StackdriverTraceExporter"/> class.
         /// </summary>
         /// <param name="projectId">Project ID to send telemetry to.</param>
-        public StackdriverTraceExporter(string projectId)
+        /// <param name="jsonCredentials">Google Cloud JsonCredentials.</param>
+        public StackdriverTraceExporter(string projectId, string jsonCredentials = null)
         {
+            this.jsonCredentials = jsonCredentials;
             this.googleCloudProjectId = new Google.Api.Gax.ResourceNames.ProjectName(projectId);
 
             // Set header mutation for every outgoing API call to Stackdriver so the BE knows
@@ -78,10 +81,11 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver
         /// Only used internally for tests.
         /// </summary>
         /// <param name="projectId">Project ID to send telemetry to.</param>
+        /// <param name="jsonCredentials">Google Cloud JsonCredentials.</param>
         /// <param name="traceServiceClient">TraceServiceClient instance to use.</param>
         [ExcludeFromCodeCoverage]
-        internal StackdriverTraceExporter(string projectId, TraceServiceClient traceServiceClient)
-            : this(projectId)
+        internal StackdriverTraceExporter(string projectId, string jsonCredentials, TraceServiceClient traceServiceClient)
+            : this(projectId, jsonCredentials)
         {
             this.traceServiceClient = traceServiceClient;
         }
@@ -95,6 +99,7 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver
                 traceWriter = new TraceServiceClientBuilder
                 {
                     Settings = this.traceServiceSettings,
+                    JsonCredentials = this.jsonCredentials,
                 }.Build();
             }
 

--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/TracerProviderBuilderExtensions.cs
@@ -40,9 +40,9 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            var activityExporter = new StackdriverTraceExporter(projectId);
+            var activityExporter = new StackdriverTraceExporter(projectId, null);
 
-            return builder.AddProcessor(new BatchExportProcessor<Activity>(activityExporter));
+            return builder.AddProcessor(new BatchActivityExportProcessor(activityExporter));
         }
     }
 }

--- a/test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests/StackdriverExporterTests.cs
+++ b/test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests/StackdriverExporterTests.cs
@@ -101,10 +101,10 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver.Tests
                     x.BatchWriteSpans(It.IsAny<BatchWriteSpansRequest>(), It.IsAny<CallSettings>()))
                 .Throws(new RpcException(Status.DefaultCancelled))
                 .Verifiable($"{nameof(TraceServiceClient.BatchWriteSpans)} was never called");
-            var activityExporter = new StackdriverTraceExporter("test", traceClientMock.Object);
+            var activityExporter = new StackdriverTraceExporter("test", null, traceClientMock.Object);
             var testExporter = new TestExporter<Activity>(RunTest);
 
-            var processor = new BatchExportProcessor<Activity>(testExporter);
+            var processor = new BatchActivityExportProcessor(testExporter);
 
             for (int i = 0; i < 10; i++)
             {
@@ -138,10 +138,10 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver.Tests
             traceClientMock.Setup(x =>
                     x.BatchWriteSpans(It.IsAny<BatchWriteSpansRequest>(), It.IsAny<CallSettings>()))
                 .Verifiable($"{nameof(TraceServiceClient.BatchWriteSpans)} was never called");
-            var activityExporter = new StackdriverTraceExporter("test", traceClientMock.Object);
+            var activityExporter = new StackdriverTraceExporter("test", null, traceClientMock.Object);
             var testExporter = new TestExporter<Activity>(RunTest);
 
-            var processor = new BatchExportProcessor<Activity>(testExporter);
+            var processor = new BatchActivityExportProcessor(testExporter);
 
             for (int i = 0; i < 10; i++)
             {


### PR DESCRIPTION
* Support Json Credentials. Otherwise it's hard to handle multiple service account within the same process.
* Upgrade OpenTelementry nuget pakcage from version `0.7.0-beta.1` to `1.0.1`