### PR TITLE
[Owin] Bump target .NET Framework and OTel SDK version

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
-        version: [net461,netcoreapp3.1,net6.0]
+        version: [net462,netcoreapp3.1,net6.0]
 
     steps:
     - uses: actions/checkout@v3

--- a/build/Common.props
+++ b/build/Common.props
@@ -6,6 +6,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)debug.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <NetFrameworkMinimumSupportedVersion>net462</NetFrameworkMinimumSupportedVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -12,6 +12,8 @@ Released 2022-Sep-20
 * Changed to depend on at least Owin 4.2.2 to resolve a
   [denial of service vulnerability](https://github.com/advisories/GHSA-3rq8-h3gj-r5c6).
   ([#648](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/648))
+* Updated project to target `net462` and OTel 1.3.1 SDK
+  ([#XXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXX))
 
 ## 1.0.0-rc.2
 

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -13,7 +13,7 @@ Released 2022-Sep-20
   [denial of service vulnerability](https://github.com/advisories/GHSA-3rq8-h3gj-r5c6).
   ([#648](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/648))
 * Updated project to target `net462` and OTel 1.3.1 SDK
-  ([#XXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXX))
+  ([#653](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/653))
 
 ## 1.0.0-rc.2
 

--- a/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
+++ b/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry instrumentation for OWIN</Description>
     <PackageTags>$(PackageTags);distributed-tracing;OWIN</PackageTags>
     <MinVerTagPrefix>Instrumentation.Owin-</MinVerTagPrefix>
@@ -11,11 +11,11 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\SemanticConventions.cs" Link="Includes\SemanticConventions.cs"/>
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Contrib.Shared\Api\SpanHelper.cs" Link="Includes\SpanHelper.cs"/>
-	<Compile Include="$(RepoRoot)\src\OpenTelemetry.Internal\Guard.cs" Link="Includes\Guard.cs"/>
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Internal\Guard.cs" Link="Includes\Guard.cs"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
     <PackageReference Include="Microsoft.Owin" Version="$(MicrosoftOwinPkgVer)" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/OpenTelemetry.Instrumentation.Owin.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/OpenTelemetry.Instrumentation.Owin.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry OWIN instrumentation</Description>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Updated to target `net462` and OTel 1.3.1 SDK

See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/652#issuecomment-1252723191

/cc @Kielek 

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
