### PR TITLE
Release OpenTelemetry.Instrumentation.Grpc as 1.0.0-beta.5

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.0-beta.5
+
 * Switched Grpc.Core package dependency to Grpc.Core.Api in the same range.
   No functional change, just less exposure to unnecessary packages.
 


### PR DESCRIPTION
For #267 