### PR TITLE
Bump OpenTelemetry Core packages to 1.3.2

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -31,7 +31,7 @@
     <MicrosoftOwinPkgVer>[4.2.2,5.0)</MicrosoftOwinPkgVer>
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
-    <OpenTelemetryCoreLatestVersion>[1.3.1,2.0)</OpenTelemetryCoreLatestVersion>
+    <OpenTelemetryCoreLatestVersion>[1.3.2,2.0)</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.4.0-rc.2]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel SDK version to `1.3.2`.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.2
 
 Released 2022-Dec-20

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel SDK version to `1.3.2`.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.0-beta.4
 
 Released 2022-Dec-07

--- a/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Docker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updates to 1.3.2 of OpenTelemetry SDK.
+[917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917)
+
 ## 1.0.0-beta.2
 
 Released 2023-Jan-11

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update `OpenTelemetry.Api` to `1.3.2`.
+([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.0-rc9.7
 
 Released 2022-Nov-28

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OTel SDK package version to 1.3.1
-  [#915](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/915)
+* Updated OTel SDK package version to 1.3.2
+  [#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917)
 
 * Update the `ActivitySource` name used to the assembly name:
 `OpenTelemetry.Instrumentation.EntityFrameworkCore`

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry.Api to 1.3.2.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.0-alpha.2
 
 Released 2022-Nov-10

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel API version to `1.3.2`.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.0-beta.4
 
 Released 2022-Dec-15

--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel API version to `1.3.2`.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.0-beta.5
 
 Released 2023-Jan-19

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry SDK to 1.3.2
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.0-rc.3
 
 Released 2022-Sep-20

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OpenTelemetry.Api to 1.3.1.
-  ([#889](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/889))
+* Update OpenTelemetry.Api to 1.3.2.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
 * Removes .NET Framework 4.7.2. It is distributed as .NET Standard 2.0.
   ([#911](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/911))
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OTel API version to `1.3.1`.
-  ([#631](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/631))
+* Update OTel API version to `1.3.2`.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
 
 ## 1.0.0-rc9.7
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel SDK version to `1.3.2`.
+  ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+
 ## 1.0.0-rc.8
 
 Released 2022-Dec-28


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/915#discussion_r1084280076

## Changes

Bump OpenTelemetry Core packages to 1.3.2
Changelog messages based on local, in-file wording.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
