### PR TITLE
Update package workflows to only restore specific project

### DIFF
--- a/.github/workflows/package-Exporter.Geneva.yml
+++ b/.github/workflows/package-Exporter.Geneva.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Exporter.Instana.yml
+++ b/.github/workflows/package-Exporter.Instana.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Exporter.Stackdriver.yml
+++ b/.github/workflows/package-Exporter.Stackdriver.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Extensions.AWSXRay.yml
+++ b/.github/workflows/package-Extensions.AWSXRay.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Extensions.AzureMonitor.yml
+++ b/.github/workflows/package-Extensions.AzureMonitor.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Extensions.Docker.yml
+++ b/.github/workflows/package-Extensions.Docker.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Extensions.PersistentStorage.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Extensions.yml
+++ b/.github/workflows/package-Extensions.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.AWS.yml
+++ b/.github/workflows/package-Instrumentation.AWS.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.AWSLambda.yml
+++ b/.github/workflows/package-Instrumentation.AWSLambda.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.AspNet.TelemetryHttpModule.yml
+++ b/.github/workflows/package-Instrumentation.AspNet.TelemetryHttpModule.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.AspNet.yml
+++ b/.github/workflows/package-Instrumentation.AspNet.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.Elasticsearch.yml
+++ b/.github/workflows/package-Instrumentation.Elasticsearch.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
+++ b/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.EventCounters.yml
+++ b/.github/workflows/package-Instrumentation.EventCounters.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.GrpcCore.yml
+++ b/.github/workflows/package-Instrumentation.GrpcCore.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.Hangfire.yml
+++ b/.github/workflows/package-Instrumentation.Hangfire.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.MassTransit.yml
+++ b/.github/workflows/package-Instrumentation.MassTransit.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.MySqlData.yml
+++ b/.github/workflows/package-Instrumentation.MySqlData.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.Owin.yml
+++ b/.github/workflows/package-Instrumentation.Owin.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.Process.yml
+++ b/.github/workflows/package-Instrumentation.Process.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.Quartz.yml
+++ b/.github/workflows/package-Instrumentation.Quartz.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
+++ b/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

--- a/.github/workflows/package-Instrumentation.Wcf.yml
+++ b/.github/workflows/package-Instrumentation.Wcf.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0 # fetching all
 
     - name: Install dependencies
-      run: dotnet restore
+      run: dotnet restore src/${{env.PROJECT}}
 
     - name: dotnet build ${{env.PROJECT}}
       run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true


### PR DESCRIPTION
Follow up to #789
Follow up to #759

Adding NET7 to Test projects broke these package workflows because they try to restore the entire solution, including test projects.

## Changes
- Only restore the required project

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
