### PR TITLE
Revert "clean up runtime instrumentation docs"

### DIFF
--- a/examples/runtime-instrumentation/Program.cs
+++ b/examples/runtime-instrumentation/Program.cs
@@ -22,7 +22,7 @@ public class Program
     public static void Main()
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddRuntimeInstrumentation()
+            .AddRuntimeMetrics()
             .AddPrometheusExporter(options =>
             {
                 options.StartHttpListener = true;

--- a/src/OpenTelemetry.Instrumentation.Runtime/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/MeterProviderBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Metrics
         /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
         /// <param name="configure">Runtime metrics options.</param>
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        public static MeterProviderBuilder AddRuntimeInstrumentation(
+        public static MeterProviderBuilder AddRuntimeMetrics(
             this MeterProviderBuilder builder,
             Action<RuntimeInstrumentOptions> configure = null)
         {

--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -10,19 +10,19 @@ collect telemetry about runtime behavior.
 
 ## Steps to enable OpenTelemetry.Instrumentation.Runtime
 
-### Step 1: Install package
+### Step 1: Install Package
 
 Add a reference to the
 [`OpenTelemetry.Instrumentation.Runtime`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime)
-package.
+package. Also, add any other instrumentations & exporters you will need.
 
 ```shell
 dotnet add package OpenTelemetry.Instrumentation.Runtime
 ```
 
-### Step 2: Enable runtime instrumentation
+### Step 2: Enable Runtime Instrumentation at application startup
 
-Runtime instrumentation should be enabled at application startup. This is
+Runtime instrumentation must be enabled at application startup. This is
 typically done in the `ConfigureServices` of your `Startup` class. The example
 below enables this instrumentation by using an extension method on
 `IServiceCollection`. This extension method requires adding the package
@@ -42,7 +42,7 @@ using OpenTelemetry.Metrics;
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddOpenTelemetryMetrics((builder) => builder
-        .AddRuntimeInstrumentation()
+        .AddRuntimeMetrics()
         .AddPrometheusExporter()
     );
 }
@@ -52,12 +52,25 @@ Or configure directly:
 
 ```csharp
 using var meterProvider = Sdk.CreateMeterProviderBuilder()
-    .AddRuntimeInstrumentation()
-    .AddPrometheusExporter()
+    .AddRuntimeMetrics()
     .Build();
 ```
 
-Refer to [Program.cs](../../examples/runtime-instrumentation/Program.cs) for a complete demo.
+## Advanced configuration
+
+By default all available runtime metrics will be added. It's also possible to
+specify only the required metrics:
+
+```csharp
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .AddRuntimeMetrics(options => options
+    {
+        options.GcEnabled = true;
+        options.ThreadingEnabled = true;
+        options.MemoryEnabled = true;
+     })
+    .Build();
+```
 
 ## Troubleshooting
 
@@ -70,4 +83,6 @@ for instructions on seeing these internal logs.
 
 ## References
 
+* [Introduction to ASP.NET
+  Core](https://docs.microsoft.com/aspnet/core/introduction-to-aspnet-core)
 * [OpenTelemetry Project](https://opentelemetry.io/)

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
         {
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                 .AddRuntimeInstrumentation()
+                 .AddRuntimeMetrics()
                  .AddInMemoryExporter(exportedItems)
                 .Build();
 


### PR DESCRIPTION
I've made a mistake and force pushed to the main directly, now revert it.