### PR TITLE
fix-package-name-otel-in-massTransit-instrumentation

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/README.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.MassTransit/README.md
@@ -36,7 +36,7 @@ services.AddMassTransit(x =>
 services.AddMassTransitHostedService();
 
 // Add OpenTelemetry and MassTransit instrumentation
-services.AddOpenTelemetrySdk(x =>
+services.AddOpenTelemetryTracing(x =>
 {
     x.AddMassTransitInstrumentation();
     x.UseJaegerExporter(config => {


### PR DESCRIPTION
fix add package in MassTransit Instrumentation with new syntax `AddOpenTelemetryTracing` instead of `AddOpenTelemetrySdk` broken syntax in README.md