### PR TITLE
WCF server example use TelemetryServiceBehavior instead of  TelemetryEndpointBehavior

### DIFF
--- a/examples/wcf/server-netframework/App.config
+++ b/examples/wcf/server-netframework/App.config
@@ -3,15 +3,15 @@
   <system.serviceModel>
     <extensions>
       <behaviorExtensions>
-        <add name="telemetryExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"	/>
+        <add name="telemetryServiceExtension" type="OpenTelemetry.Contrib.Instrumentation.Wcf.TelemetryServiceBehaviorExtensionElement, OpenTelemetry.Contrib.Instrumentation.Wcf"	/>
       </behaviorExtensions>
     </extensions>
     <behaviors>
-      <endpointBehaviors>
-        <behavior name="telemetry">
-          <telemetryExtension />
+      <serviceBehaviors>
+        <behavior name="telemetry" >
+          <telemetryServiceExtension />
         </behavior>
-      </endpointBehaviors>
+      </serviceBehaviors>
     </behaviors>
     <bindings>
       <basicHttpBinding>
@@ -26,9 +26,9 @@
       </netTcpBinding>
     </bindings>
     <services>
-      <service name="Examples.Wcf.Server.StatusService">
-        <endpoint binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="Examples.Wcf.IStatusServiceContract" />
-        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="Examples.Wcf.IStatusServiceContract" />
+      <service name="Examples.Wcf.Server.StatusService" behaviorConfiguration="telemetry">
+        <endpoint binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" contract="Examples.Wcf.IStatusServiceContract" />
+        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" contract="Examples.Wcf.IStatusServiceContract" />
         <host>
           <baseAddresses>
             <add baseAddress="http://localhost:9009/Telemetry" />


### PR DESCRIPTION
The WCF Server Example is using the `client endpoint` extensions instead of the `server service` extension. This pull request sets the example to telemetryServiceBehavior 