### PR TITLE
[Instrumentation.Runtime] Rename `RuntimeInstrumentOptions` to `RuntimeInstrumentationOptions`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Rename `RuntimeInstrumentOptions` to `RuntimeInstrumentationOptions`
+  ([#556](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/556))
+
 ## 1.0.0-rc.3
 
 Released 2022-Jul-25

--- a/src/OpenTelemetry.Instrumentation.Runtime/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/MeterProviderBuilderExtensions.cs
@@ -33,11 +33,11 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddRuntimeInstrumentation(
             this MeterProviderBuilder builder,
-            Action<RuntimeInstrumentOptions> configure = null)
+            Action<RuntimeInstrumentationOptions> configure = null)
         {
             Guard.ThrowIfNull(builder);
 
-            var options = new RuntimeInstrumentOptions();
+            var options = new RuntimeInstrumentationOptions();
             configure?.Invoke(options);
 
             var instrumentation = new RuntimeMetrics(options);

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeInstrumentationOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="RuntimeInstrumentOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="RuntimeInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
     /// <summary>
     /// Options to define the runtime metrics.
     /// </summary>
-    public class RuntimeInstrumentOptions
+    public class RuntimeInstrumentationOptions
     {
         /*
                 /// <summary>

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -219,7 +219,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
         /// Initializes a new instance of the <see cref="RuntimeMetrics"/> class.
         /// </summary>
         /// <param name="options">The options to define the metrics.</param>
-        public RuntimeMetrics(RuntimeInstrumentOptions options)
+        public RuntimeMetrics(RuntimeInstrumentationOptions options)
         {
         }
 

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeInstrumentationOptionsTests.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_All_If_Nothing_Was_Defined()
                 {
-                    var options = new RuntimeInstrumentOptions();
+                    var options = new RuntimeInstrumentationOptions();
 
                     Assert.True(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Gc_Only()
                 {
-                    var options = new RuntimeInstrumentOptions { GcEnabled = true };
+                    var options = new RuntimeInstrumentationOptions { GcEnabled = true };
 
                     Assert.True(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Jit_Only()
                 {
-                    var options = new RuntimeInstrumentOptions { JitEnabled = true };
+                    var options = new RuntimeInstrumentationOptions { JitEnabled = true };
 
                     Assert.False(options.IsGcEnabled);
                     Assert.True(options.IsJitEnabled);
@@ -69,7 +69,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Threading_Only()
                 {
-                    var options = new RuntimeInstrumentOptions { ThreadingEnabled = true };
+                    var options = new RuntimeInstrumentationOptions { ThreadingEnabled = true };
 
                     Assert.False(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Assemblies_Only()
                 {
-                    var options = new RuntimeInstrumentOptions { AssembliesEnabled = true };
+                    var options = new RuntimeInstrumentationOptions { AssembliesEnabled = true };
 
                     Assert.False(options.IsGcEnabled);
         #if NET6_0_OR_GREATER
@@ -100,7 +100,7 @@ namespace OpenTelemetry.Instrumentation.Runtime.Tests
                 [Fact]
                 public void Enable_Multiple()
                 {
-                    var options = new RuntimeInstrumentOptions { GcEnabled = true, AssembliesEnabled = true };
+                    var options = new RuntimeInstrumentationOptions { GcEnabled = true, AssembliesEnabled = true };
 
                     Assert.True(options.IsGcEnabled);
         #if NET6_0_OR_GREATER

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeInstrumentationOptionsTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="RuntimeInstrumentOptionsTests.cs" company="OpenTelemetry Authors">
+// <copyright file="RuntimeInstrumentationOptionsTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +14,9 @@
 // limitations under the License.
 // </copyright>
 
-using Xunit;
-
 namespace OpenTelemetry.Instrumentation.Runtime.Tests
 {
-    public class RuntimeInstrumentOptionsTests
+    public class RuntimeInstrumentationOptionsTests
     {
         /*
                 [Fact]


### PR DESCRIPTION
Rename options: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/553#issuecomment-1201709502

## Changes

Rename `RuntimeInstrumentOptions` to `RuntimeInstrumentationOptions`

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/553#issuecomment-1201709502
