### PR TITLE
[Exporter.Geneva] Fix analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/UncheckedASCIIEncoding.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/UncheckedASCIIEncoding.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Text;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.Geneva.TldExporter;
 
@@ -124,11 +125,7 @@ internal sealed class UncheckedASCIIEncoding : Encoding
 
     public override int GetByteCount(string chars)
     {
-        if (chars == null)
-        {
-            throw new ArgumentNullException(nameof(chars));
-        }
-
+        Guard.ThrowIfNull(chars);
         return chars.Length;
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
@@ -102,7 +102,7 @@ public class LogExporterBenchmarks
     [Benchmark]
     public void LoggerWithMessageTemplate()
     {
-        this.logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        this.logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
     }
 
     [Benchmark]
@@ -158,7 +158,7 @@ public class LogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return items[0];
     }
 
@@ -173,7 +173,7 @@ public class LogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return batchGeneratorExporter.Batch;
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDLogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDLogExporterBenchmarks.cs
@@ -157,7 +157,7 @@ public class TLDLogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return exportedItems[0];
     }
 
@@ -172,7 +172,7 @@ public class TLDLogExporterBenchmarks
             }));
 
         var logger = factory.CreateLogger("TestLogger");
-        logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         return batchGeneratorExporter.Batch;
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Stress/DummyServer.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Stress/DummyServer.cs
@@ -18,7 +18,6 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Geneva.Stress;
@@ -61,7 +60,7 @@ internal class DummyServer
                 Socket acceptSocket = this.serverSocket.Accept();
                 Task.Run(() =>
                 {
-                    int threadId = Thread.CurrentThread.ManagedThreadId;
+                    int threadId = Environment.CurrentManagedThreadId;
                     Console.WriteLine($"ThreadID {threadId}: Start reading from socket.");
                     int totalBytes = 0;
                     try

--- a/test/OpenTelemetry.Exporter.Geneva.Stress/Program.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Stress/Program.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -29,7 +30,7 @@ namespace OpenTelemetry.Exporter.Geneva.Stress;
 internal class Program
 {
     private static volatile bool s_bContinue = true;
-    private static long s_nEvents = 0;
+    private static long s_nEvents;
 
     private static ActivitySource source = new ActivitySource("OpenTelemetry.Exporter.Geneva.Stress");
 
@@ -135,7 +136,7 @@ internal class Program
                     watch.Stop();
                     var nEvents = statistics.Sum();
                     var nEventPerSecond = (int)((nEvents - s_nEvents) / (watch.ElapsedMilliseconds / 1000.0));
-                    Console.Title = string.Format("Loops: {0:n0}, Loops/Second: {1:n0}", nEvents, nEventPerSecond);
+                    Console.Title = string.Format(CultureInfo.InvariantCulture, "Loops: {0:n0}, Loops/Second: {1:n0}", nEvents, nEventPerSecond);
                 }
             },
             () =>

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
@@ -385,7 +386,7 @@ public class GenevaLogExporterTests
 
             if (hasCustomFields)
             {
-                exporterOptions.CustomFields = new string[] { "food", "Name", "Key1" };
+                exporterOptions.CustomFields = new string[] { "Food", "Name", "Key1" };
             }
 
             var exportedItems = new List<LogRecord>();
@@ -419,7 +420,7 @@ public class GenevaLogExporterTests
             using (logger.BeginScope("MyInnerInnerScope with {Name} and {Age} of custom", "John Doe", 25))
             using (logger.BeginScope(new List<KeyValuePair<string, object>> { new("Key1", "Value1"), new("Key2", "Value2") }))
             {
-                logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+                logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
             }
 
             byte[] serializedData;
@@ -445,7 +446,7 @@ public class GenevaLogExporterTests
                 var envProperties = mapping["env_properties"] as Dictionary<object, object>;
 
                 // Custom Fields
-                Assert.Equal("artichoke", mapping["food"]);
+                Assert.Equal("artichoke", mapping["Food"]);
                 Assert.Equal("John Doe", mapping["Name"]);
                 Assert.Equal("Value1", mapping["Key1"]);
 
@@ -453,7 +454,7 @@ public class GenevaLogExporterTests
                 Assert.False(mapping.ContainsKey("MyInnerScope"));
 
                 // env_properties
-                Assert.True(Equals(envProperties["price"], 3.99));
+                Assert.True(Equals(envProperties["Price"], 3.99));
                 Assert.Equal((byte)25, envProperties["Age"]);
                 Assert.Equal("Value2", envProperties["Key2"]);
 
@@ -462,8 +463,8 @@ public class GenevaLogExporterTests
             }
             else
             {
-                Assert.Equal("artichoke", mapping["food"]);
-                Assert.True(Equals(mapping["price"], 3.99));
+                Assert.Equal("artichoke", mapping["Food"]);
+                Assert.True(Equals(mapping["Price"], 3.99));
                 Assert.Equal("John Doe", mapping["Name"]);
                 Assert.Equal((byte)25, mapping["Age"]);
                 Assert.Equal("Value1", mapping["Key1"]);
@@ -757,24 +758,24 @@ public class GenevaLogExporterTests
             using (var activity = source.StartActivity("Activity"))
             {
                 // Log inside an activity to set LogRecord.TraceId and LogRecord.SpanId
-                logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99); // structured logging
+                logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99); // structured logging
             }
 
             // When the exporter options are configured with TableMappings only "customField" will be logged as a separate key in the mapping
             // "property" will be logged under "env_properties" in the mapping
-            logger.Log(LogLevel.Trace, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Trace, 101, "Log a {customField} and {property}", "CustomFieldValue", null);
-            logger.Log(LogLevel.Trace, 101, "Log a {customField} and {property}", null, "PropertyValue");
-            logger.Log(LogLevel.Debug, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Information, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Warning, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Error, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
-            logger.Log(LogLevel.Critical, 101, "Log a {customField} and {property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Trace, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Trace, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", null);
+            logger.Log(LogLevel.Trace, 101, "Log a {CustomField} and {Property}", null, "PropertyValue");
+            logger.Log(LogLevel.Debug, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Information, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Warning, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Error, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
+            logger.Log(LogLevel.Critical, 101, "Log a {CustomField} and {Property}", "CustomFieldValue", "PropertyValue");
             logger.LogInformation("Hello World!"); // unstructured logging
-            logger.LogError(new InvalidOperationException("Oops! Food is spoiled!"), "Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogError(new InvalidOperationException("Oops! Food is spoiled!"), "Hello from {Food} {Price}.", "artichoke", 3.99);
 
             // Exception with a non-ASCII character in its type name
-            logger.LogError(new CustomException\u0418(), "Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogError(new CustomException\u0418(), "Hello from {Food} {Price}.", "artichoke", 3.99);
 
             var loggerWithDefaultCategory = loggerFactory.CreateLogger("DefaultCategory");
             loggerWithDefaultCategory.LogInformation("Basic test");
@@ -837,7 +838,7 @@ public class GenevaLogExporterTests
 
             var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
 
-            logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         }
     }
 
@@ -888,7 +889,7 @@ public class GenevaLogExporterTests
                 // Emit a LogRecord and grab a copy of internal buffer for validation.
                 var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
 
-                logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+                logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
 
                 // logRecordList should have a singleLogRecord entry after the logger.LogInformation call
                 Assert.Single(logRecordList);
@@ -908,7 +909,7 @@ public class GenevaLogExporterTests
                 // Emit log on a different thread to test for multithreading scenarios
                 var thread = new Thread(() =>
                 {
-                    logger.LogInformation("Hello from another thread {food} {price}.", "artichoke", 3.99);
+                    logger.LogInformation("Hello from another thread {Food} {Price}.", "artichoke", 3.99);
                 });
                 thread.Start();
                 thread.Join();
@@ -1104,7 +1105,7 @@ public class GenevaLogExporterTests
 
             var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
 
-            logger.LogInformation("Hello from {food} {price}.", "artichoke", 3.99);
+            logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
         }
     }
 
@@ -1140,9 +1141,9 @@ public class GenevaLogExporterTests
         var TimeStampAndMappings = ((fluentdData as object[])[1] as object[])[0];
         var mapping = (TimeStampAndMappings as object[])[1] as Dictionary<object, object>;
 
-        if (mapping.ContainsKey(key))
+        if (mapping.TryGetValue(key, out var value))
         {
-            return mapping[key];
+            return value;
         }
         else
         {
@@ -1286,7 +1287,7 @@ public class GenevaLogExporterTests
 
         if (logRecord.EventId != default)
         {
-            Assert.Equal(logRecord.EventId.Id, int.Parse(mapping["eventId"].ToString()));
+            Assert.Equal(logRecord.EventId.Id, int.Parse(mapping["eventId"].ToString(), CultureInfo.InvariantCulture));
         }
 
         // Epilouge

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -322,7 +322,7 @@ public class GenevaMetricExporterTests
             {
                 if (instrument.Name == "histogramWithNoBounds")
                 {
-                    return new ExplicitBucketHistogramConfiguration { Boundaries = new double[] { } };
+                    return new ExplicitBucketHistogramConfiguration { Boundaries = Array.Empty<double>() };
                 }
 
                 return null;
@@ -334,7 +334,7 @@ public class GenevaMetricExporterTests
                     RecordMinMax = false,
                 })
             .AddView("observableLongCounter", MetricStreamConfiguration.Drop)
-            .AddView("observableDoubleCounter", new MetricStreamConfiguration { TagKeys = new string[] { } })
+            .AddView("observableDoubleCounter", new MetricStreamConfiguration { TagKeys = Array.Empty<string>() })
             .AddView(instrument =>
             {
                 if (instrument.Name == "observableLongGauge")

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -85,7 +85,7 @@ public class GenevaTraceExporterTests
         // Supported types for PrepopulatedFields should not throw an exception
         var exception = Record.Exception(() =>
         {
-            new GenevaExporterOptions
+            _ = new GenevaExporterOptions
             {
                 ConnectionString = "EtwSession=OpenTelemetry",
                 PrepopulatedFields = new Dictionary<string, object>
@@ -663,7 +663,7 @@ public class GenevaTraceExporterTests
             else
             {
                 // If CustomFields are proivded, dedicatedFields will be populated
-                if (exporterOptions.CustomFields == null || dedicatedFields.ContainsKey(tag.Key))
+                if (exporterOptions.CustomFields == null || dedicatedFields.TryGetValue(tag.Key, out _))
                 {
                     Assert.Equal(tag.Value.ToString(), mapping[tag.Key].ToString());
                 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
@@ -22,7 +22,7 @@ using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 
-public class JsonSerializerTests
+public static class JsonSerializerTests
 {
     public static IEnumerable<object[]> Data =>
         new List<object[]>
@@ -57,10 +57,82 @@ public class JsonSerializerTests
     [Theory]
     [MemberData(nameof(Data))]
     [Trait("Platform", "Any")]
-    public void TestSerialization(object value, string expected)
+    public static void TestSerialization(object value, string expected)
     {
         var buffer = new byte[65_536];
         var length = JsonSerializer.Serialize(buffer, 0, value);
         Assert.Equal(expected, Encoding.ASCII.GetString(buffer, 0, length));
+    }
+
+    [Fact]
+    [Trait("Platform", "Any")]
+    public static void JsonSerializer_Null()
+    {
+        TestSerialization(null, "null");
+    }
+
+    [Fact]
+    [Trait("Platform", "Any")]
+    public static void JsonSerializer_Boolean()
+    {
+        TestSerialization(true, "true");
+        TestSerialization(false, "false");
+    }
+
+    [Fact]
+    [Trait("Platform", "Any")]
+    public static void JsonSerializer_Numeric()
+    {
+        TestSerialization(0, "0");
+        TestSerialization(123, "123");
+        TestSerialization(-123, "-123");
+        TestSerialization(0.0f, "0");
+        TestSerialization(1.0f, "1");
+        TestSerialization(3.14f, "3.14");
+        TestSerialization(-3.14f, "-3.14");
+        TestSerialization(0.0d, "0");
+        TestSerialization(3.14d, "3.14");
+        TestSerialization(3.1415926d, "3.1415926");
+        TestSerialization(-3.1415926d, "-3.1415926");
+    }
+
+    [Fact]
+    [Trait("Platform", "Any")]
+    public static void JsonSerializer_String()
+    {
+        TestSerialization((string)null, "null");
+        TestSerialization(string.Empty, "''".Replace("'", "\""));
+        TestSerialization("Hello, World!", "'Hello, World!'".Replace("'", "\""));
+        TestSerialization("\"", "'\\\"'".Replace("'", "\""));
+        TestSerialization("\n", "'\\n'".Replace("'", "\""));
+        TestSerialization("\t", "'\\t'".Replace("'", "\""));
+        TestSerialization("\0", "'\\u0000'".Replace("'", "\""));
+        TestSerialization("\u6768", "'\\u6768'".Replace("'", "\""));
+    }
+
+    [Fact]
+    [Trait("Platform", "Any")]
+    public static void JsonSerializer_Array()
+    {
+        TestSerialization((object[])null, "null");
+        TestSerialization(Array.Empty<object>(), "[]");
+        TestSerialization(new object[] { 1, 2, 3 }, "[1,2,3]");
+    }
+
+    [Fact]
+    [Trait("Platform", "Any")]
+    public static void JsonSerializer_Map()
+    {
+        TestSerialization((Dictionary<string, object>)null, "null");
+        TestSerialization(new Dictionary<string, object>(), "{}");
+        TestSerialization(
+            new Dictionary<string, object>
+            {
+                ["foo"] = 1,
+                ["bar"] = "baz",
+                ["golden ratio"] = 0.6180340f,
+                ["pi"] = 3.14159265358979d,
+            },
+            "{'foo':1,'bar':'baz','golden ratio':0.618034,'pi':3.14159265358979}".Replace("'", "\""));
     }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
@@ -77,7 +77,7 @@ public class LogSerializationTests
         var exStack = new string('e', 16383 + 1);
         var ex = new MyException(exceptionMessage, exStack);
         var exportedFields = GetExportedFieldsAfterLogging(
-            logger => logger.LogError(ex, "Error occurred. {field1} {field2}", "value1", "value2"),
+            logger => logger.LogError(ex, "Error occurred. {Field1} {Field2}", "value1", "value2"),
             (genevaOptions) => genevaOptions.ExceptionStackExportMode = ExceptionStackExportMode.ExportAsString);
 
         var actualExceptionMessage = exportedFields["env_ex_msg"];
@@ -89,10 +89,10 @@ public class LogSerializationTests
         var actualExceptionStack = exportedFields["env_ex_stack"];
         Assert.EndsWith("...", (string)actualExceptionStack);
 
-        var actualValue = exportedFields["field1"];
+        var actualValue = exportedFields["Field1"];
         Assert.Equal("value1", actualValue);
 
-        actualValue = exportedFields["field2"];
+        actualValue = exportedFields["Field2"];
         Assert.Equal("value2", actualValue);
 
         // PrintFields(this.output, exportedFields);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using Xunit;
 using Xunit.Sdk;
@@ -54,7 +55,9 @@ public class MessagePackSerializerTests
         if (!string.IsNullOrEmpty(input) && input.Length > sizeLimit)
         {
             // We truncate the string using `.` in the last three characters which takes 3 bytes of memort
+#pragma warning disable CA1846 // Prefer 'AsSpan' over 'Substring'
             var byteCount = Encoding.ASCII.GetByteCount(input.Substring(0, sizeLimit - 3)) + 3;
+#pragma warning restore CA1846 // Prefer 'AsSpan' over 'Substring'
             Assert.Equal(0xDA, buffer[0]);
             Assert.Equal(byteCount, (buffer[1] << 8) | buffer[2]);
             Assert.Equal(byteCount, length - 3); // First three bytes are metadata
@@ -109,7 +112,9 @@ public class MessagePackSerializerTests
         if (!string.IsNullOrEmpty(input) && input.Length > sizeLimit)
         {
             // We truncate the string using `.` in the last three characters which takes 3 bytes of memory
+#pragma warning disable CA1846 // Prefer 'AsSpan' over 'Substring'
             var byteCount = Encoding.UTF8.GetByteCount(input.Substring(0, sizeLimit - 3)) + 3;
+#pragma warning restore CA1846 // Prefer 'AsSpan' over 'Substring'
             Assert.Equal(0xDA, buffer[0]);
             Assert.Equal(byteCount, (buffer[1] << 8) | buffer[2]);
             Assert.Equal(byteCount, length - 3); // First three bytes are metadata
@@ -347,7 +352,7 @@ public class MessagePackSerializerTests
     public void MessagePackSerializer_Array()
     {
         this.MessagePackSerializer_TestSerialization((object[])null);
-        this.MessagePackSerializer_TestSerialization(new object[0]);
+        this.MessagePackSerializer_TestSerialization(Array.Empty<object>());
 
         // This object array has a custom string which will be serialized as STR16
         var objectArrayWithString = new object[]
@@ -386,7 +391,7 @@ public class MessagePackSerializerTests
         _ = MessagePackSerializer.Serialize(buffer, 0, dictionaryWithStrings);
         var dictionaryWithStringsDeserialized = MessagePack.MessagePackSerializer.Deserialize<Dictionary<string, object>>(buffer);
         Assert.Equal(dictionaryWithStrings.Count, dictionaryWithStringsDeserialized.Count);
-        Assert.Equal(dictionaryWithStrings["foo"], Convert.ToInt32(dictionaryWithStringsDeserialized["foo"]));
+        Assert.Equal(dictionaryWithStrings["foo"], Convert.ToInt32(dictionaryWithStringsDeserialized["foo"], CultureInfo.InvariantCulture));
         Assert.Equal(dictionaryWithStrings["bar"], dictionaryWithStringsDeserialized["bar"]);
         Assert.Equal(dictionaryWithStrings["golden ratio"], dictionaryWithStringsDeserialized["golden ratio"]);
         Assert.Equal(dictionaryWithStrings["pi"], dictionaryWithStringsDeserialized["pi"]);


### PR DESCRIPTION
## Changes

Fix/suppress code analysis warnings in OpenTelemetry.Contrib.Exporter.Geneva.

Contributes to #950.
