### PR TITLE
update package workflows to setup dotnet 7

### DIFF
--- a/.github/workflows/package-Exporter.Geneva.yml
+++ b/.github/workflows/package-Exporter.Geneva.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Exporter.Stackdriver.yml
+++ b/.github/workflows/package-Exporter.Stackdriver.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Extensions.AzureMonitor.yml
+++ b/.github/workflows/package-Extensions.AzureMonitor.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Extensions.Docker.yml
+++ b/.github/workflows/package-Extensions.Docker.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Extensions.PersistentStorage.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Extensions.yml
+++ b/.github/workflows/package-Extensions.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.Elasticsearch.yml
+++ b/.github/workflows/package-Instrumentation.Elasticsearch.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
+++ b/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.EventCounters.yml
+++ b/.github/workflows/package-Instrumentation.EventCounters.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.MassTransit.yml
+++ b/.github/workflows/package-Instrumentation.MassTransit.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.Process.yml
+++ b/.github/workflows/package-Instrumentation.Process.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.Runtime.yml
+++ b/.github/workflows/package-Instrumentation.Runtime.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
+++ b/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 

--- a/.github/workflows/package-Instrumentation.Wcf.yml
+++ b/.github/workflows/package-Instrumentation.Wcf.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: '7.0.x'
+
     - name: Install dependencies
       run: dotnet restore src/${{env.PROJECT}}
 


### PR DESCRIPTION
Towards #732 
Follow up to #790 
Follow up to: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/790#issuecomment-1324432806

Package workflows need to setup net7 to restore and build these projects.

## Changes
-  add setup-dotnet for net7 to package workflows

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
