### PR TITLE
Minor improvements to Runtime metrics

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
         internal static readonly AssemblyName AssemblyName = typeof(RuntimeMetrics).Assembly.GetName();
         internal static readonly string InstrumentationName = AssemblyName.Name;
         internal static readonly string InstrumentationVersion = AssemblyName.Version.ToString();
-
+        private static string metricPrefix = "process.runtime.dotnet.";
         private readonly Meter meter;
 
         /// <summary>
@@ -42,48 +42,48 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
 
             if (options.IsGcEnabled)
             {
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}gc.heap", () => GC.GetTotalMemory(false), "B", "GC Heap Size");
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}gen_0-gc.count", () => GC.CollectionCount(0), description: "Gen 0 GC Count");
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}gen_1-gc.count", () => GC.CollectionCount(1), description: "Gen 1 GC Count");
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}gen_2-gc.count", () => GC.CollectionCount(2), description: "Gen 2 GC Count");
+                this.meter.CreateObservableGauge($"{metricPrefix}gc.heap", () => GC.GetTotalMemory(false), "B", "GC Heap Size");
+                this.meter.CreateObservableGauge($"{metricPrefix}gen_0-gc.count", () => GC.CollectionCount(0), description: "Gen 0 GC Count");
+                this.meter.CreateObservableGauge($"{metricPrefix}gen_1-gc.count", () => GC.CollectionCount(1), description: "Gen 1 GC Count");
+                this.meter.CreateObservableGauge($"{metricPrefix}gen_2-gc.count", () => GC.CollectionCount(2), description: "Gen 2 GC Count");
 #if NETCOREAPP3_1_OR_GREATER
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}alloc.rate", () => GC.GetTotalAllocatedBytes(), "B", "Allocation Rate");
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}gc.fragmentation", GetFragmentation, description: "GC Fragmentation");
+                this.meter.CreateObservableCounter($"{metricPrefix}alloc.rate", () => GC.GetTotalAllocatedBytes(), "B", "Allocation Rate");
+                this.meter.CreateObservableCounter($"{metricPrefix}gc.fragmentation", GetFragmentation, description: "GC Fragmentation");
 #endif
 
 #if NET6_0_OR_GREATER
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}gc.committed", () => (double)(GC.GetGCMemoryInfo().TotalCommittedBytes / 1_000_000), "MB", description: "GC Committed Bytes");
+                this.meter.CreateObservableCounter($"{metricPrefix}gc.committed", () => (double)(GC.GetGCMemoryInfo().TotalCommittedBytes / 1_000_000), "MB", description: "GC Committed Bytes");
 #endif
             }
 
 #if NET6_0_OR_GREATER
             if (options.IsJitEnabled)
             {
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}il.bytes.jitted", () => System.Runtime.JitInfo.GetCompiledILBytes(), "B", description: "IL Bytes Jitted");
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}methods.jitted.count", () => System.Runtime.JitInfo.GetCompiledMethodCount(), description: "Number of Methods Jitted");
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}time.in.jit", () => System.Runtime.JitInfo.GetCompilationTime().TotalMilliseconds, "ms", description: "Time spent in JIT");
+                this.meter.CreateObservableCounter($"{metricPrefix}il.bytes.jitted", () => System.Runtime.JitInfo.GetCompiledILBytes(), "B", description: "IL Bytes Jitted");
+                this.meter.CreateObservableCounter($"{metricPrefix}methods.jitted.count", () => System.Runtime.JitInfo.GetCompiledMethodCount(), description: "Number of Methods Jitted");
+                this.meter.CreateObservableGauge($"{metricPrefix}time.in.jit", () => System.Runtime.JitInfo.GetCompilationTime().TotalMilliseconds, "ms", description: "Time spent in JIT");
             }
 #endif
 
 #if NETCOREAPP3_1_OR_GREATER
             if (options.IsThreadingEnabled)
             {
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}monitor.lock.contention.count", () => Monitor.LockContentionCount, description: "Monitor Lock Contention Count");
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}threadpool.thread.count", () => ThreadPool.ThreadCount, description: "ThreadPool Thread Count");
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}threadpool.completed.items.count", () => ThreadPool.CompletedWorkItemCount, description: "ThreadPool Completed Work Item Count");
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}threadpool.queue.length", () => ThreadPool.PendingWorkItemCount, description: "ThreadPool Queue Length");
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}active.timer.count", () => Timer.ActiveCount, description: "Number of Active Timers");
+                this.meter.CreateObservableGauge($"{metricPrefix}monitor.lock.contention.count", () => Monitor.LockContentionCount, description: "Monitor Lock Contention Count");
+                this.meter.CreateObservableCounter($"{metricPrefix}threadpool.thread.count", () => ThreadPool.ThreadCount, description: "ThreadPool Thread Count");
+                this.meter.CreateObservableGauge($"{metricPrefix}threadpool.completed.items.count", () => ThreadPool.CompletedWorkItemCount, description: "ThreadPool Completed Work Item Count");
+                this.meter.CreateObservableCounter($"{metricPrefix}threadpool.queue.length", () => ThreadPool.PendingWorkItemCount, description: "ThreadPool Queue Length");
+                this.meter.CreateObservableCounter($"{metricPrefix}active.timer.count", () => Timer.ActiveCount, description: "Number of Active Timers");
             }
 #endif
 
             if (options.IsMemoryEnabled)
             {
-                this.meter.CreateObservableGauge($"{options.MetricPrefix}memory.usage", () => (double)(Environment.WorkingSet / 1_000_000), "MB", "Working Set");
+                this.meter.CreateObservableGauge($"{metricPrefix}memory.usage", () => (double)(Environment.WorkingSet / 1_000_000), "MB", "Working Set");
             }
 
             if (options.IsAssembliesEnabled)
             {
-                this.meter.CreateObservableCounter($"{options.MetricPrefix}assembly.count", () => AppDomain.CurrentDomain.GetAssemblies().Length, description: "Number of Assemblies Loaded");
+                this.meter.CreateObservableCounter($"{metricPrefix}assembly.count", () => AppDomain.CurrentDomain.GetAssemblies().Length, description: "Number of Assemblies Loaded");
             }
         }
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetricsOptions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetricsOptions.cs
@@ -22,11 +22,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
     public class RuntimeMetricsOptions
     {
         /// <summary>
-        /// Gets a prefix used for the metric names.
-        /// </summary>
-        public string MetricPrefix { get; } = "process.runtime.dotnet.";
-
-        /// <summary>
         /// Gets or sets a value indicating whether garbage collection metrics should be collected.
         /// </summary>
         public bool? GcEnabled { get; set; }

--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests.csproj
@@ -1,15 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="coverlet.collector" Version="1.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-        <PackageReference Include="OpenTelemetry" Version="1.2.0-rc2" />
         <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.2.0-rc2" />
         <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
         <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">

--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
     public class RuntimeMetricsTests
     {
         private const int MaxTimeToAllowForFlush = 10000;
-        private const string metricPrefix = "process.runtime.dotnet.";
+        private const string MetricPrefix = "process.runtime.dotnet.";
 
         [Fact]
         public async Task RuntimeMetricsAreCaptured()
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             Assert.True(exportedItems.Count > 1);
             var metric1 = exportedItems[0];
-            Assert.StartsWith(metricPrefix, metric1.Name);
+            Assert.StartsWith(MetricPrefix, metric1.Name);
         }
     }
 }

--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
         private const string MetricPrefix = "process.runtime.dotnet.";
 
         [Fact]
-        public async Task RuntimeMetricsAreCaptured()
+        public void RuntimeMetricsAreCaptured()
         {
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()

--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -25,17 +25,14 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 {
     public class RuntimeMetricsTests
     {
-        private MeterProvider meterProvider = null;
+        private const int MaxTimeToAllowForFlush = 10000;
+        private const string metricPrefix = "process.runtime.dotnet.";
 
         [Fact]
-        public async Task RequestMetricIsCaptured()
+        public async Task RuntimeMetricsAreCaptured()
         {
-            var metricItems = new List<Metric>();
-            var metricExporter = new InMemoryExporter<Metric>(metricItems);
-
-            var metricReader = new PeriodicExportingMetricReader(metricExporter, 500);
-
-            this.meterProvider = Sdk.CreateMeterProviderBuilder()
+            var exportedItems = new List<Metric>();
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
                  .AddRuntimeMetrics(options =>
                  {
                      options.GcEnabled = true;
@@ -49,13 +46,13 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 #endif
                      options.AssembliesEnabled = true;
                  })
-                 .AddReader(metricReader)
+                 .AddInMemoryExporter(exportedItems)
                 .Build();
 
-            await Task.Delay(TimeSpan.FromSeconds(2));
-            this.meterProvider.Dispose();
-
-            Assert.True(metricItems.Count > 1);
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            Assert.True(exportedItems.Count > 1);
+            var metric1 = exportedItems[0];
+            Assert.StartsWith(metricPrefix, metric1.Name);
         }
     }
 }


### PR DESCRIPTION
Remove metric name prefix as a public property
Remove unwanted dependencies from test
Add net5.0 target for tests
Modify the basic test structure to correctly use InMemoryExporter