### PR TITLE
Instrumentation.AwsLambda: Remove input-less Trace overloads.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
@@ -98,28 +98,6 @@ namespace OpenTelemetry.Instrumentation.AWSLambda
         }
 
         /// <summary>
-        /// Tracing wrapper for Lambda handler.
-        /// </summary>
-        /// <param name="tracerProvider">TracerProvider passed in.</param>
-        /// <param name="lambdaHandler">Lambda handler function passed in.</param>
-        /// <param name="context">Instance of lambda context.</param>
-        /// <param name="parentContext">
-        /// The optional parent context <see cref="ActivityContext"/> is used for Activity object creation.
-        /// If no parent context provided, incoming request is used to extract one.
-        /// If parent is not extracted from incoming request then X-Ray propagation is used to extract one
-        /// unless X-Ray propagation is disabled in the configuration for this wrapper.
-        /// </param>
-        public static void Trace(
-            TracerProvider tracerProvider,
-            Action<ILambdaContext> lambdaHandler,
-            ILambdaContext context,
-            ActivityContext parentContext = default)
-        {
-            Action action = () => lambdaHandler(context);
-            TraceInternal<object>(tracerProvider, action, null, context, parentContext);
-        }
-
-        /// <summary>
         /// Tracing wrapper for async Lambda handler.
         /// </summary>
         /// <typeparam name="TInput">Input.</typeparam>
@@ -172,29 +150,6 @@ namespace OpenTelemetry.Instrumentation.AWSLambda
             Func<Task> action = async () => result = await lambdaHandler(input, context);
             await TraceInternalAsync(tracerProvider, action, input, context, parentContext);
             return result;
-        }
-
-        /// <summary>
-        /// Tracing wrapper for async Lambda handler.
-        /// </summary>
-        /// <param name="tracerProvider">TracerProvider passed in.</param>
-        /// <param name="lambdaHandler">Lambda handler function passed in.</param>
-        /// <param name="context">Instance of lambda context.</param>
-        /// <param name="parentContext">
-        /// The optional parent context <see cref="ActivityContext"/> is used for Activity object creation.
-        /// If no parent context provided, incoming request is used to extract one.
-        /// If parent is not extracted from incoming request then X-Ray propagation is used to extract one
-        /// unless X-Ray propagation is disabled in the configuration.
-        /// </param>
-        /// <returns>Task.</returns>
-        public static Task TraceAsync(
-            TracerProvider tracerProvider,
-            Func<ILambdaContext, Task> lambdaHandler,
-            ILambdaContext context,
-            ActivityContext parentContext = default)
-        {
-            Func<Task> action = async () => await lambdaHandler(context);
-            return TraceInternalAsync<object>(tracerProvider, action, null, context, parentContext);
         }
 
         internal static Activity OnFunctionStart<TInput>(TInput input, ILambdaContext context, ActivityContext parentContext = default)

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -22,8 +22,6 @@
   if the parent context is not defined.
 * Breaking change: `AWSLambdaWrapper.Trace` overloads without `ILambdaContext` argument
   have been completely removed.
-* Added two new `AWSLambdaWrapper.Trace` overloads without generic input arguments.
-  ([#408](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/408))
 
 ## 1.1.0-beta1
 

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -101,32 +101,6 @@ namespace OpenTelemetry.Instrumentation.AWSLambda.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void TraceSyncWithNoInputAndNoReturn(bool setCustomParent)
-        {
-            var processor = new Mock<BaseProcessor<Activity>>();
-
-            using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddAWSLambdaConfigurations()
-                .AddProcessor(processor.Object)
-                .Build())
-            {
-                var parentContext = setCustomParent ? CreateParentContext() : default;
-                AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncNoInputAndNoReturn, this.sampleLambdaContext, parentContext);
-                var resource = tracerProvider.GetResource();
-                this.AssertResourceAttributes(resource);
-            }
-
-            // SetParentProvider -> OnStart -> OnEnd -> OnForceFlush -> OnShutdown -> Dispose
-            Assert.Equal(6, processor.Invocations.Count);
-
-            var activity = (Activity)processor.Invocations[1].Arguments[0];
-            this.AssertSpanProperties(activity, setCustomParent ? CustomParentId : XRayParentId);
-            this.AssertSpanAttributes(activity);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
         public async Task TraceAsyncWithInputAndReturn(bool setCustomParent)
         {
             var processor = new Mock<BaseProcessor<Activity>>();
@@ -164,32 +138,6 @@ namespace OpenTelemetry.Instrumentation.AWSLambda.Tests
             {
                 var parentContext = setCustomParent ? CreateParentContext() : default;
                 await AWSLambdaWrapper.TraceAsync(tracerProvider, this.sampleHandlers.SampleHandlerAsyncInputAndNoReturn, "TestStream", this.sampleLambdaContext, parentContext);
-                var resource = tracerProvider.GetResource();
-                this.AssertResourceAttributes(resource);
-            }
-
-            // SetParentProvider -> OnStart -> OnEnd -> OnForceFlush -> OnShutdown -> Dispose
-            Assert.Equal(6, processor.Invocations.Count);
-
-            var activity = (Activity)processor.Invocations[1].Arguments[0];
-            this.AssertSpanProperties(activity, setCustomParent ? CustomParentId : XRayParentId);
-            this.AssertSpanAttributes(activity);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task TraceAsyncWithNoInputAndNoReturn(bool setCustomParent)
-        {
-            var processor = new Mock<BaseProcessor<Activity>>();
-
-            using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddAWSLambdaConfigurations()
-                .AddProcessor(processor.Object)
-                .Build())
-            {
-                var parentContext = setCustomParent ? CreateParentContext() : default;
-                await AWSLambdaWrapper.TraceAsync(tracerProvider, this.sampleHandlers.SampleHandlerAsyncNoInputAndNoReturn, this.sampleLambdaContext, parentContext);
                 var resource = tracerProvider.GetResource();
                 this.AssertResourceAttributes(resource);
             }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/607#discussion_r962712458.

## Changes

* Remove `AWSLambdaWrapper.Trace` overloads without input.

For significant contributions please make sure you have completed the following items:

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes: Removed changelog entry for introduction of the change, since it was unreleased.
* ~~[ ] Design discussion issue #~~
