### PR TITLE
[Exporter.Geneva] - Change default metric exporter interval to 60sec

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -9,6 +9,12 @@
   values.
   [#721](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/721)
 
+* Add support for exporting exception stack.
+  [#672](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/672)
+
+* Change default MetricExportInterval to 60 secs from 20 secs.
+  [#722](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/722)
+
 ## 1.4.0-beta.2
 
 Released 2022-Oct-17

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Add support for exporting exception stack.
   [#672](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/672)
 
-* Change default MetricExportInterval to 60 secs from 20 secs.
+* Change the default MetricExportInterval from 20 seconds to 60 seconds.
   [#722](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/722)
 
 ## 1.4.0-beta.2

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Exporter.Geneva;
 public class GenevaMetricExporterOptions
 {
     private IReadOnlyDictionary<string, object> _prepopulatedMetricDimensions;
-    private int _metricExporterIntervalMilliseconds = 20000;
+    private int _metricExporterIntervalMilliseconds = 60000;
 
     /// <summary>
     /// Gets or sets the ConnectionString which contains semicolon separated list of key-value pairs.
@@ -33,7 +33,7 @@ public class GenevaMetricExporterOptions
     public string ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets the metric export interval in milliseconds. The default value is 20000.
+    /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
     /// </summary>
     public int MetricExportIntervalMilliseconds
     {


### PR DESCRIPTION
This aligns with the default for OTLP Exporter, and also backend expectations.