### PR TITLE
[gRPC Core client interceptor] Wrong status code if write to clientstreaming or duplexstreaming RPC fails

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
@@ -131,7 +131,11 @@ namespace OpenTelemetry.Contrib.Instrumentation.GrpcCore
             {
                 rpcScope = new ClientRpcScope<TRequest, TResponse>(context, this.options);
                 var responseContinuation = continuation(rpcScope.Context);
-                var clientRequestStreamProxy = new ClientStreamWriterProxy<TRequest>(responseContinuation.RequestStream, rpcScope.RecordRequest);
+                var clientRequestStreamProxy = new ClientStreamWriterProxy<TRequest>(
+                    responseContinuation.RequestStream,
+                    rpcScope.RecordRequest,
+                    onException: rpcScope.CompleteWithException);
+
                 var responseAsync = responseContinuation.ResponseAsync.ContinueWith(
                     responseTask =>
                     {
@@ -220,7 +224,8 @@ namespace OpenTelemetry.Contrib.Instrumentation.GrpcCore
 
                 var requestStreamProxy = new ClientStreamWriterProxy<TRequest>(
                     responseContinuation.RequestStream,
-                    rpcScope.RecordRequest);
+                    rpcScope.RecordRequest,
+                    onException: rpcScope.CompleteWithException);
 
                 var responseStreamProxy = new AsyncStreamReaderProxy<TResponse>(
                     responseContinuation.ResponseStream,

--- a/test/OpenTelemetry.Contrib.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -33,6 +33,11 @@ namespace OpenTelemetry.Contrib.Instrumentation.GrpcCore.Test
     public class GrpcCoreClientInterceptorTests
     {
         /// <summary>
+        /// A bogus server uri.
+        /// </summary>
+        private static readonly string BogusServerUri = "dns:i.dont.exist:77923";
+
+        /// <summary>
         /// Validates a successful AsyncUnary call.
         /// </summary>
         /// <returns>A task.</returns>
@@ -53,7 +58,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.GrpcCore.Test
                 FoobarService.MakeUnaryAsyncRequest,
                 StatusCode.Unavailable,
                 validateErrorDescription: false,
-                "dns:i.dont.exist:77923").ConfigureAwait(false);
+                BogusServerUri).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -88,6 +93,20 @@ namespace OpenTelemetry.Contrib.Instrumentation.GrpcCore.Test
         public async Task ClientStreamingSuccess()
         {
             await this.TestHandlerSuccess(FoobarService.MakeClientStreamingRequest).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validates a failed ClientStreaming call when the service is unavailable.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [Fact]
+        public async Task ClientStreamingUnavailable()
+        {
+            await this.TestHandlerFailure(
+                FoobarService.MakeClientStreamingRequest,
+                StatusCode.Unavailable,
+                validateErrorDescription: false,
+                BogusServerUri).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -156,6 +175,20 @@ namespace OpenTelemetry.Contrib.Instrumentation.GrpcCore.Test
         public async Task DuplexStreamingSuccess()
         {
             await this.TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validates a failed DuplexStreaming call when the service is unavailable.
+        /// </summary>
+        /// <returns>A task.</returns>
+        [Fact]
+        public async Task DuplexStreamingUnavailable()
+        {
+            await this.TestHandlerFailure(
+                FoobarService.MakeDuplexStreamingRequest,
+                StatusCode.Unavailable,
+                validateErrorDescription: false,
+                BogusServerUri).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Any exceptions during a write to a clientstreaming or duplexstreaming RPC were not tracked. They bubbled up to the caller and we were losing the opportunity to set the correct status code and description on the Span. Before this change, the newly added tests would fail with a status code of (1) canceled. That was getting set during Dispose instead of proactively at the time of the failure.

Behavior for non-streaming write failures was correct.