### PR TITLE
[Exporter.Instana] Check if env vars are defined

### DIFF
--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.0.1 [2022-Jun-02]
+## 1.0.2 [2022-Jun-02]
 
 * Application is chrashing if environment variables are not defined
 [385](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/385)

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.1 [2022-Jun-02]
+
+* Application is chrashing if environment variables are not defined
+[385](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/385)
+
 ## 1.0.1 [2022-May-25]
 
 * Instana span duration was not calculated correctly

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/SpanSender.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/SpanSender.cs
@@ -33,7 +33,10 @@ namespace OpenTelemetry.Exporter.Instana.Implementation
 
         public void Enqueue(InstanaSpan instanaSpan)
         {
-            this.spansQueue.Enqueue(instanaSpan);
+            if (this.transport.IsAvailable)
+            {
+                this.spansQueue.Enqueue(instanaSpan);
+            }
         }
 
         private async void TaskSpanSender()


### PR DESCRIPTION
If environment variables are not defined but Instana exporter is added that can cause the application to crash. 
We have to check if env vars are defined before we try to start reporting to Instana backend.
