### PR TITLE
Unify Moq (4.17.2+)

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -24,7 +24,7 @@
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
     <MicrosoftExtensionsLoggingPkgVer>[5.0,6.0)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftNETTestSdkPkgVer>[16.7.1,17.0)</MicrosoftNETTestSdkPkgVer>
-    <MoqPkgVer>[4.14.5,5.0)</MoqPkgVer>
+    <MoqPkgVer>[4.17.2,5.0)</MoqPkgVer>
     <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryPkgVer)</OpenTelemetryExporterInMemoryPkgVer>
     <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.4.1,3.0)</XUnitPkgVer>

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.5.1.24" />
     <PackageReference Include="AWSSDK.SQS" Version="3.5.0.26" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.2" />
-    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests/OpenTelemetry.Contrib.Instrumentation.AWSLambda.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/OpenTelemetry.Exporter.Instana.Tests/OpenTelemetry.Exporter.Instana.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Instana.Tests/OpenTelemetry.Exporter.Instana.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.16.1" />
+        <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
         <PackageReference Include="coverlet.collector" Version="1.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
         <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />


### PR DESCRIPTION
Fixes: N/A

## Changes

Unify Moq across whole repository.
Use 4.17.2. It is last version supporting .NET Framework 4.5.2 - required by `AWS` and `AWSXRay` projects.

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
