### PR TITLE
Add an exporter option to write EventId.Name

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -36,6 +36,8 @@ public class GenevaExporterOptions
 
     public ExceptionStackExportMode ExceptionStackExportMode { get; set; }
 
+    public bool WriteEventIdName { get; set; }
+
     public IReadOnlyDictionary<string, string> TableNameMappings
     {
         get => this._tableNameMappings;

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -33,6 +33,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
     private readonly IReadOnlyDictionary<string, object> m_customFields;
 
     private readonly ExceptionStackExportMode m_exportExceptionStack;
+    private readonly bool m_writeEventIdName;
 
     private readonly string m_defaultEventName = "Log";
     private readonly IReadOnlyDictionary<string, object> m_prepopulatedFields;
@@ -51,6 +52,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
     public MsgPackLogExporter(GenevaExporterOptions options)
     {
         this.m_exportExceptionStack = options.ExceptionStackExportMode;
+        this.m_writeEventIdName = options.WriteEventIdName;
 
         // TODO: Validate mappings for reserved tablenames etc.
         if (options.TableNameMappings != null)
@@ -428,6 +430,13 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
             cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "eventId");
             cursor = MessagePackSerializer.SerializeInt32(buffer, cursor, eventId.Id);
             cntFields += 1;
+
+            if (m_writeEventIdName)
+            {
+                cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "eventName");
+                cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, eventId.Name);
+                cntFields += 1;
+            }
         }
 
         // Part A - ex extension

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -113,6 +113,10 @@ each
 of the log. For changing the default table name for Logs, add an entry with key
 as `*`, and value as the custom table name.
 
+#### `WriteEventIdName` (optional)
+
+When set to true. The `EventId.Name` property will be written as a column in the table.
+
 ### Enable Metrics
 
 This snippet shows how to configure the Geneva Exporter for Metrics


### PR DESCRIPTION
Opening a PR to start discussion. If this approach looks reasonable, I can run tests, update changelog, and run markdownlint.

When using [codegen'd log messages](https://learn.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator), the EventId.Name field is set to the method name of the codegen'd method. This is frequently the only human readable string needed when parsing logs apart from the method's parameters which are already being recorded.

This change improves developer productivity when using those codegen'd logs as developers will frequently not need to set the Message column of the `LoggerMessage` attribute

Fixes #.

## Changes

Add `WriteEventIdName` option to GenevaExporterOptions and when true write the eventName in MsgPackLogExporter.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
