### PR TITLE
Adjust the semantic of gc count to make it exclusive

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -140,9 +140,15 @@ namespace OpenTelemetry.Instrumentation.Runtime
 
         private static IEnumerable<Measurement<long>> GetGarbageCollectionCounts()
         {
-            for (int i = 0; i < NumberOfGenerations; ++i)
+            long collectionsFromHigherGeneration = 0;
+
+            for (int gen = NumberOfGenerations - 1; gen >= 0; --gen)
             {
-                yield return new(GC.CollectionCount(i), new KeyValuePair<string, object>("gen", GenNames[i]));
+                long collectionsFromThisGeneration = GC.CollectionCount(gen);
+
+                yield return new(collectionsFromThisGeneration - collectionsFromHigherGeneration, new KeyValuePair<string, object>("gen", GenNames[gen]));
+
+                collectionsFromHigherGeneration = collectionsFromThisGeneration;
             }
         }
 


### PR DESCRIPTION
Based on discussion with @noahfalk.

If you call:
```csharp
GC.Collect(0);
GC.Collect(1);
GC.Collect(2);
```

The current implementation would give:
```
process_runtime_dotnet_gc_collections_count{gen="gen2"} 1
process_runtime_dotnet_gc_collections_count{gen="gen1"} 2
process_runtime_dotnet_gc_collections_count{gen="gen0"} 3
```

This PR would change it to:
```
process_runtime_dotnet_gc_collections_count{gen="gen2"} 1
process_runtime_dotnet_gc_collections_count{gen="gen1"} 1
process_runtime_dotnet_gc_collections_count{gen="gen0"} 1
```