### PR TITLE
Cleanup diagnosticsource listeners

### DIFF
--- a/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
@@ -41,11 +41,6 @@ namespace OpenTelemetry.Instrumentation
         {
             if (!this.handler.SupportsNullActivity && Activity.Current == null)
             {
-                if (!Sdk.SuppressInstrumentation)
-                {
-                    InstrumentationEventSource.Log.NullActivity(value.Key);
-                }
-
                 return;
             }
 
@@ -61,17 +56,11 @@ namespace OpenTelemetry.Instrumentation
                 }
                 else if (value.Key.EndsWith("Exception", StringComparison.Ordinal))
                 {
-                    if (!Sdk.SuppressInstrumentation)
-                    {
-                        this.handler.OnException(Activity.Current, value.Value);
-                    }
+                    this.handler.OnException(Activity.Current, value.Value);
                 }
                 else
                 {
-                    if (!Sdk.SuppressInstrumentation)
-                    {
-                        this.handler.OnCustom(value.Key, Activity.Current, value.Value);
-                    }
+                    this.handler.OnCustom(value.Key, Activity.Current, value.Value);
                 }
             }
             catch (Exception ex)

--- a/src/OpenTelemetry.Contrib.Shared/OpenTelemetry.Contrib.Shared.csproj
+++ b/src/OpenTelemetry.Contrib.Shared/OpenTelemetry.Contrib.Shared.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.1.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.1.0-beta1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Avoids taking SDK dependency.
These checks are redundant since 1.1, as the SDK does this check (Supress) and all Activity start/stop goes through SDK only now.