### PR TITLE
Preview: Fix conditional net5.0 target breaking build

### DIFF
--- a/.github/workflows/package-Preview.yml
+++ b/.github/workflows/package-Preview.yml
@@ -36,7 +36,7 @@ jobs:
       run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
-      run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build
+      run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Contrib.Preview has a conditional net5.0 target which causes dotnet pack to break when -no-build is used (for some reason)
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
The net5.0 conditional target in OpenTelemetry.Contrib.Preview (added to get nullable analysis in VS/IDE working) causes the build to break: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/runs/2759435669?check_suite_focus=true

Since release builds are rare I figured just re-running a build during the pack step wouldn't be a big deal.