### PR TITLE
Remove Process related metrics from .NET Runtime metrics

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Remove Process related metrics from .NET Runtime metrics
+  ([#446](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/446))
+
 ## 0.2.0-alpha.1
 
 * Updated OTel SDK package version to 1.3.0

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 #if NETCOREAPP3_1_OR_GREATER
@@ -33,7 +32,9 @@ namespace OpenTelemetry.Instrumentation.Runtime
         internal static readonly AssemblyName AssemblyName = typeof(RuntimeMetrics).Assembly.GetName();
         internal static readonly string InstrumentationName = AssemblyName.Name;
         internal static readonly string InstrumentationVersion = AssemblyName.Version.ToString();
+#if NET6_0_OR_GREATER
         private const long NanosecondsPerTick = 100;
+#endif
         private static readonly string[] GenNames = new string[] { "gen0", "gen1", "gen2", "loh", "poh" };
         private static readonly int NumberOfGenerations = 3;
         private static string metricPrefix = "process.runtime.dotnet.";
@@ -85,16 +86,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
             }
 #endif
 
-            if (options.IsProcessEnabled)
-            {
-                this.meter.CreateObservableCounter("process.cpu.time", GetProcessorTimes, "s", "Processor time of this process.");
-
-                // Not yet official: https://github.com/open-telemetry/opentelemetry-specification/pull/2392
-                this.meter.CreateObservableGauge("process.cpu.count", () => (long)Environment.ProcessorCount, description: "The number of available logical CPUs.");
-                this.meter.CreateObservableGauge("process.memory.usage", () => Process.GetCurrentProcess().WorkingSet64, "By", "The amount of physical memory in use.");
-                this.meter.CreateObservableGauge("process.memory.virtual", () => Process.GetCurrentProcess().VirtualMemorySize64, "By", "The amount of committed virtual memory.");
-            }
-
             if (options.IsAssembliesEnabled)
             {
                 this.meter.CreateObservableCounter($"{metricPrefix}assembly.count", () => (long)AppDomain.CurrentDomain.GetAssemblies().Length, description: "Number of Assemblies Loaded.");
@@ -138,12 +129,5 @@ namespace OpenTelemetry.Instrumentation.Runtime
             return measurements;
         }
 #endif
-
-        private static IEnumerable<Measurement<double>> GetProcessorTimes()
-        {
-            var process = Process.GetCurrentProcess();
-            yield return new(process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object>("state", "user"));
-            yield return new(process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object>("state", "system"));
-        }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetricsOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetricsOptions.cs
@@ -41,11 +41,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
 #endif
 
         /// <summary>
-        /// Gets or sets a value indicating whether process metrics should be collected.
-        /// </summary>
-        public bool? ProcessEnabled { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether assembly metrics should be collected.
         /// </summary>
         public bool? AssembliesEnabled { get; set; }
@@ -60,7 +55,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
 #if NETCOREAPP3_1_OR_GREATER
         && this.ThreadingEnabled == null
 #endif
-        && this.ProcessEnabled == null
         && this.AssembliesEnabled == null;
 
         /// <summary>
@@ -81,11 +75,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
         /// </summary>
         internal bool IsThreadingEnabled => this.ThreadingEnabled == true || this.IsAllEnabled;
 #endif
-
-        /// <summary>
-        /// Gets a value indicating whether process metrics is enabled.
-        /// </summary>
-        internal bool IsProcessEnabled => this.ProcessEnabled == true || this.IsAllEnabled;
 
         /// <summary>
         /// Gets a value indicating whether assembly metrics is enabled.

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsOptionsTests.cs
@@ -32,7 +32,6 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.True(options.IsThreadingEnabled);
 #endif
-            Assert.True(options.IsProcessEnabled);
             Assert.True(options.IsAssembliesEnabled);
             Assert.True(options.IsAllEnabled);
         }
@@ -49,7 +48,6 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.False(options.IsThreadingEnabled);
 #endif
-            Assert.False(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
         }
@@ -63,7 +61,6 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
             Assert.False(options.IsGcEnabled);
             Assert.True(options.IsJitEnabled);
             Assert.False(options.IsThreadingEnabled);
-            Assert.False(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
         }
@@ -80,28 +77,10 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
             Assert.False(options.IsJitEnabled);
 #endif
             Assert.True(options.IsThreadingEnabled);
-            Assert.False(options.IsProcessEnabled);
             Assert.False(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
         }
 #endif
-
-        [Fact]
-        public void Enable_Process_Only()
-        {
-            var options = new RuntimeMetricsOptions { ProcessEnabled = true };
-
-            Assert.False(options.IsGcEnabled);
-#if NET6_0_OR_GREATER
-            Assert.False(options.IsJitEnabled);
-#endif
-#if NETCOREAPP3_1_OR_GREATER
-            Assert.False(options.IsThreadingEnabled);
-#endif
-            Assert.True(options.IsProcessEnabled);
-            Assert.False(options.IsAssembliesEnabled);
-            Assert.False(options.IsAllEnabled);
-        }
 
         [Fact]
         public void Enable_Assemblies_Only()
@@ -115,7 +94,6 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.False(options.IsThreadingEnabled);
 #endif
-            Assert.False(options.IsProcessEnabled);
             Assert.True(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
         }
@@ -123,7 +101,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
         [Fact]
         public void Enable_Multiple()
         {
-            var options = new RuntimeMetricsOptions { GcEnabled = true, ProcessEnabled = true };
+            var options = new RuntimeMetricsOptions { GcEnabled = true, AssembliesEnabled = true };
 
             Assert.True(options.IsGcEnabled);
 #if NET6_0_OR_GREATER
@@ -132,8 +110,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
             Assert.False(options.IsThreadingEnabled);
 #endif
-            Assert.True(options.IsProcessEnabled);
-            Assert.False(options.IsAssembliesEnabled);
+            Assert.True(options.IsAssembliesEnabled);
             Assert.False(options.IsAllEnabled);
         }
     }

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenTelemetry.Metrics;
 using Xunit;
 
@@ -38,7 +36,6 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
 #if NETCOREAPP3_1_OR_GREATER
                      options.ThreadingEnabled = true;
 #endif
-                     options.ProcessEnabled = true;
 #if NET6_0_OR_GREATER
 
                      options.JitEnabled = true;
@@ -52,81 +49,6 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
             Assert.True(exportedItems.Count > 1);
             var metric1 = exportedItems[0];
             Assert.StartsWith(MetricPrefix, metric1.Name);
-        }
-
-        [Fact]
-        public void ProcessMetricsAreCaptured()
-        {
-            var exportedItems = new List<Metric>();
-
-            using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                 .AddRuntimeMetrics(options =>
-                 {
-                     options.ProcessEnabled = true;
-                 })
-                 .AddInMemoryExporter(exportedItems)
-                .Build();
-
-            // simple CPU spinning
-            var spinDuration = DateTime.UtcNow.AddMilliseconds(10);
-            while (DateTime.UtcNow < spinDuration)
-            {
-            }
-
-            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-
-            Assert.Equal(4, exportedItems.Count);
-
-            var cpuTimeMetric = exportedItems.First(i => i.Name == "process.cpu.time");
-            var sumReceived = GetDoubleSum(cpuTimeMetric);
-            Assert.True(sumReceived > 0);
-
-            var cpuCountMetric = exportedItems.First(i => i.Name == "process.cpu.count");
-            Assert.Equal(Environment.ProcessorCount, (int)GetLongSum(cpuCountMetric));
-
-            var memoryMetric = exportedItems.First(i => i.Name == "process.memory.usage");
-            Assert.True(GetLongSum(memoryMetric) > 0);
-
-            var virtualMemoryMetric = exportedItems.First(i => i.Name == "process.memory.virtual");
-            Assert.True(GetLongSum(virtualMemoryMetric) > 0);
-        }
-
-        private static double GetDoubleSum(Metric metric)
-        {
-            double sum = 0;
-
-            foreach (ref readonly var metricPoint in metric.GetMetricPoints())
-            {
-                if (metric.MetricType.IsSum())
-                {
-                    sum += metricPoint.GetSumDouble();
-                }
-                else
-                {
-                    sum += metricPoint.GetGaugeLastValueDouble();
-                }
-            }
-
-            return sum;
-        }
-
-        private static double GetLongSum(Metric metric)
-        {
-            double sum = 0;
-
-            foreach (ref readonly var metricPoint in metric.GetMetricPoints())
-            {
-                if (metric.MetricType.IsSum())
-                {
-                    sum += metricPoint.GetSumLong();
-                }
-                else
-                {
-                    sum += metricPoint.GetGaugeLastValueLong();
-                }
-            }
-
-            return sum;
         }
     }
 }


### PR DESCRIPTION
For #335.

## Changes

Remove Process related metrics from .NET Runtime metrics.

These metrics should be added in a separate package and with OpenTelemetry.Instrumentation.Process as a potential name.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/404#discussion_r894123445
