### PR TITLE
Bump OpenTelemetry to 1.3.0 in MySqlData instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OTel SDK package version to 1.3.0
+  ([#508](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/508))
+
 ## 1.0.0-beta.3
 
 Released 2022-Jun-29

--- a/src/OpenTelemetry.Instrumentation.MySqlData/OpenTelemetry.Instrumentation.MySqlData.csproj
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/OpenTelemetry.Instrumentation.MySqlData.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="MySql.Data" Version="6.10.7" />
-        <PackageReference Include="OpenTelemetry.Api" Version="1.3.0" />
+        <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiPkgVer)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.MySqlData/OpenTelemetry.Instrumentation.MySqlData.csproj
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/OpenTelemetry.Instrumentation.MySqlData.csproj
@@ -8,17 +8,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MySql.Data" Version="6.10.7"/>
-        <PackageReference Include="OpenTelemetry.Api" Version="1.1.0"/>
+        <PackageReference Include="MySql.Data" Version="6.10.7" />
+        <PackageReference Include="OpenTelemetry.Api" Version="1.3.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\SemanticConventions.cs" Link="Includes\SemanticConventions.cs"/>
-        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\IActivityEnumerator.cs" Link="Includes\IActivityEnumerator.cs"/>
-        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs"/>
-        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\EnumerationHelper.cs" Link="Includes\EnumerationHelper.cs"/>
-        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs"/>
-        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\StatusHelper.cs" Link="Includes\StatusHelper.cs"/>
+        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\IActivityEnumerator.cs" Link="Includes\IActivityEnumerator.cs" />
+        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
+        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\EnumerationHelper.cs" Link="Includes\EnumerationHelper.cs" />
+        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" />
+        <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\StatusHelper.cs" Link="Includes\StatusHelper.cs" />
         <Compile Include="$(RepoRoot)\src\OpenTelemetry.Internal\Guard.cs" Link="Includes\Guard.cs" />
     </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -16,7 +16,7 @@
         </PackageReference>
         <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetXUnitCliVer)" />
         <PackageReference Include="MySql.Data" Version="6.10.7" />
-        <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+        <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
@@ -16,7 +16,7 @@
         </PackageReference>
         <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetXUnitCliVer)" />
         <PackageReference Include="MySql.Data" Version="6.10.7" />
-        <PackageReference Include="OpenTelemetry" Version="1.1.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.3.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes: N/A

## Changes

Bump OpenTelemetry to 1.3.0 in MySqlData instrumentation

In AutoInstrumentation we have a plan to reuse this package. It will be good to have it build on top of the 1.3.0.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
