### PR TITLE
Replaced  TargetFrameworks from net461 and net6.0 to netstandard2.0

### DIFF
--- a/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSampler.cs
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSampler.cs
@@ -41,7 +41,7 @@ public class ApplicationInsightsSampler : Sampler
 
         this.samplingRatio = samplingRatio;
         this.Description = "ApplicationInsightsSampler{" + samplingRatio + "}";
-        var sampleRate = (int)Math.Round(samplingRatio * 100);
+        var sampleRate = (float)Math.Round(samplingRatio * 100);
         this.recordAndSampleSamplingResult = new SamplingResult(
             SamplingDecision.RecordAndSample,
             new Dictionary<string, object>

--- a/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
@@ -5,6 +5,7 @@
 Released 2022-Sept-12
 
 * Replaced  TargetFrameworks from `net461` and `net6.0` to `netstandard2.0`.
+* Changed `sampleRate` attribute type to `float`.
 
 ## 1.0.0-beta.1
 

--- a/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-beta.2
+
+Released 2022-Sept-12
+
+* Replaced  TargetFrameworks from `net461` and `net6.0` to `netstandard2.0`.
+
 ## 1.0.0-beta.1
 
 Released 2022-Sept-12

--- a/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks>
-    <!-- Added just to get proper nullable analysis in IDE -->
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
     <MinVerTagPrefix>Extensions.AzureMonitor-</MinVerTagPrefix>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks>
+    <!-- Added just to get proper nullable analysis in IDE -->
     <MinVerTagPrefix>Extensions.AzureMonitor-</MinVerTagPrefix>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #.

## Changes

Please provide a brief description of the changes here.

- Updated TargetFrameworks from `net461` and `net6.0` to `netstandard2.0`.
- Updated `CHANGELOG.md`
- Changed `sampleRate` attribute to `float`.

For significant contributions please make sure you have completed the following items:

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
*~~[ ] Design discussion issue #~~
