### PR TITLE
[Instrumentation.MysqlData] Compatibility with Mysql.Data 8.0.32.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Compatibility with Mysql.Data 8.0.32 or later. ([#901](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/901))
+
 ## 1.0.0-beta.4
 
 Released 2022-Oct-17

--- a/src/OpenTelemetry.Instrumentation.MySqlData/MySqlDataInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/MySqlDataInstrumentation.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Linq.Expressions;
 using System.Reflection;
 using MySql.Data.MySqlClient;
 using OpenTelemetry.Trace;
@@ -28,9 +29,11 @@ namespace OpenTelemetry.Instrumentation.MySqlData;
 /// </summary>
 internal class MySqlDataInstrumentation : DefaultTraceListener
 {
-    private readonly ConcurrentDictionary<long, MySqlConnectionStringBuilder> dbConn = new ConcurrentDictionary<long, MySqlConnectionStringBuilder>();
+    private readonly ConcurrentDictionary<long, MySqlConnectionStringBuilder> dbConn = new();
 
     private readonly MySqlDataInstrumentationOptions options;
+
+    private readonly Func<string, MySqlConnectionStringBuilder> builderFactory;
 
     public MySqlDataInstrumentation(MySqlDataInstrumentationOptions options = null)
     {
@@ -40,15 +43,41 @@ internal class MySqlDataInstrumentation : DefaultTraceListener
         MySqlTrace.Switch.Level = SourceLevels.Information;
 
         // Mysql.Data removed `MySql.Data.MySqlClient.MySqlTrace.QueryAnalysisEnabled` since 8.0.31 so we need to set this using reflection.
-        var queryAnalysisEnabled = typeof(MySqlTrace).GetProperty("QueryAnalysisEnabled", BindingFlags.Public | BindingFlags.Static);
+        var queryAnalysisEnabled =
+            typeof(MySqlTrace).GetProperty("QueryAnalysisEnabled", BindingFlags.Public | BindingFlags.Static);
         if (queryAnalysisEnabled != null)
         {
             queryAnalysisEnabled.SetValue(null, true);
         }
+
+        // Mysql.Data add optional param `isAnalyzed` to MySqlConnectionStringBuilder constructor since 8.0.32
+        var ctor = typeof(MySqlConnectionStringBuilder).GetConstructor(new[] { typeof(string), typeof(bool) });
+        if (ctor == null)
+        {
+            ctor = typeof(MySqlConnectionStringBuilder).GetConstructor(new[] { typeof(string) })!;
+            var p1 = Expression.Parameter(typeof(string), "connectionString");
+            var newExpression = Expression.New(ctor, p1);
+            var func = Expression.Lambda<Func<string, MySqlConnectionStringBuilder>>(newExpression, p1).Compile();
+            this.builderFactory = s => func(s);
+        }
+        else
+        {
+            var p1 = Expression.Parameter(typeof(string));
+            var p2 = Expression.Parameter(typeof(bool));
+            var newExpression = Expression.New(ctor, p1, p2);
+            var func = Expression.Lambda<Func<string, bool, MySqlConnectionStringBuilder>>(newExpression, p1, p2).Compile();
+            this.builderFactory = s => func(s, false);
+        }
     }
 
     /// <inheritdoc />
-    public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string format, params object[] args)
+    public override void TraceEvent(
+        TraceEventCache eventCache,
+        string source,
+        TraceEventType eventType,
+        int id,
+        string format,
+        params object[] args)
     {
         try
         {
@@ -58,7 +87,7 @@ internal class MySqlDataInstrumentation : DefaultTraceListener
                     // args: [driverId, connStr, threadId]
                     var driverId = (long)args[0];
                     var connStr = args[1].ToString();
-                    this.dbConn[driverId] = new MySqlConnectionStringBuilder(connStr);
+                    this.dbConn[driverId] = this.builderFactory(connStr);
                     break;
                 case MySqlTraceEventType.ConnectionClosed:
                     break;


### PR DESCRIPTION
Mysql.Data add optional param `isAnalyzed` to MySqlConnectionStringBuilder constructor since 8.0.32

Fixes #901.

## Changes

Added logic to check MySqlConnectionStringBuilder constructor.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
