### PR TITLE
Upgrade Stackdriver support to OTel 1.2.0

### DIFF
--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OTel SDK package version to 1.2.0
-* Update minimum full framework support to net462
+* Updated minimum full framework support to net462
 * Update Google.Cloud.Monitoring.V3 2.1.0 -> 2.6.0
 * Update Google.Cloud.Monitoring.V3 2.0.0 -> 2.3.0
 

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Updated OTel SDK package version to 1.2.0
+* Update minimum full framework support to net462
+* Update Google.Cloud.Monitoring.V3 2.1.0 -> 2.6.0
+* Update Google.Cloud.Monitoring.V3 2.0.0 -> 2.3.0
+
 ## 1.0.0-beta.2
 
 * Going forward the NuGet package will be

--- a/src/OpenTelemetry.Exporter.Stackdriver/OpenTelemetry.Exporter.Stackdriver.csproj
+++ b/src/OpenTelemetry.Exporter.Stackdriver/OpenTelemetry.Exporter.Stackdriver.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Description>Stackdriver .NET Exporter for OpenTelemetry.</Description>
     <PackageTags>$(PackageTags);Stackdriver;Google;GCP;distributed-tracing</PackageTags>
     <MinVerTagPrefix>Exporter.Stackdriver-</MinVerTagPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Monitoring.V3" Version="2.1.0" />
-    <PackageReference Include="Google.Cloud.Trace.V2" Version="2.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Monitoring.V3" Version="2.6.0" />
+    <PackageReference Include="Google.Cloud.Trace.V2" Version="2.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Contrib.Exporter.Stackdriver.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for Stackdriver Exporter for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Updated OTel SDK package version to 1.2.0
* Update minimum full framework support to net462
* Update Google.Cloud.Monitoring.V3 2.1.0 -> 2.6.0
* Update Google.Cloud.Monitoring.V3 2.0.0 -> 2.3.0
* Add runtime net5.0, net6.0 to test csproj