### PR TITLE
[Exporter.Geneva] Fix ExportResult on Linux

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -13,6 +13,13 @@
 supported now is .NET 4.6.2.
 [441](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/441)
 
+* Fix the incorrect `ExportResult` issue on Linux:
+[422](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/422)
+by throwing any exception caught by `UnixDomainSocketDataTransport.Send` so that
+`Export` methods cn catch it and correctly set `ExportResult` to
+`ExportResult.Failure`.
+[444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/444)
+
 ## 1.3.0-beta.2 [2022-Jun-03]
 
 * Add support for exporting `ILogger` scopes.

--- a/src/OpenTelemetry.Exporter.Geneva/UnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/UnixDomainSocketDataTransport.cs
@@ -63,14 +63,10 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
 
             this.socket.Send(data, size, SocketFlags.None);
         }
-        catch (SocketException ex)
+        catch (Exception)
         {
-            // SocketException from Socket.Send
-            ExporterEventSource.Log.ExporterException("UDS Send failed.", ex);
-        }
-        catch (Exception ex)
-        {
-            ExporterEventSource.Log.ExporterException("UDS Send failed.", ex);
+            // Re-throw the exception so that Export method catches it and sets the ExportResult correctly.
+            throw;
         }
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
@@ -163,10 +163,10 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
 
                     Console.WriteLine("Destroyed server.");
 
-                    Console.WriteLine("Client will fail during Send, but shouldn't throw exception.");
-                    dataTransport.Send(data, data.Length);
-                    Console.WriteLine("Client will fail during reconnect, but shouldn't throw exception.");
-                    dataTransport.Send(data, data.Length);
+                    Console.WriteLine("Client will fail during Send, and should throw an Exception");
+                    Assert.ThrowsAny<Exception>(() => dataTransport.Send(data, data.Length));
+                    Console.WriteLine("Client will fail during Reconnect, and should throw an Exception");
+                    Assert.ThrowsAny<Exception>(() => dataTransport.Send(data, data.Length));
 
                     using var server2 = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
                     server2.Bind(endpoint);


### PR DESCRIPTION
Fixes #422 

## Changes
- Updated `UnixDomainSocketDataTransport.Send` to throw the exception for `Export` methods to catch it and set `ExportResult` correctly

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
