### PR TITLE
Do not report 0 if GC info is not available yet

### DIFF
--- a/examples/runtime-instrumentation/Program.cs
+++ b/examples/runtime-instrumentation/Program.cs
@@ -30,6 +30,7 @@ public class Program
             })
             .Build();
 
+        // GC.Collect(0);
         Console.WriteLine(".NET Runtime metrics are available at http://localhost:9464/metrics, press any key to exit...");
         Console.ReadKey(false);
     }

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -138,7 +138,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
         {
             if (!IsGcInfoAvailable)
             {
-                // do not report the measurements as GC doesn't have this information yet
                 return Array.Empty<Measurement<long>>();
             }
 
@@ -157,7 +156,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
         {
             if (!IsGcInfoAvailable)
             {
-                // do not report the measurements as GC doesn't have this information yet
                 return Array.Empty<Measurement<long>>();
             }
 
@@ -168,7 +166,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
         {
             if (!IsGcInfoAvailable)
             {
-                // do not report the measurements as GC doesn't have this information yet
                 return Array.Empty<Measurement<long>>();
             }
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -117,6 +117,13 @@ namespace OpenTelemetry.Instrumentation.Runtime
 #if NET6_0_OR_GREATER
         private static IEnumerable<Measurement<long>> GetFragmentationSizes()
         {
+            if (GC.CollectionCount(0) == 0)
+            {
+                // gen0 collection has never happened before,
+                // do not report the measurements as GC doesn't have this information yet
+                return new Measurement<long>[] { };
+            }
+
             var generationInfo = GC.GetGCMemoryInfo().GenerationInfo;
             Measurement<long>[] measurements = new Measurement<long>[generationInfo.Length];
             int maxSupportedLength = Math.Min(generationInfo.Length, GenNames.Length);
@@ -130,8 +137,14 @@ namespace OpenTelemetry.Instrumentation.Runtime
 
         private static IEnumerable<Measurement<long>> GetGarbageCollectionHeapSizes()
         {
-            var generationInfo = GC.GetGCMemoryInfo().GenerationInfo;
+            if (GC.CollectionCount(0) == 0)
+            {
+                // gen0 collection has never happened before,
+                // do not report the measurements as GC doesn't have this information yet
+                return new Measurement<long>[] { };
+            }
 
+            var generationInfo = GC.GetGCMemoryInfo().GenerationInfo;
             Measurement<long>[] measurements = new Measurement<long>[generationInfo.Length];
             int maxSupportedLength = Math.Min(generationInfo.Length, GenNames.Length);
             for (int i = 0; i < maxSupportedLength; ++i)

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -121,7 +121,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
             {
                 // gen0 collection has never happened before,
                 // do not report the measurements as GC doesn't have this information yet
-                return new Measurement<long>[] { };
+                return Array.Empty<Measurement<long>>();
             }
 
             var generationInfo = GC.GetGCMemoryInfo().GenerationInfo;
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
             {
                 // gen0 collection has never happened before,
                 // do not report the measurements as GC doesn't have this information yet
-                return new Measurement<long>[] { };
+                return Array.Empty<Measurement<long>>();
             }
 
             var generationInfo = GC.GetGCMemoryInfo().GenerationInfo;

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
 #endif
         private static readonly string[] GenNames = new string[] { "gen0", "gen1", "gen2", "loh", "poh" };
         private static readonly int NumberOfGenerations = 3;
-        private static bool isGcInfoAvailable = false;
+        private static bool isGcInfoAvailable;
         private static string metricPrefix = "process.runtime.dotnet.";
         private readonly Meter meter;
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -60,9 +60,9 @@ namespace OpenTelemetry.Instrumentation.Runtime
 #endif
 
 #if NET6_0_OR_GREATER
-                this.meter.CreateObservableGauge($"{metricPrefix}gc.fragmentation.size", GetFragmentationSizes, description: "GC fragmentation.");
-                this.meter.CreateObservableGauge($"{metricPrefix}gc.committed", () => GC.GetGCMemoryInfo().TotalCommittedBytes, "By", description: "GC Committed Bytes.");
+                this.meter.CreateObservableGauge($"{metricPrefix}gc.committed", () => GetGarbageCollectionCommittedBytes(), "By", description: "GC Committed Bytes.");
                 this.meter.CreateObservableGauge($"{metricPrefix}gc.heapsize", () => GetGarbageCollectionHeapSizes(), "By", "Heap size for all generations.");
+                this.meter.CreateObservableGauge($"{metricPrefix}gc.fragmentation.size", GetFragmentationSizes, description: "GC fragmentation.");
 #endif
             }
 
@@ -151,6 +151,17 @@ namespace OpenTelemetry.Instrumentation.Runtime
             }
 
             return measurements;
+        }
+
+        private static IEnumerable<Measurement<long>> GetGarbageCollectionCommittedBytes()
+        {
+            if (!IsGcInfoAvailable)
+            {
+                // do not report the measurements as GC doesn't have this information yet
+                return Array.Empty<Measurement<long>>();
+            }
+
+            return new Measurement<long>[] { new(GC.GetGCMemoryInfo().TotalCommittedBytes) };
         }
 
         private static IEnumerable<Measurement<long>> GetGarbageCollectionHeapSizes()


### PR DESCRIPTION
Currently if you run https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/examples/runtime-instrumentation, the gc heapsize and fragmentation info will be zero instead of the real heap size/fragmentation. This is because there hasn't been any garbage collection so the GC info isn't available yet.

With this change, the code will detect if GC ever happened, and if not, do not report heapsize/fragmentation.