### PR TITLE
GenevaExporter - LogSerialization Fixes

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -185,6 +185,7 @@ namespace OpenTelemetry.Exporter.Geneva
             if (logRecord.State == null)
             {
                 // When State is null, OTel SDK guarantees StateValues is populated
+                // TODO: Debug.Assert?
                 listKvp = logRecord.StateValues;
             }
             else
@@ -327,8 +328,8 @@ namespace OpenTelemetry.Exporter.Geneva
             {
                 var entry = listKvp[i];
 
-                // Iteration #1 - Get those fields which become dedicated column
-                // i.e all PartB fields and opt-in part c fields.
+                // Iteration #1 - Get those fields which become dedicated columns
+                // i.e all Part B fields and opt-in Part C fields.
                 if (entry.Key == "{OriginalFormat}")
                 {
                     cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "body");
@@ -342,7 +343,7 @@ namespace OpenTelemetry.Exporter.Geneva
                     // TODO: the above null check can be optimized and avoided inside foreach.
                     if (entry.Value != null)
                     {
-                        // Geneva doesn't support null.
+                        // null is not supported.
                         cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
                         cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
                         cntFields += 1;

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -181,20 +181,16 @@ namespace OpenTelemetry.Exporter.Geneva
 
         internal int SerializeLogRecord(LogRecord logRecord)
         {
-            bool isUnstructuredLog = true;
             IReadOnlyList<KeyValuePair<string, object>> listKvp;
             if (logRecord.State == null)
             {
+                // When State is null, OTel SDK guarantees StateValues is populated
                 listKvp = logRecord.StateValues;
             }
             else
             {
+                // Attempt to see if State could be ROL_KVP.
                 listKvp = logRecord.State as IReadOnlyList<KeyValuePair<string, object>>;
-            }
-
-            if (listKvp != null)
-            {
-                isUnstructuredLog = listKvp.Count == 1;
             }
 
             var name = logRecord.CategoryName;
@@ -325,81 +321,72 @@ namespace OpenTelemetry.Exporter.Geneva
             cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, name);
             cntFields += 1;
 
-            if (isUnstructuredLog)
+            bool hasEnvProperties = false;
+            bool bodyPopulated = false;
+            for (int i = 0; i < listKvp?.Count; i++)
+            {
+                var entry = listKvp[i];
+
+                // Iteration #1 - Get those fields which become dedicated column
+                // i.e all PartB fields and opt-in part c fields.
+                if (entry.Key == "{OriginalFormat}")
+                {
+                    cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "body");
+                    cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, logRecord.FormattedMessage ?? Convert.ToString(entry.Value, CultureInfo.InvariantCulture));
+                    cntFields += 1;
+                    bodyPopulated = true;
+                    continue;
+                }
+                else if (this.m_customFields == null || this.m_customFields.ContainsKey(entry.Key))
+                {
+                    // TODO: the above null check can be optimized and avoided inside foreach.
+                    if (entry.Value != null)
+                    {
+                        // Geneva doesn't support null.
+                        cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
+                        cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
+                        cntFields += 1;
+                    }
+                }
+                else
+                {
+                    hasEnvProperties = true;
+                    continue;
+                }
+            }
+
+            if (!bodyPopulated && logRecord.FormattedMessage != null)
             {
                 cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "body");
-                cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, logRecord.FormattedMessage ?? (listKvp != null ? Convert.ToString(listKvp[0].Value, CultureInfo.InvariantCulture) : Convert.ToString(logRecord.State, CultureInfo.InvariantCulture)));
+                cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, logRecord.FormattedMessage);
                 cntFields += 1;
             }
-            else
+
+            if (hasEnvProperties)
             {
-                bool hasEnvProperties = false;
-                bool bodyPopulated = false;
+                // Iteration #2 - Get all "other" fields and collapse them into single field
+                // named "env_properties".
+                ushort envPropertiesCount = 0;
+                cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "env_properties");
+                cursor = MessagePackSerializer.WriteMapHeader(buffer, cursor, ushort.MaxValue);
+                int idxMapSizeEnvPropertiesPatch = cursor - 2;
                 for (int i = 0; i < listKvp.Count; i++)
                 {
                     var entry = listKvp[i];
-
-                    // Iteration #1 - Get those fields which become dedicated column
-                    // i.e all PartB fields and opt-in part c fields.
-                    if (entry.Key == "{OriginalFormat}")
+                    if (entry.Key == "{OriginalFormat}" || this.m_customFields.ContainsKey(entry.Key))
                     {
-                        cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "body");
-                        cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, logRecord.FormattedMessage ?? Convert.ToString(entry.Value, CultureInfo.InvariantCulture));
-                        cntFields += 1;
-                        bodyPopulated = true;
                         continue;
-                    }
-                    else if (this.m_customFields == null || this.m_customFields.ContainsKey(entry.Key))
-                    {
-                        // TODO: the above null check can be optimized and avoided inside foreach.
-                        if (entry.Value != null)
-                        {
-                            // Geneva doesn't support null.
-                            cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
-                            cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
-                            cntFields += 1;
-                        }
                     }
                     else
                     {
-                        hasEnvProperties = true;
-                        continue;
+                        cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
+                        cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
+                        envPropertiesCount += 1;
                     }
                 }
 
-                if (!bodyPopulated && logRecord.FormattedMessage != null)
-                {
-                    cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "body");
-                    cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, logRecord.FormattedMessage);
-                    cntFields += 1;
-                }
-
-                if (hasEnvProperties)
-                {
-                    // Iteration #2 - Get all "other" fields and collapse them into single field
-                    // named "env_properties".
-                    ushort envPropertiesCount = 0;
-                    cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "env_properties");
-                    cursor = MessagePackSerializer.WriteMapHeader(buffer, cursor, ushort.MaxValue);
-                    int idxMapSizeEnvPropertiesPatch = cursor - 2;
-                    for (int i = 0; i < listKvp.Count; i++)
-                    {
-                        var entry = listKvp[i];
-                        if (entry.Key == "{OriginalFormat}" || this.m_customFields.ContainsKey(entry.Key))
-                        {
-                            continue;
-                        }
-                        else
-                        {
-                            cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
-                            cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
-                            envPropertiesCount += 1;
-                        }
-                    }
-
-                    cntFields += 1;
-                    MessagePackSerializer.WriteUInt16(buffer, idxMapSizeEnvPropertiesPatch, envPropertiesCount);
-                }
+                cntFields += 1;
+                MessagePackSerializer.WriteUInt16(buffer, idxMapSizeEnvPropertiesPatch, envPropertiesCount);
             }
 
             var eventId = logRecord.EventId;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -363,7 +363,9 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                 {
                     File.Delete(path);
                 }
-                catch { }
+                catch
+                {
+                }
             }
         }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -327,15 +327,15 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
 
                 // ACT
                 // This is treated as Structured logging as the state can be converted to IReadOnlyList<KeyValuePair<string, object>>
-                logger.Log(logLevel: LogLevel.Information,
-                   eventId: default,
-                   new List<KeyValuePair<string, object>>()
-                    {
-                        new KeyValuePair<string, object>("Key1", "Value1"),
-                    },
+                logger.Log(
+                    logLevel: LogLevel.Information,
+                    eventId: default,
+                    new List<KeyValuePair<string, object>>()
+                        {
+                            new KeyValuePair<string, object>("Key1", "Value1"),
+                        },
                     exception: null,
-                    formatter: (state, ex) => "Example formatted message."
-                    );
+                    formatter: (state, ex) => "Example formatted message.");
 
                 // VALIDATE
                 Assert.Single(logRecordList);


### PR DESCRIPTION
1. Fixes an issue which dropped the LogRecord.State, when it is a KVP of size1

2. Refactored  LogExporter code a bit:
LogExporter obtains the IReadOnlyList<KeyValuePair<string, object>> by either casting the State, or from the StateValues.
Serializes each KVP to form Part C fields.
Body is only populated if IncludeFormatMessage is true *OR*  special casing {OriginalFormat} from Log extension methods.

As a result:
The below log statement, will result in empty body, as there is no formatter provided by the user, and Exporter will not attempt "ToString() on the state" to populate body.
`logger.Log(LogLevel.Information, default, state: "somestringasdata", exception: null, formatter: null);`

The below log statement will also result in empty body, if `IncludeFormattedMessage = false`, else uses the formatted message from user. Again, Exporter does not attempt any "ToString()" of the state.

`logger.Log(LogLevel.Information, default, state: "somestringasdata", exception: null, formatter: (state, ex) => "Example formatted message.");`

In short, Exporter no longer attempts to do "ToString() on state to populate body.".

3. Tests are refactored. (could be further improved, coming in next PR), categorized into "Raw Log method", vs "using extension methods on Log (with message templating)."

~4. Expecting slight perf boost (less if...else ladder), will run benchmarks and update numbers, before merging.~
// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1586 (21H2)
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT

Main branch

|                   Method |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------------------- |-----------:|---------:|---------:|-------:|----------:|
| LoggerWithGenevaExporter | 1,100.1 ns | 14.49 ns | 12.85 ns | 0.0610 |     256 B |
|       SerializeLogRecord |   797.9 ns |  7.26 ns |  6.43 ns | 0.0057 |      24 B |



with this PR

|                   Method |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------------------- |-----------:|---------:|---------:|-------:|----------:|
| LoggerWithGenevaExporter | 1,085.7 ns | 14.71 ns | 13.04 ns | 0.0610 |     256 B |
|       SerializeLogRecord |   794.0 ns |  7.82 ns |  6.93 ns | 0.0057 |      24 B |