### PR TITLE
Modify MassTransit Instrumentation to take advantage of sampling decision

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/Implementation/MassTransitDiagnosticListener.cs
@@ -41,6 +41,9 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation
 
         public override void OnStartActivity(Activity activity, object payload)
         {
+            // By this time, samplers have already run and
+            // activity.IsAllDataRequested populated accordingly.
+
             if (Sdk.SuppressInstrumentation)
             {
                 return;

--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/OpenTelemetry.Contrib.Instrumentation.MassTransit.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/OpenTelemetry.Contrib.Instrumentation.MassTransit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>OpenTelemetry instrumentation for MassTransit</Description>
@@ -7,6 +7,6 @@
     <IncludeSharedInstrumentationSource>true</IncludeSharedInstrumentationSource>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.0.2-alpha.0.29" />
+    <PackageReference Include="OpenTelemetry" Version="1.0.2-alpha.0.43" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using MassTransit.Testing;
 using Moq;
 using OpenTelemetry.Contrib.Instrumentation.MassTransit.Implementation;
+using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -315,7 +316,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             using (Sdk.CreateTracerProviderBuilder()
-                .SetSampler(new TestSampler(samplingDecision))
+                .SetSampler(new TestSampler() { SamplingAction = (samplingParameters) => new SamplingResult(samplingDecision) })
                 .AddProcessor(activityProcessor.Object)
                 .AddMassTransitInstrumentation()
                 .Build())
@@ -354,21 +355,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                             .Any(a => a.OperationName == operationName))
                     .Where(i => i.Method.Name == "OnEnd")
                     .Select(i => i.Arguments.OfType<Activity>().Single());
-        }
-
-        private class TestSampler : Sampler
-        {
-            private SamplingDecision samplingDecision;
-
-            public TestSampler(SamplingDecision samplingDecision)
-            {
-                this.samplingDecision = samplingDecision;
-            }
-
-            public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
-            {
-                return new SamplingResult(this.samplingDecision);
-            }
         }
     }
 }

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -272,6 +272,79 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
             Assert.Single(consumes);
         }
 
+        [Fact]
+        public async Task ShouldMapMassTransitTagsWhenIntrumentationIsSuppressed()
+        {
+            var activityProcessor = new Mock<BaseProcessor<Activity>>();
+            using (Sdk.CreateTracerProviderBuilder()
+                .AddProcessor(activityProcessor.Object)
+                .AddMassTransitInstrumentation()
+                .Build())
+            {
+                var harness = new InMemoryTestHarness();
+                var consumerHarness = harness.Consumer<TestConsumer>();
+                var handlerHarness = harness.Handler<TestMessage>();
+                using var scope = SuppressInstrumentationScope.Begin();
+                await harness.Start();
+                try
+                {
+                    await harness.InputQueueSendEndpoint.Send<TestMessage>(new { Text = "Hello, world!" });
+
+                    Assert.True(await harness.Consumed.SelectAsync<TestMessage>().Any());
+                    Assert.True(await consumerHarness.Consumed.SelectAsync<TestMessage>().Any());
+                    Assert.True(await handlerHarness.Consumed.SelectAsync().Any());
+                }
+                finally
+                {
+                    await harness.Stop();
+                }
+
+                var expectedMessageContext = harness.Sent.Select<TestMessage>().FirstOrDefault()?.Context;
+                Assert.NotNull(expectedMessageContext);
+            }
+
+            // Since instrumentation is suppressed, activiy is not emitted
+            Assert.Equal(3, activityProcessor.Invocations.Count); // SetParentProvider + OnShutdown + Dispose
+        }
+
+        [Theory]
+        [InlineData(SamplingDecision.Drop, false)]
+        [InlineData(SamplingDecision.RecordOnly, true)]
+        [InlineData(SamplingDecision.RecordAndSample, true)]
+        public async Task ShouldMapMassTransitTagsWhenIntrumentationWhenSampled(SamplingDecision samplingDecision, bool isActivityExpected)
+        {
+            var activityProcessor = new Mock<BaseProcessor<Activity>>();
+            using (Sdk.CreateTracerProviderBuilder()
+                .SetSampler(new TestSampler(samplingDecision))
+                .AddProcessor(activityProcessor.Object)
+                .AddMassTransitInstrumentation()
+                .Build())
+            {
+                var harness = new InMemoryTestHarness();
+                var consumerHarness = harness.Consumer<TestConsumer>();
+                var handlerHarness = harness.Handler<TestMessage>();
+                await harness.Start();
+                try
+                {
+                    await harness.InputQueueSendEndpoint.Send<TestMessage>(new { Text = "Hello, world!" });
+
+                    Assert.True(await harness.Consumed.SelectAsync<TestMessage>().Any());
+                    Assert.True(await consumerHarness.Consumed.SelectAsync<TestMessage>().Any());
+                    Assert.True(await handlerHarness.Consumed.SelectAsync().Any());
+                }
+                finally
+                {
+                    await harness.Stop();
+                }
+
+                var expectedMessageContext = harness.Sent.Select<TestMessage>().FirstOrDefault()?.Context;
+                Assert.NotNull(expectedMessageContext);
+            }
+
+            Assert.Equal(isActivityExpected, activityProcessor.Invocations.Any(invo => invo.Method.Name == nameof(activityProcessor.Object.OnStart)));
+            Assert.Equal(isActivityExpected, activityProcessor.Invocations.Any(invo => invo.Method.Name == nameof(activityProcessor.Object.OnEnd)));
+        }
+
         private IEnumerable<Activity> GetActivitiesFromInvocationsByOperationName(IEnumerable<IInvocation> invocations, string operationName)
         {
             return
@@ -281,6 +354,21 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
                             .Any(a => a.OperationName == operationName))
                     .Where(i => i.Method.Name == "OnEnd")
                     .Select(i => i.Arguments.OfType<Activity>().Single());
+        }
+
+        private class TestSampler : Sampler
+        {
+            private SamplingDecision samplingDecision;
+
+            public TestSampler(SamplingDecision samplingDecision)
+            {
+                this.samplingDecision = samplingDecision;
+            }
+
+            public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+            {
+                return new SamplingResult(this.samplingDecision);
+            }
         }
     }
 }

--- a/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/MassTransitInstrumentationTests.cs
@@ -306,6 +306,10 @@ namespace OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests
 
             // Since instrumentation is suppressed, activiy is not emitted
             Assert.Equal(3, activityProcessor.Invocations.Count); // SetParentProvider + OnShutdown + Dispose
+
+            // Processor.OnStart and Processor.OnEnd are not called
+            Assert.DoesNotContain(activityProcessor.Invocations, invo => invo.Method.Name == nameof(activityProcessor.Object.OnStart));
+            Assert.DoesNotContain(activityProcessor.Invocations, invo => invo.Method.Name == nameof(activityProcessor.Object.OnEnd));
         }
 
         [Theory]


### PR DESCRIPTION
Extends the optimization done in the [PR #1894](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1894) to optimize MassTransit Instrumentation

## Changes
- Added a check to return from the `OnStartActivity` method of the listener if the instrumentation is suppressed
- Wrap the logic in `OnStartActivity` to perform operations such as filter, set the activity DisplayName, etc. only when `activity.IsAllDataRequested` is set to `true`
- Removed the redundant filtering check in the `OnStopActivity` method of the listener
- Added unit tests to check if the instrumentation respects  `Sdk.SuppressInstrumentation` and `activity.IsAllDataRequested`