### PR TITLE
Disable MyGet nuget source

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,8 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="MyGet" value="https://www.myget.org/F/opentelemetry/api/v3/index.json" />
+    <!-- Uncomment following source, if you need to use nightly builds for OTel SDK/API
+      <add key="MyGet" value="https://www.myget.org/F/opentelemetry/api/v3/index.json" /> -->
   </packageSources>
   <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
Partially solves discussion under
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/680#issuecomment-1282415716

## Changes

Comment out MyGet nuget source. I would keep it in the source code to allow user play with OTel SDK/API nightly builds.
It is not used in any typical scenario.

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* [x] Design discussion issue #680
