### PR TITLE
[Instrumentation.StackExchangeRedis] release 1.0.0-rc9.7

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc9.7
+
+Released 2022-Jul-25
+
 * Update the `ActivitySource` name used to the assembly name: `OpenTelemetry.Instrumentation.StackExchangeRedis`.
 ([#485](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/485))
 * Drain thread is marked as background. It allows to close the application


### PR DESCRIPTION
Fixes N/A.

Follow up to #528 and #485

## Changes

Request release Instrumentation.StackExchangeRedis v. 1.0.0-rc9.7

* Update the `ActivitySource` name used to the assembly name: `OpenTelemetry.Instrumentation.StackExchangeRedis`.
([#485](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/485))
* Drain thread is marked as background. It allows to close the application
  even if the instrumentation is not disposed.
([#528](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/528))

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
