### PR TITLE
Preview: Build fixes

### DIFF
--- a/.github/workflows/package-Preview.yml
+++ b/.github/workflows/package-Preview.yml
@@ -46,5 +46,4 @@ jobs:
 
     - name: Publish Nuget
       run: |
-        nuget setApiKey ${{ secrets.NUGET_TOKEN }} -Source https://api.nuget.org/v3/index.json
-        nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json
+        nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}

--- a/build/Common.props
+++ b/build/Common.props
@@ -43,7 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesPkgVer)" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersPkgVer)" Condition="'$(SkipAnalysis)'!='true'" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePkgVer)" Condition="'$(Configuration)'=='Release'"/>
+    <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePkgVer)" Condition="'$(Configuration)'=='Release'" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersPkgVer)" Condition="'$(EnableAnalysis)'=='true' and '$(SkipAnalysis)'!='true'" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Attempting to fix a couple of issues observed with the 1.0.0-beta1 push of OpenTelemetry.Contrib.Preview:

* Microsoft.CodeCoverage is showing up as a package dependency
* Symbols push failed