### PR TITLE
Add code owner for ElasticSearch instrumentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,14 +6,14 @@
 
 src/OpenTelemetry.Contrib.Exporter.Stackdriver/                             @open-telemetry/dotnet-contrib-approvers
 src/OpenTelemetry.Contrib.Extensions.AWSXRay/                               @open-telemetry/dotnet-contrib-approvers @srprash @lupengamzn
-src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/                    @open-telemetry/dotnet-contrib-approvers
+src/OpenTelemetry.Contrib.Instrumentation.Elasticsearch/                    @open-telemetry/dotnet-contrib-approvers @ejsmith
 src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/              @open-telemetry/dotnet-contrib-approvers
 src/OpenTelemetry.Contrib.Instrumentation.MassTransit/                      @open-telemetry/dotnet-contrib-approvers @alexvaluyskiy
 src/OpenTelemetry.Contrib.Instrumentation.GrpcCore/                         @open-telemetry/dotnet-contrib-approvers @pcwiese
 
 test/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests/                      @open-telemetry/dotnet-contrib-approvers
 test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/                        @open-telemetry/dotnet-contrib-approvers @srprash @lupengamzn
-test/OpenTelemetry.Contrib.Instrumentation.Elasticsearch.Tests/             @open-telemetry/dotnet-contrib-approvers
+test/OpenTelemetry.Contrib.Instrumentation.Elasticsearch.Tests/             @open-telemetry/dotnet-contrib-approvers @ejsmith
 test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests/        @open-telemetry/dotnet-contrib-approvers
 test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/               @open-telemetry/dotnet-contrib-approvers @alexvaluyskiy
 test/OpenTelemetry.Contrib.Instrumentation.GrpcCore.Tests/                  @open-telemetry/dotnet-contrib-approvers @pcwiese


### PR DESCRIPTION
## Changes
- Added @ejsmith as the code owner for ElasticSearch instrumentation `src` and `test`