### PR TITLE
Remove unnecessary notes from readme

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -297,23 +297,6 @@ metric is available in the .NET version you are running.
 Some GC related metrics are unavailable until at least one garbage collection
 has occurred.
 
-## Note
-
-OTel API updated System.Diagnostics.DiagnosticSource preview to version 7.0.0
-since [1.4.0-alpha.2](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-alpha.2).
-
-With this update, applications targeting .NET 5 and lower will receive a
-warning at build time as described [here](https://github.com/dotnet/runtime/pull/72518)
-(note: building using older versions of the .NET SDK produces an error at
-build time). This is because .NET 5 reached EOL in May 2022 and .NET
-Core 3.1 reaches EOL in December 2022.
-
-There is no guarantee that System.Diagnostics.DiagnosticSource will continue
-to work on older versions of .NET. However, the build warning can be
-suppressed by setting the SuppressTfmSupportBuildWarnings MSBuild property.
-
-This does not affect applications targeting .NET Framework.
-
 ## References
 
 * [OpenTelemetry Project](https://opentelemetry.io/)


### PR DESCRIPTION
Already mentioned this in changelog: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md#unreleased , so I think this is just too much notes.