### PR TITLE
[Exporter.Geneva] Add test case for multithreading scenarios

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -873,9 +873,9 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                     // Validation
                     Assert.Equal(messagePackDataSize, receivedDataSize);
 
-                    // Emit log on a different thread to test for multithreading scenarios
                     logRecordList.Clear();
 
+                    // Emit log on a different thread to test for multithreading scenarios
                     Task.Run(() =>
                     {
                         logger.LogInformation("Hello from another thread {food} {price}.", "artichoke", 3.99);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -879,7 +879,7 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                     Task.Run(() =>
                     {
                         logger.LogInformation("Hello from another thread {food} {price}.", "artichoke", 3.99);
-                    });
+                    }).Wait();
 
                     // logRecordList should have a singleLogRecord entry after the logger.LogInformation call
                     Assert.Single(logRecordList);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -876,10 +876,12 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                     logRecordList.Clear();
 
                     // Emit log on a different thread to test for multithreading scenarios
-                    Task.Run(() =>
+                    var thread = new Thread(() =>
                     {
                         logger.LogInformation("Hello from another thread {food} {price}.", "artichoke", 3.99);
-                    }).Wait();
+                    });
+                    thread.Start();
+                    thread.Join();
 
                     // logRecordList should have a singleLogRecord entry after the logger.LogInformation call
                     Assert.Single(logRecordList);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -445,13 +445,15 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                     Assert.Equal(messagePackDataSize, receivedDataSize);
 
                     // Create activity on a different thread to test for multithreading scenarios
-                    Task.Run(() =>
+                    var thread = new Thread(() =>
                     {
                         using (var activity = source.StartActivity("ActivityFromAnotherThread", ActivityKind.Internal))
                         {
                             messagePackDataSize = exporter.SerializeActivity(activity);
                         }
-                    }).Wait();
+                    });
+                    thread.Start();
+                    thread.Join();
 
                     receivedDataSize = serverSocket.Receive(receivedData);
                     Assert.Equal(messagePackDataSize, receivedDataSize);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -24,6 +24,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -429,7 +430,8 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
 
                     // Emit trace and grab a copy of internal buffer for validation.
                     var source = new ActivitySource(sourceName);
-                    int messagePackDataSize;
+                    int messagePackDataSize = 0;
+
                     using (var activity = source.StartActivity("Foo", ActivityKind.Internal))
                     {
                         messagePackDataSize = exporter.SerializeActivity(activity);
@@ -440,6 +442,18 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                     int receivedDataSize = serverSocket.Receive(receivedData);
 
                     // Validation
+                    Assert.Equal(messagePackDataSize, receivedDataSize);
+
+                    // Create activity on a different thread to test for multithreading scenarios
+                    Task.Run(() =>
+                    {
+                        using (var activity = source.StartActivity("ActivityFromAnotherThread", ActivityKind.Internal))
+                        {
+                            messagePackDataSize = exporter.SerializeActivity(activity);
+                        }
+                    });
+
+                    receivedDataSize = serverSocket.Receive(receivedData);
                     Assert.Equal(messagePackDataSize, receivedDataSize);
                 }
                 catch (Exception)

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -415,6 +415,7 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                         })
                         .Build();
                     using Socket serverSocket = server.Accept();
+                    serverSocket.ReceiveTimeout = 10000;
 
                     // Create a test exporter to get MessagePack byte data for validation of the data received via Socket.
                     var exporter = new GenevaTraceExporter(new GenevaExporterOptions

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -451,7 +451,7 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                         {
                             messagePackDataSize = exporter.SerializeActivity(activity);
                         }
-                    });
+                    }).Wait();
 
                     receivedDataSize = serverSocket.Receive(receivedData);
                     Assert.Equal(messagePackDataSize, receivedDataSize);


### PR DESCRIPTION
## Changes
- Add test case for multithreading scenarios for `GenevaTraceExporter` and `GenevaLogExporter`