### PR TITLE
Add EventId.Name support to Geneva exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -428,6 +428,13 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
             cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "eventId");
             cursor = MessagePackSerializer.SerializeInt32(buffer, cursor, eventId.Id);
             cntFields += 1;
+
+            if (eventId.Name != null)
+            {
+                cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "eventName");
+                cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, eventId.Name);
+                cntFields += 1;
+            }
         }
 
         // Part A - ex extension


### PR DESCRIPTION
## Changes

Geneva Exporter presently supports exporting `EventId.Id` as `eventId`.

However, [EventId struct](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.eventid?view=dotnet-plat-ext-7.0) **has two fields**:
- `Id` <- this one was exported.
- `Name` <- this one was not exported and simply ignored!?

Akin to `EventId.Id` being exported to `eventId`, the fix is to export the `EventId.Name` to `eventName`. Having the name on event enables much richer expressive definition of a `named event` using existing .NET API. It also enables full transparency into existing standard events, such as `Microsoft.Hosting.Lifetime` events. Instead of looking at cryptic Event IDs, devs can right away identify the meaning of event by using its name. It was a big mistake of not exporting it right away.

Examples of existing built-in ASP.NET event that uses named event, how it'd look like when sent to Geneva:
```
[
	{
		"TypeCode": 255,
		"Body": "0x2A13681400000000636EF762"
	},
	{
		"env_ver": "4.0",
		"env_name": "Log",
		"env_time": {
			"TypeCode": 255,
			"Body": "0x2A13681400000000636EF762"
		},
		"severityText": "Information",
		"severityNumber": 9,
		"name": "Microsoft.Hosting.Lifetime",
		"body": "Now listening on: {address}",
		"env_properties": {
			"address": "http://localhost:5252"
		},
		"eventId": 14,
		"eventName": "ListeningOnAddress"
	}
]
```

How to use it:
```
                logger.LogInformation(
                    new EventId(
                        12345,
                        "MyCustomEvent"),
                    "Hello {object}",
                    new { UserName = "maxgolov" }
                );
```

Subsequently devs can slice and dice their logs by `eventName` field. Our codebase heavily uses similar patterns and it is absolute necessity for us to implement support for the proper export of `EventId.Name` in order to fully onboard to OpenTelemetry.