### PR TITLE
Update the contributing doc to mention about adding date to CHANGELOG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,8 +137,10 @@ and the new feature doesn't fit it.
 
 ### How to request for release of package
 
-Submit a PR with `CHANGELOG.md` file reflecting the version to be released.
-Also, tag the maintainers of this repository who can release the package.
+Submit a PR with `CHANGELOG.md` file reflecting the version to be released along
+with the date. Refer to this
+[file](./src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md) for an example. Also,
+tag the maintainers of this repository who can release the package.
 
 ## Style Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,10 +137,11 @@ and the new feature doesn't fit it.
 
 ### How to request for release of package
 
-Submit a PR with `CHANGELOG.md` file reflecting the version to be released along
-with the date. Refer to this
-[file](./src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md) for an example. Also,
-tag the maintainers of this repository who can release the package.
+* Submit a PR with `CHANGELOG.md` file reflecting the version to be released
+along with the date in the following format `[yyyy-MMM-dd`]`. For example:
+"1.2.0-beta.2 [2022-May-15]".
+* Tag the maintainers of this repository
+(@open-telemetry/dotnet-contrib-maintainers) who can release the package.
 
 ## Style Guide
 


### PR DESCRIPTION
Addresses the [comment](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/470/files#r909677814).

## Changes
- Update the contributing doc to mention about adding date to CHANGELOG
