### PR TITLE
[Exporter.Geneva] Add support for ILogger scopes

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add support for exporting `ILogger` scopes.
+[390](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/390)
+
 ## 1.3.0-beta.1 [2022-May-27]
 
 * Enable PassThru TableNameMappings using the logger category name.


### PR DESCRIPTION
A potential approach to fix #389

## Changes
- Add support for exporting ILogger scopes

## Note:
This PR demonstrates one possible way of exporting scopes. We would release a beta package with this feature to gather feedback.

### Example1:
```
using (logger.BeginScope("MyScope"))
{
    logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
}
```

Output:
Same table as before, with an additional column "Scopes", which will be a list of 1 element. That element is a Map with 1 key value pair. with "scope", ""MyScope" as values.

### Example2:
```
using (logger.BeginScope("MyOuterScope"))
using (logger.BeginScope("MyInnerScope"))
{
    logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
}
```

Output:
Same table as before, with an additional column "Scopes", which will be a list of 2 elements. Each element is a Map with 1 key value pair. with {"scope", ""MyOuterScope"}, {"scope", ""MyInnerScope"}, as values respectively .

### Example 3: (using formatted string in Scopes)
```
using (logger.BeginScope("MyOuterScope"))
using (logger.BeginScope("MyInnerScope"))
using (logger.BeginScope("MyInnerInnerScope with {name} and {age} of custom", "John Doe", 35))
{
    logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
}
```

Same table as before, with an additional column "Scopes", which will be a list of 3 elements. Elements 1 and 2 is a Map with 1 key value pair. with {"scope", ""MyOuterScope"}, {"scope", ""MyInnerScope"}, as values respectively .
Element3 is a Map with 3 key value pairs, {""name"":""John Doe"",""age"":35,""{OriginalFormat}"":""MyInnerInnerScope with {name} and {age} of custom""}


### Example 4: (using IReadOnlyList<KeyValuePair<string, object>> in scopes)

```
using (logger.BeginScope("MyOuterScope"))
using (logger.BeginScope("MyInnerScope"))
using (logger.BeginScope(new List<KeyValuePair<string, object>> { new KeyValuePair<string, object>("MyKey", "MyValue") }))
{
    logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
}
```

Same table as before, with an additional column "Scopes", which will be a list of 3 elements. Elements 1 and 2 is a Map with 1 key value pair. with {"scope", ""MyOuterScope"}, {"scope", ""MyInnerScope"}, as values respectively .
Element3 is a Map with one key value pair: {"MyKey":"MyValue"}



For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
