### PR TITLE
[Exporter.Geneva][Patch for 1.3.0] Fix overflow bucket serialization for GenevaExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Dec-07
+
+* Fix the overflow bucket value serialization for Histogram.
+  ([#805](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/805))
+
 ## 1.3.0
 
 Released 2022-Jul-28

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -7,7 +7,7 @@
 Released 2022-Dec-07
 
 * Fix the overflow bucket value serialization for Histogram.
-  ([#805](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/805))
+  ([#807](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/807))
 
 ## 1.3.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaMetricExporter.cs
@@ -393,7 +393,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                     if (bucket.ExplicitBound != double.PositiveInfinity)
                     {
                         MetricSerializer.SerializeUInt64(this.bufferForHistogramMetrics, ref bufferIndex, Convert.ToUInt64(bucket.ExplicitBound));
-                        lastExplicitBound = bucket.ExplicitBound;
                     }
                     else
                     {
@@ -404,6 +403,8 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                     MetricSerializer.SerializeUInt32(this.bufferForHistogramMetrics, ref bufferIndex, Convert.ToUInt32(bucket.BucketCount));
                     bucketCount++;
                 }
+
+                lastExplicitBound = bucket.ExplicitBound;
             }
 
             // Write the number of items in distribution emitted and reset back to end.

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -671,7 +671,6 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                         if (bucket.ExplicitBound != double.PositiveInfinity)
                         {
                             Assert.Equal(bucket.ExplicitBound, valueCountPairs.Columns[listIterator].Value);
-                            lastExplicitBound = bucket.ExplicitBound;
                         }
                         else
                         {
@@ -683,6 +682,8 @@ namespace OpenTelemetry.Exporter.Geneva.Tests
                         listIterator++;
                         bucketsWithPositiveCount++;
                     }
+
+                    lastExplicitBound = bucket.ExplicitBound;
                 }
 
                 Assert.Equal(bucketsWithPositiveCount, valueCountPairs.DistributionSize);


### PR DESCRIPTION
Refer to #805

The values for overflow buckets should be serialized as the value-count pair: __LastBucketValue + 1_,count_

For eg. for a Histogram with the boundaries: [25,50,100], if the value recorded is 150, it should be serialized as the following value-count pair: (101, 1)

## Changes
- Fix the serialization for overflow bucket

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
