### PR TITLE
minor refactoring on histogram bucket serialization

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -423,6 +423,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
             {
                 if (bucket.BucketCount == 0)
                 {
+                    // the underlying implementation of buckets, of type HistogramBuckets is a BST, which is sorted
                     lastExplicitBound = bucket.ExplicitBound;
                     continue;
                 }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -421,11 +421,18 @@ public class GenevaMetricExporter : BaseExporter<Metric>
             double lastExplicitBound = default;
             foreach (var bucket in buckets)
             {
-                if (bucket.BucketCount > 0)
+                if (bucket.BucketCount == 0)
                 {
+                    lastExplicitBound = bucket.ExplicitBound;
+                    continue;
+                }
+                else
+                {
+                    bucketCount++;
                     if (bucket.ExplicitBound != double.PositiveInfinity)
                     {
                         MetricSerializer.SerializeUInt64(this.bufferForHistogramMetrics, ref bufferIndex, Convert.ToUInt64(bucket.ExplicitBound));
+                        lastExplicitBound = bucket.ExplicitBound;
                     }
                     else
                     {
@@ -434,10 +441,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                     }
 
                     MetricSerializer.SerializeUInt32(this.bufferForHistogramMetrics, ref bufferIndex, Convert.ToUInt32(bucket.BucketCount));
-                    bucketCount++;
                 }
-
-                lastExplicitBound = bucket.ExplicitBound;
             }
 
             // Write the number of items in distribution emitted and reset back to end.

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -246,37 +246,499 @@ public class GenevaMetricExporterTests
             Assert.Equal(11, exportedItems.Count);
 
             // check serialization for longCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
 
             // check serialization for doubleCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
 
             // check serialization for longUpDownCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
 
             // check serialization for doubleUpDownCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
 
             // check serialization for histogram
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
 
             // check serialization for observableLongCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
 
             // check serialization for observableDoubleCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[6], exporter, exporterOptions);
 
             // check serialization for observableLongGauge
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[7], exporter, exporterOptions);
 
             // check serialization for observableDoubleGauge
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[8], exporter, exporterOptions);
 
             // check serialization for observableUpDownLongCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[9], exporter, exporterOptions);
 
             // check serialization for observableUpDownDoubleCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[10], exporter, exporterOptions);
         }
         finally
         {
@@ -468,22 +930,274 @@ public class GenevaMetricExporterTests
             Assert.Empty(exportedItems.Where(item => item.Name == "observableLongCounter" || item.Name == "observableDoubleGauge"));
 
             // check serialization for longCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);
 
             // check serialization for doubleCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[1], exporter, exporterOptions);
 
             // check serialization for histogramWithCustomBounds
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[2], exporter, exporterOptions);
 
             // check serialization for histogramWithNoBounds
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[3], exporter, exporterOptions);
 
             // check serialization for observableDoubleCounter
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[4], exporter, exporterOptions);
 
             // check serialization for observableLongGauge
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net47)'
+Before:
             this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net6.0)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net48)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net471)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net462)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+
+/* Unmerged change from project 'OpenTelemetry.Exporter.Geneva.Tests (net472)'
+Before:
+            this.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+After:
+            GenevaMetricExporterTests.CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
+*/
+            CheckSerializationForSingleMetricPoint(exportedItems[5], exporter, exporterOptions);
         }
         finally
         {
@@ -637,7 +1351,22 @@ public class GenevaMetricExporterTests
         }
     }
 
-    private void CheckSerializationForSingleMetricPoint(Metric metric, GenevaMetricExporter exporter, GenevaMetricExporterOptions exporterOptions)
+    private static void CheckHistogramBucketSerialization(HistogramBucket bucket, HistogramValueCountPairs valueCountPairs, int listIterator, double lastExplicitBound)
+    {
+
+        if (bucket.ExplicitBound != double.PositiveInfinity)
+        {
+            Assert.Equal(bucket.ExplicitBound, valueCountPairs.Columns[listIterator].Value);
+        }
+        else
+        {
+            Assert.Equal((ulong)lastExplicitBound + 1, valueCountPairs.Columns[listIterator].Value);
+        }
+
+        Assert.Equal(bucket.BucketCount, valueCountPairs.Columns[listIterator].Count);
+    }
+
+    private static void CheckSerializationForSingleMetricPoint(Metric metric, GenevaMetricExporter exporter, GenevaMetricExporterOptions exporterOptions)
     {
         var metricType = metric.MetricType;
         var metricPointsEnumerator = metric.GetMetricPoints().GetEnumerator();
@@ -764,27 +1493,14 @@ public class GenevaMetricExporterTests
             double lastExplicitBound = default;
             foreach (var bucket in metricPoint.GetHistogramBuckets())
             {
-                if (bucket.BucketCount == 0)
+                if (bucket.BucketCount > 0)
                 {
-                    lastExplicitBound = bucket.ExplicitBound;
-                }
-                else
-                {
-                    if (bucket.ExplicitBound != double.PositiveInfinity)
-                    {
-                        Assert.Equal(bucket.ExplicitBound, valueCountPairs.Columns[listIterator].Value);
-                        lastExplicitBound = bucket.ExplicitBound;
-                    }
-                    else
-                    {
-                        Assert.Equal((ulong)lastExplicitBound + 1, valueCountPairs.Columns[listIterator].Value);
-                    }
-
-                    Assert.Equal(bucket.BucketCount, valueCountPairs.Columns[listIterator].Count);
-
+                    CheckHistogramBucketSerialization(bucket, valueCountPairs, listIterator, lastExplicitBound);
                     listIterator++;
                     bucketsWithPositiveCount++;
                 }
+
+                lastExplicitBound = bucket.ExplicitBound;
             }
 
             Assert.Equal(bucketsWithPositiveCount, valueCountPairs.DistributionSize);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -316,7 +316,7 @@ public class GenevaMetricExporterTests
                 {
                     Name = "renamedhistogramWithCustomBounds",
                     Description = "modifiedDescription",
-                    Boundaries = new double[] { 500, 1000 },
+                    Boundaries = new double[] { 500, 1000, 10000 },
                 })
             .AddView(instrument =>
             {
@@ -398,7 +398,8 @@ public class GenevaMetricExporterTests
         // Record the following values for histogramWithCustomBounds:
         // (-inf - 500] : 3
         // (500 - 1000] : 1
-        // (1000 - +inf) : 1
+        // (1000 - 10000] : 0
+        // (10000 - +inf) : 1
         //
         // The corresponding value-count pairs to be sent for histogramWithCustomBounds:
         // 500: 3
@@ -409,7 +410,7 @@ public class GenevaMetricExporterTests
         histogramWithCustomBounds.Record(150, new("tag1", "value1"), new("tag2", "value2"));
         histogramWithCustomBounds.Record(150, new("tag1", "value1"), new("tag2", "value2"));
         histogramWithCustomBounds.Record(750, new("tag1", "value1"), new("tag2", "value2"));
-        histogramWithCustomBounds.Record(2500, new("tag1", "value1"), new("tag2", "value2"));
+        histogramWithCustomBounds.Record(50000, new("tag1", "value1"), new("tag2", "value2"));
 
         // Record the following values for histogramWithNoBounds:
         // (-inf - 500] : 3
@@ -763,11 +764,16 @@ public class GenevaMetricExporterTests
             double lastExplicitBound = default;
             foreach (var bucket in metricPoint.GetHistogramBuckets())
             {
-                if (bucket.BucketCount > 0)
+                if (bucket.BucketCount == 0)
+                {
+                    lastExplicitBound = bucket.ExplicitBound;
+                }
+                else
                 {
                     if (bucket.ExplicitBound != double.PositiveInfinity)
                     {
                         Assert.Equal(bucket.ExplicitBound, valueCountPairs.Columns[listIterator].Value);
+                        lastExplicitBound = bucket.ExplicitBound;
                     }
                     else
                     {
@@ -779,8 +785,6 @@ public class GenevaMetricExporterTests
                     listIterator++;
                     bucketsWithPositiveCount++;
                 }
-
-                lastExplicitBound = bucket.ExplicitBound;
             }
 
             Assert.Equal(bucketsWithPositiveCount, valueCountPairs.DistributionSize);


### PR DESCRIPTION
## Changes
Minor refactoring which sacrifice conciseness for better readability/maintainability.
Related to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/805
No behavior change.
