### PR TITLE
Upgrade AWS and AWS.Lambda to OTel 1.2.0

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - OpenTelemetry.Contrib.Instrumentation.AWS
 
+## Unreleased
+
+* Updated OTel SDK package version to 1.2.0
+* Update minimum full framework support to net462
+* Update AWSSDK.Core 3.5.1.24 -> 3.7.11.2
+
 ## 1.0.1 [2021-Feb-24]
 
 This is the first release for the `OpenTelemetry.Contrib.Instrumentation.AWS`

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OTel SDK package version to 1.2.0
-* Update minimum full framework support to net462
+* Updated minimum full framework support to net462
 * Update AWSSDK.Core 3.5.1.24 -> 3.7.11.2
 
 ## 1.0.1 [2021-Feb-24]

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/OpenTelemetry.Contrib.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/OpenTelemetry.Contrib.Instrumentation.AWS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <Description>AWS client instrumentation for OpenTelemetry .NET</Description>
 	<MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - OpenTelemetry.Contrib.Instrumentation.AWSLambda
 
+## Unreleased
+
+* Updated OTel SDK package version to 1.2.0
+* Update minimum full framework support to net462
+* Update AWSSDK.Lambda.Core 1.2.0 -> 2.1.0
+
 ## 1.1.0-beta1 [2021-May-26]
 
 This is the first release for the `OpenTelemetry.Contrib.Instrumentation.AWSLambda`

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda/OpenTelemetry.Contrib.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda/OpenTelemetry.Contrib.Instrumentation.AWSLambda.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="OpenTelemetry.Contrib.Extensions.AWSXRay" Version="1.0.1" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <Description>Unit test project for AWS client instrumentation for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.24" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.26" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.2" />
-    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.11.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.55" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.34" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -24,7 +24,7 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Instrumentation.AWS\OpenTelemetry.Contrib.Instrumentation.AWS.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Compile Remove="Tools\CustomWebResponse.cs" />
     <Compile Remove="Tools\HttpResponseMessageBody.cs" />
     <Reference Include="System.Net.Http" />

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
 
                 scan_request.TableName = "SampleProduct";
                 scan_request.AttributesToGet = new List<string>() { "Id", "Name" };
-#if NET452
+#if NET462
                 ddb.Scan(scan_request);
 #else
                 ddb.ScanAsync(scan_request).Wait();
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
         }
 
         [Fact]
-#if NET452
+#if NET462
         public void TestDDBScanUnsuccessful()
 #else
         public async Task TestDDBScanUnsuccessful()
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
 
                 try
                 {
-#if NET452
+#if NET462
                     ddb.Scan(scan_request);
 #else
                     await ddb.ScanAsync(scan_request);
@@ -148,7 +148,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
                 var send_msg_req = new SendMessageRequest();
                 send_msg_req.QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue";
                 send_msg_req.MessageBody = "Hello from OT";
-#if NET452
+#if NET462
                 sqs.SendMessage(send_msg_req);
 #else
                 sqs.SendMessageAsync(send_msg_req).Wait();

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/CustomResponses.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/CustomResponses.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
 {
     internal static class CustomResponses
     {
-#if NET452
+#if NET462
         public static void SetResponse(
             AmazonServiceClient client, string content, string requestId, bool isOK)
         {

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequest.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequest.cs
@@ -28,7 +28,7 @@ using Amazon.Runtime.Internal.Transform;
 
 namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
 {
-#if NET452
+#if NET462
     internal class MockHttpRequest : IHttpRequest<Stream>
     {
         private Stream requestStream = null;

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequestFactory.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequestFactory.cs
@@ -22,7 +22,7 @@ using Amazon.Runtime;
 
 namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
 {
-#if NET452
+#if NET462
     internal class MockHttpRequestFactory : IHttpRequestFactory<Stream>
     {
         public Action GetResponseAction { get; set; }

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockWebResponse.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockWebResponse.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests
 {
     internal class MockWebResponse
     {
-#if NET452
+#if NET462
         public static HttpWebResponse CreateFromResource(string resourceName)
         {
             var rawResponse = Utils.GetResourceText(resourceName);

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <Description>Unit test project of OpenTelemetry instrumentation for AWS Lambda</Description>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IncludeSharedInstrumentationSource>true</IncludeSharedInstrumentationSource>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
* Updated OTel SDK package version to 1.2.0
* Update minimum full framework support to net462
* Update AWSSDK.Lambda.Core 1.2.0 -> 2.1.0
* Update AWSSDK.Core 3.5.1.24 -> 3.7.11.2
* Run tests against net5.0 & net6.0