### PR TITLE
[MassTransit] Add MassTransit ActivitySource to configuration (#326)

### DIFF
--- a/src/OpenTelemetry.Instrumentation.MassTransit/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.MassTransit/TracerProviderBuilderExtensions.cs
@@ -43,6 +43,7 @@ public static class TracerProviderBuilderExtensions
 
         builder.AddInstrumentation(() => new MassTransitInstrumentation(options));
         builder.AddSource(MassTransitDiagnosticListener.ActivitySourceName);
+        builder.AddSource(MassTransitInstrumentation.MassTransitDiagnosticListenerName);
 
         builder.AddLegacySource(OperationName.Consumer.Consume);
         builder.AddLegacySource(OperationName.Consumer.Handle);

--- a/src/OpenTelemetry.Instrumentation.MassTransit/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.MassTransit/TracerProviderBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class TracerProviderBuilderExtensions
 
         builder.AddInstrumentation(() => new MassTransitInstrumentation(options));
         builder.AddSource(MassTransitDiagnosticListener.ActivitySourceName);
-        builder.AddSource(MassTransitInstrumentation.MassTransitDiagnosticListenerName); 
+        builder.AddSource(MassTransitInstrumentation.MassTransitDiagnosticListenerName);
 
         builder.AddLegacySource(OperationName.Consumer.Consume);
         builder.AddLegacySource(OperationName.Consumer.Handle);

--- a/src/OpenTelemetry.Instrumentation.MassTransit/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.MassTransit/TracerProviderBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class TracerProviderBuilderExtensions
 
         builder.AddInstrumentation(() => new MassTransitInstrumentation(options));
         builder.AddSource(MassTransitDiagnosticListener.ActivitySourceName);
-        builder.AddSource(MassTransitInstrumentation.MassTransitDiagnosticListenerName);
+        builder.AddSource(MassTransitInstrumentation.MassTransitDiagnosticListenerName); 
 
         builder.AddLegacySource(OperationName.Consumer.Consume);
         builder.AddLegacySource(OperationName.Consumer.Handle);


### PR DESCRIPTION
Fix #326.

## Changes

Added MassTransit source to AddMassTransitInstrumentation extension to make it traceable for MassTransit v8.


* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
