### PR TITLE
[Geneva.Exporter] remove obsolete comment from tests

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
@@ -13,7 +13,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="KaitaiStruct.Runtime.CSharp" Version="0.9.0" />
-    <!-- MessagePack 2.x doesn't support net452 and net46 so we have to stick with MessagePack 1.x -->
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <!--KaitaiStruct.Runtime.CSharp which is used to deserialize metrics data is not a strong-named assembly.
     StrongNamer signs any unsigned assemblies present in the project dependencies -->


### PR DESCRIPTION
Fixes: N/A

## Changes
 
Remove obsolete comment from tests (reference to net452).

All frameworks are even by the newest version https://www.nuget.org/packages/MessagePack/2.4.35
Upgrade requires changes in the test code.

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
