### PR TITLE
[Exporter.Geneva] Fix overflow bucket value serialization for Histogram

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added support for
   [DateTimeOffset](https://learn.microsoft.com/dotnet/api/system.datetimeoffset).
   ([#797](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/797))
+* Fix the overflow bucket value serialization for Histogram.
+  ([#805](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/805))
 
 ## 1.4.0-beta.5
 

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -426,7 +426,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                     if (bucket.ExplicitBound != double.PositiveInfinity)
                     {
                         MetricSerializer.SerializeUInt64(this.bufferForHistogramMetrics, ref bufferIndex, Convert.ToUInt64(bucket.ExplicitBound));
-                        lastExplicitBound = bucket.ExplicitBound;
                     }
                     else
                     {
@@ -437,6 +436,8 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                     MetricSerializer.SerializeUInt32(this.bufferForHistogramMetrics, ref bufferIndex, Convert.ToUInt32(bucket.BucketCount));
                     bucketCount++;
                 }
+
+                lastExplicitBound = bucket.ExplicitBound;
             }
 
             // Write the number of items in distribution emitted and reset back to end.

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -768,7 +768,6 @@ public class GenevaMetricExporterTests
                     if (bucket.ExplicitBound != double.PositiveInfinity)
                     {
                         Assert.Equal(bucket.ExplicitBound, valueCountPairs.Columns[listIterator].Value);
-                        lastExplicitBound = bucket.ExplicitBound;
                     }
                     else
                     {
@@ -780,6 +779,8 @@ public class GenevaMetricExporterTests
                     listIterator++;
                     bucketsWithPositiveCount++;
                 }
+
+                lastExplicitBound = bucket.ExplicitBound;
             }
 
             Assert.Equal(bucketsWithPositiveCount, valueCountPairs.DistributionSize);


### PR DESCRIPTION
The values for overflow buckets should be serialized as the value-count pair: __LastBucketValue + 1_,count_

For eg. for a Histogram with the boundaries: [25,50,100], if the value recorded is 150, it should be serialized as the following value-count pair: (101, 150)

## Changes
- Fix the serialization for overflow bucket

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
