### PR TITLE
[Instrumentation.Runtime] Change API for GC Heap Size

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Change API for GC Heap Size for .NET 6 where the API has a bug
+  ([#495](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/495))
+
 ## 1.0.0-rc.1
 
 Released 2022-Jun-29

--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -114,7 +114,7 @@ The APIs used to retrieve the values are:
   For .NET 6, heap size is retrieved with an internal method `GC.GetGenerationSize`,
   which is how the [well-known EventCounters](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/available-counters)
   retrieve the values.
-  See source code [here](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs#L110-L114).
+  See source code [here](https://github.com/dotnet/runtime/blob/b4dd16b4418de9b3af08ae85f0f3653e55dc420a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs#L110-L114).
 
 * [GCGenerationInfo.FragmentationAfterBytes Property](https://docs.microsoft.com/dotnet/api/system.gcgenerationinfo.fragmentationafterbytes)
   Gets the fragmentation in bytes on exit from the reported collection.

--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -110,7 +110,7 @@ The APIs used to retrieve the values are:
 
 * Heap size is retrieved with an internal method `GC.GetGenerationSize`,
 which is how the [well-known EventCounters](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/available-counters)
-retrieves the values.
+retrieve the values.
 See source code [here](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs#L110-L114).
 
 * [GCGenerationInfo.FragmentationAfterBytes Property](https://docs.microsoft.com/dotnet/api/system.gcgenerationinfo.fragmentationafterbytes)

--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -108,10 +108,13 @@ The APIs used to retrieve the values are:
 * [GCMemoryInfo.TotalCommittedBytes](https://docs.microsoft.com/dotnet/api/system.gcmemoryinfo.totalcommittedbytes):
   Gets the total committed bytes of the managed heap.
 
-* Heap size is retrieved with an internal method `GC.GetGenerationSize`,
-which is how the [well-known EventCounters](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/available-counters)
-retrieve the values.
-See source code [here](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs#L110-L114).
+* [GC.GetGCMemoryInfo().GenerationInfo[i].SizeAfterBytes](https://docs.microsoft.com/dotnet/api/system.gcgenerationinfo):
+  Represents the size in bytes of a generation on exit of the GC reported in GCMemoryInfo.
+  Note that this API on .NET 6 has a [bug](https://github.com/dotnet/runtime/pull/60309).
+  For .NET 6, heap size is retrieved with an internal method `GC.GetGenerationSize`,
+  which is how the [well-known EventCounters](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/available-counters)
+  retrieve the values.
+  See source code [here](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs#L110-L114).
 
 * [GCGenerationInfo.FragmentationAfterBytes Property](https://docs.microsoft.com/dotnet/api/system.gcgenerationinfo.fragmentationafterbytes)
   Gets the fragmentation in bytes on exit from the reported collection.

--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -108,8 +108,10 @@ The APIs used to retrieve the values are:
 * [GCMemoryInfo.TotalCommittedBytes](https://docs.microsoft.com/dotnet/api/system.gcmemoryinfo.totalcommittedbytes):
   Gets the total committed bytes of the managed heap.
 
-* [GC.GetGCMemoryInfo().GenerationInfo[i].SizeAfterBytes](https://docs.microsoft.com/dotnet/api/system.gcgenerationinfo):
-  Represents the size in bytes of a generation on exit of the GC reported in GCMemoryInfo.
+* Heap size is retrieved with an internal method `GC.GetGenerationSize`,
+which is how the [well-known EventCounters](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/available-counters)
+retrieves the values.
+See source code [here](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs#L110-L114).
 
 * [GCGenerationInfo.FragmentationAfterBytes Property](https://docs.microsoft.com/dotnet/api/system.gcgenerationinfo.fragmentationafterbytes)
   Gets the fragmentation in bytes on exit from the reported collection.

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -88,7 +88,8 @@ namespace OpenTelemetry.Instrumentation.Runtime
                 }
             }
 
-            if (!isCodeRunningOnBuggyRuntimeVersion || getGenerationSize != null)  // Either Environment.Version > 6 or (it's 6 but internal API GC.GetGenerationSize is valid)
+            // Either Environment.Version is not 6 or (it's 6 but internal API GC.GetGenerationSize is valid)
+            if (!isCodeRunningOnBuggyRuntimeVersion || getGenerationSize != null)
             {
                 // TODO: change to ObservableUpDownCounter
                 MeterInstance.CreateObservableGauge(

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -76,7 +76,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
                 unit: "bytes",
                 description: "The amount of committed virtual memory for the managed GC heap, as observed during the latest garbage collection. Committed virtual memory may be larger than the heap size because it includes both memory for storing existing objects (the heap size) and some extra memory that is ready to handle newly allocated objects in the future. The value will be unavailable until at least one garbage collection has occurred.");
 
-            // TODO: GC.GetGCMemoryInfo().GenerationInfo[i].SizeAfterBytes is better but it has a bug in .NET 6. See context in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/496
+            // GC.GetGCMemoryInfo().GenerationInfo[i].SizeAfterBytes is better but it has a bug in .NET 6. See context in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/496
             Func<int, ulong> getGenerationSize = null;
             bool isCodeRunningOnBuggyRuntimeVersion = Environment.Version.Major == 6;
             if (isCodeRunningOnBuggyRuntimeVersion)


### PR DESCRIPTION
## Changes

Use internal method `GC.GetGenerationSize` for GC Heap Size.

.NET 6.0 has a bug in computing those generation sizes for the `GC.GetGCMemoryInfo()` API and it was fixed in .NET 7.

Note that the heap sizes are not retrieved in one transactional query with `GC.GetGCMemoryInfo()`. It'd be better to change it back to `GC.GetGCMemoryInfo().GenerationInfo[i].SizeAfterBytes` for .NET 7 when appropriate.

For significant contributions please make sure you have completed the following items:

* [x] Design discussion issue #335
