### PR TITLE
Add support for the native Activity properties Status and StatusDescription

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -8,6 +8,10 @@
 * TraceExporter bug fix to not export non-recorded Activities.
 [352](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/352)
 
+* Add support for the native `Activity` properties `Status` and
+`StatusDescription`.
+[359](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/359)
+
 ## 1.2.6 [2022-Apr-21]
 
 * Set GenevaMetricExporter temporality preference back to Delta.
@@ -15,9 +19,9 @@
 
 ## 1.2.5 [2022-Apr-20] Broken
 
-Note: This release was broken due to the GenevaMetricExporter
-using a TemporalityPreference of Cumulative instead of Delta, it has been
-unlisted from NuGet.
+Note: This release was broken due to the GenevaMetricExporter using a
+TemporalityPreference of Cumulative instead of Delta, it has been unlisted from
+NuGet.
 [303](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/303)
 is the PR that introduced this bug to GenevaMetricExporterExtensions.cs
 
@@ -26,20 +30,17 @@ is the PR that introduced this bug to GenevaMetricExporterExtensions.cs
 
 ## 1.2.4 [2022-Apr-20] Broken
 
-This is the first release of the `OpenTelemetry.Exporter.Geneva`
-project.
-Note: This release was broken due to using OpenTelemetry 1.2.0-rc5.
-Therefore, it has been unlisted on NuGet.
+This is the first release of the `OpenTelemetry.Exporter.Geneva` project. Note:
+This release was broken due to using OpenTelemetry 1.2.0-rc5. Therefore, it has
+been unlisted on NuGet.
 
-* LogExporter modified to stop calling `ToString()`
-on `LogRecord.State` to obtain Log body. It now
-obtains body from `LogRecord.FormattedMessage`
-or special casing "{OriginalFormat}" only.
+* LogExporter modified to stop calling `ToString()` on `LogRecord.State` to
+obtain Log body. It now obtains body from `LogRecord.FormattedMessage` or
+special casing "{OriginalFormat}" only.
 [295](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/295)
 
-* Fixed a bug which causes LogExporter to not
-serialize if the `LogRecord.State` had a
-single KeyValuePair.
+* Fixed a bug which causes LogExporter to not serialize if the `LogRecord.State`
+had a single KeyValuePair.
 [295](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/295)
 
 * Update OTel SDK version to `1.2.0-rc5`.


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet/issues/2569

## Changes
- Add support for the native Activity properties `Status` and `StatusDescription` for GenevaExporter. All the other exporters in the public repo have added support for the native Activity properties `Status` and `StatusDescription`.

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes


## Benchmark Results

There is no measurable impact on the perf numbers.

// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=6.0.300
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
  DefaultJob : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT

### main branch


|                    Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------------- |----------:|---------:|---------:|-------:|----------:|
|      CreateBoringActivity |  16.83 ns | 0.180 ns | 0.168 ns |      - |         - |
|     CreateTediousActivity | 319.15 ns | 2.474 ns | 2.193 ns | 0.0648 |     408 B |
| CreateInterestingActivity | 631.70 ns | 3.194 ns | 2.832 ns | 0.0648 |     408 B |
|         SerializeActivity | 490.15 ns | 6.587 ns | 6.161 ns | 0.0124 |      80 B |


### With the changes in this PR


|                    Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------------- |----------:|---------:|---------:|-------:|----------:|
|      CreateBoringActivity |  16.95 ns | 0.338 ns | 0.316 ns |      - |         - |
|     CreateTediousActivity | 309.26 ns | 1.010 ns | 0.843 ns | 0.0648 |     408 B |
| CreateInterestingActivity | 635.43 ns | 7.435 ns | 6.591 ns | 0.0648 |     408 B |
|         SerializeActivity | 492.03 ns | 4.338 ns | 4.058 ns | 0.0124 |      80 B |
