### PR TITLE
[Not for merging] Mapping different kinds of memory between System.Diagnostics.Process and Process Explorer

### DIFF
--- a/examples/runtime-instrumentation/Program.cs
+++ b/examples/runtime-instrumentation/Program.cs
@@ -22,11 +22,10 @@ public class Program
     public static void Main()
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddRuntimeInstrumentation()
-            .AddPrometheusExporter(options =>
+            .AddProcessInstrumentation()
+            .AddConsoleExporter((exporterOptions, metricReaderOptions) =>
             {
-                options.StartHttpListener = true;
-                options.ScrapeResponseCacheDurationMilliseconds = 0;
+                metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 1000;
             })
             .Build();
 

--- a/examples/runtime-instrumentation/runtime-instrumentation.csproj
+++ b/examples/runtime-instrumentation/runtime-instrumentation.csproj
@@ -6,7 +6,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0-alpha.2" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.4.0-alpha.2" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Runtime\OpenTelemetry.Instrumentation.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\OpenTelemetry.Instrumentation.Process\OpenTelemetry.Instrumentation.Process.csproj" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using System.Threading;
@@ -23,63 +21,33 @@ using Diagnostics = System.Diagnostics;
 
 namespace OpenTelemetry.Instrumentation.Process;
 
-internal class ProcessMetrics
+internal sealed class ProcessMetrics
 {
     internal static readonly AssemblyName AssemblyName = typeof(ProcessMetrics).Assembly.GetName();
     internal static readonly Meter MeterInstance = new(AssemblyName.Name, AssemblyName.Version.ToString());
 
+    private static readonly ThreadLocal<InstrumentsValues> CurrentThreadInstrumentsValues = new(() => new InstrumentsValues());
+
     public ProcessMetrics(ProcessInstrumentationOptions options)
     {
-        ThreadSafeInstrumentValues threadSafeInstrumentValues = new();
-
         // TODO: change to ObservableUpDownCounter
         MeterInstance.CreateObservableGauge(
             "process.memory.usage",
-            () => threadSafeInstrumentValues.GetMemoryUsage(),
+            () => CurrentThreadInstrumentsValues.Value.GetMemoryUsage(),
             unit: "By",
             description: "The amount of physical memory in use.");
 
         // TODO: change to ObservableUpDownCounter
         MeterInstance.CreateObservableGauge(
             "process.memory.virtual",
-            () => threadSafeInstrumentValues.GetVirtualMemoryUsage(),
+            () => CurrentThreadInstrumentsValues.Value.GetVirtualMemoryUsage(),
             unit: "By",
             description: "The amount of committed virtual memory.");
     }
 
-    private class ThreadSafeInstrumentValues
+    private sealed class InstrumentsValues
     {
-        private readonly ThreadLocal<Dictionary<int, InstrumentsValues>> threadIdToInstrumentValues = new(() =>
-        {
-            return new Dictionary<int, InstrumentsValues>();
-        });
-
-        internal double GetMemoryUsage()
-        {
-            if (!this.threadIdToInstrumentValues.Value.ContainsKey(Environment.CurrentManagedThreadId))
-            {
-                this.threadIdToInstrumentValues.Value.Add(Environment.CurrentManagedThreadId, new InstrumentsValues());
-            }
-
-            this.threadIdToInstrumentValues.Value.TryGetValue(Environment.CurrentManagedThreadId, out var instrumentValues);
-            return instrumentValues.GetMemoryUsage();
-        }
-
-        internal double GetVirtualMemoryUsage()
-        {
-            if (!this.threadIdToInstrumentValues.Value.ContainsKey(Environment.CurrentManagedThreadId))
-            {
-                this.threadIdToInstrumentValues.Value.Add(Environment.CurrentManagedThreadId, new InstrumentsValues());
-            }
-
-            this.threadIdToInstrumentValues.Value.TryGetValue(Environment.CurrentManagedThreadId, out var instrumentsValues);
-            return instrumentsValues.GetVirtualMemoryUsage();
-        }
-    }
-
-    private class InstrumentsValues
-    {
-        private readonly Diagnostics.Process currentProcess = Diagnostics.Process.GetCurrentProcess();
+        private static readonly Diagnostics.Process CurrentProcess = Diagnostics.Process.GetCurrentProcess();
         private double? memoryUsage;
         private double? virtualMemoryUsage;
 
@@ -115,9 +83,9 @@ internal class ProcessMetrics
 
         private void Snapshot()
         {
-            this.currentProcess.Refresh();
-            this.memoryUsage = this.currentProcess.WorkingSet64;
-            this.virtualMemoryUsage = this.currentProcess.PagedMemorySize64;
+            CurrentProcess.Refresh();
+            this.memoryUsage = CurrentProcess.WorkingSet64;
+            this.virtualMemoryUsage = CurrentProcess.PagedMemorySize64;
         }
     }
 }


### PR DESCRIPTION
Used OTel Console Exporter to log out different fields of System.Diagnostics.Process and compare them with the values reported by [Process Explorer](https://learn.microsoft.com/en-us/sysinternals/downloads/process-explorer).

The export interval of Console Exporter was set to be 1 second and so does the refresh interval of Process Explorer.
Process Explorer does not support exporting a snapshot at a given timestamp; therefore, the snapshot below from Process Explorer was taken from manually.
The timestamp difference between the console log from Console Exporter and the values observed from Process Explorer should be less than 2 seconds.

```console
Refresh()

Export process.memory.usage, The amount of workingSet64, Unit: By, Meter: OpenTelemetry.Instrumentation.Process/0.0.0.0
(2022-09-30T21:20:25.4082092Z, 2022-09-30T21:20:43.4169199Z] DoubleGauge
Value: 32808960

Export process.memory.pagedMemorySize, The amount of pagedMemorySize, Unit: By, Meter: OpenTelemetry.Instrumentation.Process/0.0.0.0
(2022-09-30T21:20:25.4113453Z, 2022-09-30T21:20:43.4169202Z] DoubleGauge
Value: 17805312

Export process.memory.pagedSystemMemorySize, The amount of pagedSystemMemorySize, Unit: By, Meter: OpenTelemetry.Instrumentation.Process/0.0.0.0
(2022-09-30T21:20:25.4114016Z, 2022-09-30T21:20:43.4169206Z] DoubleGauge
Value: 226896

Export process.memory.nonPagedSystemMemorySize, The amount of nonPagedSystemMemorySize, Unit: By, Meter: OpenTelemetry.Instrumentation.Process/0.0.0.0
(2022-09-30T21:20:25.4114187Z, 2022-09-30T21:20:43.4169208Z] DoubleGauge
Value: 23872

Export process.memory.privateMemorySize, The amount of PrivateMemorySize, Unit: By, Meter: OpenTelemetry.Instrumentation.Process/0.0.0.0
(2022-09-30T21:20:25.4114391Z, 2022-09-30T21:20:43.4169209Z] DoubleGauge
Value: 17805312
```

![image](https://user-images.githubusercontent.com/16979322/193361381-47fa449b-bcd6-456a-a0b6-b23408fb44d7.png)

This is the name-mapping table based on the above observation:

| System.Diagnostics.Process field name  | column name in Process Explorer |
| -------------------------------------- | ---------------- |
| pagedMemorySize64, privateMemorySize64 | Private Bytes    |
| pagedSystemMemorySize64                | Paged Pool       |
| nonpagedSystemMemorySize64             | Nonpaged Pool    |
| workingSet64                           | Working Set      |

From [OTel Process Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md#metric-instruments),
the "process.memory.virtual" instrument should be reflecting "The amount of committed virtual memory."

The definition of committed virtual memory from Mark Russinovich's [blogpost](https://techcommunity.microsoft.com/t5/windows-blog-archive/pushing-the-limits-of-windows-virtual-memory/ba-p/723750) is defined as: 
"There are two types of process virtual memory that do count toward the commit limit: private and pagefile-backed."
Windows tracks the private bytes usage with the Private Bytes performance counter. While there are no process-specific counter to look for pagefile-backed virtual memory.

Due to the above mentioning reasons, and the fact that there is no existing field from System.Diagnostic.Process to get pagefile-backed virtual memory usage, I propose to use "private virtual memory dedicated to the currentProcess" as the description for the .NET implementation of the gauge "process.memory.virtual".

