### PR TITLE
[Instrumentation.Runtime] Two internal refactors

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -40,21 +40,21 @@ namespace OpenTelemetry.Instrumentation.Runtime
         private const long NanosecondsPerTick = 100;
 #endif
         private const int NumberOfGenerations = 3;
+        private const string MetricPrefix = "process.runtime.dotnet.";
 
         private static readonly string[] GenNames = new string[] { "gen0", "gen1", "gen2", "loh", "poh" };
         private static bool isGcInfoAvailable;
-        private static string metricPrefix = "process.runtime.dotnet.";
 
         static RuntimeMetrics()
         {
             MeterInstance.CreateObservableCounter(
-                $"{metricPrefix}gc.collections.count",
+                $"{MetricPrefix}gc.collections.count",
                 () => GetGarbageCollectionCounts(),
                 description: "Number of garbage collections that have occurred since process start.");
 
 #if NETCOREAPP3_1_OR_GREATER
             MeterInstance.CreateObservableCounter(
-                $"{metricPrefix}gc.allocations.size",
+                $"{MetricPrefix}gc.allocations.size",
                 () => GC.GetTotalAllocatedBytes(),
                 unit: "bytes",
                 description: "Count of bytes allocated on the managed GC heap since the process start. .NET objects are allocated from this heap. Object allocations from unmanaged languages such as C/C++ do not use this heap.");
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
 #if NET6_0_OR_GREATER
             // TODO: change to ObservableUpDownCounter
             MeterInstance.CreateObservableGauge(
-                $"{metricPrefix}gc.committed_memory.size",
+                $"{MetricPrefix}gc.committed_memory.size",
                 () =>
                 {
                     if (!IsGcInfoAvailable)
@@ -93,7 +93,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
             {
                 // TODO: change to ObservableUpDownCounter
                 MeterInstance.CreateObservableGauge(
-                    $"{metricPrefix}gc.heap.size",
+                    $"{MetricPrefix}gc.heap.size",
                     () =>
                     {
                         if (!IsGcInfoAvailable)
@@ -127,7 +127,7 @@ namespace OpenTelemetry.Instrumentation.Runtime
             {
                 // TODO: change to ObservableUpDownCounter
                 MeterInstance.CreateObservableGauge(
-                    $"{metricPrefix}gc.heap.fragmentation.size",
+                    $"{MetricPrefix}gc.heap.fragmentation.size",
                     () =>
                     {
                         if (!IsGcInfoAvailable)
@@ -152,18 +152,18 @@ namespace OpenTelemetry.Instrumentation.Runtime
 
 #if NET6_0_OR_GREATER
             MeterInstance.CreateObservableCounter(
-                $"{metricPrefix}jit.il_compiled.size",
+                $"{MetricPrefix}jit.il_compiled.size",
                 () => JitInfo.GetCompiledILBytes(),
                 unit: "bytes",
                 description: "Count of bytes of intermediate language that have been compiled since the process start.");
 
             MeterInstance.CreateObservableCounter(
-                $"{metricPrefix}jit.methods_compiled.count",
+                $"{MetricPrefix}jit.methods_compiled.count",
                 () => JitInfo.GetCompiledMethodCount(),
                 description: "The number of times the JIT compiler compiled a method since the process start. The JIT compiler may be invoked multiple times for the same method to compile with different generic parameters, or because tiered compilation requested different optimization settings.");
 
             MeterInstance.CreateObservableCounter(
-                $"{metricPrefix}jit.compilation_time",
+                $"{MetricPrefix}jit.compilation_time",
                 () => JitInfo.GetCompilationTime().Ticks * NanosecondsPerTick,
                 unit: "ns",
                 description: "The amount of time the JIT compiler has spent compiling methods since the process start.");
@@ -171,42 +171,42 @@ namespace OpenTelemetry.Instrumentation.Runtime
 
 #if NETCOREAPP3_1_OR_GREATER
             MeterInstance.CreateObservableCounter(
-                $"{metricPrefix}monitor.lock_contention.count",
+                $"{MetricPrefix}monitor.lock_contention.count",
                 () => Monitor.LockContentionCount,
                 description: "The number of times there was contention when trying to acquire a monitor lock since the process start. Monitor locks are commonly acquired by using the lock keyword in C#, or by calling Monitor.Enter() and Monitor.TryEnter().");
 
             // TODO: change to ObservableUpDownCounter
             MeterInstance.CreateObservableGauge(
-                $"{metricPrefix}thread_pool.threads.count",
+                $"{MetricPrefix}thread_pool.threads.count",
                 () => (long)ThreadPool.ThreadCount,
                 description: "The number of thread pool threads that currently exist.");
 
             MeterInstance.CreateObservableCounter(
-                $"{metricPrefix}thread_pool.completed_items.count",
+                $"{MetricPrefix}thread_pool.completed_items.count",
                 () => ThreadPool.CompletedWorkItemCount,
                 description: "The number of work items that have been processed by the thread pool since the process start.");
 
             // TODO: change to ObservableUpDownCounter
             MeterInstance.CreateObservableGauge(
-                $"{metricPrefix}thread_pool.queue.length",
+                $"{MetricPrefix}thread_pool.queue.length",
                 () => ThreadPool.PendingWorkItemCount,
                 description: "The number of work items that are currently queued to be processed by the thread pool.");
 
             // TODO: change to ObservableUpDownCounter
             MeterInstance.CreateObservableGauge(
-                $"{metricPrefix}timer.count",
+                $"{MetricPrefix}timer.count",
                 () => Timer.ActiveCount,
                 description: "The number of timer instances that are currently active. Timers can be created by many sources such as System.Threading.Timer, Task.Delay, or the timeout in a CancellationSource. An active timer is registered to tick at some point in the future and has not yet been canceled.");
 #endif
 
             // TODO: change to ObservableUpDownCounter
             MeterInstance.CreateObservableGauge(
-                $"{metricPrefix}assemblies.count",
+                $"{MetricPrefix}assemblies.count",
                 () => (long)AppDomain.CurrentDomain.GetAssemblies().Length,
                 description: "The number of .NET assemblies that are currently loaded.");
 
             var exceptionCounter = MeterInstance.CreateCounter<long>(
-                $"{metricPrefix}exceptions.count",
+                $"{MetricPrefix}exceptions.count",
                 description: "Count of exceptions that have been thrown in managed code, since the observation started. The value will be unavailable until an exception has been thrown after OpenTelemetry.Instrumentation.Runtime initialization.");
 
             AppDomain.CurrentDomain.FirstChanceException += (source, e) =>


### PR DESCRIPTION
Fixes #.

## Changes

Refactor some private code for minor non-blocker comments.

* Improve a unit test about `thread_pool.completed_items.count`: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/510#discussion_r927128513
* Change an internal variable type to `const`: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/555#discussion_r935004840

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
