### PR TITLE
[Instrumentation.EventCounters] Support long event source names better in EventCounters instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 * Update OpenTelemetry.Api to 1.3.1.
-* Changed `EventCounter` prefix to `ec` and started abbreviating event source name
-  when instrument name is longer that 63 characters.
+* Change `EventCounter` prefix to `ec` and abbreviate event source name
+  when instrument name is longer than 63 characters.
   ([#740](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/740))
 
 ## 1.0.0-alpha.1

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Unreleased
 
 * Update OpenTelemetry.Api to 1.3.1.
-* Change `EventCounter` prefix to `ec` and abbreviate event source name
-  when instrument name is longer than 63 characters.
+* Change `EventCounter` prefix to `ec` and trim the event source name to keep instrument name under 63 characters.
   ([#740](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/740))
 
 ## 1.0.0-alpha.1

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Update OpenTelemetry.Api to 1.3.1.
-* Change `EventCounter` prefix to `ec` and trim the event source name to keep instrument name under 63 characters.
+* Change `EventCounter` prefix to `ec` and trim the event source name to keep
+  instrument name under 63 characters.
   ([#740](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/740))
 
 ## 1.0.0-alpha.1

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Update OpenTelemetry.Api to 1.3.1.
+* Changed `EventCounter` prefix to `ec` and started abbreviating event source name
+  when instrument name is longer that 63 characters.
+  ([#740](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/740))
 
 ## 1.0.0-alpha.1
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -140,7 +140,15 @@ internal sealed class EventCountersMetrics : EventListener
             return string.Concat(Prefix, ".", sourceName, ".", eventName);
         }
 
-        var abbreviation = new StringBuilder(sourceName.Length);
+        var maxEventSourceLength = MaxInstrumentNameLength - Prefix.Length - 1 - eventName.Length;
+        if (maxEventSourceLength < 2) 
+        {
+            // event name is too long, there is not enough space for sourceName.
+            // let ec.<eventName> flow to metrics SDK and filter if needed.
+            return string.Concat(Prefix, ".", eventName);
+        }
+
+        var abbreviation = new StringBuilder(maxEventSourceLength);
         int ind = 0;
         while (ind >= 0 && ind < sourceName.Length)
         {
@@ -151,6 +159,11 @@ internal sealed class EventCountersMetrics : EventListener
 
             if (ind < sourceName.Length)
             {
+                if (abbreviation.Length + 2 >= maxEventSourceLength)
+                {
+                    break;
+                }
+
                 abbreviation.Append(char.ToLowerInvariant(sourceName[ind])).Append('.');
             }
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -126,10 +126,10 @@ internal sealed class EventCountersMetrics : EventListener
     /// <summary>
     /// If instrument name is too long, abbreviates event source name.
     /// E.g. instrument for `Microsoft-AspNetCore-Server-Kestrel`, `tls-handshakes-per-second`
-    /// would be too long (64 chars), so it's abbreviated to `ec.m.a.s.k.tls-handshakes-per-second`
-    /// instead of `ec.Microsoft-AspNetCore-Server-Kestrel.tls-handshakes-per-second`.
-    ///
-    /// If after that instrument name is still invalid, it will be validated and ignored later in the pipeline.
+    /// would be too long (64 chars), so it's shortened to `ec.Microsoft-AspNetCore-Server-Kestre.tls-handshakes-per-second`.
+    /// 
+    /// If there is no room for event source name, returns `ec.{event name}` and 
+    /// if it's still too long, it will be validated and ignored later in the pipeline.
     /// </summary>
     private static string GetInstrumentName(string sourceName, string eventName)
     {

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -37,6 +37,7 @@ internal sealed class EventCountersMetrics : EventListener
     private readonly List<EventSource> preInitEventSources = new();
     private readonly ConcurrentDictionary<(string, string), Instrument> instruments = new();
     private readonly ConcurrentDictionary<(string, string), double> values = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EventCountersMetrics"/> class.
     /// </summary>

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -19,7 +19,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
-using System.Text;
 
 namespace OpenTelemetry.Instrumentation.EventCounters;
 
@@ -148,48 +147,7 @@ internal sealed class EventCountersMetrics : EventListener
             return string.Concat(Prefix, ".", eventName);
         }
 
-        var abbreviation = new StringBuilder(maxEventSourceLength);
-        int ind = 0;
-        while (ind >= 0 && ind < sourceName.Length)
-        {
-            while (ind < sourceName.Length && (sourceName[ind] == '.' || sourceName[ind] == '-'))
-            {
-                ind++;
-            }
-
-            if (ind < sourceName.Length)
-            {
-                abbreviation.Append(char.ToLowerInvariant(sourceName[ind])).Append('.');
-                if (abbreviation.Length + 2 >= maxEventSourceLength)
-                {
-                    // stop if there is no room to add another letter and a dot after
-                    break;
-                }
-            }
-
-            int nextDot = sourceName.IndexOf('.', ind);
-            int nextDash = sourceName.IndexOf('-', ind);
-
-            if (nextDot < 0)
-            {
-                if (nextDash < 0)
-                {
-                    break;
-                }
-
-                ind = nextDash;
-            }
-            else if (nextDash < 0)
-            {
-                ind = nextDot;
-            }
-            else
-            {
-                ind = Math.Min(nextDot, nextDash);
-            }
-        }
-
-        return string.Concat(Prefix, ".", abbreviation.ToString(), eventName);
+        return string.Concat(Prefix, ".", sourceName.Substring(0, maxEventSourceLength - 1), ".", eventName);
     }
 
     private void EnableEvents(EventSource eventSource)

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -141,10 +141,10 @@ internal sealed class EventCountersMetrics : EventListener
         }
 
         var maxEventSourceLength = MaxInstrumentNameLength - Prefix.Length - 1 - eventName.Length;
-        if (maxEventSourceLength < 2) 
+        if (maxEventSourceLength < 2)
         {
             // event name is too long, there is not enough space for sourceName.
-            // let ec.<eventName> flow to metrics SDK and filter if needed.
+            // let ec.<eventName> flow to metrics SDK and it will suppress it if needed.
             return string.Concat(Prefix, ".", eventName);
         }
 
@@ -159,12 +159,12 @@ internal sealed class EventCountersMetrics : EventListener
 
             if (ind < sourceName.Length)
             {
+                abbreviation.Append(char.ToLowerInvariant(sourceName[ind])).Append('.');
                 if (abbreviation.Length + 2 >= maxEventSourceLength)
                 {
+                    // stop if there is no room to add another letter and a dot after
                     break;
                 }
-
-                abbreviation.Append(char.ToLowerInvariant(sourceName[ind])).Append('.');
             }
 
             int nextDot = sourceName.IndexOf('.', ind);

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -140,8 +140,7 @@ internal sealed class EventCountersMetrics : EventListener
             return string.Concat(Prefix, ".", sourceName, ".", eventName);
         }
 
-        int maxEventSourceNameLength = MaxInstrumentNameLength - Prefix.Length - 2 - eventName.Length;
-        var abbreviation = new StringBuilder(maxEventSourceNameLength);
+        var abbreviation = new StringBuilder(sourceName.Length);
         int ind = 0;
         while (ind >= 0 && ind < sourceName.Length)
         {
@@ -192,10 +191,9 @@ internal sealed class EventCountersMetrics : EventListener
             ValueTuple<string, string> metricKey = new(eventSourceName, name);
             _ = this.values.AddOrUpdate(metricKey, value, isGauge ? (_, _) => value : (_, existing) => existing + value);
 
-            var instrumentName = GetInstrumentName(eventSourceName, name);
-
             if (!this.instruments.ContainsKey(metricKey))
             {
+                var instrumentName = GetInstrumentName(eventSourceName, name);
                 Instrument instrument = isGauge
                     ? MeterInstance.CreateObservableGauge(instrumentName, () => this.values[metricKey])
                     : MeterInstance.CreateObservableCounter(instrumentName, () => this.values[metricKey]);

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -148,9 +148,9 @@ internal sealed class EventCountersMetrics : EventListener
             return string.Concat(Prefix, ".", eventName);
         }
 
-        while (maxEventSourceLength > 0 && (sourceName[maxEventSourceLength - 1] == '.' || sourceName[maxEventSourceLength - 1] == '-'))  
+        while (maxEventSourceLength > 0 && (sourceName[maxEventSourceLength - 1] == '.' || sourceName[maxEventSourceLength - 1] == '-'))
         {
-            maxEventSourceLength --;
+            maxEventSourceLength--;
         }
 
         return string.Concat(Prefix, ".", sourceName.Substring(0, maxEventSourceLength), ".", eventName);

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Threading.Tasks;
 using OpenTelemetry.Metrics;
 using Xunit;
@@ -68,7 +69,7 @@ public class EventCountersMetricsTests
         meterProvider.ForceFlush();
 
         // Assert
-        var metric = metricItems.Find(x => x.Name == "EventCounters.a.c");
+        var metric = metricItems.Find(x => x.Name == "ec.a.c");
         Assert.NotNull(metric);
         Assert.Equal(MetricType.DoubleGauge, metric.MetricType);
         Assert.Equal(1997.0202, GetActualValue(metric));
@@ -98,7 +99,7 @@ public class EventCountersMetricsTests
         meterProvider.ForceFlush();
 
         // Assert
-        var metric = metricItems.Find(x => x.Name == "EventCounters.b.inc-c");
+        var metric = metricItems.Find(x => x.Name == "ec.b.inc-c");
         Assert.NotNull(metric);
         Assert.Equal(MetricType.DoubleSum, metric.MetricType);
         Assert.Equal(3, GetActualValue(metric));
@@ -126,7 +127,7 @@ public class EventCountersMetricsTests
         meterProvider.ForceFlush();
 
         // Assert
-        var metric = metricItems.Find(x => x.Name == "EventCounters.c.poll-c");
+        var metric = metricItems.Find(x => x.Name == "ec.c.poll-c");
         Assert.NotNull(metric);
         Assert.Equal(MetricType.DoubleGauge, metric.MetricType);
         Assert.Equal(20, GetActualValue(metric));
@@ -154,7 +155,7 @@ public class EventCountersMetricsTests
         meterProvider.ForceFlush();
 
         // Assert
-        var metric = metricItems.Find(x => x.Name == "EventCounters.d.inc-poll-c");
+        var metric = metricItems.Find(x => x.Name == "ec.d.inc-poll-c");
         Assert.NotNull(metric);
         Assert.Equal(MetricType.DoubleSum, metric.MetricType);
         Assert.Equal(2, GetActualValue(metric));
@@ -184,7 +185,7 @@ public class EventCountersMetricsTests
         meterProvider.ForceFlush();
 
         // Assert
-        var metric = metricItems.Find(x => x.Name == "EventCounters.a.c");
+        var metric = metricItems.Find(x => x.Name == "ec.a.c");
         Assert.NotNull(metric);
         Assert.Equal(MetricType.DoubleGauge, metric.MetricType);
 
@@ -212,6 +213,69 @@ public class EventCountersMetricsTests
         });
 
         Assert.Equal("Use the `OpenTelemetry.Instrumentation.Runtime` or `OpenTelemetry.Instrumentation.Process` instrumentations.", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("Microsoft-AspNetCore-Server-Kestrel-1", "tls-handshakes-per-second", "ec.m.a.s.k.1.tls-handshakes-per-second")]
+    [InlineData("Microsoft-AspNetCore-Server-Kestrel-1", "tls-handshakes-per-sec", "ec.Microsoft-AspNetCore-Server-Kestrel-1.tls-handshakes-per-sec")]
+    [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-stopped", "ec.Microsoft.AspNetCore.Http.Connections-1.connections-stopped")]
+    [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-timed-out-longer", "ec.m.a.h.c.1.connections-timed-out-longer")]
+    public async Task EventSourceNameAbbreviation(string sourceName, string eventName, string expectedInstrumentName)
+    {
+        // Arrange
+        List<Metric> metricItems = new();
+        EventSource source = new(sourceName);
+        IncrementingEventCounter connections = new(eventName, source);
+
+        var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddEventCountersInstrumentation(options =>
+            {
+                options.AddEventSources(source.Name);
+            })
+            .AddInMemoryExporter(metricItems)
+            .Build();
+
+        // Act
+        connections.Increment(1);
+        await Task.Delay(Delay);
+        meterProvider.ForceFlush();
+
+        // Assert
+        Metric metric = metricItems.Find(m => m.Name == expectedInstrumentName);
+        Assert.NotNull(metric);
+        Assert.Equal(1, GetActualValue(metric));
+    }
+
+    [Fact]
+    public async Task InstrumentNameTooLong()
+    {
+        // Arrange
+        List<Metric> metricItems = new();
+        EventSource source = new("source");
+
+        // ec.s. + event name is 63;
+        string veryLongEventName = new string('e', 59);
+        IncrementingEventCounter connections = new(veryLongEventName, source);
+
+        var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddEventCountersInstrumentation(options =>
+            {
+                options.AddEventSources(source.Name);
+            })
+            .AddInMemoryExporter(metricItems)
+            .Build();
+
+        // Act
+        connections.Increment(1);
+        await Task.Delay(Delay);
+        meterProvider.ForceFlush();
+
+        // Assert
+        foreach (var item in metricItems)
+        {
+            Assert.False(item.Name.StartsWith("ec.source.ee"));
+            Assert.False(item.Name.StartsWith("ec.s.ee"));
+        }
     }
 
     // polling and eventcounter with same instrument name?

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -254,7 +254,7 @@ public class EventCountersMetricsTests
         EventSource source = new("source");
 
         // ec.s. + event name is 63;
-        string veryLongEventName = new string('e', 59);
+        string veryLongEventName = new string('e', 100);
         IncrementingEventCounter connections = new(veryLongEventName, source);
 
         var meterProvider = Sdk.CreateMeterProviderBuilder()

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -220,6 +220,7 @@ public class EventCountersMetricsTests
     [InlineData("Microsoft-AspNetCore-Server-Kestrel-1", "tls-handshakes-per-sec", "ec.Microsoft-AspNetCore-Server-Kestrel-1.tls-handshakes-per-sec")]
     [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-stopped", "ec.Microsoft.AspNetCore.Http.Connections-1.connections-stopped")]
     [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-timed-out-longer", "ec.Microsoft.AspNetCore.Http.Conne.connections-timed-out-longer")]
+    [InlineData("Microsoft.AspNetCore.Http.Conn.Something", "connections-timed-out-longer", "ec.Microsoft.AspNetCore.Http.Conn.connections-timed-out-longer")]
     [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-very-very-long-event-name", "ec.very-very-very-very-very-very-very-very-very-long-event-name")]
     [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-very-long-event-name", "ec.Micr.very-very-very-very-very-very-very-very-long-event-name")]
     [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-long-event-name", "ec.Microsoft.very-very-very-very-very-very-very-long-event-name")]

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -216,14 +216,14 @@ public class EventCountersMetricsTests
     }
 
     [Theory]
-    [InlineData("Microsoft-AspNetCore-Server-Kestrel-1", "tls-handshakes-per-second", "ec.m.a.s.k.1.tls-handshakes-per-second")]
+    [InlineData("Microsoft-AspNetCore-Server-Kestrel-1", "tls-handshakes-per-second", "ec.Microsoft-AspNetCore-Server-Kestre.tls-handshakes-per-second")]
     [InlineData("Microsoft-AspNetCore-Server-Kestrel-1", "tls-handshakes-per-sec", "ec.Microsoft-AspNetCore-Server-Kestrel-1.tls-handshakes-per-sec")]
     [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-stopped", "ec.Microsoft.AspNetCore.Http.Connections-1.connections-stopped")]
-    [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-timed-out-longer", "ec.m.a.h.c.1.connections-timed-out-longer")]
+    [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-timed-out-longer", "ec.Microsoft.AspNetCore.Http.Conne.connections-timed-out-longer")]
     [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-very-very-long-event-name", "ec.very-very-very-very-very-very-very-very-very-long-event-name")]
-    [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-very-long-event-name", "ec.m.a.very-very-very-very-very-very-very-very-long-event-name")]
-    [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-long-event-name", "ec.m.a.o.t.very-very-very-very-very-very-very-long-event-name")]
-    public async Task EventSourceNameAbbreviation(string sourceName, string eventName, string expectedInstrumentName)
+    [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-very-long-event-name", "ec.Micr.very-very-very-very-very-very-very-very-long-event-name")]
+    [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-long-event-name", "ec.Microsoft.very-very-very-very-very-very-very-long-event-name")]
+    public async Task EventSourceNameShortening(string sourceName, string eventName, string expectedInstrumentName)
     {
         // Arrange
         List<Metric> metricItems = new();

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -220,6 +220,9 @@ public class EventCountersMetricsTests
     [InlineData("Microsoft-AspNetCore-Server-Kestrel-1", "tls-handshakes-per-sec", "ec.Microsoft-AspNetCore-Server-Kestrel-1.tls-handshakes-per-sec")]
     [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-stopped", "ec.Microsoft.AspNetCore.Http.Connections-1.connections-stopped")]
     [InlineData("Microsoft.AspNetCore.Http.Connections-1", "connections-timed-out-longer", "ec.m.a.h.c.1.connections-timed-out-longer")]
+    [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-very-very-long-event-name", "ec.very-very-very-very-very-very-very-very-very-long-event-name")]
+    [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-very-long-event-name", "ec.m.a.very-very-very-very-very-very-very-very-long-event-name")]
+    [InlineData("Microsoft.AspNetCore.One.Two", "very-very-very-very-very-very-very-long-event-name", "ec.m.a.o.t.very-very-very-very-very-very-very-long-event-name")]
     public async Task EventSourceNameAbbreviation(string sourceName, string eventName, string expectedInstrumentName)
     {
         // Arrange


### PR DESCRIPTION
EventCounters instrumentation does not work for several [well-known EventSources](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/available-counters?source=recommendations).

E.g. `Microsoft-AspNetCore-Server-Kestrel` or most of the counters in `Microsoft.AspNetCore.Http.Connections`.
It happens because of instrument length limitations (63 symbols).

End users can't do anything about it except republish all events, so we need to find a reasonable way to allow at least well-known event sources. Kestrel counters, for example, are extremely useful and can't be measured in other ways (DiagSource/ActivitySource instrumentation in hosting).

So, `EventCounters.Microsoft-AspNetCore-Server-Kestrel.` is already 50 chars and it doesn't even include event name.

This change proposes:
- use `ec.` prefix instead of `EventCounters.` - It seems less important than event source/event names
- When the instrument name in EventCounters is too long, I ~~suggest abbreviating~~ shorten the event source portion of it:
 `ec.Microsoft-AspNetCore-Server-Kestrel.tls-handshakes-per-second` -> `ec.Microsoft-AspNetCore-Server-Kestr.tls-handshakes-per-second`. It generates stable and common name for a single instrument.


Happy to consider other options for shortening the name. 

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
