### PR TITLE
[Extensions.AzureMonitor.ApplicationInsightsSampler] fix unit test

### DIFF
--- a/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
@@ -27,11 +27,12 @@ public class ApplicationInsightsSamplerTests
     [Fact]
     public void VerifyHashAlgorithmCorrectness()
     {
-        byte[] testBytes = new byte[]
+        byte[] testBytes1 = new byte[]
         {
             0x8F, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF, 0xFF,
-            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
         };
         byte[] testBytes2 = new byte[]
         {
@@ -40,26 +41,26 @@ public class ApplicationInsightsSamplerTests
             0x8F, 0x9F, 0xAF, 0xBF,
             0xCF, 0xDF, 0xEF, 0xFF,
         };
-        ActivityTraceId testId = ActivityTraceId.CreateFromBytes(testBytes);
+        ActivityTraceId testId1 = ActivityTraceId.CreateFromBytes(testBytes1);
         ActivityTraceId testId2 = ActivityTraceId.CreateFromBytes(testBytes2);
 
-        ActivityContext parentContext = default(ActivityContext);
-        SamplingParameters testParams = new SamplingParameters(parentContext, testId, "TestActivity", ActivityKind.Internal);
+        ActivityContext parentContext = default;
+        SamplingParameters testParams1 = new SamplingParameters(parentContext, testId1, "TestActivity", ActivityKind.Internal);
         SamplingParameters testParams2 = new SamplingParameters(parentContext, testId2, "TestActivity", ActivityKind.Internal);
 
-        var zeroSampler = new ApplicationInsightsSampler(0);
-        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(1);
-
-        // 0.86 is below the sample score for testId1, but strict enough to drop testId2
-        ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(0.86f);
-
-        Assert.Equal(SamplingDecision.Drop, zeroSampler.ShouldSample(testParams).Decision);
+        // Verify sample ratio: 0
+        ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(0);
+        Assert.Equal(SamplingDecision.Drop, zeroSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.Drop, zeroSampler.ShouldSample(testParams2).Decision);
 
-        Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams).Decision);
+        // Verify sample ratio: 1
+        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(1);
+        Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams2).Decision);
 
-        Assert.Equal(SamplingDecision.Drop, ratioSampler.ShouldSample(testParams).Decision);
+        // 0.5 is below the sample score for testId1, but strict enough to drop testId2
+        ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(0.5f);
+        Assert.Equal(SamplingDecision.Drop, ratioSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, ratioSampler.ShouldSample(testParams2).Decision);
     }
 

--- a/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
@@ -58,7 +58,7 @@ public class ApplicationInsightsSamplerTests
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams2).Decision);
 
-        // 0.5 is below the sample score for testId1, but strict enough to drop testId2
+        // 0.5 is below the sample score for testId2, but strict enough to drop testId1
         ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(0.5f);
         Assert.Equal(SamplingDecision.Drop, ratioSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, ratioSampler.ShouldSample(testParams2).Decision);

--- a/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
@@ -49,17 +49,17 @@ public class ApplicationInsightsSamplerTests
         SamplingParameters testParams2 = new SamplingParameters(parentContext, testId2, "TestActivity", ActivityKind.Internal);
 
         // Verify sample ratio: 0
-        ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(0);
+        ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(samplingRatio: 0);
         Assert.Equal(SamplingDecision.Drop, zeroSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.Drop, zeroSampler.ShouldSample(testParams2).Decision);
 
         // Verify sample ratio: 1
-        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(1);
+        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(samplingRatio: 1);
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams2).Decision);
 
         // 0.5 is below the sample score for testId2, but strict enough to drop testId1
-        ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(0.5f);
+        ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(samplingRatio: 0.5f);
         Assert.Equal(SamplingDecision.Drop, ratioSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, ratioSampler.ShouldSample(testParams2).Decision);
     }

--- a/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
@@ -27,14 +27,14 @@ public class ApplicationInsightsSamplerTests
     [Fact]
     public void VerifyHashAlgorithmCorrectness()
     {
-        byte[] testBytes1 = new byte[]
+        byte[] testBytes1 = new byte[] // hex string: 8fffffffffffffff0000000000000000
         {
             0x8F, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF, 0xFF,
             0, 0, 0, 0,
             0, 0, 0, 0,
         };
-        byte[] testBytes2 = new byte[]
+        byte[] testBytes2 = new byte[] // hex string: 0f1f2f3f4f5f6f7f8f9fafbfcfdfefff
         {
             0x0F, 0x1F, 0x2F, 0x3F,
             0x4F, 0x5F, 0x6F, 0x7F,
@@ -58,7 +58,8 @@ public class ApplicationInsightsSamplerTests
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams2).Decision);
 
-        // 0.5 is below the sample score for testId2, but strict enough to drop testId1
+        // Verify sample ratio: 0.5.
+        // This is below the sample score for testId2, but strict enough to drop testId1
         ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(samplingRatio: 0.5f);
         Assert.Equal(SamplingDecision.Drop, ratioSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, ratioSampler.ShouldSample(testParams2).Decision);


### PR DESCRIPTION
Fixes #891

This test validates the sampler. The test is evaluating two TraceIds, and asserting that for a given sampling ratio, one should be dropped and the other should be sampled. It seems that sampling ratio is too high.

The sampling calculator was changed in #846, `TraceId.ToHexString().ToLowerInvariant()` was changed to `TraceId.ToHexString().ToUpperInvariant()`. This broke the unit test, but wasn't caught because the test wasn't executing in the CI.

#890 fixed the project to run tests, and disabled this broken test.

## Changes
- Changed unittest sample ratio `0.86` to `0.5`.
- some refactoring to make the test easier to read.

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
