### PR TITLE
[WIP] Use bitwise combination for metrics options

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/AssemblyMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/AssemblyMetricOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyMetricOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/AssemblyMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/AssemblyMetricOptions.cs
@@ -1,0 +1,44 @@
+// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.Instrumentation.Runtime.Options
+{
+    /// <summary>
+    /// Enum for assembly related metrics.
+    /// </summary>
+    [Flags]
+    public enum AssemblyMetricOptions : int
+    {
+        /// <summary>
+        /// Do not set flag for any metrics.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
+        /// Set flag for all options.
+        /// </summary>
+        All = Count,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of the number
+        /// of the assemblies that have been loaded into the execution context
+        /// of this application domain.
+        /// </summary>
+        Count = 0b1,
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/ExceptionMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/ExceptionMetricOptions.cs
@@ -1,0 +1,42 @@
+// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.Instrumentation.Runtime.Options
+{
+    /// <summary>
+    /// Enum for exception related metrics.
+    /// </summary>
+    [Flags]
+    public enum ExceptionMetricOptions : int
+    {
+        /// <summary>
+        /// Do not set flag for any metrics.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
+        /// Set flag for all options.
+        /// </summary>
+        All = Count,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of exception thrown in managed code.
+        /// </summary>
+        Count = 0b1,
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/ExceptionMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/ExceptionMetricOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="ExceptionMetricOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/GcMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/GcMetricOptions.cs
@@ -1,0 +1,74 @@
+// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.Instrumentation.Runtime.Options
+{
+    /// <summary>
+    /// Enum for garbage collection metrics.
+    /// </summary>
+    [Flags]
+    public enum GcMetricOptions : int
+    {
+        /// <summary>
+        /// Do not set flag for any metrics.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
+        /// Set flag for all options.
+        /// </summary>
+        All = Count
+#if NETCOREAPP3_1_OR_GREATER
+            | AllocatedBytes
+#endif
+
+#if NET6_0_OR_GREATER
+            | CommitedBytes | HeapSize | FragmentationSize
+#endif
+            ,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for garbage collection count.
+        /// </summary>
+        Count = 0b1,
+
+#if NETCOREAPP3_1_OR_GREATER
+        /// <summary>
+        /// Set flag for whether to collect metrics for bytes allocated over the lifetime of the process.
+        /// </summary>
+        AllocatedBytes = 0b10,
+#endif
+
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Set flag for whether to collect metrics for commited bytes.
+        /// </summary>
+        CommitedBytes = 0b100,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for heap size for each generation.
+        /// </summary>
+        HeapSize = 0b1000,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for fragmentation size.
+        /// </summary>
+        FragmentationSize = 0b10000,
+#endif
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/JitMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/JitMetricOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="JitMetricOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/JitMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/JitMetricOptions.cs
@@ -1,0 +1,54 @@
+// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+using System;
+
+namespace OpenTelemetry.Instrumentation.Runtime.Options
+{
+    /// <summary>
+    /// Enum for JIT compiler metrics.
+    /// </summary>
+    [Flags]
+    public enum JitMetricOptions : int
+    {
+        /// <summary>
+        /// Do not set flag for any metrics.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
+        /// Set flag for all options.
+        /// </summary>
+        All = TotalBytes | MethodCount | ProcessingTime,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of bytes of intermediate language that have been compiled.
+        /// </summary>
+        TotalBytes = 0b1,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of methods that have been compiled.
+        /// </summary>
+        MethodCount = 0b10,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the amount of time the JIT Compiler has spent compiling methods.
+        /// </summary>
+        ProcessingTime = 0b100,
+    }
+}
+#endif

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/ThreadingMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/ThreadingMetricOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="ThreadingMetricOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Runtime/Options/ThreadingMetricOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/Options/ThreadingMetricOptions.cs
@@ -1,0 +1,64 @@
+// <copyright file="GcMetricOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETCOREAPP3_1_OR_GREATER
+using System;
+
+namespace OpenTelemetry.Instrumentation.Runtime.Options
+{
+    /// <summary>
+    /// Enum for Threading related metrics.
+    /// </summary>
+    [Flags]
+    public enum ThreadingMetricOptions : int
+    {
+        /// <summary>
+        /// Do not set flag for any metrics.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
+        /// Set flag for all options.
+        /// </summary>
+        All = MonitorLockContentionCount | ThreadPoolThreadCount | ThreadPoolCompletedWorkItemCount | ThreadPoolPendingWorkItemCount | ActiveTimerCount,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of times there was contention when trying to take the monitor's lock.
+        /// </summary>
+        MonitorLockContentionCount = 0b1,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of thread pool threads that currently exist.
+        /// </summary>
+        ThreadPoolThreadCount = 0b10,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of work items that have been processed so far.
+        /// </summary>
+        ThreadPoolCompletedWorkItemCount = 0b100,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of work items that are currently queued to be processed.
+        /// </summary>
+        ThreadPoolPendingWorkItemCount = 0b1000,
+
+        /// <summary>
+        /// Set flag for whether to collect metrics for the number of timers that are currently active.
+        /// </summary>
+        ActiveTimerCount = 0b10000,
+    }
+}
+#endif


### PR DESCRIPTION
Exploring option improvement after discussion here https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/431#discussion_r900354914

Still working in progress, but requesting for suggestions on whether it seems to be the right direction, and on naming.

## Changes

Use bitwise combination for metrics options.

Pro:
* More granular control on every single metrics.

Con:
* A ton of options to be maintained. Not much to worry about if using default config, which is enabling all flags.
* Old issue still remains: it might be counterintuitive to have `.AddRuntimeMetrics()` as enabling all options as default, and after adding an option, say `.AddRuntimeMetrics(options => { options.GcEnabled = true; })`, all options other than `GcEnabled` will be disabled.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
