### PR TITLE
Changed owner for OpenTelemetry.Extensions.Docker

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -21,7 +21,7 @@ components:
   src/OpenTelemetry.Extensions/:
     - codeblanch
   src/OpenTelemetry.Extensions.Docker/:
-    - swetharavichandrancisco
+    - iskiselev
   src/OpenTelemetry.Extensions.PersistentStorage.Abstractions/:
     - vishweshbankwar
   src/OpenTelemetry.Extensions.PersistentStorage/:


### PR DESCRIPTION
## Changes
Docker extensions was created by Cisco / AppDynamics developer as team work assignment. @swetharavichandrancisco is no longer involved in this work and have not expressed wish to continue support it, so I'd updating owner to myself to continue support of project created by our team.

