### PR TITLE
Fix issue -propagation type is not case insensitive

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 * Make the context propagation extraction case insensitive.
   ([#483](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/483))
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -1,10 +1,7 @@
 # Changelog
 
 ## Unreleased
-  
-## 1.0.0-beta6
-
-* Fix issue -propagation type is not case insensitive
+* Make the context propagation extraction case insensitive.
   ([#483](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/483))
 
 ## 1.0.0-beta.5

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+  
+## 1.0.0-beta6
+
+* Fix issue -propagation type is not case insensitive
+  ([#483](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/483))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
@@ -166,7 +166,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore
                 for (var i = 0; i < metadata.Count; i++)
                 {
                     var entry = metadata[i];
-                   if (string.Equals(entry.Key, key, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(entry.Key, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return new string[1] { entry.Value };
                     }

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
@@ -166,7 +166,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore
                 for (var i = 0; i < metadata.Count; i++)
                 {
                     var entry = metadata[i];
-                    if (entry.Key.Equals(key))
+                   if (string.Equals(entry.Key, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return new string[1] { entry.Value };
                     }


### PR DESCRIPTION
Make the context propagation extraction case insensitive. See link:[#3149](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3149)
## Changes
Do a case-insensitive comparison in the Grpc.Core instrumentation