### PR TITLE
[Instrumentation.EntityFrameworkCore] Bump OTel to 1.3.1

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OTel SDK package version to 1.2.0
-  [#347](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/347)
+* Updated OTel SDK package version to 1.3.1
+  [#XXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXX)
 
 * Update the `ActivitySource` name used to the assembly name:
 `OpenTelemetry.Instrumentation.EntityFrameworkCore`

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Microsoft.EntityFrameworkCore instrumentation for OpenTelemetry .NET</Description>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes N/A

## Changes

Bump OTel to 1.3.1 in Instrumentation.EntityFrameworkCore

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
