### PR TITLE
Add vars for OpenTelemetryCoreLatestPreRelease and OpenTelemetryExporterInMemoryLatestPreReleasePkgVer.

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -27,7 +27,7 @@
     <MicrosoftNETTestSdkPkgVer>[16.11.0,17.0)</MicrosoftNETTestSdkPkgVer>
     <MoqPkgVer>[4.17.2,5.0)</MoqPkgVer>
     <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryCoreLatestVersion)</OpenTelemetryExporterInMemoryPkgVer>
-    <OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>$(OpenTelemetryCoreLatestPreRelease)</OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>
+    <OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>$(OpenTelemetryCoreLatestPrereleaseVersion)</OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>
     <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.4.2,3.0)</XUnitPkgVer>
 </PropertyGroup>

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -27,8 +27,9 @@
     <MicrosoftNETTestSdkPkgVer>[16.11.0,17.0)</MicrosoftNETTestSdkPkgVer>
     <MoqPkgVer>[4.17.2,5.0)</MoqPkgVer>
     <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryCoreLatestVersion)</OpenTelemetryExporterInMemoryPkgVer>
+    <OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>$(OpenTelemetryCoreLatestPreRelease)</OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>
     <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.4.2,3.0)</XUnitPkgVer>
-  </PropertyGroup>
+</PropertyGroup>
 
 </Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -36,7 +36,7 @@
     <OpenTelemetryCoreLatestPreRelease>[1.4.0-beta.2]</OpenTelemetryCoreLatestPreRelease>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
-</PropertyGroup>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0' and '$(TargetFramework)' != 'netstandard2.1'">
     <!-- Nullable analysis really only works on .net standard 2.1 and newer. -->

--- a/build/Common.props
+++ b/build/Common.props
@@ -33,7 +33,7 @@
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTelemetryCoreLatestVersion>[1.3.1,2.0)</OpenTelemetryCoreLatestVersion>
-    <OpenTelemetryCoreLatestPreRelease>[1.4.0-beta.2]</OpenTelemetryCoreLatestPreRelease>
+    <OpenTelemetryCoreLatestPrereleaseVersion>[1.4.0-beta.2]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
   </PropertyGroup>

--- a/build/Common.props
+++ b/build/Common.props
@@ -33,9 +33,10 @@
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTelemetryCoreLatestVersion>[1.3.1,2.0)</OpenTelemetryCoreLatestVersion>
+    <OpenTelemetryCoreLatestPreRelease>[1.4.0-beta.2]</OpenTelemetryCoreLatestPreRelease>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
-  </PropertyGroup>
+</PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0' and '$(TargetFramework)' != 'netstandard2.1'">
     <!-- Nullable analysis really only works on .net standard 2.1 and newer. -->

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestPreRelease)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="[1.4.0-beta.2]" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestPreRelease)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
+++ b/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestPreRelease)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
+++ b/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestPreRelease)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestPreRelease)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestPreRelease)" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryLatestPreReleasePkgVer)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPkgVer)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryLatestPreReleasePkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/OpenTelemetry.Instrumentation.Runtime.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/OpenTelemetry.Instrumentation.Runtime.Tests.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPkgVer)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.2" />
+        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryLatestPreReleasePkgVer)" />
         <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
         <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Changes
Addressed https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/751#discussion_r1012232038
