### PR TITLE
Geneva Exporter - Set metric exporter temporality to delta

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 1.2.6 [2022-Apr-21]
 
 * Set GenevaMetricExporter temporality preference back to Delta.
-[xxx](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/xxx)
+[323](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/323)
 
 ## 1.2.5 [2022-Apr-20] Broken
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-## 1.2.5 [2022-Apr-20]
+## 1.2.6 [2022-Apr-21]
+
+* Set GenevaMetricExporter temporality preference back to Delta.
+[xxx](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/xxx)
+
+## 1.2.5 [2022-Apr-20] Broken
+
+Note: This release was broken due to the GenevaMetricExporter
+using a TemporalityPreference of Cumulative instead of Delta, it has been
+unlisted from NuGet.
 
 * Update OTel SDK version to `1.2.0`.
 [319](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/319)

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -12,6 +12,8 @@
 Note: This release was broken due to the GenevaMetricExporter
 using a TemporalityPreference of Cumulative instead of Delta, it has been
 unlisted from NuGet.
+[303](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/303)
+is the PR that introduced this bug to GenevaMetricExporterExtensions.cs
 
 * Update OTel SDK version to `1.2.0`.
 [319](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/319)

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaMetricExporterExtensions.cs
@@ -29,6 +29,7 @@ public static class GenevaMetricExporterExtensions
 
         var options = new GenevaMetricExporterOptions();
         configure?.Invoke(options);
-        return builder.AddReader(new PeriodicExportingMetricReader(new GenevaMetricExporter(options), options.MetricExportIntervalMilliseconds));
+        return builder.AddReader(new PeriodicExportingMetricReader(new GenevaMetricExporter(options), options.MetricExportIntervalMilliseconds)
+        { TemporalityPreference = MetricReaderTemporalityPreference.Delta });
     }
 }


### PR DESCRIPTION
Ask for maintainers @open-telemetry/dotnet-maintainers 
- Release version 1.2.6 of the Geneva Exporter
- Unlist version 1.2.5 of the Geneva Exporter from NuGet