### PR TITLE
Update TracerProviderBuilderExtensions.cs

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/EntityFrameworkCoreTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/EntityFrameworkCoreTracerProviderBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="EntityFrameworkCoreTracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/TracerProviderBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Trace
     /// <summary>
     /// Extension methods to simplify registering of dependency instrumentation.
     /// </summary>
-    public static class TracerProviderBuilderExtensions
+    public static class EntityFrameworkCoreTracerProviderBuilderExtensions
     {
         /// <summary>
         /// Enables Microsoft.EntityFrameworkCore instrumentation.


### PR DESCRIPTION
Hello I cannot use together 2 Instrumentation, because they define in 2 classes with same namespace and name.
To fix it I propose to rename TracerProviderBuilderExtensions -> EntityFrameworkCoreTracerProviderBuilderExtensions
```
.AddGrpcCoreInstrumentation()
.AddEntityFrameworkCoreInstrumentation()
```


same issue: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/62
