### PR TITLE
Repro for #824 int[] and other primitive array types do not serialize properly

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MessagePackSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MessagePackSerializer.cs
@@ -635,6 +635,32 @@ internal static class MessagePackSerializer
                 return SerializeUnicodeString(buffer, cursor, v);
             case IDictionary<string, object> v:
                 return SerializeMap(buffer, cursor, v);
+            case bool[] v:
+                return SerializeArray(buffer, cursor, v);
+            case byte[] v:
+                return SerializeArray(buffer, cursor, v);
+            case sbyte[] v:
+                return SerializeArray(buffer, cursor, v);
+            case short[] v:
+                return SerializeArray(buffer, cursor, v);
+            case ushort[] v:
+                return SerializeArray(buffer, cursor, v);
+            case int[] v:
+                return SerializeArray(buffer, cursor, v);
+            case uint[] v:
+                return SerializeArray(buffer, cursor, v);
+            case long[] v:
+                return SerializeArray(buffer, cursor, v);
+            case ulong[] v:
+                return SerializeArray(buffer, cursor, v);
+            case float[] v:
+                return SerializeArray(buffer, cursor, v);
+            case double[] v:
+                return SerializeArray(buffer, cursor, v);
+            case DateTime[] v:
+                return SerializeArray(buffer, cursor, v);
+            case DateTimeOffset[] v:
+                return SerializeArray(buffer, cursor, v);
             case object[] v:
                 return SerializeArray(buffer, cursor, v);
             case DateTime v:

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MessagePackSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MessagePackSerializer.cs
@@ -524,7 +524,7 @@ internal static class MessagePackSerializer
         cursor = WriteArrayHeader(buffer, cursor, array.Length);
         for (int i = 0; i < array.Length; i++)
         {
-            cursor = Serialize(buffer, cursor, array[i]);
+            cursor = Serialize(buffer, cursor, (T)array[i]);
         }
 
         return cursor;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
@@ -369,6 +369,216 @@ public class MessagePackSerializerTests
     }
 
     [Fact]
+    public void MessagePackSerializer_BoolArray()
+    {
+        this.MessagePackSerializer_TestSerialization((bool[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<bool>());
+
+        var arr = new bool[]
+        {
+            true, false, true,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_ByteArray()
+    {
+        this.MessagePackSerializer_TestSerialization((byte[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<byte>());
+
+        var arr = new byte[]
+        {
+            1,
+            100,
+            255,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_SbyteArray()
+    {
+        this.MessagePackSerializer_TestSerialization((sbyte[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<sbyte>());
+
+        var arr = new sbyte[]
+        {
+            1,
+            100,
+            -100,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_ShortArray()
+    {
+        this.MessagePackSerializer_TestSerialization((short[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<short>());
+
+        var arr = new short[]
+        {
+            1,
+            1000,
+            -10000,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_UshortArray()
+    {
+        this.MessagePackSerializer_TestSerialization((ushort[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<ushort>());
+
+        var arr = new ushort[]
+        {
+            1,
+            10000,
+            65000,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_IntArray()
+    {
+        this.MessagePackSerializer_TestSerialization((int[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<int>());
+
+        var arr = new int[]
+        {
+            1,
+            6180340,
+            -314159265,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_UintArray()
+    {
+        this.MessagePackSerializer_TestSerialization((uint[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<uint>());
+
+        var arr = new uint[]
+        {
+            1,
+            6180340,
+            4_000_000_000,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_LongArray()
+    {
+        this.MessagePackSerializer_TestSerialization((long[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<long>());
+
+        var arr = new long[]
+        {
+            1,
+            -4_000_000_000_000_000_000,
+            9_000_000_000_000_000_000,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_UlongArray()
+    {
+        this.MessagePackSerializer_TestSerialization((ulong[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<ulong>());
+
+        var arr = new ulong[]
+        {
+            1,
+            6180340,
+            18_000_000_000_000_000_000,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_FloatArray()
+    {
+        this.MessagePackSerializer_TestSerialization((float[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<float>());
+
+        var arr = new float[]
+        {
+            1,
+            3.14159f,
+            -3.14159f,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_DoubleArray()
+    {
+        this.MessagePackSerializer_TestSerialization((double[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<double>());
+
+        var arr = new double[]
+        {
+            1,
+            3.14159d,
+            -3.14159d,
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_DateTimeArray()
+    {
+        this.MessagePackSerializer_TestSerialization((DateTime[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<DateTime>());
+
+        var arr = new DateTime[]
+        {
+            DateTime.Parse("2014-05-05 10:01:11"),
+            DateTime.Parse("2016-04-27 11:02:22"),
+            DateTime.Parse("2018-07-22 14:05:33"),
+            DateTime.Parse("2021-02-09 23:07:44"),
+            DateTime.Parse("2121-02-24 00:00:00"),
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
+    public void MessagePackSerializer_DateTimeOffsetArray()
+    {
+        this.MessagePackSerializer_TestSerialization((DateTimeOffset[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<DateTimeOffset>());
+
+        var arr = new DateTimeOffset[]
+        {
+            DateTimeOffset.Parse("2014-05-05 10:01:11"),
+            DateTimeOffset.Parse("2016-04-27 11:02:22"),
+            DateTimeOffset.Parse("2018-07-22 14:05:33"),
+            DateTimeOffset.Parse("2021-02-09 23:07:44"),
+            DateTimeOffset.Parse("2121-02-24 00:00:00"),
+        };
+
+        this.MessagePackSerializer_TestSerialization(arr);
+    }
+
+    [Fact]
     public void MessagePackSerializer_Map()
     {
         this.MessagePackSerializer_TestSerialization((Dictionary<string, object>)null);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
@@ -24,6 +24,8 @@ namespace OpenTelemetry.Exporter.Geneva.Tests;
 
 public class MessagePackSerializerTests
 {
+    private static readonly int[] ArraySizesToTest = new[] { byte.MaxValue, ushort.MaxValue, ushort.MaxValue + 1, };
+
     private void AssertBytes(byte[] expected, byte[] actual, int length)
     {
         Assert.Equal(expected.Length, length);
@@ -38,11 +40,32 @@ public class MessagePackSerializerTests
         }
     }
 
-    private void MessagePackSerializer_TestSerialization(object obj)
+    private void MessagePackSerializer_TestSerialization(object obj, int bufferSize = 64 * 1024)
     {
-        var buffer = new byte[64 * 1024];
+        var buffer = new byte[bufferSize];
         var length = MessagePackSerializer.Serialize(buffer, 0, obj);
         this.AssertBytes(MessagePack.MessagePackSerializer.Serialize(obj), buffer, length);
+    }
+
+    private void MessagePackSerializer_TestStructArraySerialization<T>(T[] seedArr)
+        where T : struct
+    {
+        this.MessagePackSerializer_TestSerialization((T[])null);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<T>());
+        this.MessagePackSerializer_TestSerialization(seedArr);
+
+        foreach (int arrSize in ArraySizesToTest)
+        {
+            var bigArr = new T[arrSize];
+            for (int i = 0; i < arrSize; i++)
+            {
+                bigArr[i] = seedArr[i % seedArr.Length];
+            }
+
+            // Big enough for arrSize elements of the biggest expected sizeof(T) plus some extra
+            int bufferSize = 64 * (arrSize + 64);
+            this.MessagePackSerializer_TestSerialization(bigArr, bufferSize);
+        }
     }
 
     private void MessagePackSerializer_TestASCIIStringSerialization(string input)
@@ -385,9 +408,6 @@ public class MessagePackSerializerTests
     [Fact]
     public void MessagePackSerializer_ByteArray()
     {
-        this.MessagePackSerializer_TestSerialization((byte[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<byte>());
-
         var arr = new byte[]
         {
             1,
@@ -395,15 +415,12 @@ public class MessagePackSerializerTests
             255,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_SbyteArray()
     {
-        this.MessagePackSerializer_TestSerialization((sbyte[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<sbyte>());
-
         var arr = new sbyte[]
         {
             1,
@@ -411,15 +428,12 @@ public class MessagePackSerializerTests
             -100,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_ShortArray()
     {
-        this.MessagePackSerializer_TestSerialization((short[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<short>());
-
         var arr = new short[]
         {
             1,
@@ -427,15 +441,12 @@ public class MessagePackSerializerTests
             -10000,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_UshortArray()
     {
-        this.MessagePackSerializer_TestSerialization((ushort[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<ushort>());
-
         var arr = new ushort[]
         {
             1,
@@ -443,15 +454,12 @@ public class MessagePackSerializerTests
             65000,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_IntArray()
     {
-        this.MessagePackSerializer_TestSerialization((int[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<int>());
-
         var arr = new int[]
         {
             1,
@@ -459,15 +467,12 @@ public class MessagePackSerializerTests
             -314159265,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_UintArray()
     {
-        this.MessagePackSerializer_TestSerialization((uint[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<uint>());
-
         var arr = new uint[]
         {
             1,
@@ -475,15 +480,12 @@ public class MessagePackSerializerTests
             4_000_000_000,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_LongArray()
     {
-        this.MessagePackSerializer_TestSerialization((long[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<long>());
-
         var arr = new long[]
         {
             1,
@@ -491,15 +493,12 @@ public class MessagePackSerializerTests
             9_000_000_000_000_000_000,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_UlongArray()
     {
-        this.MessagePackSerializer_TestSerialization((ulong[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<ulong>());
-
         var arr = new ulong[]
         {
             1,
@@ -507,15 +506,12 @@ public class MessagePackSerializerTests
             18_000_000_000_000_000_000,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_FloatArray()
     {
-        this.MessagePackSerializer_TestSerialization((float[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<float>());
-
         var arr = new float[]
         {
             1,
@@ -523,15 +519,12 @@ public class MessagePackSerializerTests
             -3.14159f,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_DoubleArray()
     {
-        this.MessagePackSerializer_TestSerialization((double[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<double>());
-
         var arr = new double[]
         {
             1,
@@ -539,15 +532,12 @@ public class MessagePackSerializerTests
             -3.14159d,
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_DateTimeArray()
     {
-        this.MessagePackSerializer_TestSerialization((DateTime[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<DateTime>());
-
         var arr = new DateTime[]
         {
             DateTime.Parse("2014-05-05 10:01:11"),
@@ -557,15 +547,12 @@ public class MessagePackSerializerTests
             DateTime.Parse("2121-02-24 00:00:00"),
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]
     public void MessagePackSerializer_DateTimeOffsetArray()
     {
-        this.MessagePackSerializer_TestSerialization((DateTimeOffset[])null);
-        this.MessagePackSerializer_TestSerialization(Array.Empty<DateTimeOffset>());
-
         var arr = new DateTimeOffset[]
         {
             DateTimeOffset.Parse("2014-05-05 10:01:11"),
@@ -575,7 +562,7 @@ public class MessagePackSerializerTests
             DateTimeOffset.Parse("2121-02-24 00:00:00"),
         };
 
-        this.MessagePackSerializer_TestSerialization(arr);
+        this.MessagePackSerializer_TestStructArraySerialization(arr);
     }
 
     [Fact]


### PR DESCRIPTION
This is for reproducing the issue described in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/824

Add unit tests and naive implementation of serialization for primitive arrays.

Tests currently fail because MsgPack writes primitive arrays differently than object[]:

I did not finish the fixes because I wasn't sure if just directly copying code from MsgPack was the right solution. Happy to handoff if there is someone with more context or I can finish it with guidance on the desired fix.

Fixes #.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #824 
