### PR TITLE
Leverage modern .NET features for improved perf.

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -1,0 +1,38 @@
+Microsoft.Extensions.Logging.GenevaLoggingExtensions
+OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>
+OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>.GenevaBaseExporter() -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string>
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.GenevaExporterOptions() -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.TableNameMappings.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.TableNameMappings.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaLogExporter
+OpenTelemetry.Exporter.Geneva.GenevaLogExporter.GenevaLogExporter(OpenTelemetry.Exporter.Geneva.GenevaExporterOptions options) -> void
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporter
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.GenevaMetricExporter(OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions options) -> void
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.ConnectionString.get -> string
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.ConnectionString.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.GenevaMetricExporterOptions() -> void
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.MetricExportIntervalMilliseconds.get -> int
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.MetricExportIntervalMilliseconds.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.PrepopulatedMetricDimensions.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.PrepopulatedMetricDimensions.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaTraceExporter
+OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.GenevaTraceExporter(OpenTelemetry.Exporter.Geneva.GenevaExporterOptions options) -> void
+override OpenTelemetry.Exporter.Geneva.GenevaLogExporter.Dispose(bool disposing) -> void
+override OpenTelemetry.Exporter.Geneva.GenevaLogExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.Dispose(bool disposing) -> void
+override OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> batch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.Dispose(bool disposing) -> void
+override OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions options, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions> configure = null) -> OpenTelemetry.Metrics.MeterProviderBuilder

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -5,7 +5,7 @@
     <Description>An OpenTelemetry .NET exporter that exports to local ETW or UDS</Description>
     <Authors>OpenTelemetry Authors</Authors>
     <NoWarn>$(NoWarn),NU5104,CS1591,SA1123,SA1310,CA1031,CA1810,CA1822,CA2000,CA2208,SA1204,SA1201,SA1202,SA1308,SA1309,SA1311,SA1402,SA1602,SA1649</NoWarn>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <MinVerTagPrefix>Exporter.Geneva-</MinVerTagPrefix>
     <EnableAnalysis>true</EnableAnalysis>


### PR DESCRIPTION
## Changes

- When serializing objects, recognize ISpanFormattable on .NET 6 in order to avoid a temp string allocation in that case.

- Use binary primitives to serialize scalar types more efficiently (avoiding repeated bound checks).
