### PR TITLE
Upgrade OpenTelemetry to 1.4.0-beta.3.8

### DIFF
--- a/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
+++ b/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
@@ -61,7 +61,7 @@ internal sealed class ActivityEventAttachingLogProcessor : BaseProcessor<LogReco
                 tags[nameof(data.EventId)] = data.EventId;
             }
 
-            var activityEvent = new ActivityEvent("log", data.Timestamp, tags);
+
 
             data.ForEachScope(ProcessScope, new State(tags, this));
 
@@ -84,6 +84,7 @@ internal sealed class ActivityEventAttachingLogProcessor : BaseProcessor<LogReco
                 tags[nameof(data.FormattedMessage)] = data.FormattedMessage;
             }
 
+            var activityEvent = new ActivityEvent("log", data.Timestamp, tags);
             activity.AddEvent(activityEvent);
 
             if (data.Exception != null)

--- a/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
+++ b/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.4.0-beta.3.8" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
+++ b/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.4.0-beta.3.8" />
+    <PackageReference Include="OpenTelemetry" Version="1.4.0-beta.3.8"/>
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
@@ -32,9 +32,9 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
         ShouldListenTo = source => true,
     };
 
-    private readonly ILogger logger;
-    private readonly ILoggerFactory loggerFactory;
-    private OpenTelemetryLoggerOptions options;
+
+
+
     private bool sampled;
 
     public ActivityEventAttachingLogProcessorTests()
@@ -47,25 +47,12 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
         };
 
         ActivitySource.AddActivityListener(this.activityListener);
-
-        this.loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder.AddOpenTelemetry(options =>
-            {
-                this.options = options;
-                options.AttachLogsToActivityEvent();
-            });
-            builder.AddFilter(typeof(ActivityEventAttachingLogProcessorTests).FullName, LogLevel.Trace);
-        });
-
-        this.logger = this.loggerFactory.CreateLogger<ActivityEventAttachingLogProcessorTests>();
     }
 
     public void Dispose()
     {
         this.activitySource.Dispose();
         this.activityListener.Dispose();
-        this.loggerFactory.Dispose();
     }
 
     [Theory]
@@ -82,24 +69,35 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
         bool recordException = false)
     {
         this.sampled = sampled;
-        this.options.IncludeFormattedMessage = includeFormattedMessage;
-        this.options.ParseStateValues = parseStateValues;
-        this.options.IncludeScopes = includeScopes;
 
+        using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options
+                        .SetIncludeScopes(includeScopes)
+                        .SetIncludeFormattedMessage(includeFormattedMessage)
+                        .SetParseStateValues(parseStateValues);
+                    options.AttachLogsToActivityEvent();
+                });
+                builder.AddFilter(typeof(ActivityEventAttachingLogProcessorTests).FullName, LogLevel.Trace);
+            });
+
+        ILogger logger = loggerFactory.CreateLogger<ActivityEventAttachingLogProcessorTests>();
         Activity activity = this.activitySource.StartActivity("Test");
 
-        using IDisposable scope = this.logger.BeginScope("{NodeId}", 99);
+        using IDisposable scope = logger.BeginScope("{NodeId}", 99);
 
-        this.logger.LogInformation(eventId, "Hello OpenTelemetry {UserId}!", 8);
+        logger.LogInformation(eventId, "Hello OpenTelemetry {UserId}!", 8);
 
         Activity innerActivity = null;
         if (recordException)
         {
             innerActivity = this.activitySource.StartActivity("InnerTest");
 
-            using IDisposable innerScope = this.logger.BeginScope("{RequestId}", "1234");
+            using IDisposable innerScope = logger.BeginScope("{RequestId}", "1234");
 
-            this.logger.LogError(new InvalidOperationException("Goodbye OpenTelemetry."), "Exception event.");
+            logger.LogError(new InvalidOperationException("Goodbye OpenTelemetry."), "Exception event.");
 
             innerActivity.Dispose();
         }


### PR DESCRIPTION
Support latest OpenTelemetry `1.4.0-beta.3.8`

## Changes

Latest OpenTelemetry API brings   `System.Diagnostics.DiagnosticSource`  version 7.0.0.
The  `ActivityEvent::Tags` property was redefined to be of type `Activity.TagsLinkedList(tags)` rather than  `ActivityTagsCollection`, which makes impossible to add key/value to the dictionary once the the `ActivityEvent` was created. 
This PR initializes the  `ActivityEvent`  after all tags had been added to `ActivityTagsCollection`