### PR TITLE
[Instrumentation.AspNet] Remove AddAspNetInstrumentation with default parameter

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -9,4 +9,5 @@ OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordExceptio
 OpenTelemetry.Metrics.MeterProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions> configureAspNetInstrumentationOptions = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Removes `AddAspNetInstrumentation` method with default configure parameter.
+  ([#942](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/942))
+
 ## 1.0.0-rc9.7
 
 Released 2022-Nov-28

--- a/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
@@ -29,16 +29,24 @@ public static class TracerProviderBuilderExtensions
     /// Enables the incoming requests automatic data collection for ASP.NET.
     /// </summary>
     /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
-    /// <param name="configureAspNetInstrumentationOptions">ASP.NET Request configuration options.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddAspNetInstrumentation(this TracerProviderBuilder builder) =>
+        AddAspNetInstrumentation(builder, configure: null);
+
+    /// <summary>
+    /// Enables the incoming requests automatic data collection for ASP.NET.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="configure">ASP.NET Request configuration options.</param>
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddAspNetInstrumentation(
         this TracerProviderBuilder builder,
-        Action<AspNetInstrumentationOptions> configureAspNetInstrumentationOptions = null)
+        Action<AspNetInstrumentationOptions> configure)
     {
         Guard.ThrowIfNull(builder);
 
         var aspnetOptions = new AspNetInstrumentationOptions();
-        configureAspNetInstrumentationOptions?.Invoke(aspnetOptions);
+        configure?.Invoke(aspnetOptions);
 
         builder.AddInstrumentation(() => new AspNetInstrumentation(aspnetOptions));
         builder.AddSource(TelemetryHttpModule.AspNetSourceName);


### PR DESCRIPTION
Propagate recommendations from https://github.com/open-telemetry/opentelemetry-dotnet/pull/3653/files#r970049254

## Changes

Remove `AddAspNetInstrumentation `  with default parameter

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
