### PR TITLE
Do not assign people to draft pull requests

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -11,3 +11,5 @@ jobs:
     name: Assign Reviewers
     steps:
       - uses: dyladan/component-owners@main
+        with:
+          assign-owners: ${{ github.event.pull_request.draft == false }}


### PR DESCRIPTION
## Changes

I opened #908 as a draft to prevent spamming people, but as a custom workflow is used instead of `CODEOWNERS` it didn't have the desired effect.

This PR changes the workflow to only assign when the pull request is not a draft.

If the current behaviour is intentional, feel free to close this pull request.
