### PR TITLE
[Instrumentation.StackExchangeRedis] Mark Drain thread as background

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
-* Update the `ActivitySource` name used to the assembly name: `OpenTelemetry.Instrumentation.StackExchangeRedis`
-[#485](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/485)
+* Update the `ActivitySource` name used to the assembly name: `OpenTelemetry.Instrumentation.StackExchangeRedis`.
+([#485](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/485))
+* Drain thread is marked as background. It allows to close the application
+  even if the instrumentation is not disposed.
+([#528](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/528))
 
 ## 1.0.0-rc9.6
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -66,6 +66,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
             this.drainThread = new Thread(this.DrainEntries)
             {
                 Name = "OpenTelemetry.Redis",
+                IsBackground = true,
             };
             this.drainThread.Start();
 


### PR DESCRIPTION
Fixes N./A.

Related to https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/947

## Changes

Mark `DrainThread` as background.
Foreground threads prevent a process from terminating.

AutoIstrumentation dispose all instrumentation `OnExit` event. This thread prevents process to rise this event. Instrumented application cannot be closed.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
