### PR TITLE
Reduce package dependency by swapping out Grpc.Core for Grpc.Core.Api.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Switched Grpc.Core package dependency to Grpc.Core.Api in the same range.
+  No functional change, just less exposure to unnecessary packages.
+
 ## 1.0.0-beta.4
 
 * Going forward the NuGet package will be

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="[3.6.1,4.0)" />
-    <PackageReference Include="Grpc" Version="[2.23.0,3.0)" />
+    <PackageReference Include="Grpc.Core.Api" Version="[2.23.0,3.0)" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The full Grpc.Core package reference is not necessary.
Grpc.Core.Api is the only package shareable between the managed wrapper around Grpc.Core and grpc-dotnet.