### PR TITLE
[Instrumentation.EntityFrameworkCore] Fix analysis warning

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/EntityFrameworkInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/EntityFrameworkInstrumentationOptions.cs
@@ -34,7 +34,7 @@ public class EntityFrameworkInstrumentationOptions
     /// <summary>
     /// Gets or sets a value indicating whether or not the <see cref="EntityFrameworkInstrumentation"/> should add the text of <see cref="CommandType.Text"/> commands as the <see cref="SemanticConventions.AttributeDbStatement"/> tag. Default value: False.
     /// </summary>
-    public bool SetDbStatementForText { get; set; } = false;
+    public bool SetDbStatementForText { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an Activity from the db command.


### PR DESCRIPTION
## Changes

Fix code analysis warning in OpenTelemetry.Instrumentation.EntityFrameworkCore.

Contributes to #950.
