### PR TITLE
Add exception logging to stackdriver

### DIFF
--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/CHANGELOG.md
@@ -2,5 +2,10 @@
 
 ## Unreleased
 
+* Update OTel SDK package version to 1.1.0-beta4
+* Log exceptions when failing to export data to stackdriver
+
+## Initial Release
+
 * Updated OTel SDK package version to 1.1.0-beta1
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))

--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/Implementation/ExporterStackdriverEventSource.cs
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/Implementation/ExporterStackdriverEventSource.cs
@@ -56,6 +56,21 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver.Implementation
             this.WriteEvent(2, ex);
         }
 
+        [NonEvent]
+        public void ExportMethodException(Exception ex)
+        {
+            if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                this.ExportMethodException(ToInvariantString(ex));
+            }
+        }
+
+        [Event(3, Message = "Stackdriver exporter encountered an error while exporting. Exception: {0}", Level = EventLevel.Error)]
+        public void ExportMethodException(string ex)
+        {
+            this.WriteEvent(1, ex);
+        }
+
         /// <summary>
         /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
         /// appropriate for diagnostics tracing.

--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/OpenTelemetry.Contrib.Exporter.Stackdriver.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Monitoring.V3" Version="2.1.0" />
     <PackageReference Include="Google.Cloud.Trace.V2" Version="2.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.1.0-beta1" />
+    <PackageReference Include="OpenTelemetry" Version="1.1.0-beta4" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Contrib.Exporter.Stackdriver/StackdriverTraceExporter.cs
+++ b/src/OpenTelemetry.Contrib.Exporter.Stackdriver/StackdriverTraceExporter.cs
@@ -114,8 +114,10 @@ namespace OpenTelemetry.Contrib.Exporter.Stackdriver
             {
                 traceWriter.BatchWriteSpans(batchSpansRequest);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                ExporterStackdriverEventSource.Log.ExportMethodException(ex);
+
                 return ExportResult.Failure;
             }
 


### PR DESCRIPTION
- When stackdriver fails to communicate/export spans to stackdriver
  service log errors.
- Upgrade Otel SDK to 1.1.0-beta4

https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/139