### PR TITLE
[GenevaExporter] Update MsgPackTraceExporter for new Enumerate* DS7 APIs

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * Update OpenTelemetry to 1.4.0-rc.1
   ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
+* Add support in logs for prefix-based table name mapping configuration.
+  [#796](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/796)
+* Updated the trace exporter to use the new performance APIs introduced in
+  `System.Diagnostics.DiagnosticSource` v7.0.
+  [#838](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/838)
 
 ## 1.4.0-beta.6
 
@@ -14,11 +19,8 @@ Released 2022-Dec-09
   ([#797](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/797))
 * Fix the overflow bucket value serialization for Histogram.
   ([#805](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/805))
-* Fix EventSource logging
+* Fix EventSource logging.
   ([#813](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/813))
-
-* Add support in logs for prefix-based table name mapping configuration.
-  [#796](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/796)
 
 ## 1.4.0-beta.5
 


### PR DESCRIPTION
## Changes

* Updates `MsgPackTraceExporter` to use the new DS7 "Enumerate" APIs which help with perf.

## Benchmarks

(Modified the benchmark to also use links for this run.)

Before:

|            Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|------------------ |---------:|--------:|--------:|-------:|----------:|
| SerializeActivity | 341.9 ns | 5.34 ns | 4.99 ns | 0.0076 |      96 B |

After:

|            Method |     Mean |   Error |  StdDev | Allocated |
|------------------ |---------:|--------:|--------:|----------:|
| SerializeActivity | 260.0 ns | 4.42 ns | 4.13 ns |         - |

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes

