### PR TITLE
[AutoFlushActivityProcessorTests] fix flaky flush test

### DIFF
--- a/test/OpenTelemetry.Extensions.Tests/Trace/AutoFlushActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/AutoFlushActivityProcessorTests.cs
@@ -42,7 +42,7 @@ public class AutoFlushActivityProcessorTests
         using var activity = source.StartActivity("name", ActivityKind.Server);
         activity.Stop();
 
-        mockExporting.Protected().Verify("OnForceFlush", Times.Once(), 5_000);
+        mockExporting.Protected().Verify("OnForceFlush", Times.AtLeastOnce(), 5_000);
     }
 
     [Fact]


### PR DESCRIPTION
This test occasionally fails, impacting other PRs.

```
  Failed OpenTelemetry.Extensions.Tests.Trace.AutoFlushActivityProcessorTests.AutoFlushActivityProcessor_FlushAfterLocalServerSideRootSpans_EndMatchingSpan_Flush [149 ms]
  Error Message:
   Moq.MockException : 
Expected invocation on the mock once, but was 2 times: mock => mock.OnForceFlush(5000)

Performed invocations:

   Mock<BaseProcessor<Activity>:1> (mock):

      BaseProcessor<Activity>.SetParentProvider(TracerProviderSdk)
      BaseProcessor<Activity>.SetParentProvider(TracerProviderSdk)
      BaseProcessor<Activity>.OnStart(Activity)
      BaseProcessor<Activity>.OnEnd(Activity)
      BaseProcessor<Activity>.OnForceFlush(5000)
      BaseProcessor<Activity>.OnEnd(Activity)
      BaseProcessor<Activity>.OnForceFlush(5000)

  Stack Trace:
     at Moq.Mock.Verify(Mock mock, LambdaExpression expression, Times times, String failMessage) in C:\projects\moq4\src\Moq\Mock.cs:line 330
   at Moq.Protected.ProtectedMock`1.InternalVerify(String methodName, Type[] genericTypeArguments, Times times, Boolean exactParameterMatch, Object[] args) in C:\projects\moq4\src\Moq\Protected\ProtectedMock.cs:line 234
   at Moq.Protected.ProtectedMock`1.Verify(String methodName, Times times, Object[] args) in C:\projects\moq4\src\Moq\Protected\ProtectedMock.cs:line 206
   at OpenTelemetry.Extensions.Tests.Trace.AutoFlushActivityProcessorTests.AutoFlushActivityProcessor_FlushAfterLocalServerSideRootSpans_EndMatchingSpan_Flush() in D:\a\opentelemetry-dotnet-contrib\opentelemetry-dotnet-contrib\test\OpenTelemetry.Extensions.Tests\Trace\AutoFlushActivityProcessorTests.cs:line 45
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```

## Changes
- change `Times.Once()` to `Times.AtLeastOnce()`

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
