### PR TITLE
Add Component Owners for OpenTelemetry.Extensions.AzureMonitor

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -21,6 +21,9 @@ components:
     - SergeyKanzhelev
   src/OpenTelemetry.Extensions/:
     - codeblanch
+  src/OpenTelemetry.Extensions.AzureMonitor/:
+    - rajkumar-rangaraj
+    - vishweshbankwar
   src/OpenTelemetry.Extensions.Docker/:
     - iskiselev
   src/OpenTelemetry.Extensions.PersistentStorage.Abstractions/:


### PR DESCRIPTION
## Changes

Add Component Owners for `OpenTelemetry.Extensions.AzureMonitor`

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
