### PR TITLE
Provide cpu time with state tags

### DIFF
--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -76,6 +76,8 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
             Assert.Single(exportedItems);
+            var metric1 = exportedItems[0];
+            Assert.Equal("process.cpu.time", metric1.Name);
 
             var sumReceived = GetDoubleSum(exportedItems);
             Assert.True(sumReceived > 0);

--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.True(exportedItems.Count > 0);
+            Assert.Single(exportedItems);
 
             var sumReceived = GetDoubleSum(exportedItems);
             Assert.True(sumReceived > 0);


### PR DESCRIPTION
Split the "process.cpu.time" metric into multiple values with a state tag as mentioned in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md#process