### PR TITLE
[Instrumentation.Process] Update OTel API version to 1.4.0-beta.2 and change runtime metrics type to ObservableUpDownCounter

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+* Update OTel API version to be `1.4.0-beta.2` and change process metrics type
+  from ObservableGauge to `ObservableUpDownCounter`.
+  Instruments being affected are: "process.memory.usage",
+  "process.memory.virtual" and "process.threads".
+  ([#751](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/751))
+
 ## 0.1.0-alpha.1
 
 Released 2022-Oct-14

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## Unreleased
 
 * Update OTel API version to be `1.4.0-beta.2` and change process metrics type
-  from ObservableGauge to `ObservableUpDownCounter`.
-  Instruments being affected are: "process.memory.usage",
-  "process.memory.virtual" and "process.threads".
+  from ObservableGauge to `ObservableUpDownCounter`. Updated instruments are:
+  "process.memory.usage", "process.memory.virtual" and "process.threads".
   ([#751](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/751))
 
 ## 0.1.0-alpha.1

--- a/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
+++ b/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0-beta.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -38,8 +38,7 @@ internal sealed class ProcessMetrics
         this.lastCollectedUserProcessorTime = Diagnostics.Process.GetCurrentProcess().UserProcessorTime.TotalSeconds;
         this.lastCollectedPrivilegedProcessorTime = Diagnostics.Process.GetCurrentProcess().PrivilegedProcessorTime.TotalSeconds;
 
-        // TODO: change to ObservableUpDownCounter
-        this.MeterInstance.CreateObservableGauge(
+        this.MeterInstance.CreateObservableUpDownCounter(
             "process.memory.usage",
             () =>
             {
@@ -48,8 +47,7 @@ internal sealed class ProcessMetrics
             unit: "By",
             description: "The amount of physical memory allocated for this process.");
 
-        // TODO: change to ObservableUpDownCounter
-        this.MeterInstance.CreateObservableGauge(
+        this.MeterInstance.CreateObservableUpDownCounter(
             "process.memory.virtual",
             () =>
             {
@@ -81,8 +79,7 @@ internal sealed class ProcessMetrics
             unit: "1",
             description: "Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process.");
 
-        // TODO: change to ObservableUpDownCounter
-        this.MeterInstance.CreateObservableGauge(
+        this.MeterInstance.CreateObservableUpDownCounter(
             "process.threads",
             () =>
             {

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -49,9 +49,9 @@ complete demo.
 
 The amount of physical memory allocated for this process.
 
-| Units | Instrument Type   | Value Type |
-|-------|-------------------|------------|
-|  `By` |  ObservableGauge  | `Double`   |
+| Units | Instrument Type         | Value Type |
+|-------|-------------------------|------------|
+| `By`  | ObservableUpDownCounter | `Double`   |
 
 The API used to retrieve the value is:
 
@@ -64,9 +64,9 @@ allocated for the associated process.
 The amount of virtual memory allocated for this process
 that cannot be shared with other processes.
 
-| Units | Instrument Type   | Value Type |
-|-------|-------------------|------------|
-|  `By` |  ObservableGauge  | `Double`   |
+| Units | Instrument Type         | Value Type |
+|-------|-------------------------|------------|
+|  `By` | ObservableUpDownCounter | `Double`   |
 
 The API used to retrieve the value is:
 
@@ -111,9 +111,9 @@ Gets the privileged processor time for this process.
 
 Process threads count.
 
-| Units           | Instrument Type   | Value Type |
-|-----------------|-------------------|------------|
-| `{threads}`     | ObservableGauge   | `Int32`    |
+| Units      | Instrument Type         | Value Type |
+|------------|-------------------------|------------|
+| `{threads}`| ObservableUpDownCounter | `Int32`    |
 
 The API used to retrieve the value is:
 

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPkgVer)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.2" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -158,7 +158,7 @@ public class ProcessMetricsTests
         {
             if (metric.MetricType.IsLong())
             {
-                sum += metricPoint.GetGaugeLastValueLong();
+                sum += metricPoint.GetSumLong();
             }
         }
 


### PR DESCRIPTION
## Changes

Addressed TODO.
Update OTel API version to be `1.4.0-beta.2` and change process metrics type from ObservableGauge to `ObservableUpDownCounter`. Updated instruments are: "process.memory.usage", "process.memory.virtual" and "process.threads".
* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
