### PR TITLE
[Intrumentation.WCF] Bump OTel package to 1.3.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OTel SDK package version to 1.2.0
-  [#347](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/347)
+* Updated OTel SDK package version to 1.3.0
+  ([#569](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/569))
 
 ## 1.0.0-rc.6
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
+++ b/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
Fixes N/A

## Changes

[Intrumentation.WCF] Bump OTel package to 1.3.0

This library is candidate to be part of AutoInstrumentation. It will be great to have released based on common OTel package version.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
