### PR TITLE
Update the owner for OpenTelemetry.Extensions.Docker.Tests

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -90,7 +90,7 @@ components:
   test/OpenTelemetry.Extensions.Tests/:
     - codeblanch
   test/OpenTelemetry.Extensions.Docker.Tests/:
-    - swetharavichandrancisco
+    - iskiselev
   test/OpenTelemetry.Extensions.PersistentStorage.Tests/:
     - vishweshbankwar
   test/OpenTelemetry.Instrumentation.AWSLambda.Tests/:


### PR DESCRIPTION
## Changes
- Update the component owner for `test/OpenTelemetry.Extensions.Docker.Tests` to @iskiselev