### PR TITLE
Add issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/comp_exporter_geneva.md
+++ b/.github/ISSUE_TEMPLATE/comp_exporter_geneva.md
@@ -1,0 +1,42 @@
+---
+name: OpenTelemetry.Exporter.Geneva
+about: Issue with OpenTelemetry.Exporter.Geneva
+labels: comp:exporter.geneva
+---
+
+# Issue with OpenTelemetry.Exporter.Geneva
+
+List of [all OpenTelemetry NuGet
+packages](https://www.nuget.org/profiles/OpenTelemetry) and version that you are
+using (e.g. `OpenTelemetry 1.0.2`):
+
+* [OpenTelemetry.Exporter.Geneva
+  1.2.6](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva/1.2.6)
+
+Runtime version (e.g. `net462`, `net48`, `netcoreapp3.1`, `net6.0` etc. You can
+find this information from the `*.csproj` file):
+
+* TBD
+
+**Is this a feature request or a bug?**
+
+* [ ] Feature Request
+* [ ] Bug
+
+**What is the expected behavior?**
+
+What did you expect to see?
+
+**What is the actual behavior?**
+
+What did you see instead? If you are reporting a bug, create a self-contained
+project using the template of your choice and apply the minimum required code to
+result in the issue you're observing. We will close this issue if:
+
+* The repro project you share with us is complex. We can't investigate custom
+  projects, so don't point us to such, please.
+* If we can not reproduce the behavior you're reporting.
+
+## Additional Context
+
+Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/comp_exporter_geneva.md
+++ b/.github/ISSUE_TEMPLATE/comp_exporter_geneva.md
@@ -25,7 +25,7 @@ find this information from the `*.csproj` file):
 
 **What is the expected behavior?**
 
-What did you expect to see?
+What do you expect to see?
 
 **What is the actual behavior?**
 

--- a/.github/ISSUE_TEMPLATE/miscellaneous.md
+++ b/.github/ISSUE_TEMPLATE/miscellaneous.md
@@ -7,7 +7,7 @@ about: Issue that does not fit into other categories
 
 **What are you trying to achieve?**
 
-What did you expect to see?
+What do you expect to see?
 
 **Additional context.**
 

--- a/.github/ISSUE_TEMPLATE/miscellaneous.md
+++ b/.github/ISSUE_TEMPLATE/miscellaneous.md
@@ -1,0 +1,15 @@
+---
+name: Miscellaneous (anything else)
+about: Issue that does not fit into other categories
+---
+
+# Issue that does not fit into other categories
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing
+documentation, please share the link to it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Fixes #.
+
+## Changes
+
+Please provide a brief description of the changes here.
+
+For significant contributions please make sure you have completed the following items:
+
+* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
+* [ ] Design discussion issue #


### PR DESCRIPTION
Created the issue templates and PR template.

Regarding issue template, I try to follow the specification repo so we have targeted issue for each project. In this PR I only included one example - once it's merged we can add similar templates for other projects (and also update the contributing.md doc to remind contributors when they add a new project).

These are the tags I would propose:
```text
comp:contrib.extensions.awsxray
comp:contrib.instrumentation.aws
comp:contrib.instrumentation.awslambda
comp:contrib.shared
comp:exporter.geneva
comp:exporter.stackdriver
comp:extensions
comp:extensions.azuremonitor
comp:extensions.persistentstorage
comp:instrumentation.elasticsearchclient
comp:instrumentation.entityframeworkcore
comp:instrumentation.grpccore
comp:instrumentation.hangfire
comp:instrumentation.masstransit
comp:instrumentation.mysqldata
comp:instrumentation.owin
comp:instrumentation.quartz
comp:instrumentation.runtime
comp:instrumentation.wcf
```