### PR TITLE
Add WCF ServiceBehavior implementation. Resolves #142.

### DIFF
--- a/examples/wcf/client-netframework/App.config
+++ b/examples/wcf/client-netframework/App.config
@@ -3,7 +3,7 @@
   <system.serviceModel>
     <extensions>
       <behaviorExtensions>
-        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryBehaviourExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"	/>
+        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"	/>
       </behaviorExtensions>
     </extensions>
     <behaviors>

--- a/examples/wcf/server-netframework/App.config
+++ b/examples/wcf/server-netframework/App.config
@@ -3,7 +3,7 @@
   <system.serviceModel>
     <extensions>
       <behaviorExtensions>
-        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryBehaviourExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"	/>
+        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"	/>
       </behaviorExtensions>
     </extensions>
     <behaviors>

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## Unreleased
 
-* Added enricher for WCF activity
-  ([#126])(<https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/126>)
+* Added `TelemetryServiceBehavior`. **Breaking change** (config update
+  required): Renamed `TelemetryBehaviourExtensionElement` ->
+  `TelemetryEndpointBehaviorExtensionElement`
+  ([#152](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/152))
+
+## 1.0.0-rc2
 
 * Updated OTel SDK package version to 1.1.0-beta1
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))
+
+* Added enricher for WCF activity
+  ([#126](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/126))

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/README.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/README.md
@@ -59,7 +59,7 @@ the clients you want to instrument:
   <system.serviceModel>
     <extensions>
       <behaviorExtensions>
-        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryBehaviourExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"   />
+        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"   />
       </behaviorExtensions>
     </extensions>
     <behaviors>
@@ -103,8 +103,8 @@ Example project available in
 
 ## WCF Server Configuration (.NET Framework)
 
-Add the `IDispatchMessageInspector` instrumentation via a behavior extension on
-the services you want to instrument:
+Add the `IDispatchMessageInspector` instrumentation via an endpoint behavior extension on
+the service endpoints you want to instrument:
 
 <!-- markdownlint-disable MD013 -->
 ```xml
@@ -113,7 +113,7 @@ the services you want to instrument:
   <system.serviceModel>
     <extensions>
       <behaviorExtensions>
-        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryBehaviourExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf" />
+        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf" />
       </behaviorExtensions>
     </extensions>
     <behaviors>
@@ -148,6 +148,49 @@ the services you want to instrument:
 Example project available in
 [examples/wcf/server-netframework](../../examples/wcf/server-netframework/)
 folder.
+
+To add the `IDispatchMessageInspector` instrumentation for all endpoints of a service, use the service behavior extension on
+the services you want to instrument:
+
+<!-- markdownlint-disable MD013 -->
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.serviceModel>
+    <extensions>
+      <behaviorExtensions>
+        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryServiceBehaviorExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf" />
+      </behaviorExtensions>
+    </extensions>
+    <behaviors>
+      <serviceBehaviors>
+        <behavior name="telemetry">
+          <telemetryExtension />
+        </behavior>
+      </serviceBehaviors>
+    </behaviors>
+    <bindings>
+      <netTcpBinding>
+        <binding name="netTCPConfig">
+          <security mode="None" />
+        </binding>
+      </netTcpBinding>
+    </bindings>
+    <services>
+      <service name="Examples.Wcf.Server.StatusService" behaviorConfiguration="telemetry">
+        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" contract="Examples.Wcf.IStatusServiceContract" />
+        <host>
+          <baseAddresses>
+            <add baseAddress="net.tcp://localhost:9090/Telemetry" />
+          </baseAddresses>
+        </host>
+      </service>
+    </services>
+  </system.serviceModel>
+</configuration>
+```
+<!-- markdownlint-enable MD013 -->
+
 
 ## References
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/README.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/README.md
@@ -103,8 +103,8 @@ Example project available in
 
 ## WCF Server Configuration (.NET Framework)
 
-Add the `IDispatchMessageInspector` instrumentation via an endpoint behavior extension on
-the service endpoints you want to instrument:
+Add the `IDispatchMessageInspector` instrumentation via an endpoint behavior
+extension on the service endpoints you want to instrument:
 
 <!-- markdownlint-disable MD013 -->
 ```xml
@@ -149,8 +149,9 @@ Example project available in
 [examples/wcf/server-netframework](../../examples/wcf/server-netframework/)
 folder.
 
-To add the `IDispatchMessageInspector` instrumentation for all endpoints of a service, use the service behavior extension on
-the services you want to instrument:
+To add the `IDispatchMessageInspector` instrumentation for all endpoints of a
+service, use the service behavior extension on the services you want to
+instrument:
 
 <!-- markdownlint-disable MD013 -->
 ```xml
@@ -190,7 +191,6 @@ the services you want to instrument:
 </configuration>
 ```
 <!-- markdownlint-enable MD013 -->
-
 
 ## References
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryEndpointBehavior.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryEndpointBehavior.cs
@@ -24,13 +24,13 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 {
 #if NETFRAMEWORK
     /// <summary>
-    /// An <see cref="IEndpointBehavior"/> implementation whichs add the <see
+    /// An <see cref="IEndpointBehavior"/> implementation which adds the <see
     /// cref="TelemetryClientMessageInspector"/> to client endpoints and the
     /// <see cref="TelemetryDispatchMessageInspector"/> to service endpoints.
     /// </summary>
 #else
     /// <summary>
-    /// An <see cref="IEndpointBehavior"/> implementation whichs add the <see
+    /// An <see cref="IEndpointBehavior"/> implementation which adds the <see
     /// cref="TelemetryClientMessageInspector"/> to client endpoints.
     /// </summary>
 #endif
@@ -62,6 +62,18 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
         public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
         {
 #if NETFRAMEWORK
+            ApplyDispatchBehaviorToEndpoint(endpointDispatcher);
+#endif
+        }
+
+        /// <inheritdoc/>
+        public void Validate(ServiceEndpoint endpoint)
+        {
+        }
+
+#if NETFRAMEWORK
+        internal static void ApplyDispatchBehaviorToEndpoint(EndpointDispatcher endpointDispatcher)
+        {
             var actionMappings = new Dictionary<string, ActionMetadata>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var dispatchOperation in endpointDispatcher.DispatchRuntime.Operations)
@@ -74,12 +86,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
             }
 
             endpointDispatcher.DispatchRuntime.MessageInspectors.Add(new TelemetryDispatchMessageInspector(actionMappings));
+        }
 #endif
-        }
-
-        /// <inheritdoc/>
-        public void Validate(ServiceEndpoint endpoint)
-        {
-        }
     }
 }

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryEndpointBehaviorExtensionElement.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryEndpointBehaviorExtensionElement.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="TelemetryEndpointBehaviorExtensionElement.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+using System;
+using System.ServiceModel.Configuration;
+
+namespace OpenTelemetry.Contrib.Instrumentation.Wcf
+{
+    /// <summary>
+    /// A <see cref="BehaviorExtensionElement"/> for registering <see cref="TelemetryEndpointBehavior"/> on a service endpoint through configuration.
+    /// </summary>
+    public class TelemetryEndpointBehaviorExtensionElement : BehaviorExtensionElement
+    {
+        /// <inheritdoc/>
+        public override Type BehaviorType => typeof(TelemetryEndpointBehavior);
+
+        /// <inheritdoc/>
+        protected override object CreateBehavior()
+        {
+            return new TelemetryEndpointBehavior();
+        }
+    }
+}
+#endif

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryServiceBehavior.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryServiceBehavior.cs
@@ -1,0 +1,66 @@
+﻿// <copyright file="TelemetryServiceBehavior.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+
+namespace OpenTelemetry.Contrib.Instrumentation.Wcf
+{
+#if NETFRAMEWORK
+    /// <summary>
+    /// An <see cref="IServiceBehavior"/> implementation add the the
+    /// <see cref="TelemetryDispatchMessageInspector"/> to service operations.
+    /// </summary>
+    public class TelemetryServiceBehavior : IServiceBehavior
+    {
+        /// <inheritdoc />
+        public void AddBindingParameters(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase, System.Collections.ObjectModel.Collection<ServiceEndpoint> endpoints, System.ServiceModel.Channels.BindingParameterCollection bindingParameters)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+        {
+            foreach (var channelDispatcherBase in serviceHostBase.ChannelDispatchers)
+            {
+                var channelDispatcher = (ChannelDispatcher)channelDispatcherBase;
+                foreach (var endpointDispatcher in channelDispatcher.Endpoints)
+                {
+                    var actionMappings = new Dictionary<string, ActionMetadata>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var dispatchOperation in endpointDispatcher.DispatchRuntime.Operations)
+                    {
+                        actionMappings[dispatchOperation.Action] = new ActionMetadata
+                        {
+                            ContractName = $"{endpointDispatcher.ContractNamespace}{endpointDispatcher.ContractName}",
+                            OperationName = dispatchOperation.Name,
+                        };
+                    }
+
+                    endpointDispatcher.DispatchRuntime.MessageInspectors.Add(new TelemetryDispatchMessageInspector(actionMappings));
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Validate(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
+        {
+        }
+    }
+#endif
+}

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryServiceBehavior.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryServiceBehavior.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 {
 #if NETFRAMEWORK
     /// <summary>
-    /// An <see cref="IServiceBehavior"/> implementation add the the
+    /// An <see cref="IServiceBehavior"/> implementation to add the
     /// <see cref="TelemetryDispatchMessageInspector"/> to service operations.
     /// </summary>
     public class TelemetryServiceBehavior : IServiceBehavior
@@ -42,17 +42,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
                 var channelDispatcher = (ChannelDispatcher)channelDispatcherBase;
                 foreach (var endpointDispatcher in channelDispatcher.Endpoints)
                 {
-                    var actionMappings = new Dictionary<string, ActionMetadata>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var dispatchOperation in endpointDispatcher.DispatchRuntime.Operations)
-                    {
-                        actionMappings[dispatchOperation.Action] = new ActionMetadata
-                        {
-                            ContractName = $"{endpointDispatcher.ContractNamespace}{endpointDispatcher.ContractName}",
-                            OperationName = dispatchOperation.Name,
-                        };
-                    }
-
-                    endpointDispatcher.DispatchRuntime.MessageInspectors.Add(new TelemetryDispatchMessageInspector(actionMappings));
+                    TelemetryEndpointBehavior.ApplyDispatchBehaviorToEndpoint(endpointDispatcher);
                 }
             }
         }

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryServiceBehaviorExtensionElement.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryServiceBehaviorExtensionElement.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryBehaviourExtensionElement.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="TelemetryServiceBehaviorExtensionElement.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,17 +21,17 @@ using System.ServiceModel.Configuration;
 namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 {
     /// <summary>
-    /// A <see cref="BehaviorExtensionElement"/> for registering <see cref="TelemetryEndpointBehavior"/> on service through configuation.
+    /// A <see cref="BehaviorExtensionElement"/> for registering <see cref="TelemetryServiceBehavior"/> on a service through configuration.
     /// </summary>
-    public class TelemetryBehaviourExtensionElement : BehaviorExtensionElement
+    public class TelemetryServiceBehaviorExtensionElement : BehaviorExtensionElement
     {
         /// <inheritdoc/>
-        public override Type BehaviorType => typeof(TelemetryEndpointBehavior);
+        public override Type BehaviorType => typeof(TelemetryServiceBehavior);
 
         /// <inheritdoc/>
         protected override object CreateBehavior()
         {
-            return new TelemetryEndpointBehavior();
+            return new TelemetryServiceBehavior();
         }
     }
 }


### PR DESCRIPTION
Adds IServiceOperationBehavior implementation to enable based configuration of WCF services at the service level.
Refer [Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/api/system.servicemodel.description.iservicebehavior?view=netframework-4.8)