### PR TITLE
Replace Gitter with Slack channel link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,18 +8,18 @@ See the [public meeting
 notes](https://docs.google.com/document/d/1yjjD6aBcLxlRazYrawukDgrhZMObwHARJbB9glWdHj8/edit?usp=sharing)
 for a summary description of past meetings. To request edit access, join the
 meeting or get in touch on
-[Gitter](https://gitter.im/open-telemetry/opentelemetry-dotnet).
+[Slack](https://cloud-native.slack.com/archives/C01N3BC2W7Q).
 
 ## Find a Buddy and Get Started Quickly
 
 If you are looking for someone to help you find a starting point and be a
-resource for your first contribution, join our Gitter and find a buddy!
+resource for your first contribution, join our Slack channel and find a buddy!
 
-1. Join [Gitter.im](https://gitter.im) and join our [chat
-   room](https://gitter.im/open-telemetry/opentelemetry-dotnet).
+1. Create your [CNCF Slack account](http://slack.cncf.io/) and join the
+   [otel-dotnet](https://cloud-native.slack.com/archives/C01N3BC2W7Q) channel.
 2. Post in the room with an introduction to yourself, what area you are
    interested in (check issues marked with [help
-   wanted](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/labels/help%20wanted)),
+   wanted](https://github.com/open-telemetry/opentelemetry-dotnet/labels/help%20wanted)),
    and say you are looking for a buddy. We will match you with someone who has
    experience in that area.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ resource for your first contribution, join our Slack channel and find a buddy!
    [otel-dotnet](https://cloud-native.slack.com/archives/C01N3BC2W7Q) channel.
 2. Post in the room with an introduction to yourself, what area you are
    interested in (check issues marked with [help
-   wanted](https://github.com/open-telemetry/opentelemetry-dotnet/labels/help%20wanted)),
+   wanted](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/labels/help%20wanted)),
    and say you are looking for a buddy. We will match you with someone who has
    experience in that area.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry .NET Contrib
 
-[![Gitter](https://badges.gitter.im/open-telemetry/opentelemetry-dotnet.svg)](https://gitter.im/open-telemetry/opentelemetry-dotnet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/dotnet-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01N3BC2W7Q)
 [![Build
 Status](https://action-badges.now.sh/open-telemetry/opentelemetry-dotnet-contrib)](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions)
 


### PR DESCRIPTION
Replacing Gitter links with Slack channel links