### PR TITLE
[Instrumentation.Process] Dropping Snapshot

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,8 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="MyGet" value="https://www.myget.org/F/opentelemetry/api/v3/index.json" />
+    <!-- Uncomment following source, if you need to use nightly builds for OTel SDK/API
+      <add key="MyGet" value="https://www.myget.org/F/opentelemetry/api/v3/index.json" /> -->
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -156,13 +156,9 @@ public class ProcessMetricsTests
 
         foreach (ref readonly var metricPoint in metric.GetMetricPoints())
         {
-            if (metric.MetricType.IsGauge())
+            if (metric.MetricType.IsLong())
             {
                 sum += metricPoint.GetGaugeLastValueLong();
-            }
-            else if (metric.MetricType.IsDouble())
-            {
-                sum += metricPoint.GetSumDouble();
             }
         }
 

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -46,7 +46,7 @@ public class ProcessMetricsTests
         var cpuUtilizationMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.utilization");
         Assert.NotNull(cpuUtilizationMetric);
         var threadMetric = exportedItems.FirstOrDefault(i => i.Name == "process.threads");
-        Assert.NotNull(cpuTimeMetric);
+        Assert.NotNull(threadMetric);
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class ProcessMetricsTests
         {
             if (metric.MetricType.IsGauge())
             {
-                sum += metricPoint.GetGaugeLastValueDouble();
+                sum += metricPoint.GetGaugeLastValueLong();
             }
             else if (metric.MetricType.IsDouble())
             {


### PR DESCRIPTION
Update to use Process.Refresh() on each callback after benchmarking the perf https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/717 and found it cheap.
Also, addressing https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/664#discussion_r993403498.