### PR TITLE
Update CHANGELOG files to use a consistent date format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,8 +138,16 @@ and the new feature doesn't fit it.
 ### How to request for release of package
 
 * Submit a PR with `CHANGELOG.md` file reflecting the version to be released
-along with the date in the following format `[yyyy-MMM-dd`]`. For example:
-"1.2.0-beta.2 [2022-May-15]".
+along with the date in the following format `yyyy-MMM-dd`.
+
+For example:
+
+```text
+## 1.2.0-beta.2
+
+Released 2022-Jun-21
+```
+
 * Tag the maintainers of this repository
 (@open-telemetry/dotnet-contrib-maintainers) who can release the package.
 

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
@@ -6,7 +6,9 @@
   instance instead of recreating with ThreadLocal
   ([#380](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/380))
 
-## 1.2.0 [2022-May-18]
+## 1.2.0
+
+Released 2022-May-18
 
 * Enhancement - AWSEKSResourceDetector - Validate ClusterName/ContainerID
   independently before adding it to the resource
@@ -15,13 +17,17 @@
   "The SSL connection could not be established"
   ([#208](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/208))
 
-## 1.1.0 [2021-Sept-20]
+## 1.1.0
+
+Released 2021-Sept-20
 
 * Added AWS resource detectors ([#149](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/149))
 * Updated OTel SDK package version to 1.1.0
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))
 
-## 1.0.1 [2021-Feb-24]
+## 1.0.1
+
+Released 2021-Feb-24
 
 This is the first release for the `OpenTelemetry.Contrib.Extensions.AWSXRay`
 project. The project targets v1.0.1 of the [OpenTelemetry

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog - OpenTelemetry.Contrib.Instrumentation.AWS
 
-## 1.0.1 [2021-Feb-24]
+## 1.0.1
+
+Released 2021-Feb-24
 
 This is the first release for the `OpenTelemetry.Contrib.Instrumentation.AWS`
 project. The release targets v1.0.1 of the

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWSLambda/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog - OpenTelemetry.Contrib.Instrumentation.AWSLambda
 
-## 1.1.0-beta1 [2021-May-26]
+## 1.1.0-beta1
+
+Released 2021-May-26
 
 This is the first release for the `OpenTelemetry.Contrib.Instrumentation.AWSLambda`
 project. The project targets v1.1.0-beta1 of the [OpenTelemetry

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -20,12 +20,16 @@ by throwing any exception caught by `UnixDomainSocketDataTransport.Send` so that
 `ExportResult.Failure`.
 [444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/444)
 
-## 1.3.0-beta.2 [2022-Jun-03]
+## 1.3.0-beta.2
+
+Released 2022-Jun-03
 
 * Add support for exporting `ILogger` scopes.
 [390](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/390)
 
-## 1.3.0-beta.1 [2022-May-27]
+## 1.3.0-beta.1
+
+Released 2022-May-27
 
 * Enable PassThru TableNameMappings using the logger category name.
 [345](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/345)
@@ -44,12 +48,16 @@ by throwing any exception caught by `UnixDomainSocketDataTransport.Send` so that
 `LogRecord.Exception.GetType().FullName`.
 [375](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/375)
 
-## 1.2.6 [2022-Apr-21]
+## 1.2.6
+
+Released 2022-Apr-21
 
 * Set GenevaMetricExporter temporality preference back to Delta.
 [323](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/323)
 
-## 1.2.5 [2022-Apr-20] Broken
+## 1.2.5 Broken
+
+Released 2022-Apr-20
 
 Note: This release was broken due to the GenevaMetricExporter using a
 TemporalityPreference of Cumulative instead of Delta, it has been unlisted from
@@ -60,7 +68,9 @@ is the PR that introduced this bug to GenevaMetricExporterExtensions.cs
 * Update OTel SDK version to `1.2.0`.
 [319](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/319)
 
-## 1.2.4 [2022-Apr-20] Broken
+## 1.2.4 Broken
+
+Released 2022-Apr-20
 
 This is the first release of the `OpenTelemetry.Exporter.Geneva` project. Note:
 This release was broken due to using OpenTelemetry 1.2.0-rc5. Therefore, it has

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,17 +2,23 @@
 
 ## Unreleased
 
-## 1.0.2 [2022-Jun-02]
+## 1.0.2
+
+Released 2022-Jun-02
 
 * Application is chrashing if environment variables are not defined
 [385](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/385)
 
-## 1.0.1 [2022-May-25]
+## 1.0.1
+
+Released 2022-May-25
 
 * Instana span duration was not calculated correctly
 [376](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/376)
 
-## 1.0.0 [2022-May-24]
+## 1.0.0
+
+Released 2022-May-24
 
 * This is the first release of the `OpenTelemetry.Exporter.Instana`
 project.

--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 1.0.0-beta.3
 
+Released 2022-Jun-29
+
 * Fix incomplete db.statement when the length>300
   [(#424)](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/424)
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 1.0.0-rc.1
 
+Released 2022-Jun-29
+
 Major refactor of the runtime instrumentation. Renamed API signature and metrics.
 Removed the options to turn off certain metrics.
 


### PR DESCRIPTION
## Changes
- Update CHANGELOG files to use a consistent date format

This follows the format used in the main repo.