### PR TITLE
Move memory metric to process metrics

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -78,14 +78,11 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
             }
 #endif
 
-            if (options.IsMemoryEnabled)
-            {
-                this.meter.CreateObservableGauge($"{metricPrefix}memory.usage", () => (double)(Environment.WorkingSet / 1_000_000), "MB", "Working Set");
-            }
-
             if (options.IsProcessEnabled)
             {
                 this.meter.CreateObservableCounter("process.cpu.time", this.GetProcessorTimes, "s", "Processor time of this process");
+				this.meter.CreateObservableGauge("process.memory.usage", () => Process.GetCurrentProcess().WorkingSet64, "By", "The amount of physical memory in use");
+                this.meter.CreateObservableGauge("process.memory.virtual", () => Process.GetCurrentProcess().VirtualMemorySize64, "By", "The amount of committed virtual memory");
             }
 
             if (options.IsAssembliesEnabled)

--- a/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -81,7 +81,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
             if (options.IsProcessEnabled)
             {
                 this.meter.CreateObservableCounter("process.cpu.time", this.GetProcessorTimes, "s", "Processor time of this process");
-				this.meter.CreateObservableGauge("process.memory.usage", () => Process.GetCurrentProcess().WorkingSet64, "By", "The amount of physical memory in use");
+                this.meter.CreateObservableGauge("process.memory.usage", () => Process.GetCurrentProcess().WorkingSet64, "By", "The amount of physical memory in use");
                 this.meter.CreateObservableGauge("process.memory.virtual", () => Process.GetCurrentProcess().VirtualMemorySize64, "By", "The amount of committed virtual memory");
             }
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetricsOptions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.Runtime/RuntimeMetricsOptions.cs
@@ -41,11 +41,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
 #endif
 
         /// <summary>
-        /// Gets or sets a value indicating whether memory metrics should be collected.
-        /// </summary>
-        public bool? MemoryEnabled { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether process metrics should be collected.
         /// </summary>
         public bool? ProcessEnabled { get; set; }
@@ -65,7 +60,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
 #if NETCOREAPP3_1_OR_GREATER
         && this.ThreadingEnabled == null
 #endif
-        && this.MemoryEnabled == null
         && this.ProcessEnabled == null
         && this.AssembliesEnabled == null;
 
@@ -87,11 +81,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime
         /// </summary>
         internal bool IsThreadingEnabled => this.ThreadingEnabled == true || this.IsAllEnabled;
 #endif
-
-        /// <summary>
-        /// Gets a value indicating whether memory metrics is enabled.
-        /// </summary>
-        internal bool IsMemoryEnabled => this.MemoryEnabled == true || this.IsAllEnabled;
 
         /// <summary>
         /// Gets a value indicating whether process metrics is enabled.

--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsOptionsTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsOptionsTests.cs
@@ -32,7 +32,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.True(options.IsThreadingEnabled);
 #endif
-            Assert.True(options.IsMemoryEnabled);
             Assert.True(options.IsProcessEnabled);
             Assert.True(options.IsAssembliesEnabled);
             Assert.True(options.IsAllEnabled);
@@ -50,7 +49,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.False(options.IsThreadingEnabled);
 #endif
-            Assert.False(options.IsMemoryEnabled);
             Assert.False(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
@@ -65,7 +63,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
             Assert.False(options.IsGcEnabled);
             Assert.True(options.IsJitEnabled);
             Assert.False(options.IsThreadingEnabled);
-            Assert.False(options.IsMemoryEnabled);
             Assert.False(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
@@ -83,30 +80,11 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
             Assert.False(options.IsJitEnabled);
 #endif
             Assert.True(options.IsThreadingEnabled);
-            Assert.False(options.IsMemoryEnabled);
             Assert.False(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
         }
 #endif
-
-        [Fact]
-        public void Enable_Memory_Only()
-        {
-            var options = new RuntimeMetricsOptions { MemoryEnabled = true };
-
-            Assert.False(options.IsGcEnabled);
-#if NET6_0_OR_GREATER
-            Assert.False(options.IsJitEnabled);
-#endif
-#if NETCOREAPP3_1_OR_GREATER
-            Assert.False(options.IsThreadingEnabled);
-#endif
-            Assert.True(options.IsMemoryEnabled);
-            Assert.False(options.IsProcessEnabled);
-            Assert.False(options.IsAssembliesEnabled);
-            Assert.False(options.IsAllEnabled);
-        }
 
         [Fact]
         public void Enable_Process_Only()
@@ -120,7 +98,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.False(options.IsThreadingEnabled);
 #endif
-            Assert.False(options.IsMemoryEnabled);
             Assert.True(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
@@ -138,7 +115,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.False(options.IsThreadingEnabled);
 #endif
-            Assert.False(options.IsMemoryEnabled);
             Assert.False(options.IsProcessEnabled);
             Assert.True(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
@@ -147,7 +123,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
         [Fact]
         public void Enable_Multiple()
         {
-            var options = new RuntimeMetricsOptions { GcEnabled = true, MemoryEnabled = true };
+            var options = new RuntimeMetricsOptions { GcEnabled = true, ProcessEnabled = true };
 
             Assert.True(options.IsGcEnabled);
 #if NET6_0_OR_GREATER
@@ -156,8 +132,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.False(options.IsThreadingEnabled);
 #endif
-            Assert.True(options.IsMemoryEnabled);
-            Assert.False(options.IsProcessEnabled);
+            Assert.True(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
         }

--- a/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenTelemetry.Metrics;
 using Xunit;
 
@@ -37,7 +38,6 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
                      options.ThreadingEnabled = true;
 #endif
-                     options.MemoryEnabled = true;
                      options.ProcessEnabled = true;
 #if NET6_0_OR_GREATER
 
@@ -75,29 +75,26 @@ namespace OpenTelemetry.Contrib.Instrumentation.Runtime.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.Single(exportedItems);
-            var metric1 = exportedItems[0];
-            Assert.Equal("process.cpu.time", metric1.Name);
+            Assert.Equal(3, exportedItems.Count);
 
-            var sumReceived = GetDoubleSum(exportedItems);
+            var cpuTimeMetric = exportedItems.First(i => i.Name == "process.cpu.time");
+            var sumReceived = GetDoubleSum(cpuTimeMetric);
             Assert.True(sumReceived > 0);
         }
 
-        private static double GetDoubleSum(List<Metric> metrics)
+        private static double GetDoubleSum(Metric metric)
         {
             double sum = 0;
-            foreach (var metric in metrics)
+
+            foreach (ref readonly var metricPoint in metric.GetMetricPoints())
             {
-                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
+                if (metric.MetricType.IsSum())
                 {
-                    if (metric.MetricType.IsSum())
-                    {
-                        sum += metricPoint.GetSumDouble();
-                    }
-                    else
-                    {
-                        sum += metricPoint.GetGaugeLastValueDouble();
-                    }
+                    sum += metricPoint.GetSumDouble();
+                }
+                else
+                {
+                    sum += metricPoint.GetGaugeLastValueDouble();
                 }
             }
 


### PR DESCRIPTION
According to  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md#process moving the "memory.usage" to the process metrics.

Change metric to expose value in bytes instead of MB.
Add "process.memory.virtual" also