### PR TITLE
changelog for release: Extensions.AzureMonitor 1.0.0-beta1

### DIFF
--- a/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Changelog
 
-## Unreleased
+## 1.0.0-beta.1
+
+Released 2022-Sept-12
+
+* Add "sampleRate" to `SamplingResult`.
+  ([#623](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/623))


### PR DESCRIPTION
Requesting a release for OpenTelemetry.Extensions.AzureMonitor v1.0.0-beta1, following instructions on [How to request for release of package](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md#how-to-request-for-release-of-package).
I used next Monday for the release date.


@rajkumar-rangaraj I added a changelog entry for #623.

@utpilla please review.


