### PR TITLE
[Instrumentation.Process] Added the metrics for CpuTime and CpuUtilization.

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -36,10 +36,14 @@ public class ProcessMetricsTests
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-        Assert.True(exportedItems.Count == 2);
+        Assert.True(exportedItems.Count == 4);
         var physicalMemoryMetric = exportedItems.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetric);
         var virtualMemoryMetric = exportedItems.FirstOrDefault(i => i.Name == "process.memory.virtual");
         Assert.NotNull(virtualMemoryMetric);
+        var cpuTimeMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.time");
+        Assert.NotNull(cpuTimeMetric);
+        var cpuUtilizationMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.utilization");
+        Assert.NotNull(cpuUtilizationMetric);
     }
 }


### PR DESCRIPTION
## Changes
Working towards: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/447
Background: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/335
Following OTel [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md#metric-instruments).

For the `process.cpu.time` metric, [Process.TotalProcessorTime](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.totalprocessortime?view=net-6.0) was used to get the value.

For the `process.cpu.utilization` metric, it was defined as the "difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process" in the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md#metric-instruments).
In this PR, the last measurement was defined as the last time `GetCpuUtilization()` callback function was invoked. 
At the collection phase of the metricReader of the Exporter, `GetCpuUtilization()` will be triggered.
The `lastCollectionTimestamp ` and `lastCollectionCpuTime ` will be updated before the current CPU utilization result was returned.

The unit defined in the spec for the above two mentioning CPU metrics are "s" (second). In this PR, the values were being calculated by converting [TimeSpan.Ticks](https://docs.microsoft.com/en-us/dotnet/api/system.timespan.ticks?view=net-6.0)
to seconds for more granularity.

Please note that currently, broken down by different states , i.e. `user`, `system`, or `wait` for CPU related metrics is not implemented in this PR because of the following reasons.
1. There is no easy way to get the `wait` state from the existing Process releated APIs from .net.
2. I am unsure how beneficial to the user given this broken down by states information.

The plan is to release an alpha version of the `OpenTelemetry.Instrumentation.Process` package and collect customer feedback. And based on the feedback, we decide whether the division by states feature should be implemented for CPU-related metrics or not.

