### PR TITLE
Table level customization of `CustomFields`

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add support for table level customization of customFields
 
 ## 1.4.0-beta.4
 

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -597,9 +597,27 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
 
     private bool IsCustomField(string field, string table)
     {
-        return this.m_customFields == null ||
-            this.m_customFields.TryGetValue(field, out var tables) &&
-            (tables == null || tables.Contains(table));
+        // No custom fields or `*`
+        if (this.m_customFields == null)
+        {
+            return true;
+        }
+
+        // `Table/column` or `Column`
+        if (this.m_customFields.TryGetValue(field, out var tables) &&
+            (tables != null || tables.Contains(table)))
+        {
+            return true;
+        }
+
+        // `Table/*`
+        if (this.m_customFields.TryGetValue("*", out tables) &&
+            (tables != null || tables.Contains(table)))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 
@@ -87,6 +88,7 @@ public class LogExporterBenchmarks
                         ["cloud.roleInstance"] = "CY1SCH030021417",
                         ["cloud.roleVer"] = "9.0.15289.2",
                     };
+                    exporterOptions.CustomFields = new[] { "TestLogger/food" };
                 });
 
                 loggerOptions.IncludeFormattedMessage = this.IncludeFormattedMessage;


### PR DESCRIPTION
Fixes #.

## Changes

CustomFields are now supported at a table level
- `` : All fields are in separate columns
- `*`: All fields are in separate columns
- `A`: Fields with name `A` from all tables are in separate columns
- `A/B`: Fields with name `B` in a table `A` are in separate column
- `A/*`: All fields in a table `A` are in separate column.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
