### PR TITLE
Remove unused Activity reflection code

### DIFF
--- a/src/OpenTelemetry.Contrib.Shared/Api/ActivityHelperExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Shared/Api/ActivityHelperExtensions.cs
@@ -28,37 +28,6 @@ namespace OpenTelemetry.Trace;
 internal static class ActivityHelperExtensions
 {
     /// <summary>
-    /// Gets the status of activity execution.
-    /// Activity class in .NET does not support 'Status'.
-    /// This extension provides a workaround to retrieve Status from special tags with key name otel.status_code and otel.status_description.
-    /// </summary>
-    /// <param name="activity">Activity instance.</param>
-    /// <param name="statusCode"><see cref="StatusCode"/>.</param>
-    /// <param name="statusDescription">Status description.</param>
-    /// <returns><see langword="true"/> if <see cref="Status"/> was found on the supplied Activity.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
-    public static bool TryGetStatus(this Activity activity, out StatusCode statusCode, out string statusDescription)
-    {
-        Debug.Assert(activity != null, "Activity should not be null");
-
-        ActivityStatusTagEnumerator state = default;
-
-        ActivityTagsEnumeratorFactory<ActivityStatusTagEnumerator>.Enumerate(activity, ref state);
-
-        if (!state.StatusCode.HasValue)
-        {
-            statusCode = default;
-            statusDescription = null;
-            return false;
-        }
-
-        statusCode = state.StatusCode.Value;
-        statusDescription = state.StatusDescription;
-        return true;
-    }
-
-    /// <summary>
     /// Gets the value of a specific tag on an <see cref="Activity"/>.
     /// </summary>
     /// <param name="activity">Activity instance.</param>
@@ -70,87 +39,16 @@ internal static class ActivityHelperExtensions
     {
         Debug.Assert(activity != null, "Activity should not be null");
 
+        // TODO: Update to use
+        // https://docs.microsoft.com/dotnet/api/system.diagnostics.activity.enumeratetagobjects?view=net-7.0
+        // instead of reflection. See:
+        // https://github.com/open-telemetry/opentelemetry-dotnet/blob/928d77056c1d353d8ba72ad3b4b565398117b352/src/OpenTelemetry.Api/Internal/ActivityHelperExtensions.cs#L85-L98
+
         ActivitySingleTagEnumerator state = new ActivitySingleTagEnumerator(tagName);
 
         ActivityTagsEnumeratorFactory<ActivitySingleTagEnumerator>.Enumerate(activity, ref state);
 
         return state.Value;
-    }
-
-    /// <summary>
-    /// Enumerates all the key/value pairs on an <see cref="Activity"/> without performing an allocation.
-    /// </summary>
-    /// <typeparam name="T">The struct <see cref="IActivityEnumerator{T}"/> implementation to use for the enumeration.</typeparam>
-    /// <param name="activity">Activity instance.</param>
-    /// <param name="tagEnumerator">Tag enumerator.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
-    public static void EnumerateTags<T>(this Activity activity, ref T tagEnumerator)
-        where T : struct, IActivityEnumerator<KeyValuePair<string, object>>
-    {
-        Debug.Assert(activity != null, "Activity should not be null");
-
-        ActivityTagsEnumeratorFactory<T>.Enumerate(activity, ref tagEnumerator);
-    }
-
-    /// <summary>
-    /// Enumerates all the <see cref="ActivityLink"/>s on an <see cref="Activity"/> without performing an allocation.
-    /// </summary>
-    /// <typeparam name="T">The struct <see cref="IActivityEnumerator{T}"/> implementation to use for the enumeration.</typeparam>
-    /// <param name="activity">Activity instance.</param>
-    /// <param name="linkEnumerator">Link enumerator.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
-    public static void EnumerateLinks<T>(this Activity activity, ref T linkEnumerator)
-        where T : struct, IActivityEnumerator<ActivityLink>
-    {
-        Debug.Assert(activity != null, "Activity should not be null");
-
-        ActivityLinksEnumeratorFactory<T>.Enumerate(activity, ref linkEnumerator);
-    }
-
-    /// <summary>
-    /// Enumerates all the key/value pairs on an <see cref="ActivityLink"/> without performing an allocation.
-    /// </summary>
-    /// <typeparam name="T">The struct <see cref="IActivityEnumerator{T}"/> implementation to use for the enumeration.</typeparam>
-    /// <param name="activityLink">ActivityLink instance.</param>
-    /// <param name="tagEnumerator">Tag enumerator.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
-    public static void EnumerateTags<T>(this ActivityLink activityLink, ref T tagEnumerator)
-        where T : struct, IActivityEnumerator<KeyValuePair<string, object>>
-    {
-        ActivityTagsEnumeratorFactory<T>.Enumerate(activityLink, ref tagEnumerator);
-    }
-
-    /// <summary>
-    /// Enumerates all the <see cref="ActivityEvent"/>s on an <see cref="Activity"/> without performing an allocation.
-    /// </summary>
-    /// <typeparam name="T">The struct <see cref="IActivityEnumerator{T}"/> implementation to use for the enumeration.</typeparam>
-    /// <param name="activity">Activity instance.</param>
-    /// <param name="eventEnumerator">Event enumerator.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
-    public static void EnumerateEvents<T>(this Activity activity, ref T eventEnumerator)
-        where T : struct, IActivityEnumerator<ActivityEvent>
-    {
-        Debug.Assert(activity != null, "Activity should not be null");
-
-        ActivityEventsEnumeratorFactory<T>.Enumerate(activity, ref eventEnumerator);
-    }
-
-    /// <summary>
-    /// Enumerates all the key/value pairs on an <see cref="ActivityEvent"/> without performing an allocation.
-    /// </summary>
-    /// <typeparam name="T">The struct <see cref="IActivityEnumerator{T}"/> implementation to use for the enumeration.</typeparam>
-    /// <param name="activityEvent">ActivityEvent instance.</param>
-    /// <param name="tagEnumerator">Tag enumerator.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
-    public static void EnumerateTags<T>(this ActivityEvent activityEvent, ref T tagEnumerator)
-        where T : struct, IActivityEnumerator<KeyValuePair<string, object>>
-    {
-        ActivityTagsEnumeratorFactory<T>.Enumerate(activityEvent, ref tagEnumerator);
     }
 
     private struct ActivitySingleTagEnumerator : IActivityEnumerator<KeyValuePair<string, object>>
@@ -177,69 +75,16 @@ internal static class ActivityHelperExtensions
         }
     }
 
-    private struct ActivityStatusTagEnumerator : IActivityEnumerator<KeyValuePair<string, object>>
-    {
-        public StatusCode? StatusCode;
-
-        public string StatusDescription;
-
-        public bool ForEach(KeyValuePair<string, object> item)
-        {
-            switch (item.Key)
-            {
-                case SpanAttributeConstants.StatusCodeKey:
-                    this.StatusCode = StatusHelper.GetStatusCodeForTagValue(item.Value as string);
-                    break;
-                case SpanAttributeConstants.StatusDescriptionKey:
-                    this.StatusDescription = item.Value as string;
-                    break;
-            }
-
-            return !this.StatusCode.HasValue || this.StatusDescription == null;
-        }
-    }
-
     private static class ActivityTagsEnumeratorFactory<TState>
         where TState : struct, IActivityEnumerator<KeyValuePair<string, object>>
     {
         private static readonly object EmptyActivityTagObjects = typeof(Activity).GetField("s_emptyTagObjects", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
-
-        private static readonly object EmptyActivityEventTags = typeof(ActivityEvent).GetField("s_emptyTags", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
 
         private static readonly DictionaryEnumerator<string, object, TState>.AllocationFreeForEachDelegate
             ActivityTagObjectsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(
                 typeof(Activity).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).FieldType);
 
         private static readonly DictionaryEnumerator<string, object, TState>.ForEachDelegate ForEachTagValueCallbackRef = ForEachTagValueCallback;
-
-        private static readonly DictionaryEnumerator<string, object, TState>.AllocationFreeForEachDelegate ActivityEventTagsEnumerator;
-
-        private static readonly DictionaryEnumerator<string, object, TState>.AllocationFreeForEachDelegate ActivityLinkTagsEnumerator;
-
-        static ActivityTagsEnumeratorFactory()
-        {
-            var activityEventTagsField = typeof(ActivityEvent).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic);
-            if (activityEventTagsField != null)
-            {
-                // .NET 7 API
-                ActivityEventTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(activityEventTagsField.FieldType);
-            }
-            else
-            {
-                ActivityEventTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(typeof(ActivityTagsCollection));
-            }
-
-            var activityLinkTagsField = typeof(ActivityLink).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic);
-            if (activityLinkTagsField != null)
-            {
-                // .NET 7 API
-                ActivityLinkTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(activityLinkTagsField.FieldType);
-            }
-            else
-            {
-                ActivityLinkTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(typeof(ActivityTagsCollection));
-            }
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Enumerate(Activity activity, ref TState state)
@@ -257,101 +102,7 @@ internal static class ActivityHelperExtensions
                 ForEachTagValueCallbackRef);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Enumerate(ActivityLink activityLink, ref TState state)
-        {
-            var tags = activityLink.Tags;
-
-            if (tags is null)
-            {
-                return;
-            }
-
-            ActivityLinkTagsEnumerator(
-                tags,
-                ref state,
-                ForEachTagValueCallbackRef);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Enumerate(ActivityEvent activityEvent, ref TState state)
-        {
-            var tags = activityEvent.Tags;
-
-            if (ReferenceEquals(tags, EmptyActivityEventTags))
-            {
-                return;
-            }
-
-            ActivityEventTagsEnumerator(
-                tags,
-                ref state,
-                ForEachTagValueCallbackRef);
-        }
-
         private static bool ForEachTagValueCallback(ref TState state, KeyValuePair<string, object> item)
-            => state.ForEach(item);
-    }
-
-    private static class ActivityLinksEnumeratorFactory<TState>
-        where TState : struct, IActivityEnumerator<ActivityLink>
-    {
-        private static readonly object EmptyActivityLinks = typeof(Activity).GetField("s_emptyLinks", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
-
-        private static readonly ListEnumerator<ActivityLink, TState>.AllocationFreeForEachDelegate
-            ActivityLinksEnumerator = ListEnumerator<ActivityLink, TState>.BuildAllocationFreeForEachDelegate(
-                typeof(Activity).GetField("_links", BindingFlags.Instance | BindingFlags.NonPublic).FieldType);
-
-        private static readonly ListEnumerator<ActivityLink, TState>.ForEachDelegate ForEachLinkCallbackRef = ForEachLinkCallback;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Enumerate(Activity activity, ref TState state)
-        {
-            var activityLinks = activity.Links;
-
-            if (ReferenceEquals(activityLinks, EmptyActivityLinks))
-            {
-                return;
-            }
-
-            ActivityLinksEnumerator(
-                activityLinks,
-                ref state,
-                ForEachLinkCallbackRef);
-        }
-
-        private static bool ForEachLinkCallback(ref TState state, ActivityLink item)
-            => state.ForEach(item);
-    }
-
-    private static class ActivityEventsEnumeratorFactory<TState>
-        where TState : struct, IActivityEnumerator<ActivityEvent>
-    {
-        private static readonly object EmptyActivityEvents = typeof(Activity).GetField("s_emptyEvents", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
-
-        private static readonly ListEnumerator<ActivityEvent, TState>.AllocationFreeForEachDelegate
-            ActivityEventsEnumerator = ListEnumerator<ActivityEvent, TState>.BuildAllocationFreeForEachDelegate(
-                typeof(Activity).GetField("_events", BindingFlags.Instance | BindingFlags.NonPublic).FieldType);
-
-        private static readonly ListEnumerator<ActivityEvent, TState>.ForEachDelegate ForEachEventCallbackRef = ForEachEventCallback;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Enumerate(Activity activity, ref TState state)
-        {
-            var activityEvents = activity.Events;
-
-            if (ReferenceEquals(activityEvents, EmptyActivityEvents))
-            {
-                return;
-            }
-
-            ActivityEventsEnumerator(
-                activityEvents,
-                ref state,
-                ForEachEventCallbackRef);
-        }
-
-        private static bool ForEachEventCallback(ref TState state, ActivityEvent item)
             => state.ForEach(item);
     }
 }

--- a/src/OpenTelemetry.Contrib.Shared/Api/ActivityHelperExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Shared/Api/ActivityHelperExtensions.cs
@@ -210,10 +210,36 @@ internal static class ActivityHelperExtensions
             ActivityTagObjectsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(
                 typeof(Activity).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).FieldType);
 
-        private static readonly DictionaryEnumerator<string, object, TState>.AllocationFreeForEachDelegate
-            ActivityTagsCollectionEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(typeof(ActivityTagsCollection));
-
         private static readonly DictionaryEnumerator<string, object, TState>.ForEachDelegate ForEachTagValueCallbackRef = ForEachTagValueCallback;
+
+        private static readonly DictionaryEnumerator<string, object, TState>.AllocationFreeForEachDelegate ActivityEventTagsEnumerator;
+
+        private static readonly DictionaryEnumerator<string, object, TState>.AllocationFreeForEachDelegate ActivityLinkTagsEnumerator;
+
+        static ActivityTagsEnumeratorFactory()
+        {
+            var activityEventTagsField = typeof(ActivityEvent).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (activityEventTagsField != null)
+            {
+                // .NET 7 API
+                ActivityEventTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(activityEventTagsField.FieldType);
+            }
+            else
+            {
+                ActivityEventTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(typeof(ActivityTagsCollection));
+            }
+
+            var activityLinkTagsField = typeof(ActivityLink).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (activityLinkTagsField != null)
+            {
+                // .NET 7 API
+                ActivityLinkTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(activityLinkTagsField.FieldType);
+            }
+            else
+            {
+                ActivityLinkTagsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(typeof(ActivityTagsCollection));
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Enumerate(Activity activity, ref TState state)
@@ -241,7 +267,7 @@ internal static class ActivityHelperExtensions
                 return;
             }
 
-            ActivityTagsCollectionEnumerator(
+            ActivityLinkTagsEnumerator(
                 tags,
                 ref state,
                 ForEachTagValueCallbackRef);
@@ -257,7 +283,7 @@ internal static class ActivityHelperExtensions
                 return;
             }
 
-            ActivityTagsCollectionEnumerator(
+            ActivityEventTagsEnumerator(
                 tags,
                 ref state,
                 ForEachTagValueCallbackRef);


### PR DESCRIPTION
Fixes #640

## Changes

* Removed all the reflection enumeration code which wasn't being used including the stuff that is bugged when redirecting to the DS7 version. 

* Dropped in a TODO about updating to remove the rest. Need to wait for DS7/OTel 1.4.x to complete that part of it.