### PR TITLE
[Exporter.Geneva] Move TableNameMappings checks to GenevaExporterOptions class

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## Unreleased
 
 * Update OTel SDK version to `1.3.1`.
-  ([#631](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/631))
+  [#631](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/631)
+
+* The option `TableNameMappings` of `GenevaExporterOptions` will not support
+  string values that are null, empty, or consist only of white-space characters.
+  It will also not support string values that contain non-ASCII characters.
+  [646](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/646)
 
 ## 1.4.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.Geneva;
@@ -44,9 +45,14 @@ public class GenevaExporterOptions
 
             foreach (var entry in value)
             {
-                if (entry.Value is null)
+                if (string.IsNullOrWhiteSpace(entry.Value))
                 {
-                    throw new ArgumentNullException(entry.Key, $"{nameof(this.TableNameMappings)} must not contain null values.");
+                    throw new ArgumentException($"A string-typed value provided for {nameof(this.TableNameMappings)} must not be null, empty, or consist only of white-space characters.");
+                }
+
+                if (Encoding.UTF8.GetByteCount(entry.Value) != entry.Value.Length)
+                {
+                    throw new ArgumentException($"A string-typed value provided for {nameof(this.TableNameMappings)} must not contain non-ASCII characters.", entry.Value);
                 }
 
                 copy[entry.Key] = entry.Value;

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -58,11 +58,6 @@ public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
             var tempTableMappings = new Dictionary<string, string>(options.TableNameMappings.Count, StringComparer.Ordinal);
             foreach (var kv in options.TableNameMappings)
             {
-                if (Encoding.UTF8.GetByteCount(kv.Value) != kv.Value.Length)
-                {
-                    throw new ArgumentException("The value: \"{tableName}\" provided for TableNameMappings option contains non-ASCII characters", kv.Value);
-                }
-
                 if (kv.Key == "*")
                 {
                     if (kv.Value == "*")

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
@@ -36,16 +36,6 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
         if (options.TableNameMappings != null
             && options.TableNameMappings.TryGetValue("Span", out var customTableName))
         {
-            if (string.IsNullOrWhiteSpace(customTableName))
-            {
-                throw new ArgumentException("TableName mapping for Span is invalid.");
-            }
-
-            if (Encoding.UTF8.GetByteCount(customTableName) != customTableName.Length)
-            {
-                throw new ArgumentException("The \"{customTableName}\" provided for TableNameMappings option contains non-ASCII characters", customTableName);
-            }
-
             partAName = customTableName;
         }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -62,15 +62,14 @@ public class GenevaLogExporterTests
         });
 
         // Throw on null value - include key in exception message
-        var ex = Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentException>(() =>
         {
             new GenevaExporterOptions
             {
                 TableNameMappings = new Dictionary<string, string> { ["TestCategory"] = null },
             };
         });
-        Assert.Contains("TableNameMappings must not contain null values.", ex.Message);
-        Assert.Equal("TestCategory", ex.ParamName);
+        Assert.Contains("A string-typed value provided for TableNameMappings must not be null, empty, or consist only of white-space characters.", ex.Message);
 
         // Throw when TableNameMappings is null
         Assert.Throws<ArgumentNullException>(() =>


### PR DESCRIPTION
## Changes
- Move `TableNameMappings` checks from `GenevaTraceExporter` and `GenevaLogExporter` ctor to `GenevaExporterOptions` class

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
