### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 1.1.0
+
+Released 2022-Dec-20
 
 * Updated `Transport` with exception-handling and a couple of bug fixes ([#747](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/747)):
   * Adds `InstanaExporterEventSource` to provide for error logging.

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0
+## 1.0.2
 
 Released 2022-Dec-20
 


### PR DESCRIPTION
[Exporter.Instana] Release 1.1.0.  Fixes [747](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/747).

## Changes
- Adds `InstanaExporterEventSource` to provide for error logging.
- Adds exception-handling to `Transport` with logging via `InstanaExporterEventSource`.
- Fixes `Transport` request buffering to remove potential for exceeding underlying array capacity.
- Fixes `Transport` to remove potential for lost spans due to buffer length.
