### PR TITLE
Update OTel SDK package version to 1.3.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OTel SDK package version to 1.3.0
+  ([#411](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/411))
+
 ## 0.1.0-alpha.1
 
 * This is the first release of `OpenTelemetry.Instrumentation.Runtime` package.

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1;net6.0</TargetFrameworks>
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc2" />
+        <PackageReference Include="OpenTelemetry.Api" Version="1.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/OpenTelemetry.Instrumentation.Runtime.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/OpenTelemetry.Instrumentation.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="1.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.2.0-rc2" />
+        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.3.0" />
         <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
         <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fixes #.

## Changes

Update OTel SDK package version to 1.3.0

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
