### PR TITLE
[Instrumentation.Runtime] Reintroduce heap size metric

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -51,6 +51,13 @@ internal class RuntimeMetrics
             () => GetGarbageCollectionCounts(),
             description: "Number of garbage collections that have occurred since process start.");
 
+        // TODO: change to ObservableUpDownCounter
+        MeterInstance.CreateObservableGauge(
+            "process.runtime.dotnet.gc.heap.live",
+            () => GC.GetTotalMemory(false),
+            "bytes",
+            "Count of bytes currently in use by live objects in the GC heap.");
+
 #if NETCOREAPP3_1_OR_GREATER
         MeterInstance.CreateObservableCounter(
             "process.runtime.dotnet.gc.allocations.size",

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -75,6 +75,9 @@ public class RuntimeMetricsTests
         var gcCountMetric = exportedItems.FirstOrDefault(i => i.Name == "process.runtime.dotnet.gc.collections.count");
         Assert.NotNull(gcCountMetric);
 
+        var currentHeapSizeMetric = exportedItems.FirstOrDefault(i => i.Name == "process.runtime.dotnet.gc.heap.live");
+        Assert.NotNull(currentHeapSizeMetric);
+
 #if NETCOREAPP3_1_OR_GREATER
         var gcAllocationSizeMetric = exportedItems.FirstOrDefault(i => i.Name == "process.runtime.dotnet.gc.allocations.size");
         Assert.NotNull(gcAllocationSizeMetric);


### PR DESCRIPTION
Fixes #682.

## Changes

Add an instrument to report current heap size at the time of observation.
Rename from previous `process.runtime.dotnet.gc.heap` to `process.runtime.dotnet.gc.heap.live` to disambiguate from `process.runtime.dotnet.gc.heap.size`
