### PR TITLE
Handle DateTimeOffset in the same way as DateTime

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Added support for
+  [DateTimeOffset](https://learn.microsoft.com/dotnet/api/system.datetimeoffset).
+  ([#797](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/797))
+
 ## 1.4.0-beta.5
 
 Released 2022-Nov-21

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MessagePackSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MessagePackSerializer.cs
@@ -563,6 +563,8 @@ internal static class MessagePackSerializer
                 return SerializeArray(buffer, cursor, v);
             case DateTime v:
                 return SerializeUtcDateTime(buffer, cursor, v.ToUniversalTime());
+            case DateTimeOffset v:
+                return SerializeUtcDateTime(buffer, cursor, v.UtcDateTime);
             default:
                 string repr = null;
 


### PR DESCRIPTION
Many .NET users are adopting DateTimeOffset, there seem to be a common expectation that DateTimeOffset should be handled in the same way as DateTime.

Additional context:
* https://stackoverflow.com/questions/4331189/datetime-vs-datetimeoffset
* https://github.com/open-telemetry/opentelemetry-dotnet/blob/943c856c1c6295a536bc8a1c89896febc0be6107/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/TimestampHelpers.cs