### PR TITLE
fix workflow persistenstorage.extensions

### DIFF
--- a/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet pack ${{env.PROJECT}}
-      run: dotnet pack src/${{env.PROJECT}} --configuration Release  run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions.PersistentStorage.Abstractions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
+      run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions.PersistentStorage.Abstractions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet pack ${{env.PROJECT}}
-      run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build
+      run: dotnet pack src/${{env.PROJECT}} --configuration Release  run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet pack ${{env.PROJECT}}
-      run: dotnet pack src/${{env.PROJECT}} --configuration Release  run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
+      run: dotnet pack src/${{env.PROJECT}} --configuration Release  run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions.PersistentStorage.Abstractions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/package-Extensions.PersistentStorage.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.yml
@@ -36,7 +36,7 @@ jobs:
       run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
-      run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build
+      run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/package-Extensions.PersistentStorage.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.yml
@@ -36,7 +36,7 @@ jobs:
       run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
-      run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
+      run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions.PersistentStorage has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/package-Extensions.PersistentStorage.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.yml
@@ -36,7 +36,7 @@ jobs:
       run: dotnet test test/${{env.PROJECT}}.Tests
 
     - name: dotnet pack ${{env.PROJECT}}
-      run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.Extensions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
+      run: dotnet pack src/${{env.PROJECT}} --configuration Release --no-build
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3

--- a/src/OpenTelemetry.Extensions.PersistentStorage/OpenTelemetry.Extensions.PersistentStorage.csproj
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/OpenTelemetry.Extensions.PersistentStorage.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
     <Description>OpenTelemetry Persistent Storage</Description>
     <MinVerTagPrefix>Extensions.PersistentStorage-</MinVerTagPrefix>
   </PropertyGroup>


### PR DESCRIPTION
dotnet pack fails with following error

C:\Program Files\dotnet\sdk\6.0.301\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(221,5): error NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below: [D:\a\opentelemetry-dotnet-contrib\opentelemetry-dotnet-contrib\src\OpenTelemetry.Extensions.PersistentStorage.Abstractions\OpenTelemetry.Extensions.PersistentStorage.Abstractions.csproj]

[10](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/runs/6976309124?check_suite_focus=true#step:5:11)C:\Program Files\dotnet\sdk\6.0.301\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(221,5): error NU5128: - Add lib or ref assemblies for the net6.0 target framework [D:\a\opentelemetry-dotnet-contrib\opentelemetry-dotnet-contrib\src\OpenTelemetry.Extensions.PersistentStorage.Abstractions\OpenTelemetry.Extensions.PersistentStorage.Abstractions.csproj]

[11](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/runs/6976309124?check_suite_focus=true#step:5:12)


updating the workflow to remove no-build option in pack. This is taken from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/69f98cb0ce78ac4619df5d6735a8848ad6cbde89/.github/workflows/package-Extensions.yml#L39


