### PR TITLE
Add Piotr as Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ expected to directly contribute to every component.
 Approvers
 ([@open-telemetry/dotnet-contrib-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-approvers)):
 
-* This list is currently empty.
+* [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
 
 *Find more about the approver role in [community
 repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*


### PR DESCRIPTION
@Kielek has been actively contributing to this repo for a few months now. He is already an approver in the instrumentation repo (https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation) since Apr 2022 and has made significant contributions to the overall project in the past year.

Contributions include active reviews, efforts to standardize code style, diagnostics, project structure across all components for this repo, and expanding test coverage.

Link to all the PRs submitted by Piotr: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pulls?q=is%3Apr+author%3Akielek


