### PR TITLE
Bump OTel to 1.4.0-rc.3

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -32,7 +32,7 @@
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTelemetryCoreLatestVersion>[1.3.2,2.0)</OpenTelemetryCoreLatestVersion>
-    <OpenTelemetryCoreLatestPrereleaseVersion>[1.4.0-rc.2]</OpenTelemetryCoreLatestPrereleaseVersion>
+    <OpenTelemetryCoreLatestPrereleaseVersion>[1.4.0-rc.3]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry to 1.4.0-rc.3
+  ([#944](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/944))
+
 ## 1.4.0-rc.2
 
 Released 2023-Jan-30

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OpenTelemetry to 1.4.0-rc.2
-  ([#880](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/880))
+* Update OpenTelemetry to 1.4.0-rc.3
+  ([#944](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/944))
 
 ## 1.0.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry API to 1.4.0-rc.3
+  ([#944](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/944))
+
 ## 1.0.0-alpha.4
 
 Released 2023-Jan-11

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry API to 1.4.0-rc.3
+  ([#944](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/944))
+
 ## 1.1.0-beta.3
 
 Released 2023-Jan-11


### PR DESCRIPTION
Fixes N/A.

## Changes

Bump OTel to last unstable release for packages using unstable release.
Needed by AutoInstrumentation project (please expect release for Process and Runtime projects).

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
