### PR TITLE
Add net5.0 to CI build

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os: [windows-latest,ubuntu-latest]
-        version: [net461,netcoreapp2.1,netcoreapp3.1]
+        version: [net461,netcoreapp2.1,netcoreapp3.1,net5.0]
         exclude:
           - os: ubuntu-latest
             version: net461

--- a/test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry Microsoft.EntityFrameworkCore instrumentation</Description>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
WCF Tests was already having net5.0 target, but it was not running in the CI job. This enabled it for all projects which has net5.,0 test target