### PR TITLE
[Extensions.PersistentStorage] Fix analysis warnings

### DIFF
--- a/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ OpenTelemetry.Extensions.PersistentStorage.FileBlob.FileBlob(string fullPath) ->
 OpenTelemetry.Extensions.PersistentStorage.FileBlob.FullPath.get -> string
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose() -> void
-OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.FileBlobProvider(string path, long maxSizeInBytes = 52428800, int maintenancePeriodInMilliseconds = 120000, long retentionPeriodInMilliseconds = 172800000, int writeTimeoutInMilliseconds = 60000) -> void
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryDelete() -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryLease(int leasePeriodMilliseconds) -> bool
@@ -13,3 +12,4 @@ override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnGetBlobs(
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryGetBlob(out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
+virtual OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ OpenTelemetry.Extensions.PersistentStorage.FileBlob.FileBlob(string fullPath) ->
 OpenTelemetry.Extensions.PersistentStorage.FileBlob.FullPath.get -> string
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose() -> void
-OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.FileBlobProvider(string path, long maxSizeInBytes = 52428800, int maintenancePeriodInMilliseconds = 120000, long retentionPeriodInMilliseconds = 172800000, int writeTimeoutInMilliseconds = 60000) -> void
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryDelete() -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryLease(int leasePeriodMilliseconds) -> bool
@@ -13,3 +12,4 @@ override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnGetBlobs(
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryGetBlob(out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
+virtual OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ OpenTelemetry.Extensions.PersistentStorage.FileBlob.FileBlob(string fullPath) ->
 OpenTelemetry.Extensions.PersistentStorage.FileBlob.FullPath.get -> string
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose() -> void
-OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void
 OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.FileBlobProvider(string path, long maxSizeInBytes = 52428800, int maintenancePeriodInMilliseconds = 120000, long retentionPeriodInMilliseconds = 172800000, int writeTimeoutInMilliseconds = 60000) -> void
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryDelete() -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlob.OnTryLease(int leasePeriodMilliseconds) -> bool
@@ -13,3 +12,4 @@ override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnGetBlobs(
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryCreateBlob(byte[] buffer, out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
 override OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.OnTryGetBlob(out OpenTelemetry.Extensions.PersistentStorage.Abstractions.PersistentBlob blob) -> bool
+virtual OpenTelemetry.Extensions.PersistentStorage.FileBlobProvider.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Extensions.PersistentStorage/FileBlob.cs
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/FileBlob.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using OpenTelemetry.Extensions.PersistentStorage.Abstractions;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Extensions.PersistentStorage;
 
@@ -57,6 +58,8 @@ public class FileBlob : PersistentBlob
 
     protected override bool OnTryWrite(byte[] buffer, int leasePeriodMilliseconds = 0)
     {
+        Guard.ThrowIfNull(buffer);
+
         string path = this.FullPath + ".tmp";
 
         try

--- a/src/OpenTelemetry.Extensions.PersistentStorage/FileBlobProvider.cs
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/FileBlobProvider.cs
@@ -110,7 +110,7 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public void Dispose(bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (!this.disposedValue)
         {

--- a/src/OpenTelemetry.Extensions.PersistentStorage/PersistentStorageHelper.cs
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/PersistentStorageHelper.cs
@@ -204,9 +204,14 @@ internal static class PersistentStorageHelper
 
     internal static string GetSHA256Hash(string input)
     {
-        var hashString = new StringBuilder();
-
         byte[] inputBits = Encoding.Unicode.GetBytes(input);
+
+#if NET6_0_OR_GREATER
+#pragma warning disable CA1308 // Normalize strings to uppercase
+        return Convert.ToHexString(SHA256.HashData(inputBits)).ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
+#else
+        var hashString = new StringBuilder();
         using (var sha256 = SHA256.Create())
         {
             byte[] hashBits = sha256.ComputeHash(inputBits);
@@ -217,6 +222,7 @@ internal static class PersistentStorageHelper
         }
 
         return hashString.ToString();
+#endif
     }
 
     private static long CalculateFolderSize(string path)


### PR DESCRIPTION
## Changes

Fix/suppress code analysis warnings in OpenTelemetry.Contrib.Extensions.PersistentStorage.

Contributes to #950.
