### PR TITLE
Fixed #778 - Added deprecation notice for MassTransit v8 and later.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.MassTransit/README.md
+++ b/src/OpenTelemetry.Instrumentation.MassTransit/README.md
@@ -7,6 +7,8 @@ Automatically instruments
 [DiagnosticSource](https://masstransit-project.com/advanced/monitoring/diagnostic-source.html)
 events emitted by [MassTransit](https://masstransit-project.com/) library.
 
+> **NOTE that this only works with MassTransit v7 (and earlier, where supported)**. MassTransit v8.0.0 and later have built-in direct support for Open Telemetry via `ActivitySource`.
+
 ## Installation
 
 ```shell


### PR DESCRIPTION
This PR updates the README for MassTransit to notify developers that this package is **NOT** required for MassTransit v8 and later.

Fixes #.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
