### PR TITLE
[Exporter.Geneva] Clean-up GenevaTraceExporter Benchmarks

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging;

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TraceExporterBenchmarks.cs
@@ -103,5 +103,15 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmark
         {
             this.exporter.SerializeActivity(this.activity);
         }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            this.activity.Dispose();
+            this.sourceTestData.Dispose();
+            this.activitySource.Dispose();
+            this.exporter.Dispose();
+            this.tracerProvider.Dispose();
+        }
     }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TraceExporterBenchmarks.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
@@ -22,18 +21,16 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 /*
-BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1415 (21H2)
-AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
-.NET SDK=6.0.101
-  [Host]     : .NET 5.0.12 (5.0.1221.52207), X64 RyuJIT
-  DefaultJob : .NET 5.0.12 (5.0.1221.52207), X64 RyuJIT
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
+.NET SDK=7.0.100-preview.6.22352.1
+  [Host]     : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT
+  DefaultJob : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT
 
-|                    Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
-|-------------------------- |----------:|---------:|---------:|-------:|----------:|
-|      CreateBoringActivity |  16.05 ns | 0.053 ns | 0.049 ns |      - |         - |
-|     CreateTediousActivity | 509.26 ns | 2.105 ns | 1.969 ns | 0.0486 |     408 B |
-| CreateInterestingActivity | 959.87 ns | 6.014 ns | 5.625 ns | 0.0477 |     408 B |
-|         SerializeActivity | 506.55 ns | 3.862 ns | 3.612 ns | 0.0095 |      80 B |
+|            Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
+|------------------ |---------:|---------:|---------:|-------:|----------:|
+|    ExportActivity | 687.2 ns | 13.73 ns | 20.55 ns | 0.0648 |     408 B |
+| SerializeActivity | 392.3 ns |  4.87 ns |  4.32 ns | 0.0062 |      40 B |
 */
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmark
@@ -41,12 +38,11 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmark
     [MemoryDiagnoser]
     public class TraceExporterBenchmarks
     {
-        private readonly Random r = new Random();
         private readonly Activity activity;
         private readonly GenevaTraceExporter exporter;
-        private readonly ActivitySource sourceBoring = new ActivitySource("OpenTelemetry.Exporter.Geneva.Benchmark.Boring");
-        private readonly ActivitySource sourceTedious = new ActivitySource("OpenTelemetry.Exporter.Geneva.Benchmark.Tedious");
-        private readonly ActivitySource sourceInteresting = new ActivitySource("OpenTelemetry.Exporter.Geneva.Benchmark.Interesting");
+        private readonly ActivitySource sourceTestData = new ActivitySource("OpenTelemetry.Exporter.Geneva.Benchmark.TestData");
+        private readonly ActivitySource activitySource = new ActivitySource("OpenTelemetry.Exporter.Geneva.Benchmark");
+        private readonly TracerProvider tracerProvider;
 
         public TraceExporterBenchmarks()
         {
@@ -56,11 +52,11 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmark
             {
                 ActivityStarted = null,
                 ActivityStopped = null,
-                ShouldListenTo = (activitySource) => activitySource.Name == this.sourceTedious.Name,
+                ShouldListenTo = (activitySource) => activitySource.Name == this.sourceTestData.Name,
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
             });
 
-            using (var tedious = this.sourceTedious.StartActivity("Benchmark"))
+            using (var tedious = this.sourceTestData.StartActivity("Benchmark"))
             {
                 this.activity = tedious;
                 this.activity?.SetTag("tagString", "value");
@@ -71,7 +67,6 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmark
             this.exporter = new GenevaTraceExporter(new GenevaExporterOptions
             {
                 ConnectionString = "EtwSession=OpenTelemetry",
-                CustomFields = new List<string> { "azureResourceProvider", "clientRequestId" },
                 PrepopulatedFields = new Dictionary<string, object>
                 {
                     ["cloud.role"] = "BusyWorker",
@@ -80,9 +75,9 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmark
                 },
             });
 
-            Sdk.CreateTracerProviderBuilder()
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
-                .AddSource(this.sourceInteresting.Name)
+                .AddSource(this.activitySource.Name)
                 .AddGenevaTraceExporter(options =>
                 {
                     options.ConnectionString = "EtwSession=OpenTelemetry";
@@ -97,24 +92,10 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmark
         }
 
         [Benchmark]
-        public void CreateBoringActivity()
-        {
-            // this activity won't be created as there is no listener
-            using var activity = this.sourceBoring.StartActivity("Benchmark");
-        }
-
-        [Benchmark]
-        public void CreateTediousActivity()
-        {
-            // this activity will be created and feed into an ActivityListener that simply drops everything on the floor
-            using var activity = this.sourceTedious.StartActivity("Benchmark");
-        }
-
-        [Benchmark]
-        public void CreateInterestingActivity()
+        public void ExportActivity()
         {
             // this activity will be created and feed into the actual Geneva exporter
-            using var activity = this.sourceInteresting.StartActivity("Benchmark");
+            using var activity = this.activitySource.StartActivity("Benchmark");
         }
 
         [Benchmark]

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/README.md
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/README.md
@@ -1,0 +1,10 @@
+# OpenTelemetry GenevaExporter Benchmarks
+
+Navigate to `./test/OpenTelemetry.Exporter.Geneva.Benchmark` directory and run
+the following command:
+
+```sh
+dotnet run -c Release -f net6.0 -- -m
+``
+
+Then choose the benchmark class that you want to run by entering the required option number from the list of options shown on the Console window.

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/README.md
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/README.md
@@ -7,5 +7,5 @@ the following command:
 dotnet run -c Release -f net6.0 -- -m
 ``
 
-Then choose the benchmark class that you want to run by entering the required 
+Then choose the benchmark class that you want to run by entering the required
 option number from the list of options shown on the Console window.

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/README.md
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/README.md
@@ -7,4 +7,5 @@ the following command:
 dotnet run -c Release -f net6.0 -- -m
 ``
 
-Then choose the benchmark class that you want to run by entering the required option number from the list of options shown on the Console window.
+Then choose the benchmark class that you want to run by entering the required 
+option number from the list of options shown on the Console window.


### PR DESCRIPTION
The benchmark methods that were removed in this PR are already covered in the main repo.

## Changes
- Clean-up GenevaTraceExporter Benchmarks
- Add a README file to the project

