### PR TITLE
Exporter-Geneva - Refactor benchmarks for logging

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/Food.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/Food.cs
@@ -1,0 +1,30 @@
+// <copyright file="Food.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Exporter.Geneva.Benchmark
+{
+    public static partial class Food
+    {
+        [LoggerMessage(
+            EventId = 0,
+            Level = LogLevel.Information,
+            Message = "Hello from {food} {price}.")]
+        public static partial void SayHello(
+            ILogger logger, string food, double price);
+    }
+}

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
 		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,)" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
 		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.4" />
 	</ItemGroup>
 


### PR DESCRIPTION
Refactoring LogBenchmarks. 
Removed a lot stuff already covered by the core SDK itself : https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/test/Benchmarks/Logs/LogBenchmarks.cs