### PR TITLE
Allow to customize exporter and batching timers

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry
 OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void
+static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions options, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure, System.Func<OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord>, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord>> newProcessorDelegate = null) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
@@ -24,13 +24,23 @@ namespace Microsoft.Extensions.Logging;
 
 public static class GenevaLoggingExtensions
 {
-    public static OpenTelemetryLoggerOptions AddGenevaLogExporter(this OpenTelemetryLoggerOptions options, Action<GenevaExporterOptions> configure)
+
+    public static OpenTelemetryLoggerOptions AddGenevaLogExporter(
+        this OpenTelemetryLoggerOptions options,
+        Action<GenevaExporterOptions> configure,
+        Func<BaseExporter<LogRecord>, BaseProcessor<LogRecord>> newProcessorDelegate = null)
     {
         Guard.ThrowIfNull(options);
 
         var genevaOptions = new GenevaExporterOptions();
         configure?.Invoke(genevaOptions);
         var exporter = new GenevaLogExporter(genevaOptions);
+
+        if (newProcessorDelegate != null)
+        {
+            return options.AddProcessor(newProcessorDelegate(exporter));
+        }
+
         if (exporter.IsUsingUnixDomainSocket)
         {
             return options.AddProcessor(new BatchLogRecordExportProcessor(exporter));

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Extensions.Logging;
 
 public static class GenevaLoggingExtensions
 {
-
     public static OpenTelemetryLoggerOptions AddGenevaLogExporter(
         this OpenTelemetryLoggerOptions options,
         Action<GenevaExporterOptions> configure,


### PR DESCRIPTION
Fixes #923

## Changes

Allow to customize batching processor, and/or batching processor timers.

**Usage**

New optional parameter added to `AddGenevaLogExporter` method. This parameter allows to supply a delegate to create a custom export processor. That way all logs emitted by process could show up at Unix Domain Socket sink in near-realtime rather than waiting for the next batching interval. This would be functionally similar to ETW behavior on Windows.

If new optional parameter is not supplied, then previous behavior with default instance of `BatchLogRecordExportProcessor` would take effect.

```
builder.AddOpenTelemetry(options =>
{
    options.AddGenevaLogExporter(exporterOptions =>
    {
        exporterOptions.ConnectionString = OpenTelemetryGenevaEndpoint;
        exporterOptions.CustomFields = new List<string> { "traceId", "eventName", "eventId", "componentId", "roleName" };
    },                            
    // Supply custom export processor: SimpleLogRecordExportProcessor or BatchLogRecordExportProcessor.
    // Below we configure near-realtime BatchLogRecordExportProcessor with delay of 100ms :
    (exporter) => new BatchLogRecordExportProcessor(exporter,
        maxQueueSize : 2048,
        scheduledDelayMilliseconds : 100,
        exporterTimeoutMilliseconds : 1000,
        maxExportBatchSize : 1)
    )
```

I am not sure if I need to modify the `PublicAPI.Shipped.txt`. This functionality could also be added by adding a completely new 3-parameters static function, i.e. not breaking the existing 2-parameters method.