### PR TITLE
[Instrumentation.Runtime] Enable CodeAnalysis for Runtime Instrumentation library

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/AssemblyInfo.cs
@@ -14,8 +14,10 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Runtime.CompilerServices;
 
+[assembly: CLSCompliant(false)]
 #if SIGNED
 [assembly: InternalsVisibleTo("OpenTelemetry.Instrumentation.Runtime.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]
 #else

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -4,6 +4,7 @@
     <Description>dotnet runtime instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);runtime</PackageTags>
     <MinVerTagPrefix>Instrumentation.Runtime-</MinVerTagPrefix>
+    <EnableAnalysis>true</EnableAnalysis>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -39,9 +39,9 @@ namespace OpenTelemetry.Instrumentation.Runtime
 #if NET6_0_OR_GREATER
         private const long NanosecondsPerTick = 100;
 #endif
+        private const int NumberOfGenerations = 3;
 
         private static readonly string[] GenNames = new string[] { "gen0", "gen1", "gen2", "loh", "poh" };
-        private static readonly int NumberOfGenerations = 3;
         private static bool isGcInfoAvailable;
         private static string metricPrefix = "process.runtime.dotnet.";
 


### PR DESCRIPTION
Enable CodeAnalysis for Runtime Instrumentation library.

## Changes

Set `EnableAnalysis` to `true` in `OpenTelemetry.Instrumentation.Runtime.csproj`.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes: not needed.
* [x] Design discussion issue [#553#issuecomment-1201716753](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/553#issuecomment-1201716753)
