### PR TITLE
exporter/geneva - Minor readme file tweaks

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -29,7 +29,7 @@ Install the latest stable version of
 dotnet add package OpenTelemetry.Exporter.Geneva
 ```
 
-This snippet shows how to configure the Geneva Exporter for logs
+This snippet shows how to configure the Geneva Exporter for Logs
 
 ```csharp
 using var loggerFactory = LoggerFactory.Create(loggingBuilder => loggingBuilder
@@ -48,9 +48,9 @@ For ASP.NET applications, this should be in `Global.aspx.cs`.
 
 Since OpenTelemetry .NET SDK is a
 [LoggingProvider](https://docs.microsoft.com/dotnet/core/extensions/logging-providers),
-use the built-in mechanism to apply [log
+use the built-in mechanism to apply [Log
 filtering](https://docs.microsoft.com/dotnet/core/extensions/logging?tabs=command-line#how-filtering-rules-are-applied).
-This filtering lets you control the logs that are sent to each registered
+This filtering lets you control the Logs that are sent to each registered
 provider, including the OpenTelemetry provider. `OpenTelemetry` is the
 [alias](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.provideraliasattribute)
 for `OpenTelemetryLoggerProvider`, that may be used when configuring filtering
@@ -59,12 +59,12 @@ rules.
 **NOTE:** _Some application types (e.g. [ASP.NET
 Core](https://docs.microsoft.com/aspnet/core/fundamentals/logging/#configure-logging-1))
 have default logging settings. Please review them to make sure
-`OpenTelemetryLoggingProvider` is configured to receive logs of appropriate
+`OpenTelemetryLoggingProvider` is configured to receive Logs of appropriate
 levels and category.
 
 ### Enable Traces
 
-This snippet shows how to configure the Geneva Exporter for traces
+This snippet shows how to configure the Geneva Exporter for Traces
 
 ```csharp
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -80,12 +80,12 @@ The above code must be in application startup. In case of ASP.NET Core
 applications, this should be in `ConfigureServices` of `Startup` class.
 For ASP.NET applications, this should be in `Global.aspx.cs`.
 
-### GenevaExporterOptions (for logs and traces)
+### GenevaExporterOptions (for Logs and Traces)
 
 `GenevaExporterOptions` contains various options to configure the Geneva
 Exporter.
 
-#### `ConnectionString` (required)
+#### `ConnectionString` (required for Logs and Traces)
 
 On Linux the connection string has the format `Endpoint=unix:{UDS Path}`.
 
@@ -97,28 +97,25 @@ A list of fields which should be stored as individual table columns.
 
 #### `PrepopulatedFields` (optional)
 
-This is a collection of fields that will be applied to all the logs and traces
+This is a collection of fields that will be applied to all the Logs and Traces
 sent through this exporter.
 
 #### `TableNameMappings` (optional)
 
-This defines the mapping for the table name used to store traces and logs.
+This defines the mapping for the table name used to store Logs and Traces.
 
-The default table name used for traces is `Span`. For changing the table name
-for traces, add an entry with key as `Span`, and value as the custom table name.
+The default table name used for Traces is `Span`. For changing the table name
+for Traces, add an entry with key as `Span`, and value as the custom table name.
 
-The default table name used for logs is `Log`. Mappings can be specified for
+The default table name used for Logs is `Log`. Mappings can be specified for
 each
 [category](https://docs.microsoft.com/dotnet/core/extensions/logging#log-category)
-of the log. For changing the default table name for logs, add an entry with key
+of the log. For changing the default table name for Logs, add an entry with key
 as `*`, and value as the custom table name.
 
 ### Enable Metrics
 
-**NOTE:** _Version 1.2.x of the Geneva Exporter (which adds Metrics support)
-does not support .NET versions lower than .NET Framework 4.6.1._
-
-This snippet shows how to configure the Geneva Exporter for metrics
+This snippet shows how to configure the Geneva Exporter for Metrics
 
 ```csharp
 using var meterProvider = Sdk.CreateMeterProviderBuilder()
@@ -134,12 +131,12 @@ The above code must be in application startup. In case of ASP.NET Core
 applications, this should be in `ConfigureServices` of `Startup` class.
 For ASP.NET applications, this should be in `Global.aspx.cs`.
 
-### GenevaMetricExporterOptions (for metrics)
+### GenevaMetricExporterOptions (for Metrics)
 
 `GenevaMetricExporterOptions` contains various options which are required to
 configure the GenevaMetricExporter.
 
-#### `ConnectionString` (required for metrics)
+#### `ConnectionString` (required for Metrics)
 
 On Windows **DO NOT** provide an ETW session name for Metrics, only specify
 Account and Namespace. For example:
@@ -151,7 +148,7 @@ For example:
 
 #### `MetricExportIntervalMilliseconds` (optional)
 
-Set the exporter's periodic time interval to export metrics. The default value
+Set the exporter's periodic time interval to export Metrics. The default value
 is 20000 milliseconds.
 
 #### `PrepopulatedMetricDimensions` (optional)
@@ -170,5 +167,5 @@ Geneva Exporters uses an
 with the name "OpenTelemetry-Exporter-Geneva" for its internal logging. Please
 follow the [troubleshooting guide for OpenTelemetry
 .NET](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#troubleshooting)
-for instructions on seeing logs from the geneva exporter, as well as other
+for instructions on seeing Logs from the geneva exporter, as well as other
 OpenTelemetry components.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/341#issuecomment-1121673453

## Changes

- Capitalize Logs, Traces, Metrics
- Omit note about using OTel 1.2.* since it is already the stable version