### PR TITLE
Remove EntityFramework Instrumentation entry from component_owners.yml

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -9,7 +9,6 @@ components:
     - lupengamzn
   src/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient/:
     - ejsmith
-  src/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore/:
   src/OpenTelemetry.Contrib.Instrumentation.GrpcCore/:
     - pcwiese
   src/OpenTelemetry.Contrib.Instrumentation.MassTransit/:
@@ -34,7 +33,6 @@ components:
     - lupengamzn
   test/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient.Tests/:
     - ejsmith
-  test/OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCoreTests/:
   test/OpenTelemetry.Contrib.Instrumentation.GrpcCore.Tests/:
     - pcwiese
   test/OpenTelemetry.Contrib.Instrumentation.MassTransit.Tests/:


### PR DESCRIPTION
# Changes
- Remove EntityFramework Instrumentation entry from `component_owners.yml`

This might be causing the Assign Reviewers workflow to error out with this message: `must be a string or array of strings`.
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/runs/5548204554?check_suite_focus=true