### PR TITLE
[Exporter.Geneva] Simplify exporter options for PrepopulatedFields

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -91,25 +91,22 @@ public class GenevaExporterOptions
                 var val = entry.Value;
                 switch (val)
                 {
-                    case bool vb:
-                    case byte vui8:
-                    case sbyte vi8:
-                    case short vi16:
-                    case ushort vui16:
-                    case int vi32:
-                    case uint vui32:
-                    case long vi64:
-                    case ulong vui64:
-                    case float vf:
-                    case double vd:
-                    case string vs:
+                    case bool:
+                    case byte:
+                    case sbyte:
+                    case short:
+                    case ushort:
+                    case int:
+                    case uint:
+                    case long:
+                    case ulong:
+                    case float:
+                    case double:
+                    case string:
                         break;
+                    case null:
+                        throw new ArgumentNullException(entry.Key, $"{nameof(this.PrepopulatedFields)} must not contain null values.");
                     default:
-                        if (entry.Value == null)
-                        {
-                            throw new ArgumentNullException(entry.Key, $"{nameof(this.PrepopulatedFields)} must not contain null values.");
-                        }
-
                         throw new ArgumentException($"Type `{entry.Value.GetType()}` (key = `{entry.Key}`) is not allowed. Only bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, and string are supported.");
                 }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
             // Supported types for PrepopulatedFields should not throw an exception
             var exception = Record.Exception(() =>
             {
-                using var exporter = new GenevaTraceExporter(new GenevaExporterOptions
+                new GenevaExporterOptions
                 {
                     ConnectionString = "EtwSession=OpenTelemetry",
                     PrepopulatedFields = new Dictionary<string, object>
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                         ["double"] = double.MaxValue,
                         ["string"] = string.Empty,
                     },
-                });
+                };
             });
 
             Assert.Null(exception);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -81,6 +81,32 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                     },
                 });
             });
+
+            // Supported types for PrepopulatedFields should not throw an exception
+            var exception = Record.Exception(() =>
+            {
+                using var exporter = new GenevaTraceExporter(new GenevaExporterOptions
+                {
+                    ConnectionString = "EtwSession=OpenTelemetry",
+                    PrepopulatedFields = new Dictionary<string, object>
+                    {
+                        ["bool"] = true,
+                        ["byte"] = byte.MaxValue,
+                        ["sbyte"] = sbyte.MaxValue,
+                        ["short"] = short.MaxValue,
+                        ["ushort"] = ushort.MaxValue,
+                        ["int"] = int.MaxValue,
+                        ["uint"] = uint.MaxValue,
+                        ["long"] = long.MaxValue,
+                        ["ulong"] = ulong.MaxValue,
+                        ["float"] = float.MaxValue,
+                        ["double"] = double.MaxValue,
+                        ["string"] = string.Empty,
+                    },
+                });
+            });
+
+            Assert.Null(exception);
         }
 
         [Fact]


### PR DESCRIPTION
## Changes
- Simplify exporter options for PrepopulatedFields
- Add a test case for supported types to not throw an exception
