### PR TITLE
refactor runtime instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/MeterProviderBuilderExtensions.cs
@@ -33,11 +33,11 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddRuntimeMetrics(
             this MeterProviderBuilder builder,
-            Action<RuntimeMetricsOptions> configure = null)
+            Action<RuntimeInstrumentOptions> configure = null)
         {
             Guard.ThrowIfNull(builder);
 
-            var options = new RuntimeMetricsOptions();
+            var options = new RuntimeInstrumentOptions();
             configure?.Invoke(options);
 
             var instrumentation = new RuntimeMetrics(options);

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeInstrumentOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeInstrumentOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="RuntimeMetricsOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="RuntimeInstrumentOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
     /// <summary>
     /// Options to define the runtime metrics.
     /// </summary>
-    public class RuntimeMetricsOptions
+    public class RuntimeInstrumentOptions
     {
         /*
                 /// <summary>

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
     /// <summary>
     /// .NET runtime instrumentation.
     /// </summary>
-    internal class RuntimeMetrics : IDisposable
+    internal class RuntimeMetrics
     {
         internal static readonly AssemblyName AssemblyName = typeof(RuntimeMetrics).Assembly.GetName();
         internal static readonly Meter MeterInstance = new(AssemblyName.Name, AssemblyName.Version.ToString());
@@ -194,7 +194,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
         /// Initializes a new instance of the <see cref="RuntimeMetrics"/> class.
         /// </summary>
         /// <param name="options">The options to define the metrics.</param>
-        public RuntimeMetrics(RuntimeMetricsOptions options)
+        public RuntimeMetrics(RuntimeInstrumentOptions options)
         {
         }
 
@@ -214,12 +214,6 @@ namespace OpenTelemetry.Instrumentation.Runtime
 
                 return isGcInfoAvailable;
             }
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            MeterInstance?.Dispose();
         }
 
         private static IEnumerable<Measurement<long>> GetGarbageCollectionCounts()

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeInstrumentOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeInstrumentOptionsTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="RuntimeMetricsOptionsTests.cs" company="OpenTelemetry Authors">
+// <copyright file="RuntimeInstrumentOptionsTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,13 +18,13 @@ using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Runtime.Tests
 {
-    public class RuntimeMetricsOptionsTests
+    public class RuntimeInstrumentOptionsTests
     {
         /*
                 [Fact]
                 public void Enable_All_If_Nothing_Was_Defined()
                 {
-                    var options = new RuntimeMetricsOptions();
+                    var options = new RuntimeInstrumentOptions();
 
                     Assert.True(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Gc_Only()
                 {
-                    var options = new RuntimeMetricsOptions { GcEnabled = true };
+                    var options = new RuntimeInstrumentOptions { GcEnabled = true };
 
                     Assert.True(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Jit_Only()
                 {
-                    var options = new RuntimeMetricsOptions { JitEnabled = true };
+                    var options = new RuntimeInstrumentOptions { JitEnabled = true };
 
                     Assert.False(options.IsGcEnabled);
                     Assert.True(options.IsJitEnabled);
@@ -71,7 +71,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Threading_Only()
                 {
-                    var options = new RuntimeMetricsOptions { ThreadingEnabled = true };
+                    var options = new RuntimeInstrumentOptions { ThreadingEnabled = true };
 
                     Assert.False(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Assemblies_Only()
                 {
-                    var options = new RuntimeMetricsOptions { AssembliesEnabled = true };
+                    var options = new RuntimeInstrumentOptions { AssembliesEnabled = true };
 
                     Assert.False(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -102,7 +102,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Multiple()
                 {
-                    var options = new RuntimeMetricsOptions { GcEnabled = true, AssembliesEnabled = true };
+                    var options = new RuntimeInstrumentOptions { GcEnabled = true, AssembliesEnabled = true };
 
                     Assert.True(options.IsGcEnabled);
         #if NET6_0_OR_GREATER


### PR DESCRIPTION
Rename `RuntimeMetricsOptions` to `RuntimeInstrumentOptions` - it doesn't make sense to have the "metrics" name in the options as the instrumentation library could have other signals (logs, traces).