### PR TITLE
Refactor props file to have latest version of core pkgs

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -26,7 +26,7 @@
     <MicrosoftExtensionsLoggingPkgVer>[5.0.0,7.0)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftNETTestSdkPkgVer>[16.11.0,17.0)</MicrosoftNETTestSdkPkgVer>
     <MoqPkgVer>[4.17.2,5.0)</MoqPkgVer>
-    <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryPkgVer)</OpenTelemetryExporterInMemoryPkgVer>
+    <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryCoreLatestVersion)</OpenTelemetryExporterInMemoryPkgVer>
     <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.4.2,3.0)</XUnitPkgVer>
   </PropertyGroup>

--- a/build/Common.props
+++ b/build/Common.props
@@ -32,8 +32,7 @@
     <MicrosoftOwinPkgVer>[4.2.2,5.0)</MicrosoftOwinPkgVer>
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
-    <OpenTelemetryApiPkgVer>[1.3.1,2.0)</OpenTelemetryApiPkgVer>
-    <OpenTelemetryPkgVer>$(OpenTelemetryApiPkgVer)</OpenTelemetryPkgVer>
+    <OpenTelemetryCoreLatestVersion>[1.3.1,2.0)</OpenTelemetryCoreLatestVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
   </PropertyGroup>

--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.4.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj">

--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -79,13 +79,13 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="[5.2.7,6.0)" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="[5.2.7,6.0)" />
     <PackageReference Include="Microsoft.AspNet.WebPages" Version="[3.2.7,4.0)" />
-    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.4.0-beta.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj">

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -84,7 +84,7 @@ namespace Examples.AspNet
                     });
                     break;
                 case "prometheus":
-                    meterBuilder.AddPrometheusExporter();
+                    meterBuilder.AddPrometheusHttpListener();
                     break;
                 default:
                     meterBuilder.AddConsoleExporter((exporterOptions, metricReaderOptions) =>

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -84,7 +84,7 @@ namespace Examples.AspNet
                     });
                     break;
                 case "prometheus":
-                    meterBuilder.AddPrometheusHttpListener();
+                    meterBuilder.AddPrometheusExporter();
                     break;
                 default:
                     meterBuilder.AddConsoleExporter((exporterOptions, metricReaderOptions) =>

--- a/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Updates to 1.3.1 of OpenTelemetry SDK.
+
 ## 1.0.0-beta.1
 
 Released 2022-Jul-28

--- a/src/OpenTelemetry.Extensions.Docker/OpenTelemetry.Extensions.Docker.csproj
+++ b/src/OpenTelemetry.Extensions.Docker/OpenTelemetry.Extensions.Docker.csproj
@@ -5,6 +5,6 @@
     <MinVerTagPrefix>Extensions.Docker-</MinVerTagPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
@@ -23,6 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Api" Version="1.3.1" />
+        <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="[1.7.0,1.8.0)" />
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Internal\Guard.cs" Link="Includes\Guard.cs" />

--- a/src/OpenTelemetry.Instrumentation.MassTransit/OpenTelemetry.Instrumentation.MassTransit.csproj
+++ b/src/OpenTelemetry.Instrumentation.MassTransit/OpenTelemetry.Instrumentation.MassTransit.csproj
@@ -8,7 +8,7 @@
     <EnablePublicApi>true</EnablePublicApi>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.MySqlData/OpenTelemetry.Instrumentation.MySqlData.csproj
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/OpenTelemetry.Instrumentation.MySqlData.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="MySql.Data" Version="6.10.7" />
-        <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiPkgVer)" />
+        <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
+++ b/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="Microsoft.Owin" Version="$(MicrosoftOwinPkgVer)" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
+++ b/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeRedisPkgVer)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPkgVer)" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
+++ b/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Exporter.Stackdriver.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Exporter.Stackdriver.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryApiPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
@@ -16,7 +16,7 @@
         </PackageReference>
         <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetXUnitCliVer)" />
         <PackageReference Include="MySql.Data" Version="6.10.7" />
-        <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
+        <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
"OpenTelemetryCoreLatestVersion" should point to the latest stable version of the core packages. The name reflects it is latest stable. We could add another latest-prerelease, for those projects that want to depend on it.