### PR TITLE
Update README for projects missing the number of package downloads

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
@@ -1,6 +1,7 @@
 # ASP.NET Telemetry HttpModule for OpenTelemetry
 
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
 
 The ASP.NET Telemetry HttpModule enables distributed tracing of incoming ASP.NET
 requests using the OpenTelemetry API.

--- a/src/OpenTelemetry.Instrumentation.Wcf/README.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/README.md
@@ -1,6 +1,7 @@
 # WCF Instrumentation for OpenTelemetry .NET
 
 [![nuget](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Wcf.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Wcf/)
+[![nuget](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Wcf.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Wcf/)
 
 Instruments WCF clients and/or services using implementations of
 `IClientMessageInspector` and `IDispatchMessageInspector` respectively.


### PR DESCRIPTION
## Changes
- Add the link for number of package downloads for:
  - `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`
  - `OpenTelemetry.Instrumentation.Wcf`
