### PR TITLE
[Instrumentation.Process] Release 1.0.0-alpha.2

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-alpha.2
+
+Released 2022-Nov-18
+
 * Update OpenTelemetry API to 1.4.0-beta.3 ([#774](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/774))
 
 ## 1.0.0-alpha.1


### PR DESCRIPTION
Follow up to #774

## Changes

`Instrumentation.Process` Release `1.0.0-alpha.2.`

It will make easier way to bump OTel in AutoInstrumentation project.

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
