### PR TITLE
[Instrumentation.EventCounters] Fix analysis warnings

### DIFF
--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -216,8 +216,8 @@ public class EventCountersMetricsTests
         // Assert
         foreach (var item in metricItems)
         {
-            Assert.False(item.Name.StartsWith("ec.source.ee"));
-            Assert.False(item.Name.StartsWith("ec.s.ee"));
+            Assert.False(item.Name.StartsWith("ec.source.ee", StringComparison.Ordinal));
+            Assert.False(item.Name.StartsWith("ec.s.ee", StringComparison.Ordinal));
         }
     }
 


### PR DESCRIPTION
## Changes

Fix code analysis warnings in OpenTelemetry.Instrumentation.EventCounters.

Contributes to #950.
