### PR TITLE
[Instrumentation.EventCounters] Avoid race condition and performance trap in EventCountersMetrics

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -71,11 +71,6 @@ internal sealed class EventCountersMetrics : EventListener
             }
         }
     }
-    
-    private void EnableEvents(EventSource eventSource)
-    {
-         this.EnableEvents(eventSource, EventLevel.Critical, EventKeywords.None, GetEnableEventsArguments(this.options));
-    }
 
     /// <inheritdoc />
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
@@ -124,6 +119,11 @@ internal sealed class EventCountersMetrics : EventListener
 
     private static Dictionary<string, string> GetEnableEventsArguments(EventCountersInstrumentationOptions options) =>
         new() { { "EventCounterIntervalSec", options.RefreshIntervalSecs.ToString() } };
+
+    private void EnableEvents(EventSource eventSource)
+    {
+        this.EnableEvents(eventSource, EventLevel.Critical, EventKeywords.None, GetEnableEventsArguments(this.options));
+    }
 
     private void UpdateInstrumentWithEvent(bool isGauge, string eventSourceName, string name, double value)
     {

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -30,7 +30,7 @@ internal sealed class EventCountersMetrics : EventListener
     internal static readonly Meter MeterInstance = new(typeof(EventCountersMetrics).Assembly.GetName().Name, typeof(EventCountersMetrics).Assembly.GetName().Version.ToString());
 
     private readonly EventCountersInstrumentationOptions options;
-    private readonly ConcurrentQueue<EventSource> preInitEventSources = new();
+    private readonly List<EventSource> preInitEventSources = new();
     private readonly ConcurrentDictionary<(string, string), Instrument> instruments = new();
     private readonly ConcurrentDictionary<(string, string), double> values = new();
 
@@ -40,28 +40,41 @@ internal sealed class EventCountersMetrics : EventListener
     /// <param name="options">The options to define the metrics.</param>
     public EventCountersMetrics(EventCountersInstrumentationOptions options)
     {
-        this.options = options;
-
-        while (this.preInitEventSources.TryDequeue(out EventSource eventSource))
+        lock (this.preInitEventSources)
         {
-            if (this.options.ShouldListenToSource(eventSource.Name))
+            this.options = options;
+
+            foreach (EventSource eventSource in this.preInitEventSources)
             {
-                this.EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.None, GetEnableEventsArguments(this.options));
+                if (this.options.ShouldListenToSource(eventSource.Name))
+                {
+                    this.EnableEvents(eventSource);
+                }
             }
+
+            this.preInitEventSources.Clear();
         }
     }
 
     /// <inheritdoc />
-    protected override void OnEventSourceCreated(EventSource source)
+    protected override void OnEventSourceCreated(EventSource eventSource)
     {
-        if (this.options == null)
+        lock (this.preInitEventSources)
         {
-            this.preInitEventSources.Enqueue(source);
+            if (this.options == null)
+            {
+                this.preInitEventSources.Add(eventSource);
+            }
+            else if (this.options.ShouldListenToSource(eventSource.Name))
+            {
+                this.EnableEvents(eventSource);
+            }
         }
-        else if (this.options.ShouldListenToSource(source.Name))
-        {
-            this.EnableEvents(source, EventLevel.LogAlways, EventKeywords.None, GetEnableEventsArguments(this.options));
-        }
+    }
+    
+    private void EnableEvents(EventSource eventSource)
+    {
+         this.EnableEvents(eventSource, EventLevel.Critical, EventKeywords.None, GetEnableEventsArguments(this.options));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This PR fixes two issues with the current implementation:
- Uses `EventLevel.Critical` instead of `EventLevel.LogAlways`
  - Counters don't require a specific log level to work. Depending on the `EventSource` implementor, this change can avoid a lot of overhead (preparing and serializing event arguments, potentially taking more expensive code paths).
- Avoids a race condition when initializing the `EventCountersMetrics` instance
  - As `OnEventSourceCreated` can run before the constructor is done, you can run into a situation where you fail to enable an `EventSource` instance. A simple lock avoids this race.
  - Example course of events:
    - Thread A calls into `OnEventSourceCreated` and sees options aren't set yet
    - Thread B executes the constructor, processing any entries in `preInitEventSources`
    - Thread A adds the `EventSource` into `preInitEventSources`
    - Nothing will process and enable that `EventSource` instance
