### PR TITLE
Add Utkarsh as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Maintainers
 * [Mikel Blanchard](https://github.com/CodeBlanch), CoStar Group
 * [Prashant Srivastava](https://github.com/srprash), AWS
 * [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Google
+* [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 
 *Find more about the maintainer role in [community
 repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*


### PR DESCRIPTION
Proposing to add @utpilla as a maintainer for the contrib repo.

Utkarsh already has an approver role in the main repo (https://github.com/open-telemetry/opentelemetry-dotnet) since May 2021, and has made significant contributions to the overall project in the past year. While I'd love to get him as a maintainer for the main repo as well, I feel starting with the contrib repo would help gain valuable experience. 

Majority of the components in this repo are instrumentation libraries, and Utkarsh has enabled the foundation work (natively supporting legacy activity) on top of which most of the instrumentation libraries are built on. We recently had some discussions in the SIG meetings about ramping up this repo, to host more instrumentation libraries (some moving over from main repo) etc., which would make this the right moment to get additional expert hands!