### PR TITLE
Modify ElasticSearch Instrumentation to take advantage of sampling decision

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
@@ -82,7 +82,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.Implementati
                 ActivityInstrumentationHelper.SetKindProperty(activity, ActivityKind.Client);
 
                 var method = this.methodFetcher.Fetch(payload);
-                activity.DisplayName = this.GetDisplayName(activity, method);
 
                 if (this.options.SuppressDownstreamInstrumentation)
                 {

--- a/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.csproj
@@ -7,7 +7,7 @@
     <IncludeSharedInstrumentationSource>true</IncludeSharedInstrumentationSource>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.0.2-alpha.0.29" />
+    <PackageReference Include="OpenTelemetry" Version="1.1.0-beta1" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Extends the optimization done in [PR #1894](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1894) to optimize ElasticSearch Instrumentation

## Changes
- Added a check to return from the OnStartActivity method of the listener if the instrumentation is suppressed
- Wrap the logic in OnStartActivity to perform operations such as fetch uri, set the activity DisplayName, etc. only when - activity.IsAllDataRequested is set to true
- Added unit tests to check if the instrumentation respects `Sdk.SuppressInstrumentation` and `activity.IsAllDataRequested`