### PR TITLE
WCF: action is assigned with null if operation name is not defined(#169)

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-rc5
+
+* Fixed an `ArgumentNullException` setting `Activity`.`DisplayName` when
+  processing service requests with empty actions
+  ([#170](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/170))
+
 ## 1.0.0-rc4
 
 * Removed `Propagator` property on `WcfInstrumentationOptions`

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryClientMessageInspector.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryClientMessageInspector.cs
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 
             if (activity != null)
             {
-                string action = request.Headers.Action ?? string.Empty;
+                string action = !string.IsNullOrEmpty(request.Headers.Action) ? request.Headers.Action : string.Empty;
                 activity.DisplayName = action;
 
                 Propagators.DefaultTextMapPropagator.Inject(

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryClientMessageInspector.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryClientMessageInspector.cs
@@ -68,8 +68,16 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 
             if (activity != null)
             {
-                string action = !string.IsNullOrEmpty(request.Headers.Action) ? request.Headers.Action : string.Empty;
-                activity.DisplayName = action;
+                string action;
+                if (!string.IsNullOrEmpty(request.Headers.Action))
+                {
+                    action = request.Headers.Action;
+                    activity.DisplayName = action;
+                }
+                else
+                {
+                    action = string.Empty;
+                }
 
                 Propagators.DefaultTextMapPropagator.Inject(
                     new PropagationContext(activity.Context, Baggage.Current),

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryClientMessageInspector.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryClientMessageInspector.cs
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 
             if (activity != null)
             {
-                string action = request.Headers.Action;
+                string action = request.Headers.Action ?? string.Empty;
                 activity.DisplayName = action;
 
                 Propagators.DefaultTextMapPropagator.Inject(

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
@@ -66,8 +66,16 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 
             if (activity != null)
             {
-                string action = !string.IsNullOrEmpty(request.Headers.Action) ? request.Headers.Action : string.Empty;
-                activity.DisplayName = action;
+                string action;
+                if (!string.IsNullOrEmpty(request.Headers.Action))
+                {
+                    action = request.Headers.Action;
+                    activity.DisplayName = action;
+                }
+                else
+                {
+                    action = string.Empty;
+                }
 
                 if (activity.IsAllDataRequested)
                 {

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 
             if (activity != null)
             {
-                string action = request.Headers.Action;
+                string action = request.Headers.Action ?? string.Empty;
                 activity.DisplayName = action;
 
                 if (activity.IsAllDataRequested)

--- a/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf
 
             if (activity != null)
             {
-                string action = request.Headers.Action ?? string.Empty;
+                string action = !string.IsNullOrEmpty(request.Headers.Action) ? request.Headers.Action : string.Empty;
                 activity.DisplayName = action;
 
                 if (activity.IsAllDataRequested)

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/TelemetryClientMessageInspectorTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/TelemetryClientMessageInspectorTests.cs
@@ -128,13 +128,15 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
         [InlineData(true, false, true, true)]
         [InlineData(true, false, true, true, true)]
         [InlineData(true, false, true, true, true, true)]
+        [InlineData(true, false, true, true, true, true, true)]
         public async Task OutgoingRequestInstrumentationTest(
             bool instrument,
             bool filter = false,
             bool suppressDownstreamInstrumentation = true,
             bool includeVersion = false,
             bool enrich = false,
-            bool enrichmentException = false)
+            bool enrichmentException = false,
+            bool emptyornullAction = false)
         {
 #if NETFRAMEWORK
             const string OutgoingHttpOperationName = "OpenTelemetry.HttpWebRequest.HttpRequestOut";
@@ -186,15 +188,28 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
             ServiceClient client = new ServiceClient(
                 new BasicHttpBinding(BasicHttpSecurityMode.None),
                 new EndpointAddress(new Uri(this.serviceBaseUri, "/Service")));
-            try
+                        try
             {
                 client.Endpoint.EndpointBehaviors.Add(new TelemetryEndpointBehavior());
 
-                var response = await client.ExecuteAsync(
-                    new ServiceRequest
-                    {
-                        Payload = "Hello Open Telemetry!",
-                    }).ConfigureAwait(false);
+                ServiceResponse response = null;
+                if (emptyornullAction)
+                {
+                    response = await client.ExecuteWithEmptyActionNameAsync(
+                                new ServiceRequest
+                                {
+                                    Payload = "Hello Open Telemetry!",
+                                }).ConfigureAwait(false);
+
+                }
+                else
+                {
+                    response = await client.ExecuteAsync(
+                                new ServiceRequest
+                                {
+                                    Payload = "Hello Open Telemetry!",
+                                }).ConfigureAwait(false);
+                }
             }
             finally
             {

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
@@ -89,12 +89,14 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
         [InlineData(true, false, true)]
         [InlineData(true, false, true, true)]
         [InlineData(true, false, true, true, true)]
+        [InlineData(true, false, true, true, true, true)]
         public async Task IncomingRequestInstrumentationTest(
             bool instrument,
             bool filter = false,
             bool includeVersion = false,
             bool enrich = false,
-            bool enrichmentExcecption = false)
+            bool enrichmentExcecption = false,
+            bool emptyornullAction = false)
         {
             List<Activity> stoppedActivities = new List<Activity>();
 
@@ -156,11 +158,24 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
                 new EndpointAddress(new Uri(this.serviceBaseUri, "/Service")));
             try
             {
-                var response = await client.ExecuteAsync(
-                    new ServiceRequest
-                    {
-                        Payload = "Hello Open Telemetry!",
-                    }).ConfigureAwait(false);
+                ServiceResponse response = null;
+                if (emptyornullAction)
+                {
+                    response = await client.ExecuteWithEmptyActionNameAsync(
+                        new ServiceRequest
+                        {
+                            Payload = "Hello Open Telemetry!",
+                        }).ConfigureAwait(false);
+
+                }
+                else
+                {
+                    response = await client.ExecuteAsync(
+                        new ServiceRequest
+                        {
+                            Payload = "Hello Open Telemetry!",
+                        }).ConfigureAwait(false);
+                }
             }
             finally
             {

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
             bool includeVersion = false,
             bool enrich = false,
             bool enrichmentExcecption = false,
-            bool emptyornullAction = false)
+            bool emptyOrNullAction = false)
         {
             List<Activity> stoppedActivities = new List<Activity>();
 
@@ -158,19 +158,17 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
                 new EndpointAddress(new Uri(this.serviceBaseUri, "/Service")));
             try
             {
-                ServiceResponse response = null;
-                if (emptyornullAction)
+                if (emptyOrNullAction)
                 {
-                    response = await client.ExecuteWithEmptyActionNameAsync(
+                    await client.ExecuteWithEmptyActionNameAsync(
                         new ServiceRequest
                         {
                             Payload = "Hello Open Telemetry!",
                         }).ConfigureAwait(false);
-
                 }
                 else
                 {
-                    response = await client.ExecuteAsync(
+                    await client.ExecuteAsync(
                         new ServiceRequest
                         {
                             Payload = "Hello Open Telemetry!",
@@ -200,15 +198,28 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
                 Assert.Single(stoppedActivities);
 
                 Activity activity = stoppedActivities[0];
+
+                if (emptyOrNullAction)
+                {
+                    Assert.Equal(WcfInstrumentationActivitySource.IncomingRequestActivityName, activity.DisplayName);
+                    Assert.Equal("ExecuteWithEmptyActionName", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.RpcMethodTag).Value);
+                    Assert.Equal("http://opentelemetry.io/Service/ExecuteWithEmptyActionNameResponse", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.SoapReplyActionTag).Value);
+                }
+                else
+                {
+                    Assert.Equal("http://opentelemetry.io/Service/Execute", activity.DisplayName);
+                    Assert.Equal("Execute", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.RpcMethodTag).Value);
+                    Assert.Equal("http://opentelemetry.io/Service/ExecuteResponse", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.SoapReplyActionTag).Value);
+                }
+
                 Assert.Equal(WcfInstrumentationActivitySource.IncomingRequestActivityName, activity.OperationName);
                 Assert.Equal(WcfInstrumentationConstants.WcfSystemValue, activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.RpcSystemTag).Value);
                 Assert.Equal("http://opentelemetry.io/Service", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.RpcServiceTag).Value);
-                Assert.Equal("Execute", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.RpcMethodTag).Value);
                 Assert.Equal(this.serviceBaseUri.Host, activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.NetHostNameTag).Value);
                 Assert.Equal(this.serviceBaseUri.Port, activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.NetHostPortTag).Value);
                 Assert.Equal("net.tcp", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.WcfChannelSchemeTag).Value);
                 Assert.Equal("/Service", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.WcfChannelPathTag).Value);
-                Assert.Equal("http://opentelemetry.io/Service/ExecuteResponse", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.SoapReplyActionTag).Value);
+
                 if (includeVersion)
                 {
                     Assert.Equal("Soap12 (http://www.w3.org/2003/05/soap-envelope) Addressing10 (http://www.w3.org/2005/08/addressing)", activity.TagObjects.FirstOrDefault(t => t.Key == WcfInstrumentationConstants.SoapMessageVersionTag).Value);

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/IServiceContract.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/IServiceContract.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
         [OperationContract]
         Task<ServiceResponse> ExecuteAsync(ServiceRequest request);
 
-        [OperationContract(Action ="")]
+        [OperationContract(Action = "")]
         Task<ServiceResponse> ExecuteWithEmptyActionNameAsync(ServiceRequest request);
     }
 }

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/IServiceContract.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/IServiceContract.cs
@@ -24,5 +24,8 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
     {
         [OperationContract]
         Task<ServiceResponse> ExecuteAsync(ServiceRequest request);
+
+        [OperationContract(Action ="")]
+        Task<ServiceResponse> ExecuteWithEmptyActionNameAsync(ServiceRequest request);
     }
 }

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/Service.netfx.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/Service.netfx.cs
@@ -35,6 +35,15 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
                     Payload = $"RSP: {request.Payload}",
                 });
         }
+
+        public Task<ServiceResponse> ExecuteWithEmptyActionNameAsync(ServiceRequest request)
+        {
+            return Task.FromResult(
+               new ServiceResponse
+               {
+                   Payload = $"RSP: {request.Payload}",
+               });
+        }
     }
 }
 #endif

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/ServiceClient.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/ServiceClient.cs
@@ -32,6 +32,5 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
 
         public Task<ServiceResponse> ExecuteWithEmptyActionNameAsync(ServiceRequest request)
             => this.Channel.ExecuteWithEmptyActionNameAsync(request);
-
     }
 }

--- a/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/ServiceClient.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Wcf.Tests/WCF/ServiceClient.cs
@@ -29,5 +29,9 @@ namespace OpenTelemetry.Contrib.Instrumentation.Wcf.Tests
 
         public Task<ServiceResponse> ExecuteAsync(ServiceRequest request)
             => this.Channel.ExecuteAsync(request);
+
+        public Task<ServiceResponse> ExecuteWithEmptyActionNameAsync(ServiceRequest request)
+            => this.Channel.ExecuteWithEmptyActionNameAsync(request);
+
     }
 }


### PR DESCRIPTION
` public string DisplayName
        {
            get
            {
                return _displayName ?? OperationName;
            }
            set
            {
                _displayName = (value ?? throw new ArgumentNullException("value"));
            }`
            
            Display name throws Argument null exception if action is null or operation contract name is defined in the WCF operationContract . 
            