### PR TITLE
restore Activity.Current before all IIS LifeCycle events

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Restore Activity.Current before all IIS Lifecycle events
+  ([#761](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/761))
+
 ## 1.0.0-rc9.6
 
 Released 2022-Sep-28

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModule.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModule.cs
@@ -84,12 +84,7 @@ public class TelemetryHttpModule : IHttpModule
     private void OnExecuteRequestStep(HttpContextBase context, Action step)
     {
         // Called only on 4.7.1+ runtimes
-
-        if (context.CurrentNotification == RequestNotification.ExecuteRequestHandler && !context.IsPostNotification)
-        {
-            ActivityHelper.RestoreContextIfNeeded(context.ApplicationInstance.Context);
-        }
-
+        ActivityHelper.RestoreContextIfNeeded(context.ApplicationInstance.Context);
         step();
     }
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/3286