### PR TITLE
[Instrumentation.Runtime] Add `gc.heap.fragmentation.size` back for .NET 7 and later

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add gc.heap.fragmentation.size back for .NET 7 and later
+  ([#524](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/524))
+
 ## 1.0.0-rc.2
 
 Released 2022-Jul-19


### PR DESCRIPTION
## Changes

#509 intended to only remove the metrics for .NET 6.

For .NET 7 and later, the metrics should be available.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes: reflected in #509's changelog.
* [x] Design discussion issue #335.
