### PR TITLE
[Extensions.Docker] Update CHANGELOG for 1.0.0-beta.2 release

### DIFF
--- a/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
+## 1.1.0-beta.1
+
+Released 2023-Jan-11
+
 * Updates to 1.3.1 of OpenTelemetry SDK.
+[712](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/712)
+
+* Added CGroupv2 support.
+[839](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/839)
 
 ## 1.0.0-beta.1
 

--- a/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.1.0-beta.1
+## 1.0.0-beta.2
 
 Released 2023-Jan-11
 


### PR DESCRIPTION
## Changes

Update CHANGELOG for 1.1.0-beta.1 release, that will include CGroup V2 support (https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/839, https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/693). It still will have `-beta.1` suffix to make it prerelease until decision on package name will be done (https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/881, https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/869)