### PR TITLE
Geneva package workflow only run tests on windows

### DIFF
--- a/.github/workflows/package-Exporter.Geneva.yml
+++ b/.github/workflows/package-Exporter.Geneva.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test ${{env.PROJECT}}
-      run: dotnet test test/${{env.PROJECT}}.Tests
+      run: dotnet test test/${{env.PROJECT}}.Tests --filter "Platform=Any|Platform=Windows"
 
     - name: dotnet pack ${{env.PROJECT}}
       run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build


### PR DESCRIPTION
Set filter for dotnet test. Otherwise, linux only tests will be ran and will fail.