### PR TITLE
Fix using version 3.7.100 of AWS SDK causing exception not finding EndpointResolver

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - OpenTelemetry.Contrib.Instrumentation.AWS
 
+## Unreleased
+
+* Fixed issue when using version 3.7.100 of the AWS SDK for .NET triggering an
+EndpointResolver not found exception.
+
 ## 1.0.1
 
 Released 2021-Feb-24

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Fixed issue when using version 3.7.100 of the AWS SDK for .NET triggering an
-EndpointResolver not found exception.
+  EndpointResolver not found exception.
+  ([#726](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/726))
 
 ## 1.0.1
 

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
@@ -44,6 +44,6 @@ internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
             return;
         }
 
-        pipeline.AddHandlerAfter<EndpointResolver>(new AWSTracingPipelineHandler(this.options));
+        pipeline.AddHandlerBefore<RetryHandler>(new AWSTracingPipelineHandler(this.options));
     }
 }


### PR DESCRIPTION
## Changes
Starting with version 3.7.100 of the AWS .NET SDK the EndpointResolver is replaced with a service specific version of the handler. This breaks the OpenTelemetry integration because OpenTelemetry was inserting itself just after EndpointResolver in the SDK's request pipeline.

The fix is for OpenTelemetry to inject itself before the RetryHandler which happens after endpoint resolutions. So the position will be the same in the request pipeline.

This fix will is compatible with both version 3.7.100 and versions before 3.7.100 so it will not break users that haven't upgrade their SDK version. 

This change is very similar to the AWS X-Ray change which this code is based off: https://github.com/aws/aws-xray-sdk-dotnet/pull/268 

For significant contributions please make sure you have completed the following items:

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
