### PR TITLE
release Instrumentation.AspNet.TelemetryHttpModule 1.0.0-rc9.7

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc9.7
+
+Released 2022-Nov-28
+
 * Restore Activity.Current before all IIS Lifecycle events
   ([#761](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/761))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc9.7
+
+Released 2022-Nov-28
+
 ## 1.0.0-rc9.6
 
 Released 2022-Sep-28


### PR DESCRIPTION
@open-telemetry/dotnet-contrib-maintainers

Requesting release for https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/761