### PR TITLE
[Instrumentation.Process] Add CPU metrics

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -89,7 +89,7 @@ internal sealed class ProcessMetrics
                 };
             },
             unit: "s",
-            description: "Total CPU time broken down by user state and system state.");
+            description: "Total CPU seconds broken down by different states.");
     }
 
     private void Snapshot()

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -66,9 +66,9 @@ internal sealed class ProcessMetrics
             unit: "By",
             description: "The amount of virtual memory allocated for this process that cannot be shared with other processes.");
 
-        MeterInstance.CreateObservableCounter(
+        this.MeterInstance.CreateObservableCounter(
             "process.cpu.time",
-            () => GetProcessorTimes(),
+            () => this.GetProcessorTimes(),
             unit: "s",
             description: "Total CPU time broken down by user state and system state.");
     }
@@ -80,12 +80,12 @@ internal sealed class ProcessMetrics
         this.virtualMemoryUsage = this.currentProcess.PrivateMemorySize64;
     }
 
-    private static IEnumerable<Measurement<double>> GetProcessorTimes()
+    private IEnumerable<Measurement<double>> GetProcessorTimes()
     {
         return new[]
         {
-                new Measurement<double>(CurrentProcess.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("state", "user")),
-                new Measurement<double>(CurrentProcess.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("state", "system")),
+            new Measurement<double>(this.currentProcess.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("state", "user")),
+            new Measurement<double>(this.currentProcess.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("state", "system")),
         };
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -70,7 +70,7 @@ internal sealed class ProcessMetrics
             "process.cpu.time",
             () => GetProcessorTimes(),
             unit: "s",
-            description: "Processor time of this process");
+            description: "Total CPU time broken down by user state and system state.");
     }
 
     private void Snapshot()

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Reflection;
@@ -66,12 +65,6 @@ internal sealed class ProcessMetrics
             },
             unit: "By",
             description: "The amount of virtual memory allocated for this process that cannot be shared with other processes.");
-
-        // TODO: change to ObservableUpDownCounter
-        MeterInstance.CreateObservableGauge(
-            "process.cpu.count",
-            () => Environment.ProcessorCount,
-            description: "The number of available logical CPUs");
 
         MeterInstance.CreateObservableCounter(
             "process.cpu.time",

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -37,11 +37,15 @@ public class ProcessMetricsTests
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-        Assert.True(exportedItems.Count == 2);
+        Assert.True(exportedItems.Count == 4);
         var physicalMemoryMetric = exportedItems.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetric);
         var virtualMemoryMetric = exportedItems.FirstOrDefault(i => i.Name == "process.memory.virtual");
         Assert.NotNull(virtualMemoryMetric);
+        var cpuTimeMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.time");
+        Assert.NotNull(cpuTimeMetric);
+        var cpuCountMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.count");
+        Assert.NotNull(cpuCountMetric);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -69,11 +69,16 @@ public class ProcessMetricsTests
             foreach (var tag in points.Current.Tags)
             {
                 if (tag.Key == "state" && tag.Value.ToString() == "user")
+                {
                     userTimeCaptured = true;
+                }
                 else if (tag.Key == "state" && tag.Value.ToString() == "system")
+                {
                     systemTimeCaptured = true;
+                }
             }
         }
+
         Assert.True(userTimeCaptured);
         Assert.True(systemTimeCaptured);
     }


### PR DESCRIPTION
Fixes #677.

## Changes

Adds the `process.cpu.time` counter.

