### PR TITLE
[Instrumentation.WCF] Remove AddWcfInstrumentation with default parameter

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -14,7 +14,7 @@ Released 2023-Jan-25
   ([#486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/486))
 
 * Removes `AddEntityFrameworkCoreInstrumentation` method with default configure
-  default parameter.
+  parameter.
   ([#916](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/916))
 
 * Added support to `EnrichWithIDbCommand`

--- a/src/OpenTelemetry.Instrumentation.Wcf/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Wcf/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -47,4 +47,5 @@ override OpenTelemetry.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionEle
 override OpenTelemetry.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionElement.CreateBehavior() -> object
 override OpenTelemetry.Instrumentation.Wcf.TelemetryServiceBehaviorExtensionElement.BehaviorType.get -> System.Type
 override OpenTelemetry.Instrumentation.Wcf.TelemetryServiceBehaviorExtensionElement.CreateBehavior() -> object
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddWcfInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddWcfInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddWcfInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.Wcf/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Wcf/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -29,4 +29,5 @@ OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions.SuppressDownstreamIn
 OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions.SuppressDownstreamInstrumentation.set -> void
 OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions.WcfInstrumentationOptions() -> void
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddWcfInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddWcfInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddWcfInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Update OTel SDK version to `1.3.2`.
   ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
+* Removes `AddWcfInstrumentation` method with default configure parameter.
+  ([#928](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/928))
 
 ## 1.0.0-rc.8
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TracerProviderBuilderExtensions.cs
@@ -29,9 +29,17 @@ public static class TracerProviderBuilderExtensions
     /// Enables the outgoing requests automatic data collection for WCF.
     /// </summary>
     /// <param name="builder"><see cref="TracerProviderBuilderExtensions"/> being configured.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilderExtensions"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddWcfInstrumentation(this TracerProviderBuilder builder) =>
+        AddWcfInstrumentation(builder, configure: null);
+
+    /// <summary>
+    /// Enables the outgoing requests automatic data collection for WCF.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilderExtensions"/> being configured.</param>
     /// <param name="configure">Wcf configuration options.</param>
     /// <returns>The instance of <see cref="TracerProviderBuilderExtensions"/> to chain the calls.</returns>
-    public static TracerProviderBuilder AddWcfInstrumentation(this TracerProviderBuilder builder, Action<WcfInstrumentationOptions> configure = null)
+    public static TracerProviderBuilder AddWcfInstrumentation(this TracerProviderBuilder builder, Action<WcfInstrumentationOptions> configure)
     {
         Guard.ThrowIfNull(builder);
 


### PR DESCRIPTION
Propagate recommendations from https://github.com/open-telemetry/opentelemetry-dotnet/pull/3653/files#r970049254

## Changes

Remove `AddEntityFrameworkCoreInstrumentation` with default parameter

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
