### PR TITLE
[Exporter.Geneva] Update exception logging

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/ExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/ExporterEventSource.cs
@@ -25,46 +25,55 @@ namespace OpenTelemetry.Exporter.Geneva;
 internal class ExporterEventSource : EventSource
 {
     public static readonly ExporterEventSource Log = new ExporterEventSource();
-    private const int EVENT_ID_TRACE = 1;
-    private const int EVENT_ID_METRICS = 2;
-    private const int EVENT_ID_ERROR = 3;
+    private const int EVENT_ID_TRACE = 1; // Failed to send Trace
+    private const int EVENT_ID_LOG = 2; // Failed to send Log
+    private const int EVENT_ID_METRIC = 3; // Failed to send Metric
+    private const int EVENT_ID_ERROR = 4; // Other common exporter exceptions
 
-    [NonEvent]
-    public void ExporterException(Exception ex)
+    [Event(EVENT_ID_TRACE, Message = "Exporter failed to send SpanData. Exception: {0}", Level = EventLevel.Error)]
+    public void FailedToSendTraceData(Exception ex)
     {
         if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
         {
-            this.FailedToSendSpanData(ToInvariantString(ex));
+            // https://docs.microsoft.com/en-us/windows/win32/etw/about-event-tracing
+            // ETW has a size limit: The total event size is greater than 64K. This includes the ETW header plus the data or payload.
+            // TODO: Do not hit ETW size limit even for external library exception stack. But what is the ETW header size?
+            // Source code: https://referencesource.microsoft.com/#mscorlib/system/diagnostics/eventing/eventsource.cs,867
+            // Why is size calculated like below in WriteEvent source code?
+            // descrs[0].Size = ((arg1.Length + 1) * 2);
+            // I'm assuming it calculates the size of string, then it should be:
+            // (count of chars) * sizeof(char) + sizeof(Length:int) = (str.Length * 2 + 4).
+            this.WriteEvent(EVENT_ID_TRACE, ToInvariantString(ex));
         }
     }
 
-    [Event(EVENT_ID_TRACE, Message = "Exporter failed to send SpanData. Data will not be sent. Exception: {0}", Level = EventLevel.Error)]
-    public void FailedToSendSpanData(string ex)
-    {
-        // https://docs.microsoft.com/en-us/windows/win32/etw/about-event-tracing
-        // ETW has a size limit: The total event size is greater than 64K. This includes the ETW header plus the data or payload.
-        // TODO: Do not hit ETW size limit even for external library exception stack. But what is the ETW header size?
-        // Source code: https://referencesource.microsoft.com/#mscorlib/system/diagnostics/eventing/eventsource.cs,867
-        // Why is size calculated like below in WriteEvent source code?
-        // descrs[0].Size = ((arg1.Length + 1) * 2);
-        // I'm assuming it calculates the size of string, then it should be:
-        // (count of chars) * sizeof(char) + sizeof(Length:int) = (str.Length * 2 + 4).
-        this.WriteEvent(EVENT_ID_TRACE, ex);
-    }
-
-    [Event(EVENT_ID_METRICS, Message = "Exporter failed to send MetricData. Data will not be sent. MetricNamespace = {0}, MetricName = {1}, Message: {2}", Level = EventLevel.Error)]
-    public void FailedToSendMetricData(string metricNamespace, string metricName, string message)
-    {
-        this.WriteEvent(EVENT_ID_METRICS, metricNamespace, metricName, message);
-    }
-
-    [Event(EVENT_ID_ERROR, Message = "Exporter failed.", Level = EventLevel.Error)]
-    public void ExporterError(string message)
+    [Event(EVENT_ID_LOG, Message = "Exporter failed to send log data. Exception: {0}", Level = EventLevel.Error)]
+    public void FailedToSendLogData(Exception ex)
     {
         if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
         {
-            // TODO: We should ensure that GenevaTraceExporter doesn't emit any message that could hit ETW size limit.
-            this.WriteEvent(EVENT_ID_ERROR, message);
+            // TODO: Do not hit ETW size limit even for external library exception stack.
+            this.WriteEvent(EVENT_ID_LOG, ToInvariantString(ex));
+        }
+    }
+
+    [Event(EVENT_ID_METRIC, Message = "Exporter failed to send MetricData. Data will not be sent. MonitoringAccount = {0} MetricNamespace = {1}, MetricName = {2}, Message: {3}", Level = EventLevel.Error)]
+    public void FailedToSendMetricData(string monitoringAccount, string metricNamespace, string metricName, Exception ex)
+    {
+        if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            // TODO: Do not hit ETW size limit even for external library exception stack.
+            this.WriteEvent(EVENT_ID_METRIC, monitoringAccount, metricNamespace, metricName, ToInvariantString(ex));
+        }
+    }
+
+    [Event(EVENT_ID_ERROR, Message = "Exporter failed.", Level = EventLevel.Error)]
+    public void ExporterException(string message, Exception ex)
+    {
+        if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            // TODO: Do not hit ETW size limit even for external library exception stack.
+            this.WriteEvent(EVENT_ID_ERROR, message, ToInvariantString(ex));
         }
     }
 

--- a/src/OpenTelemetry.Exporter.Geneva/ExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/ExporterEventSource.cs
@@ -30,7 +30,7 @@ internal class ExporterEventSource : EventSource
     private const int EVENT_ID_METRIC = 3; // Failed to send Metric
     private const int EVENT_ID_ERROR = 4; // Other common exporter exceptions
 
-    [Event(EVENT_ID_TRACE, Message = "Exporter failed to send SpanData. Exception: {0}", Level = EventLevel.Error)]
+    [Event(EVENT_ID_TRACE, Message = "Exporter failed to send trace data. Exception: {0}", Level = EventLevel.Error)]
     public void FailedToSendTraceData(Exception ex)
     {
         if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
@@ -57,7 +57,7 @@ internal class ExporterEventSource : EventSource
         }
     }
 
-    [Event(EVENT_ID_METRIC, Message = "Exporter failed to send MetricData. Data will not be sent. MonitoringAccount = {0} MetricNamespace = {1}, MetricName = {2}, Message: {3}", Level = EventLevel.Error)]
+    [Event(EVENT_ID_METRIC, Message = "Exporter failed to send metric data. Data will not be sent. MonitoringAccount = {0} MetricNamespace = {1}, MetricName = {2}, Message: {3}", Level = EventLevel.Error)]
     public void FailedToSendMetricData(string monitoringAccount, string metricNamespace, string metricName, Exception ex)
     {
         if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -160,7 +160,7 @@ public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
             }
             catch (Exception ex)
             {
-                ExporterEventSource.Log.ExporterException(ex); // TODO: preallocate exception or no exception
+                ExporterEventSource.Log.FailedToSendLogData(ex); // TODO: preallocate exception or no exception
                 result = ExportResult.Failure;
             }
         }
@@ -185,7 +185,7 @@ public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
             }
             catch (Exception ex)
             {
-                ExporterEventSource.Log.ExporterException(ex);
+                ExporterEventSource.Log.ExporterException("GenevaLogExporter Dispose failed.", ex);
             }
         }
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaMetricExporter.cs
@@ -198,7 +198,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                 }
                 catch (Exception ex)
                 {
-                    ExporterEventSource.Log.FailedToSendMetricData(this.metricNamespace, metric.Name, ex.Message); // TODO: preallocate exception or no exception
+                    ExporterEventSource.Log.FailedToSendMetricData(this.monitoringAccount, this.metricNamespace, metric.Name, ex); // TODO: preallocate exception or no exception
                     result = ExportResult.Failure;
                 }
             }
@@ -222,7 +222,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
             }
             catch (Exception ex)
             {
-                ExporterEventSource.Log.ExporterException(ex);
+                ExporterEventSource.Log.ExporterException("GenevaMetricExporter Dispose failed.", ex);
             }
         }
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
@@ -200,7 +200,7 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
             }
             catch (Exception ex)
             {
-                ExporterEventSource.Log.ExporterException(ex); // TODO: preallocate exception or no exception
+                ExporterEventSource.Log.FailedToSendTraceData(ex); // TODO: preallocate exception or no exception
                 result = ExportResult.Failure;
             }
         }
@@ -224,7 +224,7 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
             }
             catch (Exception ex)
             {
-                ExporterEventSource.Log.ExporterException(ex);
+                ExporterEventSource.Log.ExporterException("GenevaTraceExporter Dispose failed.", ex);
             }
         }
 

--- a/src/OpenTelemetry.Exporter.Geneva/UnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/UnixDomainSocketDataTransport.cs
@@ -66,11 +66,11 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
         catch (SocketException ex)
         {
             // SocketException from Socket.Send
-            ExporterEventSource.Log.ExporterException(ex);
+            ExporterEventSource.Log.ExporterException("UDS Send failed.", ex);
         }
         catch (Exception ex)
         {
-            ExporterEventSource.Log.ExporterException(ex);
+            ExporterEventSource.Log.ExporterException("UDS Send failed.", ex);
         }
     }
 
@@ -91,7 +91,7 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
         }
         catch (Exception ex)
         {
-            ExporterEventSource.Log.ExporterException(ex);
+            ExporterEventSource.Log.ExporterException("UDS Connect failed.", ex);
 
             // Re-throw the exception to
             // 1. fail fast in Geneva exporter contructor, or


### PR DESCRIPTION
## Changes
- Use a dedicated event for each signal when the exporter fails to send the data
- Add an event for other common exporter errors