### PR TITLE
[Extensions.AzureMonitor] Enable Code Analysis for AzureMonitor Extensions

### DIFF
--- a/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSampler.cs
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSampler.cs
@@ -71,7 +71,7 @@ public class ApplicationInsightsSampler : Sampler
             return this.recordAndSampleSamplingResult;
         }
 
-        double sampleScore = DJB2SampleScore(samplingParameters.TraceId.ToHexString().ToLowerInvariant());
+        double sampleScore = DJB2SampleScore(samplingParameters.TraceId.ToHexString().ToUpperInvariant());
 
         if (sampleScore < this.samplingRatio)
         {
@@ -90,7 +90,10 @@ public class ApplicationInsightsSampler : Sampler
 
         for (int i = 0; i < traceIdHex.Length; i++)
         {
-            hash = ((hash << 5) + hash) + (int)traceIdHex[i];
+            unchecked
+            {
+                hash = (hash << 5) + hash + (int)traceIdHex[i];
+            }
         }
 
         // Take the absolute value of the hash

--- a/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
     <MinVerTagPrefix>Extensions.AzureMonitor-</MinVerTagPrefix>
+    <EnableAnalysis>true</EnableAnalysis>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes
- Enable Code Analysis for AzureMonitor Extensions
- Move hash computation to an `unchecked` block
