### PR TITLE
Enable analysers

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -7,6 +7,7 @@
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <NetFrameworkMinimumSupportedVersion>net462</NetFrameworkMinimumSupportedVersion>
+    <AnalysisLevel>latest-All</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/build/OpenTelemetryContrib.test.ruleset
+++ b/build/OpenTelemetryContrib.test.ruleset
@@ -4,6 +4,36 @@
     <Name Resource="OpenTelemetrySDKRules_Name" />
     <Description Resource="OpenTelemetrySDKRules_Description" />
   </Localization>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="None" />
+    <Rule Id="CA1019" Action="None" />
+    <Rule Id="CA1032" Action="None" />
+    <Rule Id="CA1050" Action="None" />
+    <Rule Id="CA1051" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1063" Action="None" />
+    <Rule Id="CA1064" Action="None" />
+    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1307" Action="None" />
+    <Rule Id="CA1309" Action="None" />
+    <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA1809" Action="None" />
+    <Rule Id="CA1812" Action="None" />
+    <Rule Id="CA1813" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1822" Action="None" />
+    <Rule Id="CA1848" Action="None" />
+    <Rule Id="CA1849" Action="None" />
+    <Rule Id="CA1852" Action="None" />
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2008" Action="None" />
+    <Rule Id="CA2201" Action="None" />
+    <Rule Id="CA2213" Action="None" />
+    <Rule Id="CA5394" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA1401" Action="None" />

--- a/examples/grpc.core/Examples.GrpcCore.AspNetCore/Startup.cs
+++ b/examples/grpc.core/Examples.GrpcCore.AspNetCore/Startup.cs
@@ -110,7 +110,7 @@ public class Startup
                     tcs.SetResult(true);
                 });
 
-            return tcs.Task.ContinueWith(antecedent => tokenRegistration.Dispose());
+            return tcs.Task.ContinueWith(antecedent => tokenRegistration.Dispose(), stoppingToken);
         }
     }
 }

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayIdGenerator.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayIdGenerator.cs
@@ -41,6 +41,7 @@ public static class AWSXRayIdGenerator
 
     internal static void ReplaceTraceId(Sampler sampler = null)
     {
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var awsXRayActivityListener = new ActivityListener
         {
             ActivityStarted = (activity) =>
@@ -63,6 +64,7 @@ public static class AWSXRayIdGenerator
 
             ShouldListenTo = (_) => true,
         };
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
         ActivitySource.AddActivityListener(awsXRayActivityListener);
     }

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayIdGenerator.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayIdGenerator.cs
@@ -143,7 +143,9 @@ public static class AWSXRayIdGenerator
     /// <param name="buffer">An array of bytes to contain random numbers.</param>
     private static void NextBytes(byte[] buffer)
     {
+#pragma warning disable CA5394 // Do not use insecure randomness
         Global.NextBytes(buffer);
+#pragma warning restore CA5394 // Do not use insecure randomness
     }
 
     /// <summary>
@@ -153,7 +155,9 @@ public static class AWSXRayIdGenerator
     /// <returns>A 32-bit signed integer that is greater than or equal to 0, and less than maxValue.</returns>
     private static int Next(int maxValue)
     {
+#pragma warning disable CA5394 // Do not use insecure randomness
         return Global.Next(maxValue);
+#pragma warning restore CA5394 // Do not use insecure randomness
     }
 
     private static ActivitySamplingResult ComputeRootActivitySamplingResult(

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSEBSResourceDetector.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSEBSResourceDetector.cs
@@ -29,7 +29,9 @@ namespace OpenTelemetry.Contrib.Extensions.AWSXRay.Resources;
 public class AWSEBSResourceDetector : IResourceDetector
 {
     private const string AWSEBSMetadataWindowsFilePath = "C:\\Program Files\\Amazon\\XRay\\environment.conf";
+#if NETSTANDARD
     private const string AWSEBSMetadataLinuxFilePath = "/var/elasticbeanstalk/xray/environment.conf";
+#endif
 
     /// <summary>
     /// Detector the required and optional resource attributes from AWS ElasticBeanstalk.

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSEBSResourceDetector.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSEBSResourceDetector.cs
@@ -57,9 +57,9 @@ public class AWSEBSResourceDetector : IResourceDetector
             filePath = AWSEBSMetadataWindowsFilePath;
 #endif
 
-            var metadata = this.GetEBSMetadata(filePath);
+            var metadata = GetEBSMetadata(filePath);
 
-            resourceAttributes = this.ExtractResourceAttributes(metadata);
+            resourceAttributes = ExtractResourceAttributes(metadata);
         }
         catch (Exception ex)
         {
@@ -69,7 +69,7 @@ public class AWSEBSResourceDetector : IResourceDetector
         return resourceAttributes;
     }
 
-    internal List<KeyValuePair<string, object>> ExtractResourceAttributes(AWSEBSMetadataModel metadata)
+    internal static List<KeyValuePair<string, object>> ExtractResourceAttributes(AWSEBSMetadataModel metadata)
     {
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {
@@ -84,7 +84,7 @@ public class AWSEBSResourceDetector : IResourceDetector
         return resourceAttributes;
     }
 
-    internal AWSEBSMetadataModel GetEBSMetadata(string filePath)
+    internal static AWSEBSMetadataModel GetEBSMetadata(string filePath)
     {
         return ResourceDetectorUtils.DeserializeFromFile<AWSEBSMetadataModel>(filePath);
     }

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSEC2ResourceDetector.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSEC2ResourceDetector.cs
@@ -41,11 +41,11 @@ public class AWSEC2ResourceDetector : IResourceDetector
 
         try
         {
-            var token = this.GetAWSEC2Token();
-            var identity = this.GetAWSEC2Identity(token);
-            var hostName = this.GetAWSEC2HostName(token);
+            var token = GetAWSEC2Token();
+            var identity = GetAWSEC2Identity(token);
+            var hostName = GetAWSEC2HostName(token);
 
-            resourceAttributes = this.ExtractResourceAttributes(identity, hostName);
+            resourceAttributes = ExtractResourceAttributes(identity, hostName);
         }
         catch (Exception ex)
         {
@@ -55,7 +55,7 @@ public class AWSEC2ResourceDetector : IResourceDetector
         return resourceAttributes;
     }
 
-    internal List<KeyValuePair<string, object>> ExtractResourceAttributes(AWSEC2IdentityDocumentModel identity, string hostName)
+    internal static List<KeyValuePair<string, object>> ExtractResourceAttributes(AWSEC2IdentityDocumentModel identity, string hostName)
     {
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {
@@ -72,30 +72,30 @@ public class AWSEC2ResourceDetector : IResourceDetector
         return resourceAttributes;
     }
 
-    internal AWSEC2IdentityDocumentModel DeserializeResponse(string response)
+    internal static AWSEC2IdentityDocumentModel DeserializeResponse(string response)
     {
         return ResourceDetectorUtils.DeserializeFromString<AWSEC2IdentityDocumentModel>(response);
     }
 
-    private string GetAWSEC2Token()
+    private static string GetAWSEC2Token()
     {
         return ResourceDetectorUtils.SendOutRequest(AWSEC2MetadataTokenUrl, "PUT", new KeyValuePair<string, string>(AWSEC2MetadataTokenTTLHeader, "60")).Result;
     }
 
-    private AWSEC2IdentityDocumentModel GetAWSEC2Identity(string token)
+    private static AWSEC2IdentityDocumentModel GetAWSEC2Identity(string token)
     {
-        var identity = this.GetIdentityResponse(token);
-        var identityDocument = this.DeserializeResponse(identity);
+        var identity = GetIdentityResponse(token);
+        var identityDocument = DeserializeResponse(identity);
 
         return identityDocument;
     }
 
-    private string GetIdentityResponse(string token)
+    private static string GetIdentityResponse(string token)
     {
         return ResourceDetectorUtils.SendOutRequest(AWSEC2IdentityDocumentUrl, "GET", new KeyValuePair<string, string>(AWSEC2MetadataTokenHeader, token)).Result;
     }
 
-    private string GetAWSEC2HostName(string token)
+    private static string GetAWSEC2HostName(string token)
     {
         return ResourceDetectorUtils.SendOutRequest(AWSEC2HostNameUrl, "GET", new KeyValuePair<string, string>(AWSEC2MetadataTokenHeader, token)).Result;
     }

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSECSResourceDetector.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSECSResourceDetector.cs
@@ -36,16 +36,16 @@ public class AWSECSResourceDetector : IResourceDetector
     {
         List<KeyValuePair<string, object>> resourceAttributes = null;
 
-        if (!this.IsECSProcess())
+        if (!IsECSProcess())
         {
             return resourceAttributes;
         }
 
         try
         {
-            var containerId = this.GetECSContainerId(AWSECSMetadataPath);
+            var containerId = GetECSContainerId(AWSECSMetadataPath);
 
-            resourceAttributes = this.ExtractResourceAttributes(containerId);
+            resourceAttributes = ExtractResourceAttributes(containerId);
         }
         catch (Exception ex)
         {
@@ -55,7 +55,7 @@ public class AWSECSResourceDetector : IResourceDetector
         return resourceAttributes;
     }
 
-    internal List<KeyValuePair<string, object>> ExtractResourceAttributes(string containerId)
+    internal static List<KeyValuePair<string, object>> ExtractResourceAttributes(string containerId)
     {
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {
@@ -67,7 +67,7 @@ public class AWSECSResourceDetector : IResourceDetector
         return resourceAttributes;
     }
 
-    internal string GetECSContainerId(string path)
+    internal static string GetECSContainerId(string path)
     {
         string containerId = null;
 
@@ -87,7 +87,7 @@ public class AWSECSResourceDetector : IResourceDetector
         return containerId;
     }
 
-    internal bool IsECSProcess()
+    internal static bool IsECSProcess()
     {
         return Environment.GetEnvironmentVariable(AWSECSMetadataURLKey) != null || Environment.GetEnvironmentVariable(AWSECSMetadataURLV4Key) != null;
     }

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSLambdaResourceDetector.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/AWSLambdaResourceDetector.cs
@@ -38,7 +38,7 @@ public class AWSLambdaResourceDetector : IResourceDetector
 
         try
         {
-            resourceAttributes = this.ExtractResourceAttributes();
+            resourceAttributes = ExtractResourceAttributes();
         }
         catch (Exception ex)
         {
@@ -48,7 +48,7 @@ public class AWSLambdaResourceDetector : IResourceDetector
         return resourceAttributes;
     }
 
-    internal List<KeyValuePair<string, object>> ExtractResourceAttributes()
+    internal static List<KeyValuePair<string, object>> ExtractResourceAttributes()
     {
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/Http/ServerCertificateValidationProvider.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/Http/ServerCertificateValidationProvider.cs
@@ -80,6 +80,22 @@ internal class ServerCertificateValidationProvider
         }
     }
 
+    private static bool HasCommonCertificate(X509Chain chain, X509Certificate2Collection collection)
+    {
+        foreach (var chainElement in chain.ChainElements)
+        {
+            foreach (var certificate in collection)
+            {
+                if (Enumerable.SequenceEqual(chainElement.Certificate.GetPublicKey(), certificate.GetPublicKey()))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private bool ValidateCertificate(X509Certificate2 cert, X509Chain chain, SslPolicyErrors errors)
     {
         var isSslPolicyPassed = errors == SslPolicyErrors.None ||
@@ -119,7 +135,7 @@ internal class ServerCertificateValidationProvider
         }
 
         // check if at least one certificate in the chain is in our trust list
-        var isTrusted = this.HasCommonCertificate(chain, this.trustedCertificates);
+        var isTrusted = HasCommonCertificate(chain, this.trustedCertificates);
         if (!isTrusted)
         {
             var serverCertificates = string.Empty;
@@ -140,21 +156,5 @@ internal class ServerCertificateValidationProvider
         }
 
         return isSslPolicyPassed && isValidChain && isTrusted;
-    }
-
-    private bool HasCommonCertificate(X509Chain chain, X509Certificate2Collection collection)
-    {
-        foreach (var chainElement in chain.ChainElements)
-        {
-            foreach (var certificate in collection)
-            {
-                if (Enumerable.SequenceEqual(chainElement.Certificate.GetPublicKey(), certificate.GetPublicKey()))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 }

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/ResourceDetectorUtils.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Resources/ResourceDetectorUtils.cs
@@ -27,7 +27,9 @@ namespace OpenTelemetry.Contrib.Extensions.AWSXRay.Resources;
 /// <summary>
 /// Class for resource detector utils.
 /// </summary>
+#pragma warning disable CA1052
 public class ResourceDetectorUtils
+#pragma warning restore CA1052
 {
     internal static async Task<string> SendOutRequest(string url, string method, KeyValuePair<string, string> header, HttpClientHandler handler = null)
     {
@@ -37,11 +39,13 @@ public class ResourceDetectorUtils
             httpRequestMessage.Method = new HttpMethod(method);
             httpRequestMessage.Headers.Add(header.Key, header.Value);
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
             var httpClient = handler == null ? new HttpClient() : new HttpClient(handler);
-            using (var response = await httpClient.SendAsync(httpRequestMessage))
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            using (var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false))
             {
                 response.EnsureSuccessStatusCode();
-                return await response.Content.ReadAsStringAsync();
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Trace/AWSXRayPropagator.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Trace/AWSXRayPropagator.cs
@@ -303,10 +303,12 @@ public class AWSXRayPropagator : TextMapPropagator
     internal static string ToXRayTraceIdFormat(string traceId)
     {
         var sb = new StringBuilder();
-#if NETSTANDARD
-        sb.Append(Version[0]);
-#else
+#if NETFRAMEWORK
+#pragma warning disable CA1834
         sb.Append(Version);
+#pragma warning restore CA1834
+#else
+        sb.Append(Version[0]);
 #endif
         sb.Append(TraceIdDelimiter);
         sb.Append(traceId.Substring(0, EpochHexDigits));

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Trace/AWSXRayPropagator.cs
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/Trace/AWSXRayPropagator.cs
@@ -303,7 +303,11 @@ public class AWSXRayPropagator : TextMapPropagator
     internal static string ToXRayTraceIdFormat(string traceId)
     {
         var sb = new StringBuilder();
+#if NETSTANDARD
+        sb.Append(Version[0]);
+#else
         sb.Append(Version);
+#endif
         sb.Append(TraceIdDelimiter);
         sb.Append(traceId.Substring(0, EpochHexDigits));
         sb.Append(TraceIdDelimiter);

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -57,7 +57,7 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         {
             if (activity != null)
             {
-                this.ProcessException(activity, ex);
+                ProcessException(activity, ex);
             }
 
             throw;
@@ -66,7 +66,7 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         {
             if (activity != null)
             {
-                this.ProcessEndRequest(executionContext, activity);
+                ProcessEndRequest(executionContext, activity);
             }
         }
     }
@@ -84,7 +84,7 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         {
             if (activity != null)
             {
-                this.ProcessException(activity, ex);
+                ProcessException(activity, ex);
             }
 
             throw;
@@ -93,53 +93,14 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         {
             if (activity != null)
             {
-                this.ProcessEndRequest(executionContext, activity);
+                ProcessEndRequest(executionContext, activity);
             }
         }
 
         return ret;
     }
 
-    private Activity ProcessBeginRequest(IExecutionContext executionContext)
-    {
-        Activity activity = null;
-
-        var requestContext = executionContext.RequestContext;
-        var service = AWSServiceHelper.GetAWSServiceName(requestContext);
-        var operation = AWSServiceHelper.GetAWSOperationName(requestContext);
-
-        activity = AWSSDKActivitySource.StartActivity(service + "." + operation, ActivityKind.Client);
-
-        if (activity == null)
-        {
-            return null;
-        }
-
-        if (this.options.SuppressDownstreamInstrumentation)
-        {
-            SuppressInstrumentationScope.Enter();
-        }
-
-        if (activity.IsAllDataRequested)
-        {
-            activity.SetTag(AWSSemanticConventions.AttributeAWSServiceName, service);
-            activity.SetTag(AWSSemanticConventions.AttributeAWSOperationName, operation);
-            var client = executionContext.RequestContext.ClientConfig;
-            if (client != null)
-            {
-                var region = client.RegionEndpoint?.SystemName;
-                activity.SetTag(AWSSemanticConventions.AttributeAWSRegion, region ?? AWSSDKUtils.DetermineRegion(client.ServiceURL));
-            }
-
-            this.AddRequestSpecificInformation(activity, requestContext, service);
-        }
-
-        AwsPropagator.Inject(new PropagationContext(activity.Context, Baggage.Current), requestContext.Request.Headers, Setter);
-
-        return activity;
-    }
-
-    private void ProcessEndRequest(IExecutionContext executionContext, Activity activity)
+    private static void ProcessEndRequest(IExecutionContext executionContext, Activity activity)
     {
         var responseContext = executionContext.ResponseContext;
         var requestContext = executionContext.RequestContext;
@@ -148,7 +109,7 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         {
             if (Utils.GetTagValue(activity, AWSSemanticConventions.AttributeAWSRequestId) == null)
             {
-                activity.SetTag(AWSSemanticConventions.AttributeAWSRequestId, this.FetchRequestId(requestContext, responseContext));
+                activity.SetTag(AWSSemanticConventions.AttributeAWSRequestId, FetchRequestId(requestContext, responseContext));
             }
 
             var httpResponse = responseContext.HttpResponse;
@@ -156,7 +117,7 @@ internal class AWSTracingPipelineHandler : PipelineHandler
             {
                 int statusCode = (int)httpResponse.StatusCode;
 
-                this.AddStatusCodeToActivity(activity, statusCode);
+                AddStatusCodeToActivity(activity, statusCode);
                 activity.SetTag(AWSSemanticConventions.AttributeHttpResponseContentLength, httpResponse.ContentLength);
             }
         }
@@ -164,7 +125,7 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         activity.Stop();
     }
 
-    private void ProcessException(Activity activity, Exception ex)
+    private static void ProcessException(Activity activity, Exception ex)
     {
         if (activity.IsAllDataRequested)
         {
@@ -174,13 +135,13 @@ internal class AWSTracingPipelineHandler : PipelineHandler
 
             if (ex is AmazonServiceException amazonServiceException)
             {
-                this.AddStatusCodeToActivity(activity, (int)amazonServiceException.StatusCode);
+                AddStatusCodeToActivity(activity, (int)amazonServiceException.StatusCode);
                 activity.SetTag(AWSSemanticConventions.AttributeAWSRequestId, amazonServiceException.RequestId);
             }
         }
     }
 
-    private void AddRequestSpecificInformation(Activity activity, IRequestContext requestContext, string service)
+    private static void AddRequestSpecificInformation(Activity activity, IRequestContext requestContext, string service)
     {
         if (AWSServiceHelper.ServiceParameterMap.TryGetValue(service, out string parameter))
         {
@@ -202,12 +163,12 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         }
     }
 
-    private void AddStatusCodeToActivity(Activity activity, int status_code)
+    private static void AddStatusCodeToActivity(Activity activity, int status_code)
     {
         activity.SetTag(AWSSemanticConventions.AttributeHttpStatusCode, status_code);
     }
 
-    private string FetchRequestId(IRequestContext requestContext, IResponseContext responseContext)
+    private static string FetchRequestId(IRequestContext requestContext, IResponseContext responseContext)
     {
         string request_id = string.Empty;
         var response = responseContext.Response;
@@ -235,5 +196,42 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         }
 
         return request_id;
+    }
+
+    private Activity ProcessBeginRequest(IExecutionContext executionContext)
+    {
+        var requestContext = executionContext.RequestContext;
+        var service = AWSServiceHelper.GetAWSServiceName(requestContext);
+        var operation = AWSServiceHelper.GetAWSOperationName(requestContext);
+
+        Activity activity = AWSSDKActivitySource.StartActivity(service + "." + operation, ActivityKind.Client);
+
+        if (activity == null)
+        {
+            return null;
+        }
+
+        if (this.options.SuppressDownstreamInstrumentation)
+        {
+            SuppressInstrumentationScope.Enter();
+        }
+
+        if (activity.IsAllDataRequested)
+        {
+            activity.SetTag(AWSSemanticConventions.AttributeAWSServiceName, service);
+            activity.SetTag(AWSSemanticConventions.AttributeAWSOperationName, operation);
+            var client = executionContext.RequestContext.ClientConfig;
+            if (client != null)
+            {
+                var region = client.RegionEndpoint?.SystemName;
+                activity.SetTag(AWSSemanticConventions.AttributeAWSRegion, region ?? AWSSDKUtils.DetermineRegion(client.ServiceURL));
+            }
+
+            AddRequestSpecificInformation(activity, requestContext, service);
+        }
+
+        AwsPropagator.Inject(new PropagationContext(activity.Context, Baggage.Current), requestContext.Request.Headers, Setter);
+
+        return activity;
     }
 }

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/Utils.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/Utils.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -25,7 +26,7 @@ internal class Utils
     {
         foreach (KeyValuePair<string, object> tag in activity.TagObjects)
         {
-            if (tag.Key.Equals(tagName))
+            if (tag.Key.Equals(tagName, StringComparison.Ordinal))
             {
                 return tag.Value;
             }
@@ -41,7 +42,7 @@ internal class Utils
             return string.Empty;
         }
 
-        if (originalString.EndsWith(suffix))
+        if (originalString.EndsWith(suffix, StringComparison.Ordinal))
         {
             return originalString.Substring(0, originalString.Length - suffix.Length);
         }
@@ -69,7 +70,7 @@ internal class Utils
             return string.Empty;
         }
 
-        if (originalString.StartsWith(prefix))
+        if (originalString.StartsWith(prefix, StringComparison.Ordinal))
         {
             return originalString.Substring(prefix.Length);
         }

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
@@ -41,7 +41,7 @@ public static class TracerProviderBuilderExtensions
         var awsClientOptions = new AWSClientInstrumentationOptions();
         configure?.Invoke(awsClientOptions);
 
-        new AWSClientsInstrumentation(awsClientOptions);
+        _ = new AWSClientsInstrumentation(awsClientOptions);
         builder.AddSource("Amazon.AWS.AWSClientInstrumentation");
         return builder;
     }

--- a/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
@@ -21,7 +21,7 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation;
 
-internal class DiagnosticSourceListener : IObserver<KeyValuePair<string, object>>
+internal sealed class DiagnosticSourceListener : IObserver<KeyValuePair<string, object>>
 {
     private readonly ListenerHandler handler;
 

--- a/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
@@ -21,7 +21,9 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation;
 
-internal class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticListener>
+#pragma warning disable CA1812
+internal sealed class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticListener>
+#pragma warning restore CA1812
 {
     private readonly Func<string, ListenerHandler> handlerFactory;
     private readonly Func<DiagnosticListener, bool> diagnosticSourceFilter;
@@ -87,11 +89,11 @@ internal class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticLis
     /// <inheritdoc/>
     public void Dispose()
     {
-        this.Dispose(true);
+        this.DisposeInternal();
         GC.SuppressFinalize(this);
     }
 
-    protected virtual void Dispose(bool disposing)
+    private void DisposeInternal()
     {
         if (Interlocked.CompareExchange(ref this.disposed, 1, 0) == 1)
         {

--- a/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/InstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/InstrumentationEventSource.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Instrumentation;
 /// EventSource events emitted from the project.
 /// </summary>
 [EventSource(Name = "OpenTelemetry-Instrumentation")]
-internal class InstrumentationEventSource : EventSource
+internal sealed class InstrumentationEventSource : EventSource
 {
     public static InstrumentationEventSource Log = new InstrumentationEventSource();
 

--- a/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/MultiTypePropertyFetcher.cs
+++ b/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/MultiTypePropertyFetcher.cs
@@ -25,7 +25,9 @@ namespace OpenTelemetry.Instrumentation;
 /// PropertyFetcher fetches a property from an object.
 /// </summary>
 /// <typeparam name="T">The type of the property being fetched.</typeparam>
-internal class MultiTypePropertyFetcher<T>
+#pragma warning disable CA1812
+internal sealed class MultiTypePropertyFetcher<T>
+#pragma warning restore CA1812
 {
     private readonly string propertyName;
     private readonly ConcurrentDictionary<Type, PropertyFetch> innerFetcher = new ConcurrentDictionary<Type, PropertyFetch>();
@@ -55,7 +57,7 @@ internal class MultiTypePropertyFetcher<T>
         PropertyFetch fetcher = null;
         if (!this.innerFetcher.TryGetValue(type, out fetcher))
         {
-            var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, this.propertyName, StringComparison.InvariantCultureIgnoreCase));
+            var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, this.propertyName, StringComparison.OrdinalIgnoreCase));
             if (property == null)
             {
                 property = type.GetProperty(this.propertyName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
@@ -100,7 +102,9 @@ internal class MultiTypePropertyFetcher<T>
             return default;
         }
 
-        private class TypedPropertyFetch<TDeclaredObject, TDeclaredProperty> : PropertyFetch
+#pragma warning disable CA1812
+        private sealed class TypedPropertyFetch<TDeclaredObject, TDeclaredProperty> : PropertyFetch
+#pragma warning restore CA1812
             where TDeclaredProperty : T
         {
             private readonly Func<TDeclaredObject, TDeclaredProperty> propertyFetch;

--- a/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry.Contrib.Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -24,7 +24,9 @@ namespace OpenTelemetry.Instrumentation;
 /// PropertyFetcher fetches a property from an object.
 /// </summary>
 /// <typeparam name="T">The type of the property being fetched.</typeparam>
-internal class PropertyFetcher<T>
+#pragma warning disable CA1812
+internal sealed class PropertyFetcher<T>
+#pragma warning restore CA1812
 {
     private readonly string propertyName;
     private PropertyFetch innerFetcher;
@@ -70,7 +72,7 @@ internal class PropertyFetcher<T>
         if (this.innerFetcher == null)
         {
             var type = obj.GetType().GetTypeInfo();
-            var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, this.propertyName, StringComparison.InvariantCultureIgnoreCase));
+            var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, this.propertyName, StringComparison.OrdinalIgnoreCase));
             if (property == null)
             {
                 property = type.GetProperty(this.propertyName);
@@ -109,7 +111,9 @@ internal class PropertyFetcher<T>
             return false;
         }
 
-        private class TypedPropertyFetch<TDeclaredObject, TDeclaredProperty> : PropertyFetch
+#pragma warning disable CA1812
+        private sealed class TypedPropertyFetch<TDeclaredObject, TDeclaredProperty> : PropertyFetch
+#pragma warning restore CA1812
             where TDeclaredProperty : T
         {
             private readonly Func<TDeclaredObject, TDeclaredProperty> propertyFetch;

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/UncheckedASCIIEncoding.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/UncheckedASCIIEncoding.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Text;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.Geneva.TldExporter;
 
@@ -124,11 +125,7 @@ internal sealed class UncheckedASCIIEncoding : Encoding
 
     public override int GetByteCount(string chars)
     {
-        if (chars == null)
-        {
-            throw new ArgumentNullException(nameof(chars));
-        }
-
+        Guard.ThrowIfNull(chars);
         return chars.Length;
     }
 

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/InstanaSpanSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/InstanaSpanSerializer.cs
@@ -36,12 +36,12 @@ internal class InstanaSpanSerializer
 #pragma warning restore SA1310 // Field names should not contain underscore
     private static readonly long UnixZeroTime = new DateTime(1970, 1, 1, 0, 0, 0, 0).Ticks;
 
-    internal IEnumerator GetSpanTagsEnumerator(InstanaSpan instanaSpan)
+    internal static IEnumerator GetSpanTagsEnumerator(InstanaSpan instanaSpan)
     {
         return instanaSpan.Data.Tags.GetEnumerator();
     }
 
-    internal IEnumerator GetSpanEventsEnumerator(InstanaSpan instanaSpan)
+    internal static IEnumerator GetSpanEventsEnumerator(InstanaSpan instanaSpan)
     {
         return instanaSpan.Data.Events.GetEnumerator();
     }

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/InstanaSpanSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/InstanaSpanSerializer.cs
@@ -17,12 +17,13 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Instana.Implementation;
 
-internal class InstanaSpanSerializer
+internal static class InstanaSpanSerializer
 {
 #pragma warning disable SA1310 // Field names should not contain underscore
     private const string COMMA = ",";
@@ -46,68 +47,70 @@ internal class InstanaSpanSerializer
         return instanaSpan.Data.Events.GetEnumerator();
     }
 
-    internal async Task<byte[]> SerializeToByteArrayAsync(InstanaSpan instanaSpan)
+    internal static async Task<byte[]> SerializeToByteArrayAsync(InstanaSpan instanaSpan)
     {
         using var stream = new MemoryStream();
         using var writer = new StreamWriter(stream);
 
-        await this.SerializeToStreamWriterAsync(instanaSpan, writer);
+        await SerializeToStreamWriterAsync(instanaSpan, writer).ConfigureAwait(false);
 
-        await writer.FlushAsync();
+        await writer.FlushAsync().ConfigureAwait(false);
         return stream.ToArray();
     }
 
-    internal async Task SerializeToStreamWriterAsync(InstanaSpan instanaSpan, StreamWriter writer)
+    internal static async Task SerializeToStreamWriterAsync(InstanaSpan instanaSpan, StreamWriter writer)
     {
-        await writer.WriteAsync(OPEN_BRACE);
-        await this.AppendProperty(instanaSpan.T, "t", writer);
-        await writer.WriteAsync(COMMA);
-        await this.AppendProperty(instanaSpan.S, "s", writer);
-        await writer.WriteAsync(COMMA);
+        await writer.WriteAsync(OPEN_BRACE).ConfigureAwait(false);
+        await AppendProperty(instanaSpan.T, "t", writer).ConfigureAwait(false);
+        await writer.WriteAsync(COMMA).ConfigureAwait(false);
+        await AppendProperty(instanaSpan.S, "s", writer).ConfigureAwait(false);
+        await writer.WriteAsync(COMMA).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(instanaSpan.P))
         {
-            await this.AppendProperty(instanaSpan.P, "p", writer);
-            await writer.WriteAsync(COMMA);
+            await AppendProperty(instanaSpan.P, "p", writer).ConfigureAwait(false);
+            await writer.WriteAsync(COMMA).ConfigureAwait(false);
         }
 
         if (!string.IsNullOrEmpty(instanaSpan.Lt))
         {
-            await this.AppendProperty(instanaSpan.Lt, "lt", writer);
-            await writer.WriteAsync(COMMA);
+            await AppendProperty(instanaSpan.Lt, "lt", writer).ConfigureAwait(false);
+            await writer.WriteAsync(COMMA).ConfigureAwait(false);
         }
 
         if (instanaSpan.Tp)
         {
-            await this.AppendProperty(true.ToString().ToLower(), "tp", writer);
-            await writer.WriteAsync(COMMA);
+#pragma warning disable CA1308 // Normalize strings to uppercase
+            await AppendProperty(true.ToString().ToLowerInvariant(), "tp", writer).ConfigureAwait(false);
+#pragma warning restore CA1308 // Normalize strings to uppercase
+            await writer.WriteAsync(COMMA).ConfigureAwait(false);
         }
 
         if (instanaSpan.K != SpanKind.NOT_SET)
         {
-            await this.AppendProperty((((int)instanaSpan.K) + 1).ToString(), "k", writer);
-            await writer.WriteAsync(COMMA);
+            await AppendProperty((((int)instanaSpan.K) + 1).ToString(CultureInfo.InvariantCulture), "k", writer).ConfigureAwait(false);
+            await writer.WriteAsync(COMMA).ConfigureAwait(false);
         }
 
-        await this.AppendProperty(instanaSpan.N, "n", writer);
-        await writer.WriteAsync(COMMA);
-        await this.AppendPropertyAsync(DateToUnixMillis(instanaSpan.Ts), "ts", writer);
-        await writer.WriteAsync(COMMA);
-        await this.AppendPropertyAsync((long)(instanaSpan.D / 10_000), "d", writer);
-        await writer.WriteAsync(COMMA);
-        await this.AppendObjectAsync(this.SerializeDataAsync, "data", instanaSpan, writer);
-        await writer.WriteAsync(COMMA);
-        await this.AppendObjectAsync(SerializeFromAsync, "f", instanaSpan, writer);
-        await writer.WriteAsync(COMMA);
-        await this.AppendPropertyAsync(instanaSpan.Ec, "ec", writer);
-        await writer.WriteAsync(CLOSE_BRACE);
+        await AppendProperty(instanaSpan.N, "n", writer).ConfigureAwait(false);
+        await writer.WriteAsync(COMMA).ConfigureAwait(false);
+        await AppendPropertyAsync(DateToUnixMillis(instanaSpan.Ts), "ts", writer).ConfigureAwait(false);
+        await writer.WriteAsync(COMMA).ConfigureAwait(false);
+        await AppendPropertyAsync((long)(instanaSpan.D / 10_000), "d", writer).ConfigureAwait(false);
+        await writer.WriteAsync(COMMA).ConfigureAwait(false);
+        await AppendObjectAsync(SerializeDataAsync, "data", instanaSpan, writer).ConfigureAwait(false);
+        await writer.WriteAsync(COMMA).ConfigureAwait(false);
+        await AppendObjectAsync(SerializeFromAsync, "f", instanaSpan, writer).ConfigureAwait(false);
+        await writer.WriteAsync(COMMA).ConfigureAwait(false);
+        await AppendPropertyAsync(instanaSpan.Ec, "ec", writer).ConfigureAwait(false);
+        await writer.WriteAsync(CLOSE_BRACE).ConfigureAwait(false);
     }
 
     private static async Task SerializeFromAsync(InstanaSpan instanaSpan, StreamWriter writer)
     {
-        await writer.WriteAsync("{\"e\":\"");
-        await writer.WriteAsync(instanaSpan.F.E);
-        await writer.WriteAsync("\"}");
+        await writer.WriteAsync("{\"e\":\"").ConfigureAwait(false);
+        await writer.WriteAsync(instanaSpan.F.E).ConfigureAwait(false);
+        await writer.WriteAsync("\"}").ConfigureAwait(false);
     }
 
     private static long DateToUnixMillis(long timeStamp)
@@ -117,12 +120,12 @@ internal class InstanaSpanSerializer
 
     private static async Task SerializeTagsAsync(InstanaSpan instanaSpan, StreamWriter writer)
     {
-        await SerializeTagsLogicAsync(instanaSpan.Data.Tags, writer);
+        await SerializeTagsLogicAsync(instanaSpan.Data.Tags, writer).ConfigureAwait(false);
     }
 
     private static async Task SerializeTagsLogicAsync(Dictionary<string, string> tags, StreamWriter writer)
     {
-        await writer.WriteAsync(OPEN_BRACE);
+        await writer.WriteAsync(OPEN_BRACE).ConfigureAwait(false);
         using (var enumerator = tags.GetEnumerator())
         {
             byte i = 0;
@@ -132,18 +135,18 @@ internal class InstanaSpanSerializer
                 {
                     if (i > 0)
                     {
-                        await writer.WriteAsync(COMMA);
+                        await writer.WriteAsync(COMMA).ConfigureAwait(false);
                     }
                     else
                     {
                         i = 1;
                     }
 
-                    await writer.WriteAsync(QUOTE);
-                    await writer.WriteAsync(enumerator.Current.Key);
-                    await writer.WriteAsync(QUOTE_COLON_QUOTE);
-                    await writer.WriteAsync(enumerator.Current.Value);
-                    await writer.WriteAsync(QUOTE);
+                    await writer.WriteAsync(QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(enumerator.Current.Key).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE_COLON_QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(enumerator.Current.Value).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE).ConfigureAwait(false);
                 }
             }
             catch (InvalidOperationException)
@@ -154,37 +157,37 @@ internal class InstanaSpanSerializer
             }
         }
 
-        await writer.WriteAsync(CLOSE_BRACE);
+        await writer.WriteAsync(CLOSE_BRACE).ConfigureAwait(false);
     }
 
-    private async Task AppendProperty(string value, string name, StreamWriter json)
+    private static async Task AppendProperty(string value, string name, StreamWriter json)
     {
-        await json.WriteAsync(QUOTE);
-        await json.WriteAsync(name);
-        await json.WriteAsync(QUOTE_COLON_QUOTE);
-        await json.WriteAsync(value);
-        await json.WriteAsync(QUOTE);
+        await json.WriteAsync(QUOTE).ConfigureAwait(false);
+        await json.WriteAsync(name).ConfigureAwait(false);
+        await json.WriteAsync(QUOTE_COLON_QUOTE).ConfigureAwait(false);
+        await json.WriteAsync(value).ConfigureAwait(false);
+        await json.WriteAsync(QUOTE).ConfigureAwait(false);
     }
 
-    private async Task AppendPropertyAsync(long value, string name, StreamWriter json)
+    private static async Task AppendPropertyAsync(long value, string name, StreamWriter json)
     {
-        await json.WriteAsync(QUOTE);
-        await json.WriteAsync(name);
-        await json.WriteAsync(QUOTE_COLON);
-        await json.WriteAsync(value.ToString());
+        await json.WriteAsync(QUOTE).ConfigureAwait(false);
+        await json.WriteAsync(name).ConfigureAwait(false);
+        await json.WriteAsync(QUOTE_COLON).ConfigureAwait(false);
+        await json.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
     }
 
-    private async Task AppendObjectAsync(Func<InstanaSpan, StreamWriter, Task> valueFunction, string name, InstanaSpan instanaSpan, StreamWriter json)
+    private static async Task AppendObjectAsync(Func<InstanaSpan, StreamWriter, Task> valueFunction, string name, InstanaSpan instanaSpan, StreamWriter json)
     {
-        await json.WriteAsync(QUOTE);
-        await json.WriteAsync(name);
-        await json.WriteAsync(QUOTE_COLON);
-        await valueFunction(instanaSpan, json);
+        await json.WriteAsync(QUOTE).ConfigureAwait(false);
+        await json.WriteAsync(name).ConfigureAwait(false);
+        await json.WriteAsync(QUOTE_COLON).ConfigureAwait(false);
+        await valueFunction(instanaSpan, json).ConfigureAwait(false);
     }
 
-    private async Task SerializeDataAsync(InstanaSpan instanaSpan, StreamWriter writer)
+    private static async Task SerializeDataAsync(InstanaSpan instanaSpan, StreamWriter writer)
     {
-        await writer.WriteAsync(OPEN_BRACE);
+        await writer.WriteAsync(OPEN_BRACE).ConfigureAwait(false);
         using (var enumerator = instanaSpan.Data.data.GetEnumerator())
         {
             byte i = 0;
@@ -194,18 +197,18 @@ internal class InstanaSpanSerializer
                 {
                     if (i > 0)
                     {
-                        await writer.WriteAsync(COMMA);
+                        await writer.WriteAsync(COMMA).ConfigureAwait(false);
                     }
                     else
                     {
                         i = 1;
                     }
 
-                    await writer.WriteAsync(QUOTE);
-                    await writer.WriteAsync(enumerator.Current.Key);
-                    await writer.WriteAsync(QUOTE_COLON_QUOTE);
-                    await writer.WriteAsync(enumerator.Current.Value.ToString());
-                    await writer.WriteAsync(QUOTE);
+                    await writer.WriteAsync(QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(enumerator.Current.Key).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE_COLON_QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(enumerator.Current.Value.ToString()).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE).ConfigureAwait(false);
                 }
             }
             catch (InvalidOperationException)
@@ -218,67 +221,67 @@ internal class InstanaSpanSerializer
 
         if (instanaSpan.Data.Tags?.Count > 0)
         {
-            await writer.WriteAsync(COMMA);
+            await writer.WriteAsync(COMMA).ConfigureAwait(false);
 
             // serialize tags
-            await this.AppendObjectAsync(SerializeTagsAsync, InstanaExporterConstants.TAGS_FIELD, instanaSpan, writer);
+            await AppendObjectAsync(SerializeTagsAsync, InstanaExporterConstants.TAGS_FIELD, instanaSpan, writer).ConfigureAwait(false);
         }
 
         if (instanaSpan.Data.Events?.Count > 0)
         {
-            await writer.WriteAsync(COMMA);
+            await writer.WriteAsync(COMMA).ConfigureAwait(false);
 
             // serialize tags
-            await this.AppendObjectAsync(this.SerializeEventsAsync, InstanaExporterConstants.EVENTS_FIELD, instanaSpan, writer);
+            await AppendObjectAsync(SerializeEventsAsync, InstanaExporterConstants.EVENTS_FIELD, instanaSpan, writer).ConfigureAwait(false);
         }
 
-        await writer.WriteAsync(CLOSE_BRACE);
+        await writer.WriteAsync(CLOSE_BRACE).ConfigureAwait(false);
     }
 
-    private async Task SerializeEventsAsync(InstanaSpan instanaSpan, StreamWriter writer)
+    private static async Task SerializeEventsAsync(InstanaSpan instanaSpan, StreamWriter writer)
     {
         using (var enumerator = instanaSpan.Data.Events.GetEnumerator())
         {
             byte i = 0;
             try
             {
-                await writer.WriteAsync("[");
+                await writer.WriteAsync("[").ConfigureAwait(false);
                 while (enumerator.MoveNext())
                 {
                     if (i > 0)
                     {
-                        await writer.WriteAsync(COMMA);
+                        await writer.WriteAsync(COMMA).ConfigureAwait(false);
                     }
                     else
                     {
                         i = 1;
                     }
 
-                    await writer.WriteAsync(OPEN_BRACE);
-                    await writer.WriteAsync(QUOTE);
-                    await writer.WriteAsync(InstanaExporterConstants.EVENT_NAME_FIELD);
-                    await writer.WriteAsync(QUOTE_COLON_QUOTE);
-                    await writer.WriteAsync(enumerator.Current.Name);
-                    await writer.WriteAsync(QUOTE_COMMA_QUOTE);
-                    await writer.WriteAsync(InstanaExporterConstants.EVENT_TIMESTAMP_FIELD);
-                    await writer.WriteAsync(QUOTE_COLON_QUOTE);
-                    await writer.WriteAsync(DateToUnixMillis(enumerator.Current.Ts).ToString());
-                    await writer.WriteAsync(QUOTE);
+                    await writer.WriteAsync(OPEN_BRACE).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(InstanaExporterConstants.EVENT_NAME_FIELD).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE_COLON_QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(enumerator.Current.Name).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE_COMMA_QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(InstanaExporterConstants.EVENT_TIMESTAMP_FIELD).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE_COLON_QUOTE).ConfigureAwait(false);
+                    await writer.WriteAsync(DateToUnixMillis(enumerator.Current.Ts).ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+                    await writer.WriteAsync(QUOTE).ConfigureAwait(false);
 
                     if (enumerator.Current.Tags?.Count > 0)
                     {
-                        await writer.WriteAsync(COMMA);
-                        await writer.WriteAsync(QUOTE);
-                        await writer.WriteAsync(InstanaExporterConstants.TAGS_FIELD);
-                        await writer.WriteAsync(QUOTE);
-                        await writer.WriteAsync(COLON);
-                        await SerializeTagsLogicAsync(enumerator.Current.Tags, writer);
+                        await writer.WriteAsync(COMMA).ConfigureAwait(false);
+                        await writer.WriteAsync(QUOTE).ConfigureAwait(false);
+                        await writer.WriteAsync(InstanaExporterConstants.TAGS_FIELD).ConfigureAwait(false);
+                        await writer.WriteAsync(QUOTE).ConfigureAwait(false);
+                        await writer.WriteAsync(COLON).ConfigureAwait(false);
+                        await SerializeTagsLogicAsync(enumerator.Current.Tags, writer).ConfigureAwait(false);
                     }
 
-                    await writer.WriteAsync(CLOSE_BRACE);
+                    await writer.WriteAsync(CLOSE_BRACE).ConfigureAwait(false);
                 }
 
-                await writer.WriteAsync("]");
+                await writer.WriteAsync("]").ConfigureAwait(false);
             }
             catch (InvalidOperationException)
             {

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/ActivityProcessorBase.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/ActivityProcessorBase.cs
@@ -28,7 +28,7 @@ internal abstract class ActivityProcessorBase : IActivityProcessor
     {
         if (this.NextProcessor != null)
         {
-            await this.NextProcessor.ProcessAsync(activity, instanaSpan);
+            await this.NextProcessor.ProcessAsync(activity, instanaSpan).ConfigureAwait(false);
         }
     }
 

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/DefaultActivityProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/DefaultActivityProcessor.cs
@@ -62,7 +62,7 @@ internal class DefaultActivityProcessor : ActivityProcessorBase, IActivityProces
             instanaSpan.Tp = true;
         }
 
-        await base.ProcessAsync(activity, instanaSpan);
+        await base.ProcessAsync(activity, instanaSpan).ConfigureAwait(false);
     }
 
     private static SpanKind GetSpanKind(ActivityKind activityKind)

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/ErrorActivityProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/ErrorActivityProcessor.cs
@@ -43,6 +43,6 @@ internal class ErrorActivityProcessor : ActivityProcessorBase, IActivityProcesso
             instanaSpan.Ec = 0;
         }
 
-        await base.ProcessAsync(activity, instanaSpan);
+        await base.ProcessAsync(activity, instanaSpan).ConfigureAwait(false);
     }
 }

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/EventsActivityProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/EventsActivityProcessor.cs
@@ -51,6 +51,6 @@ internal class EventsActivityProcessor : ActivityProcessorBase, IActivityProcess
             instanaSpan.Data.Events.Add(spanEvent);
         }
 
-        await base.ProcessAsync(activity, instanaSpan);
+        await base.ProcessAsync(activity, instanaSpan).ConfigureAwait(false);
     }
 }

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/TagsActivityProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/Processors/TagsActivityProcessor.cs
@@ -53,6 +53,6 @@ internal class TagsActivityProcessor : ActivityProcessorBase, IActivityProcessor
         instanaSpan.TransformInfo.StatusCode = statusCode;
         instanaSpan.TransformInfo.StatusDesc = statusDesc;
 
-        await base.ProcessAsync(activity, instanaSpan);
+        await base.ProcessAsync(activity, instanaSpan).ConfigureAwait(false);
     }
 }

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/SpanSender.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/SpanSender.cs
@@ -18,10 +18,11 @@ using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Instana.Implementation;
 
-internal class SpanSender : ISpanSender
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
+internal sealed class SpanSender : ISpanSender
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
 {
     private readonly Task queueSenderTask;
-    private readonly Transport transport = new Transport();
     private readonly ConcurrentQueue<InstanaSpan> spansQueue = new ConcurrentQueue<InstanaSpan>();
 
     public SpanSender()
@@ -33,7 +34,7 @@ internal class SpanSender : ISpanSender
 
     public void Enqueue(InstanaSpan instanaSpan)
     {
-        if (this.transport.IsAvailable)
+        if (Transport.IsAvailable)
         {
             this.spansQueue.Enqueue(instanaSpan);
         }
@@ -48,11 +49,11 @@ internal class SpanSender : ISpanSender
             if (this.spansQueue.TryPeek(out InstanaSpan _))
             {
                 // actually send spans
-                await this.transport.SendSpansAsync(this.spansQueue);
+                await Transport.SendSpansAsync(this.spansQueue).ConfigureAwait(false);
             }
 
             // rest for a while
-            await Task.Delay(1000);
+            await Task.Delay(1000).ConfigureAwait(false);
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/Transport.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/Transport.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -24,31 +25,31 @@ using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Instana.Implementation;
 
-internal class Transport
+internal static class Transport
 {
     private const int MultiSpanBufferLimit = 4096000;
 
     private static readonly InstanaSpanSerializer InstanaSpanSerializer = new InstanaSpanSerializer();
     private static readonly MediaTypeHeaderValue MEDIAHEADER = new MediaTypeHeaderValue("application/json");
 
-    private static bool isConfigured = false;
-    private static int backendTimeout = 0;
+    private static bool isConfigured;
+    private static int backendTimeout;
     private static string configuredEndpoint = string.Empty;
     private static string configuredAgentKey = string.Empty;
     private static string bundleUrl = string.Empty;
-    private static InstanaHttpClient client = null;
+    private static InstanaHttpClient client;
 
     static Transport()
     {
         Configure();
     }
 
-    internal bool IsAvailable
+    internal static bool IsAvailable
     {
         get { return isConfigured && client != null; }
     }
 
-    internal async Task SendSpansAsync(ConcurrentQueue<InstanaSpan> spanQueue)
+    internal static async Task SendSpansAsync(ConcurrentQueue<InstanaSpan> spanQueue)
     {
         try
         {
@@ -56,14 +57,14 @@ internal class Transport
             {
                 using (StreamWriter writer = new StreamWriter(sendBuffer))
                 {
-                    await writer.WriteAsync("{\"spans\":[");
+                    await writer.WriteAsync("{\"spans\":[").ConfigureAwait(false);
                     bool first = true;
 
                     // peek instead of dequeue, because we don't yet know whether the next span
                     // fits within our MULTI_SPAN_BUFFER_LIMIT
                     while (spanQueue.TryPeek(out InstanaSpan span))
                     {
-                        var serialized = await InstanaSpanSerializer.SerializeToByteArrayAsync(span);
+                        var serialized = await InstanaSpanSerializer.SerializeToByteArrayAsync(span).ConfigureAwait(false);
 
                         if (!first)
                         {
@@ -72,27 +73,27 @@ internal class Transport
                                 break;
                             }
 
-                            await writer.WriteAsync(",");
+                            await writer.WriteAsync(",").ConfigureAwait(false);
                         }
 
                         first = false;
 
-                        await sendBuffer.WriteAsync(serialized, 0, serialized.Length);
+                        await sendBuffer.WriteAsync(serialized, 0, serialized.Length).ConfigureAwait(false);
 
                         // Now we can dequeue. Note, this means we'll be giving up/losing
                         // this span if we fail to send for any reason.
                         spanQueue.TryDequeue(out _);
                     }
 
-                    await writer.WriteAsync("]}");
+                    await writer.WriteAsync("]}").ConfigureAwait(false);
 
-                    await writer.FlushAsync();
+                    await writer.FlushAsync().ConfigureAwait(false);
                     long length = sendBuffer.Position;
                     sendBuffer.Position = 0;
 
                     HttpContent content = new StreamContent(sendBuffer, (int)length);
                     content.Headers.ContentType = MEDIAHEADER;
-                    content.Headers.Add("X-INSTANA-TIME", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString());
+                    content.Headers.Add("X-INSTANA-TIME", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
 
                     using (var httpMsg = new HttpRequestMessage()
                     {
@@ -101,7 +102,7 @@ internal class Transport
                     })
                     {
                         httpMsg.Content = content;
-                        await client.SendAsync(httpMsg);
+                        await client.SendAsync(httpMsg).ConfigureAwait(false);
                     }
                 }
             }
@@ -160,7 +161,9 @@ internal class Transport
             return;
         }
 
+#pragma warning disable CA2000
         var configuredHandler = new HttpClientHandler();
+#pragma warning restore CA2000
         string proxy = Environment.GetEnvironmentVariable(InstanaExporterConstants.ENVVAR_INSTANA_ENDPOINT_PROXY);
         if (Uri.TryCreate(proxy, UriKind.Absolute, out Uri proxyAddress))
         {
@@ -171,7 +174,9 @@ internal class Transport
 #pragma warning restore SA1130 // Use lambda syntax
         }
 
+#pragma warning disable CA5400
         client = new InstanaHttpClient(backendTimeout, configuredHandler);
+#pragma warning restore CA5400
 
         client.DefaultRequestHeaders.Add("X-INSTANA-KEY", configuredAgentKey);
     }

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/Transport.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/Transport.cs
@@ -29,7 +29,6 @@ internal static class Transport
 {
     private const int MultiSpanBufferLimit = 4096000;
 
-    private static readonly InstanaSpanSerializer InstanaSpanSerializer = new InstanaSpanSerializer();
     private static readonly MediaTypeHeaderValue MEDIAHEADER = new MediaTypeHeaderValue("application/json");
 
     private static bool isConfigured;

--- a/src/OpenTelemetry.Exporter.Instana/InstanaExporter.cs
+++ b/src/OpenTelemetry.Exporter.Instana/InstanaExporter.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using OpenTelemetry.Exporter.Instana.Implementation;
@@ -30,7 +31,7 @@ internal class InstanaExporter : BaseExporter<Activity>
     private string name;
     private ISpanSender spanSender = new SpanSender();
     private IInstanaExporterHelper instanaExporterHelper = new InstanaExporterHelper();
-    private bool shutdownCalled = false;
+    private bool shutdownCalled;
 
     public InstanaExporter(string name = "InstanaExporter", IActivityProcessor activityProcessor = null)
     {
@@ -77,7 +78,7 @@ internal class InstanaExporter : BaseExporter<Activity>
         From from = null;
         if (this.instanaExporterHelper.IsWindows())
         {
-            from = new From() { E = Process.GetCurrentProcess().Id.ToString() };
+            from = new From() { E = Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture) };
         }
 
         string serviceName = this.ExtractServiceName(ref from);
@@ -175,7 +176,7 @@ internal class InstanaExporter : BaseExporter<Activity>
     {
         InstanaSpan instanaSpan = InstanaSpanFactory.CreateSpan();
 
-        await this.activityProcessor.ProcessAsync(activity, instanaSpan);
+        await this.activityProcessor.ProcessAsync(activity, instanaSpan).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(serviceName))
         {

--- a/src/OpenTelemetry.Exporter.Instana/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Instana/TracerProviderBuilderExtensions.cs
@@ -37,6 +37,8 @@ public static class TracerProviderBuilderExtensions
             throw new ArgumentNullException(nameof(options));
         }
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
         return options.AddProcessor(new BatchActivityExportProcessor(new InstanaExporter()));
+#pragma warning restore CA2000 // Dispose objects before losing scope
     }
 }

--- a/src/OpenTelemetry.Exporter.Stackdriver/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Stackdriver/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -15,7 +15,7 @@ OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter
 OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter.StackdriverTraceExporter(string projectId) -> void
 OpenTelemetry.Exporter.Stackdriver.Utils.CommonUtils
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
-override OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batchActivity) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Exporter.Stackdriver.Implementation.GoogleCloudResourceUtils.GetDefaultResource(string projectId) -> Google.Api.MonitoredResource
 static OpenTelemetry.Exporter.Stackdriver.Implementation.GoogleCloudResourceUtils.GetProjectId() -> string
 static OpenTelemetry.Exporter.Stackdriver.Implementation.StackdriverStatsConfiguration.Default.get -> OpenTelemetry.Exporter.Stackdriver.Implementation.StackdriverStatsConfiguration

--- a/src/OpenTelemetry.Exporter.Stackdriver/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Stackdriver/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -15,7 +15,7 @@ OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter
 OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter.StackdriverTraceExporter(string projectId) -> void
 OpenTelemetry.Exporter.Stackdriver.Utils.CommonUtils
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
-override OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batchActivity) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.Stackdriver.StackdriverTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Exporter.Stackdriver.Implementation.GoogleCloudResourceUtils.GetDefaultResource(string projectId) -> Google.Api.MonitoredResource
 static OpenTelemetry.Exporter.Stackdriver.Implementation.GoogleCloudResourceUtils.GetProjectId() -> string
 static OpenTelemetry.Exporter.Stackdriver.Implementation.StackdriverStatsConfiguration.Default.get -> OpenTelemetry.Exporter.Stackdriver.Implementation.StackdriverStatsConfiguration

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/ActivityExtensions.cs
@@ -18,6 +18,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using Google.Cloud.Trace.V2;
 using Google.Protobuf.WellKnownTypes;
@@ -27,7 +28,7 @@ namespace OpenTelemetry.Exporter.Stackdriver.Implementation;
 
 internal static class ActivityExtensions
 {
-    private static Dictionary<string, string> labelsToReplace = new Dictionary<string, string>
+    private static readonly Dictionary<string, string> LabelsToReplace = new Dictionary<string, string>
     {
         { "component", "/component" },
         { "http.method", "/http/method" },
@@ -94,7 +95,7 @@ internal static class ActivityExtensions
 
         // StackDriver uses different labels that are used to categorize spans
         // replace attribute keys with StackDriver version
-        foreach (var entry in labelsToReplace)
+        foreach (var entry in LabelsToReplace)
         {
             if (span.Attributes.AttributeMap.TryGetValue(entry.Key, out var attrValue))
             {
@@ -146,7 +147,7 @@ internal static class ActivityExtensions
             case double d:
                 return new AttributeValue()
                 {
-                    StringValue = new TruncatableString() { Value = d.ToString() },
+                    StringValue = new TruncatableString() { Value = d.ToString(CultureInfo.InvariantCulture) },
                 };
             case null:
                 return new AttributeValue();

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/Constants.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/Constants.cs
@@ -20,30 +20,31 @@ namespace OpenTelemetry.Exporter.Stackdriver.Implementation;
 
 internal class Constants
 {
-    public static readonly string PackagVersionUndefined = "undefined";
+    public const string PackagVersionUndefined = "undefined";
 
-    public static readonly string LabelDescription = "OpenTelemetry string";
-    public static readonly string OpenTelemetryTask = "OpenTelemetry_task";
-    public static readonly string OpenTelemetryTaskDescription = "OpenTelemetry task identifier";
+    public const string LabelDescription = "OpenTelemetry string";
+    public const string OpenTelemetryTask = "OpenTelemetry_task";
+    public const string OpenTelemetryTaskDescription = "OpenTelemetry task identifier";
 
-    public static readonly string GcpGkeContainer = "k8s_container";
-    public static readonly string GcpGceInstance = "gce_instance";
-    public static readonly string AwsEc2Instance = "aws_ec2_instance";
-    public static readonly string Global = "global";
+    public const string GcpGkeContainer = "k8s_container";
+    public const string GcpGceInstance = "gce_instance";
+    public const string AwsEc2Instance = "aws_ec2_instance";
+    public const string Global = "global";
 
-    public static readonly string ProjectIdLabelKey = "project_id";
+    public const string ProjectIdLabelKey = "project_id";
+
+    public const string GceGcpInstanceType = "cloud.google.com/gce/instance";
+    public const string GcpInstanceIdKey = "cloud.google.com/gce/instance_id";
+    public const string GcpAccountIdKey = "cloud.google.com/gce/project_id";
+    public const string GcpZoneKey = "cloud.google.com/gce/zone";
+
+    public const string K8sContainerType = "k8s.io/container";
+    public const string K8sClusterNameKey = "k8s.io/cluster/name";
+    public const string K8sContainerNameKey = "k8s.io/container/name";
+    public const string K8sNamespaceNameKey = "k8s.io/namespace/name";
+    public const string K8sPodNameKey = "k8s.io/pod/name";
+
     public static readonly string OpenTelemetryTaskValueDefault = GenerateDefaultTaskValue();
-
-    public static readonly string GceGcpInstanceType = "cloud.google.com/gce/instance";
-    public static readonly string GcpInstanceIdKey = "cloud.google.com/gce/instance_id";
-    public static readonly string GcpAccountIdKey = "cloud.google.com/gce/project_id";
-    public static readonly string GcpZoneKey = "cloud.google.com/gce/zone";
-
-    public static readonly string K8sContainerType = "k8s.io/container";
-    public static readonly string K8sClusterNameKey = "k8s.io/cluster/name";
-    public static readonly string K8sContainerNameKey = "k8s.io/container/name";
-    public static readonly string K8sNamespaceNameKey = "k8s.io/namespace/name";
-    public static readonly string K8sPodNameKey = "k8s.io/pod/name";
 
     private static string GenerateDefaultTaskValue()
     {

--- a/src/OpenTelemetry.Exporter.Stackdriver/StackdriverTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/StackdriverTraceExporter.cs
@@ -37,7 +37,9 @@ public class StackdriverTraceExporter : BaseExporter<Activity>
     private readonly TraceServiceSettings traceServiceSettings;
     private readonly TraceServiceClient traceServiceClient;
 
+#pragma warning disable CA1810 // Initialize reference type static fields inline
     static StackdriverTraceExporter()
+#pragma warning restore CA1810 // Initialize reference type static fields inline
     {
         try
         {
@@ -87,7 +89,9 @@ public class StackdriverTraceExporter : BaseExporter<Activity>
     }
 
     /// <inheritdoc/>
+#pragma warning disable CA1725 // Parameter names should match base declaration
     public override ExportResult Export(in Batch<Activity> batchActivity)
+#pragma warning restore CA1725 // Parameter names should match base declaration
     {
         TraceServiceClient traceWriter = this.traceServiceClient;
         if (this.traceServiceClient == null)

--- a/src/OpenTelemetry.Exporter.Stackdriver/StackdriverTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/StackdriverTraceExporter.cs
@@ -89,9 +89,7 @@ public class StackdriverTraceExporter : BaseExporter<Activity>
     }
 
     /// <inheritdoc/>
-#pragma warning disable CA1725 // Parameter names should match base declaration
-    public override ExportResult Export(in Batch<Activity> batchActivity)
-#pragma warning restore CA1725 // Parameter names should match base declaration
+    public override ExportResult Export(in Batch<Activity> batch)
     {
         TraceServiceClient traceWriter = this.traceServiceClient;
         if (this.traceServiceClient == null)
@@ -107,7 +105,7 @@ public class StackdriverTraceExporter : BaseExporter<Activity>
             ProjectName = this.googleCloudProjectId,
         };
 
-        foreach (var activity in batchActivity)
+        foreach (var activity in batch)
         {
             // It should never happen that the time has no correct kind, only if OpenTelemetry is used incorrectly.
             if (activity.StartTimeUtc.Kind == DateTimeKind.Utc)

--- a/src/OpenTelemetry.Exporter.Stackdriver/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/TracerProviderBuilderExtensions.cs
@@ -36,8 +36,10 @@ public static class TracerProviderBuilderExtensions
     {
         Guard.ThrowIfNull(builder);
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var activityExporter = new StackdriverTraceExporter(projectId);
 
         return builder.AddProcessor(new BatchActivityExportProcessor(activityExporter));
+#pragma warning restore CA2000 // Dispose objects before losing scope
     }
 }

--- a/src/OpenTelemetry.Exporter.Stackdriver/Utils/CommonUtils.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Utils/CommonUtils.cs
@@ -32,6 +32,11 @@ public static class CommonUtils
     /// <returns><see cref="IEnumerable{T}"/>.</returns>
     public static IEnumerable<IEnumerable<T>> Partition<T>(this IEnumerable<T> source, int size)
     {
+        if (source == null)
+        {
+            throw new System.ArgumentNullException(nameof(source));
+        }
+
         using var enumerator = source.GetEnumerator();
         while (enumerator.MoveNext())
         {

--- a/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ OpenTelemetry.Extensions.PersistentStorage.FileBlob.FileBlob(string fullPath) ->
 OpenTelemetry.Extensions.PersistentStorage.FileBlob.FullPath.get -> string
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose() -> void
-OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.FileBlobProvider(string path, long maxSizeInBytes = 52428800, int maintenancePeriodInMilliseconds = 120000, long retentionPeriodInMilliseconds = 172800000, int writeTimeoutInMilliseconds = 60000) -> void
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryDelete() -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryLease(int leasePeriodMilliseconds) -> bool
@@ -13,3 +12,4 @@ override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnGetBlobs(
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryGetBlob(out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
+virtual OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ OpenTelemetry.Extensions.PersistentStorage.FileBlob.FileBlob(string fullPath) ->
 OpenTelemetry.Extensions.PersistentStorage.FileBlob.FullPath.get -> string
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose() -> void
-OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.FileBlobProvider(string path, long maxSizeInBytes = 52428800, int maintenancePeriodInMilliseconds = 120000, long retentionPeriodInMilliseconds = 172800000, int writeTimeoutInMilliseconds = 60000) -> void
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryDelete() -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryLease(int leasePeriodMilliseconds) -> bool
@@ -13,3 +12,4 @@ override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnGetBlobs(
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryGetBlob(out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
+virtual OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ OpenTelemetry.Extensions.PersistentStorage.FileBlob.FileBlob(string fullPath) ->
 OpenTelemetry.Extensions.PersistentStorage.FileBlob.FullPath.get -> string
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose() -> void
-OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.FileBlobProvider(string path, long maxSizeInBytes = 52428800, int maintenancePeriodInMilliseconds = 120000, long retentionPeriodInMilliseconds = 172800000, int writeTimeoutInMilliseconds = 60000) -> void
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryDelete() -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryLease(int leasePeriodMilliseconds) -> bool
@@ -13,3 +12,4 @@ override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnGetBlobs(
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryGetBlob(out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
+virtual OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Extensions.PersistentStorage/FileBlob.cs
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/FileBlob.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using OpenTelemetry.Extensions.PersistentStorage.Abstractions;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Extensions.PersistentStorage;
 
@@ -57,10 +58,7 @@ public class FileBlob : PersistentBlob
 
     protected override bool OnTryWrite(byte[] buffer, int leasePeriodMilliseconds = 0)
     {
-        if (buffer == null)
-        {
-            throw new ArgumentNullException(nameof(buffer));
-        }
+        Guard.ThrowIfNull(buffer);
 
         string path = this.FullPath + ".tmp";
 

--- a/src/OpenTelemetry.Extensions.PersistentStorage/FileBlob.cs
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/FileBlob.cs
@@ -57,6 +57,11 @@ public class FileBlob : PersistentBlob
 
     protected override bool OnTryWrite(byte[] buffer, int leasePeriodMilliseconds = 0)
     {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
         string path = this.FullPath + ".tmp";
 
         try

--- a/src/OpenTelemetry.Extensions.PersistentStorage/FileBlobProvider.cs
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/FileBlobProvider.cs
@@ -110,7 +110,7 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public void Dispose(bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (!this.disposedValue)
         {

--- a/src/OpenTelemetry.Extensions.PersistentStorage/PersistentStorageHelper.cs
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/PersistentStorageHelper.cs
@@ -204,9 +204,14 @@ internal static class PersistentStorageHelper
 
     internal static string GetSHA256Hash(string input)
     {
-        var hashString = new StringBuilder();
-
         byte[] inputBits = Encoding.Unicode.GetBytes(input);
+
+#if NET6_0_OR_GREATER
+#pragma warning disable CA1308 // Normalize strings to uppercase
+        return Convert.ToHexString(SHA256.HashData(inputBits)).ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
+#else
+        var hashString = new StringBuilder();
         using (var sha256 = SHA256.Create())
         {
             byte[] hashBits = sha256.ComputeHash(inputBits);
@@ -217,6 +222,7 @@ internal static class PersistentStorageHelper
         }
 
         return hashString.ToString();
+#endif
     }
 
     private static long CalculateFolderSize(string path)

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
@@ -22,6 +22,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 using OpenTelemetry.Instrumentation.AWSLambda.Implementation;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda;
@@ -69,6 +70,7 @@ public static class AWSLambdaWrapper
         ILambdaContext context,
         ActivityContext parentContext = default)
     {
+        Guard.ThrowIfNull(lambdaHandler);
         return TraceInternal(tracerProvider, lambdaHandler, input, context, parentContext);
     }
 
@@ -125,7 +127,7 @@ public static class AWSLambdaWrapper
     {
         Func<TInput, ILambdaContext, Task<object>> func = async (input, context) =>
         {
-            await lambdaHandler(input, context);
+            await lambdaHandler(input, context).ConfigureAwait(false);
             return null;
         };
         return TraceInternalAsync(tracerProvider, func, input, context, parentContext);
@@ -154,6 +156,7 @@ public static class AWSLambdaWrapper
         ILambdaContext context,
         ActivityContext parentContext = default)
     {
+        Guard.ThrowIfNull(lambdaHandler);
         return TraceInternalAsync(tracerProvider, lambdaHandler, input, context, parentContext);
     }
 
@@ -239,7 +242,7 @@ public static class AWSLambdaWrapper
         var activity = OnFunctionStart(input, context, parentContext);
         try
         {
-            var result = await handlerAsync(input, context);
+            var result = await handlerAsync(input, context).ConfigureAwait(false);
             AWSLambdaHttpUtils.SetHttpTagsFromResult(activity, result);
             return result;
         }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -97,7 +97,7 @@ internal class AWSLambdaHttpUtils
             {
                 queryString.Append(separator)
                     .Append(HttpUtility.UrlEncode(parameterKvp.Key))
-                    .Append("=")
+                    .Append('=')
                     .Append(HttpUtility.UrlEncode(value));
                 separator = '&';
             }

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModule.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModule.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Web;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.AspNet;
 
@@ -57,6 +58,8 @@ public class TelemetryHttpModule : IHttpModule
     /// <inheritdoc />
     public void Init(HttpApplication context)
     {
+        Guard.ThrowIfNull(context);
+
         context.BeginRequest += this.Application_BeginRequest;
         context.EndRequest += this.Application_EndRequest;
         context.Error += this.Application_Error;

--- a/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
@@ -34,7 +34,9 @@ public static class MeterProviderBuilderExtensions
     {
         Guard.ThrowIfNull(builder);
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var instrumentation = new AspNetMetrics();
+#pragma warning restore CA2000 // Dispose objects before losing scope
         builder.AddMeter(AspNetMetrics.InstrumentationName);
         return builder.AddInstrumentation(() => instrumentation);
     }

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/ElasticsearchClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/ElasticsearchClientInstrumentationOptions.cs
@@ -32,7 +32,7 @@ public class ElasticsearchClientInstrumentationOptions
     /// <summary>
     /// Gets or sets a value indicating whether the JSON request body should be parsed out of the request debug information and formatted as indented JSON.
     /// </summary>
-    public bool ParseAndFormatRequest { get; set; } = false;
+    public bool ParseAndFormatRequest { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether or not the OpenTelemetry.Instrumentation.ElasticsearchClient

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/EntityFrameworkInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/EntityFrameworkInstrumentationOptions.cs
@@ -32,5 +32,5 @@ public class EntityFrameworkInstrumentationOptions
     /// <summary>
     /// Gets or sets a value indicating whether or not the <see cref="EntityFrameworkInstrumentation"/> should add the text of <see cref="CommandType.Text"/> commands as the <see cref="SemanticConventions.AttributeDbStatement"/> tag. Default value: False.
     /// </summary>
-    public bool SetDbStatementForText { get; set; } = false;
+    public bool SetDbStatementForText { get; set; }
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using global::Grpc.Core;
 using global::Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
@@ -52,6 +53,9 @@ public class ClientTracingInterceptor : Interceptor
         ClientInterceptorContext<TRequest, TResponse> context,
         BlockingUnaryCallContinuation<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         ClientRpcScope<TRequest, TResponse> rpcScope = null;
 
         try
@@ -81,11 +85,16 @@ public class ClientTracingInterceptor : Interceptor
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         ClientRpcScope<TRequest, TResponse> rpcScope = null;
 
         try
         {
+#pragma warning  disable CA2000
             rpcScope = new ClientRpcScope<TRequest, TResponse>(context, this.options);
+#pragma warning restore CA2000
             rpcScope.RecordRequest(request);
             var responseContinuation = continuation(request, rpcScope.Context);
             var responseAsync = responseContinuation.ResponseAsync.ContinueWith(
@@ -103,7 +112,8 @@ public class ClientTracingInterceptor : Interceptor
                         rpcScope.CompleteWithException(ex.InnerException);
                         throw ex.InnerException;
                     }
-                });
+                },
+                TaskScheduler.Current);
 
             return new AsyncUnaryCall<TResponse>(
                 responseAsync,
@@ -128,11 +138,16 @@ public class ClientTracingInterceptor : Interceptor
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         ClientRpcScope<TRequest, TResponse> rpcScope = null;
 
         try
         {
+#pragma warning disable CA2000
             rpcScope = new ClientRpcScope<TRequest, TResponse>(context, this.options);
+#pragma warning restore CA2000
             var responseContinuation = continuation(rpcScope.Context);
             var clientRequestStreamProxy = new ClientStreamWriterProxy<TRequest>(
                 responseContinuation.RequestStream,
@@ -154,7 +169,8 @@ public class ClientTracingInterceptor : Interceptor
                         rpcScope.CompleteWithException(ex.InnerException);
                         throw ex.InnerException;
                     }
-                });
+                },
+                TaskScheduler.Current);
 
             return new AsyncClientStreamingCall<TRequest, TResponse>(
                 clientRequestStreamProxy,
@@ -181,11 +197,16 @@ public class ClientTracingInterceptor : Interceptor
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         ClientRpcScope<TRequest, TResponse> rpcScope = null;
 
         try
         {
+#pragma warning disable CA2000
             rpcScope = new ClientRpcScope<TRequest, TResponse>(context, this.options);
+#pragma warning restore CA2000
             rpcScope.RecordRequest(request);
             var responseContinuation = continuation(request, rpcScope.Context);
 
@@ -218,11 +239,16 @@ public class ClientTracingInterceptor : Interceptor
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         ClientRpcScope<TRequest, TResponse> rpcScope = null;
 
         try
         {
+#pragma warning disable CA2000
             rpcScope = new ClientRpcScope<TRequest, TResponse>(context, this.options);
+#pragma warning restore CA2000
             var responseContinuation = continuation(rpcScope.Context);
 
             var requestStreamProxy = new ClientStreamWriterProxy<TRequest>(

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
@@ -18,8 +18,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using global::Grpc.Core;
-using global::Grpc.Core.Interceptors;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 /// <summary>
 /// A client interceptor that starts and stops an Activity for each outbound RPC.
 /// </summary>
-/// <seealso cref="global::Grpc.Core.Interceptors.Interceptor" />
+/// <seealso cref="Interceptor" />
 public class ClientTracingInterceptor : Interceptor
 {
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptorOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptorOptions.cs
@@ -27,7 +27,7 @@ public class ClientTracingInterceptorOptions
     /// <summary>
     /// Gets or sets a value indicating whether or not to record individual message events.
     /// </summary>
-    public bool RecordMessageEvents { get; set; } = false;
+    public bool RecordMessageEvents { get; set; }
 
     /// <summary>
     /// Gets the propagator.

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -46,7 +46,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// <summary>
     /// The complete flag.
     /// </summary>
-    private long complete = 0;
+    private long complete;
 
     /// <summary>
     /// The request message counter.

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
@@ -19,8 +19,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using global::Grpc.Core;
-using global::Grpc.Core.Interceptors;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 /// <summary>
 /// A service interceptor that starts and stops an Activity for each inbound RPC.
 /// </summary>
-/// <seealso cref="global::Grpc.Core.Interceptors.Interceptor" />
+/// <seealso cref="Interceptor" />
 public class ServerTracingInterceptor : Interceptor
 {
     /// <summary>
@@ -54,6 +54,9 @@ public class ServerTracingInterceptor : Interceptor
         ServerCallContext context,
         UnaryServerMethod<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         using var rpcScope = new ServerRpcScope<TRequest, TResponse>(context, this.options);
 
         try
@@ -77,6 +80,9 @@ public class ServerTracingInterceptor : Interceptor
         ServerCallContext context,
         ClientStreamingServerMethod<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         using var rpcScope = new ServerRpcScope<TRequest, TResponse>(context, this.options);
 
         try
@@ -104,6 +110,9 @@ public class ServerTracingInterceptor : Interceptor
         ServerCallContext context,
         ServerStreamingServerMethod<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         using var rpcScope = new ServerRpcScope<TRequest, TResponse>(context, this.options);
 
         try
@@ -127,6 +136,9 @@ public class ServerTracingInterceptor : Interceptor
     /// <inheritdoc/>
     public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, DuplexStreamingServerMethod<TRequest, TResponse> continuation)
     {
+        Guard.ThrowIfNull(context);
+        Guard.ThrowIfNull(continuation);
+
         using var rpcScope = new ServerRpcScope<TRequest, TResponse>(context, this.options);
 
         try

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptorOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptorOptions.cs
@@ -27,7 +27,7 @@ public class ServerTracingInterceptorOptions
     /// <summary>
     /// Gets or sets a value indicating whether or not to record individual message events.
     /// </summary>
-    public bool RecordMessageEvents { get; set; } = false;
+    public bool RecordMessageEvents { get; set; }
 
     /// <summary>
     /// Gets the propagator.

--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
@@ -28,7 +28,7 @@ using global::Hangfire.Server;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
 
-internal class HangfireInstrumentationJobFilterAttribute : JobFilterAttribute, IServerFilter, IClientFilter
+internal sealed class HangfireInstrumentationJobFilterAttribute : JobFilterAttribute, IServerFilter, IClientFilter
 {
     private readonly HangfireInstrumentationOptions options;
 
@@ -36,6 +36,8 @@ internal class HangfireInstrumentationJobFilterAttribute : JobFilterAttribute, I
     {
         this.options = options;
     }
+
+    public HangfireInstrumentationOptions Options { get; }
 
     public void OnPerforming(PerformingContext performingContext)
     {
@@ -123,10 +125,10 @@ internal class HangfireInstrumentationJobFilterAttribute : JobFilterAttribute, I
 
     private static IEnumerable<string> ExtractActivityProperties(Dictionary<string, string> telemetryData, string key)
     {
-        return telemetryData.ContainsKey(key) ? new[] { telemetryData[key] } : Enumerable.Empty<string>();
+        return telemetryData.TryGetValue(key, out var value) ? new[] { value } : Enumerable.Empty<string>();
     }
 
-    private void SetStatusAndRecordException(Activity activity, System.Exception exception)
+    private void SetStatusAndRecordException(Activity activity, Exception exception)
     {
         activity.SetStatus(ActivityStatusCode.Error, exception.Message);
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/Implementation/QuartzDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Quartz/Implementation/QuartzDiagnosticListener.cs
@@ -53,10 +53,10 @@ internal sealed class QuartzDiagnosticListener : ListenerHandler
                 return;
             }
 
-            activity.DisplayName = this.GetDisplayName(activity);
+            activity.DisplayName = GetDisplayName(activity);
 
             ActivityInstrumentationHelper.SetActivitySourceProperty(activity, ActivitySource);
-            ActivityInstrumentationHelper.SetKindProperty(activity, this.GetActivityKind(activity));
+            ActivityInstrumentationHelper.SetKindProperty(activity, GetActivityKind(activity));
 
             try
             {
@@ -115,17 +115,17 @@ internal sealed class QuartzDiagnosticListener : ListenerHandler
         }
     }
 
-    private string GetDisplayName(Activity activity)
+    private static string GetDisplayName(Activity activity)
     {
         return activity.OperationName switch
         {
-            OperationName.Job.Execute => $"execute {this.GetTag(activity.Tags, TagName.JobName)}",
-            OperationName.Job.Veto => $"veto {this.GetTag(activity.Tags, TagName.JobName)}",
+            OperationName.Job.Execute => $"execute {GetTag(activity.Tags, TagName.JobName)}",
+            OperationName.Job.Veto => $"veto {GetTag(activity.Tags, TagName.JobName)}",
             _ => activity.DisplayName,
         };
     }
 
-    private ActivityKind GetActivityKind(Activity activity)
+    private static ActivityKind GetActivityKind(Activity activity)
     {
         return activity.OperationName switch
         {
@@ -135,7 +135,7 @@ internal sealed class QuartzDiagnosticListener : ListenerHandler
         };
     }
 
-    private string GetTag(IEnumerable<KeyValuePair<string, string>> tags, string tagName)
+    private static string GetTag(IEnumerable<KeyValuePair<string, string>> tags, string tagName)
     {
         var tag = tags.SingleOrDefault(kv => kv.Key == tagName);
         return tag.Value;

--- a/src/OpenTelemetry.Instrumentation.Quartz/OperationName.cs
+++ b/src/OpenTelemetry.Instrumentation.Quartz/OperationName.cs
@@ -24,7 +24,9 @@ public static class OperationName
     /// <summary>
     /// Quartz Job category constants.
     /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible
     public static class Job
+#pragma warning restore CA1034 // Nested types should not be visible
     {
         /// <summary>
         /// Quartz job execute diagnostic source operation name.

--- a/src/OpenTelemetry.Instrumentation.Quartz/QuartzInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Quartz/QuartzInstrumentationOptions.cs
@@ -56,5 +56,7 @@ public class QuartzInstrumentationOptions
     /// <summary>
     /// Gets or sets traced operations set.
     /// </summary>
+#pragma warning disable CA2227 // Collection properties should be read only
     public HashSet<string> TracedOperations { get; set; } = new(DefaultTracedOperations);
+#pragma warning restore CA2227 // Collection properties should be read only
 }

--- a/src/OpenTelemetry.Instrumentation.Quartz/TraceProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Quartz/TraceProviderBuilderExtensions.cs
@@ -17,6 +17,7 @@
 using System;
 using OpenTelemetry.Instrumentation.Quartz;
 using OpenTelemetry.Instrumentation.Quartz.Implementation;
+using OpenTelemetry.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenTelemetry.Trace;
@@ -36,6 +37,8 @@ public static class TraceProviderBuilderExtensions
         this TracerProviderBuilder builder,
         Action<QuartzInstrumentationOptions> configureQuartzInstrumentationOptions = null)
     {
+        Guard.ThrowIfNull(builder);
+
         var options = new QuartzInstrumentationOptions();
         configureQuartzInstrumentationOptions?.Invoke(options);
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryContractBehaviorAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryContractBehaviorAttribute.cs
@@ -18,6 +18,7 @@ using System;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Wcf;
 #if NETFRAMEWORK
@@ -45,6 +46,7 @@ public sealed class TelemetryContractBehaviorAttribute : Attribute, IContractBeh
     /// <inheritdoc />
     public void ApplyClientBehavior(ContractDescription contractDescription, ServiceEndpoint endpoint, ClientRuntime clientRuntime)
     {
+        Guard.ThrowIfNull(clientRuntime);
         TelemetryEndpointBehavior.ApplyClientBehaviorToClientRuntime(clientRuntime);
     }
 
@@ -52,6 +54,7 @@ public sealed class TelemetryContractBehaviorAttribute : Attribute, IContractBeh
     public void ApplyDispatchBehavior(ContractDescription contractDescription, ServiceEndpoint endpoint, DispatchRuntime dispatchRuntime)
     {
 #if NETFRAMEWORK
+        Guard.ThrowIfNull(dispatchRuntime);
         TelemetryEndpointBehavior.ApplyDispatchBehaviorToEndpoint(dispatchRuntime.EndpointDispatcher);
 #endif
     }

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
@@ -45,6 +45,9 @@ public class TelemetryDispatchMessageInspector : IDispatchMessageInspector
     /// <inheritdoc/>
     public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
     {
+        Guard.ThrowIfNull(request);
+        Guard.ThrowIfNull(channel);
+
         try
         {
             if (WcfInstrumentationActivitySource.Options == null || WcfInstrumentationActivitySource.Options.IncomingRequestFilter?.Invoke(request) == false)

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryEndpointBehavior.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryEndpointBehavior.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Wcf;
 #if NETFRAMEWORK
@@ -43,6 +44,7 @@ public class TelemetryEndpointBehavior : IEndpointBehavior
     /// <inheritdoc/>
     public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
     {
+        Guard.ThrowIfNull(clientRuntime);
         ApplyClientBehaviorToClientRuntime(clientRuntime);
     }
 
@@ -50,6 +52,7 @@ public class TelemetryEndpointBehavior : IEndpointBehavior
     public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
     {
 #if NETFRAMEWORK
+        Guard.ThrowIfNull(endpointDispatcher);
         ApplyDispatchBehaviorToEndpoint(endpointDispatcher);
 #endif
     }

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryServiceBehavior.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryServiceBehavior.cs
@@ -18,6 +18,7 @@
 using System.ServiceModel;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Wcf;
 
@@ -35,6 +36,8 @@ public class TelemetryServiceBehavior : IServiceBehavior
     /// <inheritdoc/>
     public void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
     {
+        Guard.ThrowIfNull(serviceHostBase);
+
         foreach (var channelDispatcherBase in serviceHostBase.ChannelDispatchers)
         {
             var channelDispatcher = (ChannelDispatcher)channelDispatcherBase;

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEBSResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEBSResourceDetector.cs
@@ -37,10 +37,9 @@ public class TestAWSEBSResourceDetector
     [Fact]
     public void TestExtractResourceAttributes()
     {
-        var ebsResourceDetector = new AWSEBSResourceDetector();
         var sampleModel = new SampleAWSEBSMetadataModel();
 
-        var resourceAttributes = ebsResourceDetector.ExtractResourceAttributes(sampleModel).ToDictionary(x => x.Key, x => x.Value);
+        var resourceAttributes = AWSEBSResourceDetector.ExtractResourceAttributes(sampleModel).ToDictionary(x => x.Key, x => x.Value);
 
         Assert.Equal("aws", resourceAttributes[AWSSemanticConventions.AttributeCloudProvider]);
         Assert.Equal("aws_elastic_beanstalk", resourceAttributes[AWSSemanticConventions.AttributeCloudPlatform]);
@@ -53,8 +52,7 @@ public class TestAWSEBSResourceDetector
     [Fact]
     public void TestGetEBSMetadata()
     {
-        var ebsResourceDetector = new AWSEBSResourceDetector();
-        var ebsMetadata = ebsResourceDetector.GetEBSMetadata(AWSEBSMetadataFilePath);
+        var ebsMetadata = AWSEBSResourceDetector.GetEBSMetadata(AWSEBSMetadataFilePath);
 
         Assert.Equal("1234567890", ebsMetadata.DeploymentId);
         Assert.Equal("Test AWS Elastic Beanstalk Environment Name", ebsMetadata.EnvironmentName);

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEC2ResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEC2ResourceDetector.cs
@@ -35,10 +35,9 @@ public class TestAWSEC2ResourceDetector
     [Fact]
     public void TestExtractResourceAttributes()
     {
-        var ec2ResourceDetector = new AWSEC2ResourceDetector();
         var sampleEC2IdentityDocumentModel = new SampleAWSEC2IdentityDocumentModel();
         var hostName = "Test host name";
-        var resourceAttributes = ec2ResourceDetector.ExtractResourceAttributes(sampleEC2IdentityDocumentModel, hostName).ToDictionary(x => x.Key, x => x.Value);
+        var resourceAttributes = AWSEC2ResourceDetector.ExtractResourceAttributes(sampleEC2IdentityDocumentModel, hostName).ToDictionary(x => x.Key, x => x.Value);
 
         Assert.Equal("aws", resourceAttributes[AWSSemanticConventions.AttributeCloudProvider]);
         Assert.Equal("aws_ec2", resourceAttributes[AWSSemanticConventions.AttributeCloudPlatform]);
@@ -55,9 +54,7 @@ public class TestAWSEC2ResourceDetector
     {
         var ec2IdentityDocument = "{\"accountId\": \"123456789012\", \"architecture\": \"x86_64\", \"availabilityZone\": \"us-east-1a\", \"billingProducts\": null, \"devpayProductCodes\": null, \"marketplaceProductCodes\": null, \"imageId\": \"ami-12345678901234567\", \"instanceId\": \"i-12345678901234567\", \"instanceType\": \"t2.micro\", \"kernelId\": null, \"pendingTime\": \"2021-08-11T22:41:54Z\", \"privateIp\": \"123.456.789.123\", \"ramdiskId\": null, \"region\": \"us-east-1\", \"version\": \"2021-08-11\"}";
 
-        var ec2ResourceDetector = new AWSEC2ResourceDetector();
-
-        var ec2IdentityDocumentModel = ec2ResourceDetector.DeserializeResponse(ec2IdentityDocument);
+        var ec2IdentityDocumentModel = AWSEC2ResourceDetector.DeserializeResponse(ec2IdentityDocument);
 
         Assert.Equal("123456789012", ec2IdentityDocumentModel.AccountId);
         Assert.Equal("us-east-1a", ec2IdentityDocumentModel.AvailabilityZone);

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
@@ -40,10 +40,9 @@ public class TestAWSECSResourceDetector
     [Fact]
     public void TestExtractResourceAttributes()
     {
-        var ecsResourceDetector = new AWSECSResourceDetector();
         var containerId = "Test container id";
 
-        var resourceAttributes = ecsResourceDetector.ExtractResourceAttributes(containerId).ToDictionary(x => x.Key, x => x.Value);
+        var resourceAttributes = AWSECSResourceDetector.ExtractResourceAttributes(containerId).ToDictionary(x => x.Key, x => x.Value);
 
         Assert.Equal("aws", resourceAttributes[AWSSemanticConventions.AttributeCloudProvider]);
         Assert.Equal("aws_ecs", resourceAttributes[AWSSemanticConventions.AttributeCloudPlatform]);
@@ -53,8 +52,7 @@ public class TestAWSECSResourceDetector
     [Fact]
     public void TestGetECSContainerId()
     {
-        var ecsResourceDetector = new AWSECSResourceDetector();
-        var ecsContainerId = ecsResourceDetector.GetECSContainerId(AWSECSMetadataFilePath);
+        var ecsContainerId = AWSECSResourceDetector.GetECSContainerId(AWSECSMetadataFilePath);
 
         Assert.Equal("a4d00c9dd675d67f866c786181419e1b44832d4696780152e61afd44a3e02856", ecsContainerId);
     }
@@ -65,8 +63,7 @@ public class TestAWSECSResourceDetector
         Environment.SetEnvironmentVariable(AWSECSMetadataURLKey, "TestECSURIKey");
         Environment.SetEnvironmentVariable(AWSECSMetadataURLV4Key, "TestECSURIV4Key");
 
-        var ecsResourceDetector = new AWSECSResourceDetector();
-        var isEcsProcess = ecsResourceDetector.IsECSProcess();
+        var isEcsProcess = AWSECSResourceDetector.IsECSProcess();
 
         Assert.True(isEcsProcess);
     }
@@ -74,8 +71,7 @@ public class TestAWSECSResourceDetector
     [Fact]
     public void TestIsNotECSProcess()
     {
-        var ecsResourceDetector = new AWSECSResourceDetector();
-        var isEcsProcess = ecsResourceDetector.IsECSProcess();
+        var isEcsProcess = AWSECSResourceDetector.IsECSProcess();
 
         Assert.False(isEcsProcess);
     }

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEKSResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEKSResourceDetector.cs
@@ -38,11 +38,10 @@ public class TestAWSEKSResourceDetector
     [Fact]
     public void TestExtractResourceAttributes()
     {
-        var eksResourceDetector = new AWSEKSResourceDetector();
         var clusterName = "Test cluster name";
         var containerId = "Test container id";
 
-        var resourceAttributes = eksResourceDetector.ExtractResourceAttributes(clusterName, containerId).ToDictionary(x => x.Key, x => x.Value);
+        var resourceAttributes = AWSEKSResourceDetector.ExtractResourceAttributes(clusterName, containerId).ToDictionary(x => x.Key, x => x.Value);
 
         Assert.Equal(4, resourceAttributes.Count);
         Assert.Equal("aws", resourceAttributes[AWSSemanticConventions.AttributeCloudProvider]);
@@ -54,10 +53,9 @@ public class TestAWSEKSResourceDetector
     [Fact]
     public void TestExtractResourceAttributesWithEmptyClusterName()
     {
-        var eksResourceDetector = new AWSEKSResourceDetector();
         var containerId = "Test container id";
 
-        var resourceAttributes = eksResourceDetector.ExtractResourceAttributes(string.Empty, containerId).ToDictionary(x => x.Key, x => x.Value);
+        var resourceAttributes = AWSEKSResourceDetector.ExtractResourceAttributes(string.Empty, containerId).ToDictionary(x => x.Key, x => x.Value);
 
         // Validate the count of resourceAttributes -> Excluding cluster name, there will be only three resourceAttributes
         Assert.Equal(3, resourceAttributes.Count);
@@ -69,10 +67,9 @@ public class TestAWSEKSResourceDetector
     [Fact]
     public void TestExtractResourceAttributesWithEmptyContainerId()
     {
-        var eksResourceDetector = new AWSEKSResourceDetector();
         var clusterName = "Test cluster name";
 
-        var resourceAttributes = eksResourceDetector.ExtractResourceAttributes(clusterName, string.Empty).ToDictionary(x => x.Key, x => x.Value);
+        var resourceAttributes = AWSEKSResourceDetector.ExtractResourceAttributes(clusterName, string.Empty).ToDictionary(x => x.Key, x => x.Value);
 
         // Validate the count of resourceAttributes -> Excluding container id, there will be only three resourceAttributes
         Assert.Equal(3, resourceAttributes.Count);
@@ -104,8 +101,7 @@ public class TestAWSEKSResourceDetector
     {
         var awsEKSClusterInformation = "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": {\"name\": \"cluster-info\", \"namespace\": \"amazon-cloudwatch\", \"selfLink\": \"/api/v1/namespaces/amazon-cloudwatch/configmaps/cluster-info\", \"uid\": \"0734438c-48f4-45c3-b06d-b6f16f7f0e1e\", \"resourceVersion\": \"25911\", \"creationTimestamp\": \"2021-07-23T18:41:56Z\", \"annotations\": {\"kubectl.kubernetes.io/last-applied-configuration\": \"{\\\"apiVersion\\\":\\\"v1\\\",\\\"data\\\":{\\\"cluster.name\\\":\\\"Test\\\",\\\"logs.region\\\":\\\"us-west-2\\\"},\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"name\\\":\\\"cluster-info\\\",\\\"namespace\\\":\\\"amazon-cloudwatch\\\"}}\\n\"}}, \"data\": {\"cluster.name\": \"Test\", \"logs.region\": \"us-west-2\"}}";
 
-        var eksResourceDetector = new AWSEKSResourceDetector();
-        var eksClusterInformation = eksResourceDetector.DeserializeResponse(awsEKSClusterInformation);
+        var eksClusterInformation = AWSEKSResourceDetector.DeserializeResponse(awsEKSClusterInformation);
 
         Assert.Equal("Test", eksClusterInformation.Data.ClusterName);
     }

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Trace/TestAWSXRayPropagator.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Trace/TestAWSXRayPropagator.cs
@@ -29,7 +29,12 @@ public class TestAWSXRayPropagator
     private const string TraceId = "5759e988bd862e3fe1be46a994272793";
     private const string ParentId = "53995c3f42cd8ad8";
 
+#if NETFRAMEWORK
     private static readonly string[] Empty = new string[0];
+#else
+    private static readonly string[] Empty = Array.Empty<string>();
+#endif
+
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
     {
         if (headers.TryGetValue(name, out var value))

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/HttpResponseMessageBody.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/HttpResponseMessageBody.cs
@@ -26,8 +26,8 @@ internal class HttpResponseMessageBody : IHttpResponseBody
 {
     private HttpClient httpClient;
     private HttpResponseMessage response;
-    private bool disposeClient = false;
-    private bool disposed = false;
+    private bool disposeClient;
+    private bool disposed;
 
     public HttpResponseMessageBody(HttpResponseMessage response, HttpClient httpClient, bool disposeClient)
     {

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequest.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequest.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests;
 #if NET452
 internal class MockHttpRequest : IHttpRequest<Stream>
 {
-    private Stream requestStream = null;
+    private Stream requestStream;
 
     public MockHttpRequest(Uri requestUri, Action action, Func<MockHttpRequest, HttpWebResponse> responseCreator = null)
     {

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockWebResponse.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockWebResponse.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 #if NET452
 using System.IO;
 #endif
-using System.Linq;
 using System.Net;
 #if !NET452
 using System.Net.Http;
@@ -121,30 +120,30 @@ internal class MockWebResponse
 
         var responseLines = rawResponse.Split('\n');
 
-        if (responseLines.Count() == 0)
+        if (responseLines.Length == 0)
         {
             throw new ArgumentException(
                 "The resource does not contain a valid HTTP response.",
-                "resourceName");
+                nameof(rawResponse));
         }
 
         response.StatusLine = responseLines[0];
         var currentLine = responseLines[0];
-        var statusCode = ParseStatusCode(currentLine);
+        _ = ParseStatusCode(currentLine);
 
-        var lineIndex = 0;
-        if (responseLines.Count() > 1)
+        int lineIndex;
+        if (responseLines.Length > 1)
         {
-            for (lineIndex = 1; lineIndex < responseLines.Count(); lineIndex++)
+            for (lineIndex = 1; lineIndex < responseLines.Length; lineIndex++)
             {
                 currentLine = responseLines[lineIndex];
-                if (currentLine.Trim() == string.Empty)
+                if (string.IsNullOrEmpty(currentLine.Trim()))
                 {
                     currentLine = responseLines[lineIndex - 1];
                     break;
                 }
 
-                var index = currentLine.IndexOf(":");
+                var index = currentLine.IndexOf(":", StringComparison.Ordinal);
                 if (index != -1)
                 {
                     var headerKey = currentLine.Substring(0, index);
@@ -154,17 +153,16 @@ internal class MockWebResponse
             }
         }
 
-        var startOfBody = rawResponse.IndexOf(currentLine) + currentLine.Length;
+        var startOfBody = rawResponse.IndexOf(currentLine, StringComparison.Ordinal) + currentLine.Length;
         response.Body = rawResponse.Substring(startOfBody).Trim();
         return response;
     }
 
     private static HttpStatusCode ParseStatusCode(string statusLine)
     {
-        var statusCode = string.Empty;
         try
         {
-            statusCode = statusLine.Split(' ')[1];
+            string statusCode = statusLine.Split(' ')[1];
             return (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), statusCode);
         }
         catch (Exception exception)

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/Utils.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/Utils.cs
@@ -53,7 +53,9 @@ internal static class Utils
 
     public static string FindResourceName(string partialName)
     {
+#pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'
         return FindResourceName(s => s.IndexOf(partialName, StringComparison.OrdinalIgnoreCase) >= 0).SingleOrDefault();
+#pragma warning restore CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'
     }
 
     public static IEnumerable<string> FindResourceName(Predicate<string> match)

--- a/test/OpenTelemetry.Contrib.Tests.Shared/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Contrib.Tests.Shared/TestActivityProcessor.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 
 namespace OpenTelemetry.Tests;
 
-internal class TestActivityProcessor : BaseProcessor<Activity>
+internal sealed class TestActivityProcessor : BaseProcessor<Activity>
 {
     public Action<Activity> StartAction;
     public Action<Activity> EndAction;
@@ -34,11 +34,11 @@ internal class TestActivityProcessor : BaseProcessor<Activity>
         this.EndAction = onEnd;
     }
 
-    public bool ShutdownCalled { get; private set; } = false;
+    public bool ShutdownCalled { get; private set; }
 
-    public bool ForceFlushCalled { get; private set; } = false;
+    public bool ForceFlushCalled { get; private set; }
 
-    public bool DisposedCalled { get; private set; } = false;
+    public bool DisposedCalled { get; private set; }
 
     public override void OnStart(Activity span)
     {
@@ -64,6 +64,7 @@ internal class TestActivityProcessor : BaseProcessor<Activity>
 
     protected override void Dispose(bool disposing)
     {
+        base.Dispose(disposing);
         this.DisposedCalled = true;
     }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
@@ -102,7 +102,7 @@ public class LogExporterBenchmarks
     [Benchmark]
     public void LoggerWithMessageTemplate()
     {
-        this.logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        this.logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
     }
 
     [Benchmark]
@@ -158,7 +158,7 @@ public class LogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return items[0];
     }
 
@@ -173,7 +173,7 @@ public class LogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return batchGeneratorExporter.Batch;
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDLogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDLogExporterBenchmarks.cs
@@ -157,7 +157,7 @@ public class TLDLogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return exportedItems[0];
     }
 
@@ -172,7 +172,7 @@ public class TLDLogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return batchGeneratorExporter.Batch;
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Stress/DummyServer.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Stress/DummyServer.cs
@@ -18,7 +18,6 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Geneva.Stress;
@@ -61,7 +60,7 @@ internal class DummyServer
                 Socket acceptSocket = this.serverSocket.Accept();
                 Task.Run(() =>
                 {
-                    int threadId = Thread.CurrentThread.ManagedThreadId;
+                    int threadId = Environment.CurrentManagedThreadId;
                     Console.WriteLine($"ThreadID {threadId}: Start reading from socket.");
                     int totalBytes = 0;
                     try

--- a/test/OpenTelemetry.Exporter.Geneva.Stress/Program.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Stress/Program.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -29,7 +30,7 @@ namespace OpenTelemetry.Exporter.Geneva.Stress;
 internal class Program
 {
     private static volatile bool s_bContinue = true;
-    private static long s_nEvents = 0;
+    private static long s_nEvents;
 
     private static ActivitySource source = new ActivitySource("OpenTelemetry.Exporter.Geneva.Stress");
 
@@ -135,7 +136,7 @@ internal class Program
                     watch.Stop();
                     var nEvents = statistics.Sum();
                     var nEventPerSecond = (int)((nEvents - s_nEvents) / (watch.ElapsedMilliseconds / 1000.0));
-                    Console.Title = string.Format("Loops: {0:n0}, Loops/Second: {1:n0}", nEvents, nEventPerSecond);
+                    Console.Title = string.Format(CultureInfo.InvariantCulture, "Loops: {0:n0}, Loops/Second: {1:n0}", nEvents, nEventPerSecond);
                 }
             },
             () =>

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
@@ -385,7 +386,7 @@ public class GenevaLogExporterTests
 
             if (hasCustomFields)
             {
-                exporterOptions.CustomFields = new string[] { "food", "Name", "Key1" };
+                exporterOptions.CustomFields = new string[] { "Food", "Name", "Key1" };
             }
 
             var exportedItems = new List<LogRecord>();
@@ -419,7 +420,7 @@ public class GenevaLogExporterTests
             using (logger.BeginScope("MyInnerInnerScope with {Name} and {Age} of custom", "John Doe", 25))
             using (logger.BeginScope(new List<KeyValuePair<string, object>> { new("Key1", "Value1"), new("Key2", "Value2") }))
             {
-                logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+                logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
             }
 
             byte[] serializedData;
@@ -445,7 +446,7 @@ public class GenevaLogExporterTests
                 var envProperties = mapping["env_properties"] as Dictionary<object, object>;
 
                 // Custom Fields
-                Assert.Equal("artichoke", mapping["food"]);
+                Assert.Equal("artichoke", mapping["Food"]);
                 Assert.Equal("John Doe", mapping["Name"]);
                 Assert.Equal("Value1", mapping["Key1"]);
 
@@ -453,7 +454,7 @@ public class GenevaLogExporterTests
                 Assert.False(mapping.ContainsKey("MyInnerScope"));
 
                 // env_properties
-                Assert.True(Equals(envProperties["price"], 3.99));
+                Assert.True(Equals(envProperties["Price"], 3.99));
                 Assert.Equal((byte)25, envProperties["Age"]);
                 Assert.Equal("Value2", envProperties["Key2"]);
 
@@ -462,8 +463,8 @@ public class GenevaLogExporterTests
             }
             else
             {
-                Assert.Equal("artichoke", mapping["food"]);
-                Assert.True(Equals(mapping["price"], 3.99));
+                Assert.Equal("artichoke", mapping["Food"]);
+                Assert.True(Equals(mapping["Price"], 3.99));
                 Assert.Equal("John Doe", mapping["Name"]);
                 Assert.Equal((byte)25, mapping["Age"]);
                 Assert.Equal("Value1", mapping["Key1"]);
@@ -757,24 +758,24 @@ public class GenevaLogExporterTests
             using (var activity = source.StartActivity("Activity"))
             {
                 // Log inside an activity to set LogRecord.TraceId and LogRecord.SpanId
-                logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99); // structured logging
+                logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99); // structured logging
             }
 
             // When the exporter options are configured with TableMappings only "customField" will be logged as a separate key in the mapping
             // "property" will be logged under "env_properties" in the mapping
-            logger.Log(LogLevel.Trace, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Trace, 101, "Log a {customField} and {property}", "CustomFieldValue", null);
-            logger.Log(LogLevel.Trace, 101, "Log a {customField} and {property}", null, "PropertyValue");
-            logger.Log(LogLevel.Debug, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Information, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Warning, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Error, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Critical, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Trace, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Trace, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", null);
+            logger.Log(LogLevel.Trace, 101, "Log a {CustomField} and {Property}", null, "PropertyValue");
+            logger.Log(LogLevel.Debug, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Information, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Warning, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Error, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Critical, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
             logger.LogInformation("Hello World!"); // unstructured logging
-            logger.LogError(new InvalidOperationException("Oops! Food is spoiled!"), "Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogError(new InvalidOperationException("Oops! Food is spoiled!"), "Hello from {Food} {Price}.", "artichoke", 3.99);
 
             // Exception with a non-ASCII character in its type name
-            logger.LogError(new CustomException\u0418(), "Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogError(new CustomException\u0418(), "Hello from {Food} {Price}.", "artichoke", 3.99);
 
             var loggerWithDefaultCategory = loggerFactory.CreateLogger("DefaultCategory");
             loggerWithDefaultCategory.LogInformation("Basic test");
@@ -837,7 +838,7 @@ public class GenevaLogExporterTests
 
             var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
 
-            logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         }
     }
 
@@ -888,7 +889,7 @@ public class GenevaLogExporterTests
                 // Emit a LogRecord and grab a copy of internal buffer for validation.
                 var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
 
-                logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+                logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
 
                 // logRecordList should have a singleLogRecord entry after the logger.LogInformation call
                 Assert.Single(logRecordList);
@@ -908,7 +909,7 @@ public class GenevaLogExporterTests
                 // Emit log on a different thread to test for multithreading scenarios
                 var thread = new Thread(() =>
                 {
-                    logger.LogInformation("Hello from another thread {food} {price}.", "artichoke", 3.99);
+                    logger.LogInformation("Hello from another thread {Food} {Price}.", "artichoke", 3.99);
                 });
                 thread.Start();
                 thread.Join();
@@ -1104,7 +1105,7 @@ public class GenevaLogExporterTests
 
             var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
 
-            logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         }
     }
 
@@ -1140,9 +1141,9 @@ public class GenevaLogExporterTests
         var TimeStampAndMappings = ((fluentdData as object[])[1] as object[])[0];
         var mapping = (TimeStampAndMappings as object[])[1] as Dictionary<object, object>;
 
-        if (mapping.ContainsKey(key))
+        if (mapping.TryGetValue(key, out var value))
         {
-            return mapping[key];
+            return value;
         }
         else
         {
@@ -1286,7 +1287,7 @@ public class GenevaLogExporterTests
 
         if (logRecord.EventId != default)
         {
-            Assert.Equal(logRecord.EventId.Id, int.Parse(mapping["eventId"].ToString()));
+            Assert.Equal(logRecord.EventId.Id, int.Parse(mapping["eventId"].ToString(), CultureInfo.InvariantCulture));
         }
 
         // Epilouge

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -322,7 +322,7 @@ public class GenevaMetricExporterTests
             {
                 if (instrument.Name == "histogramWithNoBounds")
                 {
-                    return new ExplicitBucketHistogramConfiguration { Boundaries = new double[] { } };
+                    return new ExplicitBucketHistogramConfiguration { Boundaries = Array.Empty<double>() };
                 }
 
                 return null;
@@ -334,7 +334,7 @@ public class GenevaMetricExporterTests
                     RecordMinMax = false,
                 })
             .AddView("observableLongCounter", MetricStreamConfiguration.Drop)
-            .AddView("observableDoubleCounter", new MetricStreamConfiguration { TagKeys = new string[] { } })
+            .AddView("observableDoubleCounter", new MetricStreamConfiguration { TagKeys = Array.Empty<string>() })
             .AddView(instrument =>
             {
                 if (instrument.Name == "observableLongGauge")

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -85,7 +85,7 @@ public class GenevaTraceExporterTests
         // Supported types for PrepopulatedFields should not throw an exception
         var exception = Record.Exception(() =>
         {
-            new GenevaExporterOptions
+            _ = new GenevaExporterOptions
             {
                 ConnectionString = "EtwSession=OpenTelemetry",
                 PrepopulatedFields = new Dictionary<string, object>
@@ -663,9 +663,10 @@ public class GenevaTraceExporterTests
             else
             {
                 // If CustomFields are proivded, dedicatedFields will be populated
-                if (exporterOptions.CustomFields == null || dedicatedFields.ContainsKey(tag.Key))
+                object value = null;
+                if (exporterOptions.CustomFields == null || dedicatedFields.TryGetValue(tag.Key, out value))
                 {
-                    Assert.Equal(tag.Value.ToString(), mapping[tag.Key].ToString());
+                    Assert.Equal(tag.Value.ToString(), value.ToString());
                 }
                 else
                 {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -663,10 +663,9 @@ public class GenevaTraceExporterTests
             else
             {
                 // If CustomFields are proivded, dedicatedFields will be populated
-                object value = null;
-                if (exporterOptions.CustomFields == null || dedicatedFields.TryGetValue(tag.Key, out value))
+                if (exporterOptions.CustomFields == null || dedicatedFields.TryGetValue(tag.Key, out _))
                 {
-                    Assert.Equal(tag.Value.ToString(), value.ToString());
+                    Assert.Equal(tag.Value.ToString(), mapping[tag.Key].ToString());
                 }
                 else
                 {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using OpenTelemetry.Exporter.Geneva.TldExporter;
@@ -81,7 +82,7 @@ public class JsonSerializerTests
     public void JsonSerializer_Array()
     {
         TestSerialization((object[])null, "null");
-        TestSerialization(new object[] { }, "[]");
+        TestSerialization(Array.Empty<object>(), "[]");
         TestSerialization(new object[] { 1, 2, 3 }, "[1,2,3]");
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
@@ -77,7 +77,7 @@ public class LogSerializationTests
         var exStack = new string('e', 16383 + 1);
         var ex = new MyException(exceptionMessage, exStack);
         var exportedFields = GetExportedFieldsAfterLogging(
-            logger => logger.LogError(ex, "Error occurred. {field1} {field2}", "value1", "value2"),
+            logger => logger.LogError(ex, "Error occurred. {Field1} {Field2}", "value1", "value2"),
             (genevaOptions) => genevaOptions.ExceptionStackExportMode = ExceptionStackExportMode.ExportAsString);
 
         var actualExceptionMessage = exportedFields["env_ex_msg"];
@@ -89,10 +89,10 @@ public class LogSerializationTests
         var actualExceptionStack = exportedFields["env_ex_stack"];
         Assert.EndsWith("...", (string)actualExceptionStack);
 
-        var actualValue = exportedFields["field1"];
+        var actualValue = exportedFields["Field1"];
         Assert.Equal("value1", actualValue);
 
-        actualValue = exportedFields["field2"];
+        actualValue = exportedFields["Field2"];
         Assert.Equal("value2", actualValue);
 
         // PrintFields(this.output, exportedFields);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using Xunit;
 using Xunit.Sdk;
@@ -54,7 +55,9 @@ public class MessagePackSerializerTests
         if (!string.IsNullOrEmpty(input) && input.Length > sizeLimit)
         {
             // We truncate the string using `.` in the last three characters which takes 3 bytes of memort
+#pragma warning disable CA1846 // Prefer 'AsSpan' over 'Substring'
             var byteCount = Encoding.ASCII.GetByteCount(input.Substring(0, sizeLimit - 3)) + 3;
+#pragma warning restore CA1846 // Prefer 'AsSpan' over 'Substring'
             Assert.Equal(0xDA, buffer[0]);
             Assert.Equal(byteCount, (buffer[1] << 8) | buffer[2]);
             Assert.Equal(byteCount, length - 3); // First three bytes are metadata
@@ -109,7 +112,9 @@ public class MessagePackSerializerTests
         if (!string.IsNullOrEmpty(input) && input.Length > sizeLimit)
         {
             // We truncate the string using `.` in the last three characters which takes 3 bytes of memory
+#pragma warning disable CA1846 // Prefer 'AsSpan' over 'Substring'
             var byteCount = Encoding.UTF8.GetByteCount(input.Substring(0, sizeLimit - 3)) + 3;
+#pragma warning restore CA1846 // Prefer 'AsSpan' over 'Substring'
             Assert.Equal(0xDA, buffer[0]);
             Assert.Equal(byteCount, (buffer[1] << 8) | buffer[2]);
             Assert.Equal(byteCount, length - 3); // First three bytes are metadata
@@ -347,7 +352,7 @@ public class MessagePackSerializerTests
     public void MessagePackSerializer_Array()
     {
         this.MessagePackSerializer_TestSerialization((object[])null);
-        this.MessagePackSerializer_TestSerialization(new object[0]);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<object>());
 
         // This object array has a custom string which will be serialized as STR16
         var objectArrayWithString = new object[]
@@ -386,7 +391,7 @@ public class MessagePackSerializerTests
         _ = MessagePackSerializer.Serialize(buffer, 0, dictionaryWithStrings);
         var dictionaryWithStringsDeserialized = MessagePack.MessagePackSerializer.Deserialize<Dictionary<string, object>>(buffer);
         Assert.Equal(dictionaryWithStrings.Count, dictionaryWithStringsDeserialized.Count);
-        Assert.Equal(dictionaryWithStrings["foo"], Convert.ToInt32(dictionaryWithStringsDeserialized["foo"]));
+        Assert.Equal(dictionaryWithStrings["foo"], Convert.ToInt32(dictionaryWithStringsDeserialized["foo"], CultureInfo.InvariantCulture));
         Assert.Equal(dictionaryWithStrings["bar"], dictionaryWithStringsDeserialized["bar"]);
         Assert.Equal(dictionaryWithStrings["golden ratio"], dictionaryWithStringsDeserialized["golden ratio"]);
         Assert.Equal(dictionaryWithStrings["pi"], dictionaryWithStringsDeserialized["pi"]);

--- a/test/OpenTelemetry.Exporter.Instana.Tests/InstanaExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Instana.Tests/InstanaExporterTests.cs
@@ -30,8 +30,8 @@ public class InstanaExporterTests
     private readonly Mock<IInstanaExporterHelper> instanaExporterHelperMock = new Mock<IInstanaExporterHelper>(MockBehavior.Strict);
     private readonly Mock<IActivityProcessor> activityProcessorMock = new Mock<IActivityProcessor>(MockBehavior.Strict);
     private readonly Mock<ISpanSender> spanSenderMock = new Mock<ISpanSender>(MockBehavior.Strict);
-    private InstanaSpan instanaSpan = null;
-    private InstanaExporter instanaExporter = null;
+    private InstanaSpan instanaSpan;
+    private InstanaExporter instanaExporter;
 
     [Fact]
     public void Export()

--- a/test/OpenTelemetry.Exporter.Instana.Tests/InstanaSpanFactoryTests.cs
+++ b/test/OpenTelemetry.Exporter.Instana.Tests/InstanaSpanFactoryTests.cs
@@ -19,13 +19,12 @@ using Xunit;
 
 namespace OpenTelemetry.Exporter.Instana.Tests;
 
-public class InstanaSpanFactoryTests
+public static class InstanaSpanFactoryTests
 {
-    private InstanaSpanFactory instanaSpanFactory = new InstanaSpanFactory();
-
     [Fact]
-    public void CreateSpan()
+    public static void CreateSpan()
     {
+        _ = new InstanaSpanFactory();
         InstanaSpan instanaSpan = InstanaSpanFactory.CreateSpan();
 
         Assert.NotNull(instanaSpan);

--- a/test/OpenTelemetry.Exporter.Instana.Tests/InstanaSpanSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Instana.Tests/InstanaSpanSerializerTests.cs
@@ -24,12 +24,10 @@ using Xunit;
 
 namespace OpenTelemetry.Exporter.Instana.Tests;
 
-public class InstanaSpanSerializerTests
+public static class InstanaSpanSerializerTests
 {
-    private InstanaSpanSerializer instanaSpanSerializer = new InstanaSpanSerializer();
-
     [Fact]
-    public async Task SerializeToStreamWriterAsync()
+    public static async Task SerializeToStreamWriterAsync()
     {
         InstanaSpan instanaOtelSpan = InstanaSpanFactory.CreateSpan();
         instanaOtelSpan.F = new Implementation.From() { E = "12345", H = "localhost" };
@@ -66,14 +64,14 @@ public class InstanaSpanSerializerTests
         {
             using (StreamWriter writer = new StreamWriter(sendBuffer))
             {
-                await this.instanaSpanSerializer.SerializeToStreamWriterAsync(instanaOtelSpan, writer);
+                await InstanaSpanSerializer.SerializeToStreamWriterAsync(instanaOtelSpan, writer);
                 await writer.FlushAsync();
                 long length = sendBuffer.Position;
                 sendBuffer.Position = 0;
                 sendBuffer.SetLength(length);
 
-                Newtonsoft.Json.JsonSerializer serializer = null;
-                serializer = new Newtonsoft.Json.JsonSerializer();
+                JsonSerializer serializer = null;
+                serializer = new JsonSerializer();
                 serializer.Converters.Add(new JavaScriptDateTimeConverter());
                 serializer.NullValueHandling = NullValueHandling.Ignore;
 

--- a/test/OpenTelemetry.Exporter.Stackdriver.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.Stackdriver.Tests/TestActivityProcessor.cs
@@ -34,20 +34,20 @@ public class TestActivityProcessor : BaseProcessor<Activity>, IDisposable
         this.EndAction = onEnd;
     }
 
-    public bool ShutdownCalled { get; private set; } = false;
+    public bool ShutdownCalled { get; private set; }
 
-    public bool ForceFlushCalled { get; private set; } = false;
+    public bool ForceFlushCalled { get; private set; }
 
-    public bool DisposedCalled { get; private set; } = false;
+    public bool DisposedCalled { get; private set; }
 
-    public override void OnStart(Activity activity)
+    public override void OnStart(Activity data)
     {
-        this.StartAction?.Invoke(activity);
+        this.StartAction?.Invoke(data);
     }
 
-    public override void OnEnd(Activity activity)
+    public override void OnEnd(Activity data)
     {
-        this.EndAction?.Invoke(activity);
+        this.EndAction?.Invoke(data);
     }
 
     protected override bool OnShutdown(int timeoutMilliseconds)

--- a/test/OpenTelemetry.Extensions.Docker.Tests/Resources/DockerResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Extensions.Docker.Tests/Resources/DockerResourceDetectorTests.cs
@@ -131,7 +131,7 @@ public class DockerResourceDetectorTests
             tempFile.Write(testCase.Line);
             Assert.Equal(
                 testCase.ExpectedContainerId,
-                this.GetContainerId(dockerResourceDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion)));
+                GetContainerId(dockerResourceDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion)));
         }
     }
 
@@ -173,13 +173,13 @@ public class DockerResourceDetectorTests
         Assert.Equal(dockerResourceDetector.BuildResource(Path.GetTempPath(), DockerResourceDetector.ParseMode.V2), Resource.Empty);
     }
 
-    private string GetContainerId(Resource resource)
+    private static string GetContainerId(Resource resource)
     {
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
         return resourceAttributes[DockerSemanticConventions.AttributeContainerID]?.ToString();
     }
 
-    private class TestCase
+    private sealed class TestCase
     {
         public string Name { get; set; }
 

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleLambdaContext.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleLambdaContext.cs
@@ -23,23 +23,23 @@ public class SampleLambdaContext : ILambdaContext
 {
     public string AwsRequestId { get; } = "testrequestid";
 
-    public IClientContext ClientContext { get; } = null;
+    public IClientContext ClientContext { get; }
 
     public string FunctionName { get; } = "testfunction";
 
     public string FunctionVersion { get; } = "latest";
 
-    public ICognitoIdentity Identity { get; } = null;
+    public ICognitoIdentity Identity { get; }
 
     public string InvokedFunctionArn { get; } = "arn:aws:lambda:us-east-1:111111111111:function:testfunction";
 
-    public ILambdaLogger Logger { get; } = null;
+    public ILambdaLogger Logger { get; }
 
-    public string LogGroupName { get; } = null;
+    public string LogGroupName { get; }
 
-    public string LogStreamName { get; } = null;
+    public string LogStreamName { get; }
 
-    public int MemoryLimitInMB { get; } = 0;
+    public int MemoryLimitInMB { get; }
 
-    public TimeSpan RemainingTime { get; } = default;
+    public TimeSpan RemainingTime { get; }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -429,7 +429,9 @@ public class ActivityHelperTest : IDisposable
     }
 
     [Fact]
+#pragma warning disable CA1030 // Use events where appropriate
     public void Fire_Exception_Events()
+#pragma warning restore CA1030 // Use events where appropriate
     {
         int callbacksFired = 0;
 
@@ -529,13 +531,11 @@ public class ActivityHelperTest : IDisposable
 
     private class NoopTextMapPropagator : TextMapPropagator
     {
-        private static readonly PropagationContext DefaultPropagationContext = default;
-
         public override ISet<string> Fields => null;
 
         public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
-            return DefaultPropagationContext;
+            return default;
         }
 
         public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/HttpContextHelper.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/HttpContextHelper.cs
@@ -79,9 +79,9 @@ internal class HttpContextHelper
 
         public override string GetUnknownRequestHeader(string name)
         {
-            if (this.headers.ContainsKey(name))
+            if (this.headers.TryGetValue(name, out var value))
             {
-                return this.headers[name];
+                return value;
             }
 
             return base.GetUnknownRequestHeader(name);
@@ -91,9 +91,9 @@ internal class HttpContextHelper
         {
             var name = GetKnownRequestHeaderName(index);
 
-            if (this.headers.ContainsKey(name))
+            if (this.headers.TryGetValue(name, out var value))
             {
-                return this.headers[name];
+                return value;
             }
 
             return base.GetKnownRequestHeader(index);

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigTransformTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigTransformTest.cs
@@ -391,16 +391,17 @@ public class WebConfigTransformTest
             var document = new XmlTransformableDocument();
             using var transformation = new XmlTransformation(stream, null);
             stream = null;
+#pragma warning disable CA3075 // Insecure DTD processing in XML
             document.LoadXml(originalConfiguration);
+#pragma warning restore CA3075 // Insecure DTD processing in XML
             transformation.Apply(document);
             result = XDocument.Parse(document.OuterXml);
         }
         finally
         {
-            if (stream != null)
-            {
-                stream.Dispose();
-            }
+#pragma warning disable CA1508 // Avoid dead conditional code
+            stream?.Dispose();
+#pragma warning restore CA1508 // Avoid dead conditional code
         }
 
         return result;

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigWithLocationTagTransformTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigWithLocationTagTransformTest.cs
@@ -421,16 +421,17 @@ public class WebConfigWithLocationTagTransformTest
             var document = new XmlTransformableDocument();
             using var transformation = new XmlTransformation(stream, null);
             stream = null;
+#pragma warning disable CA3075 // Insecure DTD processing in XML
             document.LoadXml(originalConfiguration);
+#pragma warning restore CA3075 // Insecure DTD processing in XML
             transformation.Apply(document);
             result = XDocument.Parse(document.OuterXml);
         }
         finally
         {
-            if (stream != null)
-            {
-                stream.Dispose();
-            }
+#pragma warning disable CA1508 // Avoid dead conditional code
+            stream?.Dispose();
+#pragma warning restore CA1508 // Avoid dead conditional code
         }
 
         return result;

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -278,8 +278,8 @@ public class EventCountersMetricsTests
         // Assert
         foreach (var item in metricItems)
         {
-            Assert.False(item.Name.StartsWith("ec.source.ee"));
-            Assert.False(item.Name.StartsWith("ec.s.ee"));
+            Assert.False(item.Name.StartsWith("ec.source.ee", StringComparison.Ordinal));
+            Assert.False(item.Name.StartsWith("ec.s.ee", StringComparison.Ordinal));
         }
     }
 

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
@@ -33,7 +33,17 @@ internal class FoobarService : Foobar.FoobarBase
     /// <summary>
     /// Default traceparent header value with the sampling bit on.
     /// </summary>
-    internal static readonly string DefaultTraceparentWithSampling = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    internal const string DefaultTraceparentWithSampling = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    /// <summary>
+    /// The request header fail with status code.
+    /// </summary>
+    internal const string RequestHeaderFailWithStatusCode = "failurestatuscode";
+
+    /// <summary>
+    /// The request header error description.
+    /// </summary>
+    internal const string RequestHeaderErrorDescription = "failuredescription";
 
     /// <summary>
     /// The default parent from a traceparent header.
@@ -59,16 +69,6 @@ internal class FoobarService : Foobar.FoobarBase
     /// The default request message size.
     /// </summary>
     internal static readonly int DefaultResponseMessageSize = ((IMessage)DefaultResponseMessage).CalculateSize();
-
-    /// <summary>
-    /// The request header fail with status code.
-    /// </summary>
-    internal static readonly string RequestHeaderFailWithStatusCode = "failurestatuscode";
-
-    /// <summary>
-    /// The request header error description.
-    /// </summary>
-    internal static readonly string RequestHeaderErrorDescription = "failuredescription";
 
     /// <summary>
     /// Starts the specified service.

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -35,7 +35,7 @@ public class GrpcCoreClientInterceptorTests
     /// <summary>
     /// A bogus server uri.
     /// </summary>
-    private static readonly string BogusServerUri = "dns:i.dont.exist:77923";
+    private const string BogusServerUri = "dns:i.dont.exist:77923";
 
     /// <summary>
     /// The default metadata func.
@@ -49,7 +49,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task AsyncUnarySuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest, DefaultMetadataFunc()).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest, DefaultMetadataFunc()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task AsyncUnaryUnavailable()
     {
-        await this.TestHandlerFailure(
+        await TestHandlerFailure(
             FoobarService.MakeUnaryAsyncRequest,
             StatusCode.Unavailable,
             validateErrorDescription: false,
@@ -73,7 +73,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task AsyncUnaryFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task ClientStreamingSuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, DefaultMetadataFunc()).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, DefaultMetadataFunc()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -107,7 +107,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task ClientStreamingUnavailable()
     {
-        await this.TestHandlerFailure(
+        await TestHandlerFailure(
             FoobarService.MakeClientStreamingRequest,
             StatusCode.Unavailable,
             validateErrorDescription: false,
@@ -121,7 +121,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task ClientStreamingFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeClientStreamingRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -145,7 +145,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task ServerStreamingSuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, DefaultMetadataFunc()).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, DefaultMetadataFunc()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -155,7 +155,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task ServerStreamingFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeServerStreamingRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -179,7 +179,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task DuplexStreamingSuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, DefaultMetadataFunc()).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, DefaultMetadataFunc()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -189,7 +189,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task DuplexStreamingUnavailable()
     {
-        await this.TestHandlerFailure(
+        await TestHandlerFailure(
             FoobarService.MakeDuplexStreamingRequest,
             StatusCode.Unavailable,
             validateErrorDescription: false,
@@ -203,7 +203,7 @@ public class GrpcCoreClientInterceptorTests
     [Fact]
     public async Task DuplexStreamingFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -376,7 +376,7 @@ public class GrpcCoreClientInterceptorTests
     /// <param name="clientRequestFunc">The client request function.</param>
     /// <param name="additionalMetadata">The additional metadata, if any.</param>
     /// <returns>A Task.</returns>
-    private async Task TestHandlerSuccess(Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc, Metadata additionalMetadata)
+    private static async Task TestHandlerSuccess(Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc, Metadata additionalMetadata)
     {
         var mockPropagator = new Mock<TextMapPropagator>();
         PropagationContext capturedPropagationContext = default;
@@ -482,7 +482,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>
     /// A Task.
     /// </returns>
-    private async Task TestHandlerFailure(
+    private static async Task TestHandlerFailure(
         Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc,
         StatusCode statusCode = StatusCode.ResourceExhausted,
         bool validateErrorDescription = true,

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -35,7 +35,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task UnaryServerHandlerSuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task UnaryServerHandlerFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task ClientStreamingServerHandlerSuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeClientStreamingRequest).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task ClientStreamingServerHandlerFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeClientStreamingRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task ServerStreamingServerHandlerSuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeServerStreamingRequest).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -85,7 +85,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task ServerStreamingServerHandlerFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeServerStreamingRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task DuplexStreamingServerHandlerSuccess()
     {
-        await this.TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest).ConfigureAwait(false);
+        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public class GrpcCoreServerInterceptorTests
     [Fact]
     public async Task DuplexStreamingServerHandlerFail()
     {
-        await this.TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest).ConfigureAwait(false);
+        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -114,7 +114,7 @@ public class GrpcCoreServerInterceptorTests
     /// <param name="clientRequestFunc">The specific client request function.</param>
     /// <param name="additionalMetadata">The additional metadata, if any.</param>
     /// <returns>A Task.</returns>
-    private async Task TestHandlerSuccess(Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc, Metadata additionalMetadata = null)
+    private static async Task TestHandlerSuccess(Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc, Metadata additionalMetadata = null)
     {
         // starts the server with the server interceptor
         var interceptorOptions = new ServerTracingInterceptorOptions { Propagator = new TraceContextPropagator(), RecordMessageEvents = true, ActivityIdentifierValue = Guid.NewGuid() };
@@ -155,7 +155,7 @@ public class GrpcCoreServerInterceptorTests
     /// <param name="clientRequestFunc">The specific client request function.</param>
     /// <param name="additionalMetadata">The additional metadata, if any.</param>
     /// <returns>A Task.</returns>
-    private async Task TestHandlerFailure(Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc, Metadata additionalMetadata = null)
+    private static async Task TestHandlerFailure(Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc, Metadata additionalMetadata = null)
     {
         // starts the server with the server interceptor
         var interceptorOptions = new ServerTracingInterceptorOptions { Propagator = new TraceContextPropagator(), ActivityIdentifierValue = Guid.NewGuid() };

--- a/test/OpenTelemetry.Instrumentation.MySqlData.Tests/MySqlDataTests.cs
+++ b/test/OpenTelemetry.Instrumentation.MySqlData.Tests/MySqlDataTests.cs
@@ -55,7 +55,7 @@ public class MySqlDataTests
 
         var traceListener = (TraceListener)Assert.Single(MySqlTrace.Listeners);
 
-        this.ExecuteSuccessQuery(traceListener, commandText, isFailure);
+        ExecuteSuccessQuery(traceListener, commandText, isFailure);
 
         Assert.Equal(3, activityProcessor.Invocations.Count);
 
@@ -170,7 +170,7 @@ public class MySqlDataTests
         }
     }
 
-    private void ExecuteSuccessQuery(TraceListener listener, string query, bool isFailure)
+    private static void ExecuteSuccessQuery(TraceListener listener, string query, bool isFailure)
     {
         // Connection opened
         listener.TraceEvent(

--- a/test/OpenTelemetry.Instrumentation.Quartz.Tests/QuartzDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Quartz.Tests/QuartzDiagnosticListenerTests.cs
@@ -106,9 +106,9 @@ public class QuartzDiagnosticListenerTests
                     if (payload is IJobDetail jobDetail)
                     {
                         var dataMap = jobDetail.JobDataMap;
-                        if (dataMap.ContainsKey("TestId"))
+                        if (dataMap.TryGetValue("TestId", out var value))
                         {
-                            a.SetTag("test.id", dataMap["TestId"]);
+                            a.SetTag("test.id", value);
                         }
                     }
                 })
@@ -229,9 +229,9 @@ public class QuartzDiagnosticListenerTests
                     if (p is IJobDetail jobDetail)
                     {
                         var dataMap = jobDetail.JobDataMap;
-                        if (dataMap.ContainsKey("TestId"))
+                        if (dataMap.TryGetValue("TestId", out var value))
                         {
-                            a.SetTag("test.id", dataMap["TestId"]);
+                            a.SetTag("test.id", value);
                         }
                     }
                 };


### PR DESCRIPTION
## Changes

Enable `<AnalysisLevel>latest-All</AnalysisLevel>` as suggested in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/900#issuecomment-1387222338.

Within the production shipping packages there are two changes that change the public API surface. As both packages are still pre-release on NuGet.org I assumed this was fine. These changes can be reverted and suppressed if preferred.

For the test projects I erred on the side of disabling rules rather than fixing them to reduce churn.

I'm leaving this as a draft for now as it touches a lot of files so might ping a lot of different reviewers. I can also split the commits up differently and/or create smaller more targeted PRs if that's preferred.

Let me know if any of these changes warrant a note in the CHANGELOG.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
