### PR TITLE
Add component owner for AWS instrumentation

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -5,6 +5,8 @@ components:
   src/OpenTelemetry.Contrib.Extensions.AWSXRay/:
     - srprash
     - lupengamzn
+  src/OpenTelemetry.Contrib.Instrumentation.AWS/:
+    - srprash
   src/OpenTelemetry.Exporter.Geneva/:
     - cijothomas
     - codeblanch
@@ -46,8 +48,10 @@ components:
   src/OpenTelemetry.Instrumentation.EventCounters/:
     - hananiel
   test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/:
-    - srprash 
+    - srprash
     - lupengamzn
+  test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/:
+    - srprash
   test/OpenTelemetry.Exporter.Geneva.Benchmark/:
     - cijothomas
     - codeblanch


### PR DESCRIPTION
Add @srprash as component owner for AWS instrumentation