### PR TITLE
Bump OTel to 1.4.0-rc.2

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -32,7 +32,7 @@
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTelemetryCoreLatestVersion>[1.3.1,2.0)</OpenTelemetryCoreLatestVersion>
-    <OpenTelemetryCoreLatestPrereleaseVersion>[1.4.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
+    <OpenTelemetryCoreLatestPrereleaseVersion>[1.4.0-rc.2]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry to 1.4.0-rc.2
+  ([#880](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/880))
+
 ## 1.4.0-rc.1
 
 Released 2022-Dec-19

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
-* Update OpenTelemetry to 1.4.0-rc.1 ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
+* Update OpenTelemetry to 1.4.0-rc.2
+  ([#880](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/880))
 
 ## 1.0.0-beta.3
 
 Released 2022-Nov-09
 
-* Update OpenTelemetry to 1.4.0-beta.2 ([#680](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/680))
+* Update OpenTelemetry to 1.4.0-beta.2
+  ([#680](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/680))
 
 * Implemented auto flush activity processor
   ([#297](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/297))

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,17 +2,22 @@
 
 ## Unreleased
 
+* Update OpenTelemetry API to 1.4.0-rc.2
+  ([#880](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/880))
+
 ## 1.0.0-alpha.3
 
 Released 2022-Dec-13
 
-* Update OpenTelemetry API to 1.4.0-rc.1 ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
+* Update OpenTelemetry API to 1.4.0-rc.1
+  ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
 
 ## 1.0.0-alpha.2
 
 Released 2022-Nov-18
 
-* Update OpenTelemetry API to 1.4.0-beta.3 ([#774](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/774))
+* Update OpenTelemetry API to 1.4.0-beta.3
+  ([#774](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/774))
 
 ## 1.0.0-alpha.1
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,17 +2,22 @@
 
 ## Unreleased
 
+* Update OpenTelemetry API to 1.4.0-rc.2
+  ([#880](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/880))
+
 ## 1.1.0-beta.2
 
 Released 2022-Dec-13
 
-* Update OpenTelemetry API to 1.4.0-rc.1 ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
+* Update OpenTelemetry API to 1.4.0-rc.1
+  ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
 
 ## 1.1.0-beta.1
 
 Released 2022-Nov-22
 
-* Update OpenTelemetry API to 1.4.0-beta.3 ([#774](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/774))
+* Update OpenTelemetry API to 1.4.0-beta.3
+  ([#774](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/774))
 
 * Change ObservableGauge to ObservableUpDownCounter for the below metrics (which
   better fit UpDownCounter semantics as they are additive.)


### PR DESCRIPTION
Fixes N/A.

## Changes

Bump OTel to last unstable release for packages using unstable release.
Needed by AutoInstrumentation project.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
