### PR TITLE
[Instrumentation.StackExchangeRedis] Update ActivitySource name

### DIFF
--- a/examples/redis/Examples.StackExchangeRedis/README.md
+++ b/examples/redis/Examples.StackExchangeRedis/README.md
@@ -10,7 +10,7 @@ this application (please look at the prerequisite for running the application in
 Activity.TraceId:          f1a47baec558ebb97e57a6fb7d029a29
 Activity.SpanId:           d0abf2503ad3d1b6
 Activity.TraceFlags:           Recorded
-Activity.ActivitySourceName: OpenTelemetry.StackExchange.Redis
+Activity.ActivitySourceName: OpenTelemetry.Instrumentation.StackExchangeRedis
 Activity.DisplayName: SET
 Activity.Kind:        Client
 Activity.StartTime:   2022-06-06T22:17:40.8927802Z
@@ -33,7 +33,7 @@ Resource associated with Activity:
 Activity.TraceId:          0db37d796826693e23b17e3b082356a4
 Activity.SpanId:           cd01d518b8b5cfa2
 Activity.TraceFlags:           Recorded
-Activity.ActivitySourceName: OpenTelemetry.StackExchange.Redis
+Activity.ActivitySourceName: OpenTelemetry.Instrumentation.StackExchangeRedis
 Activity.DisplayName: GET
 Activity.Kind:        Client
 Activity.StartTime:   2022-06-06T22:17:41.9223474Z

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Update the `ActivitySource` name used to the assembly name: `OpenTelemetry.Instrumentation.StackExchangeRedis`
+[#485](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/485)
+
 ## 1.0.0-rc9.6
 
 Released 2022-Jun-29

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -34,8 +34,8 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
     {
         internal const string RedisDatabaseIndexKeyName = "db.redis.database_index";
         internal const string RedisFlagsKeyName = "db.redis.flags";
-        internal const string ActivitySourceName = "OpenTelemetry.StackExchange.Redis";
-        internal const string ActivityName = ActivitySourceName + ".Execute";
+        internal static readonly string ActivitySourceName = typeof(StackExchangeRedisCallsInstrumentation).Assembly.GetName().Name;
+        internal static readonly string ActivityName = ActivitySourceName + ".Execute";
         internal static readonly Version Version = typeof(StackExchangeRedisCallsInstrumentation).Assembly.GetName().Version;
         internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
         internal static readonly IEnumerable<KeyValuePair<string, object>> CreationTags = new[]


### PR DESCRIPTION
Towards #484 

## Changes
- Use the assembly name as the ActivitySource name

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
