### PR TITLE
WCF: Misc cleanup

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/Implementation/ActionMetadata.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/Implementation/ActionMetadata.cs
@@ -16,7 +16,7 @@
 
 namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 {
-    internal class ActionMetadata
+    internal sealed class ActionMetadata
     {
         public string ContractName { get; set; }
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/Implementation/WcfInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/Implementation/WcfInstrumentationEventSource.cs
@@ -22,7 +22,7 @@ using System.Threading;
 namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Implementation
 {
     [EventSource(Name = "OpenTelemetry-Instrumentation-Wcf")]
-    internal class WcfInstrumentationEventSource : EventSource
+    internal sealed class WcfInstrumentationEventSource : EventSource
     {
         public static readonly WcfInstrumentationEventSource Log = new WcfInstrumentationEventSource();
 
@@ -36,9 +36,9 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Implementation
         }
 
         [Event(EventIds.RequestIsFilteredOut, Message = "Request is filtered out.", Level = EventLevel.Verbose)]
-        public void RequestIsFilteredOut(string eventName)
+        public void RequestIsFilteredOut()
         {
-            this.WriteEvent(EventIds.RequestIsFilteredOut, eventName);
+            this.WriteEvent(EventIds.RequestIsFilteredOut);
         }
 
         [Event(EventIds.RequestFilterException, Message = "InstrumentationFilter threw exception. Request will not be collected. Exception {0}.", Level = EventLevel.Error)]

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/WcfInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/WcfInstrumentationOptions.cs
@@ -27,15 +27,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
     public class WcfInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositeTextMapPropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
-        /// </summary>
-        public TextMapPropagator Propagator { get; set; } = new CompositeTextMapPropagator(new TextMapPropagator[]
-        {
-            new TraceContextPropagator(),
-            new BaggagePropagator(),
-        });
-
-        /// <summary>
         /// Gets or sets an action to enrich an Activity.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Changes

A bit of misc cleanup:

* Sealed a couple of internal classes.
* Removed the propagator from WcfInstrumentationOptions.
* Instrumentation now resets Activity.Current if it was changed and clears baggage at the end of a request.

## TODOs

* [ ] CHANGELOG update