### PR TITLE
Request release of OpenTelemetry.Contrib.Instrumentation.AWS

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.2
+
+Released 2022-Nov-11
+
 * Fixed issue when using version 3.7.100 of the AWS SDK for .NET triggering an
   EndpointResolver not found exception.
   ([#726](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/726))


### PR DESCRIPTION
Request release of OpenTelemetry.Contrib.Instrumentation.AWS because currently this library is broken for the current release of the AWS .NET SDK and was fixed by PR https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/726.

@open-telemetry/dotnet-contrib-maintainers

## Changes
Updated CHANGELOG for release of the OpenTelemetry.Contrib.Instrumentation.AWS package. 


For significant contributions please make sure you have completed the following items:

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
