### PR TITLE
Enable AnalysisLevel latest-All

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -9,6 +9,7 @@
     <NetFrameworkMinimumSupportedVersion>net462</NetFrameworkMinimumSupportedVersion>
     <NetMinimumSupportedVersion>net6.0</NetMinimumSupportedVersion>
     <NetStandardMinimumSupportedVersion>netstandard2.0</NetStandardMinimumSupportedVersion>
+    <AnalysisLevel>latest-All</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/build/OpenTelemetryContrib.test.ruleset
+++ b/build/OpenTelemetryContrib.test.ruleset
@@ -4,6 +4,36 @@
     <Name Resource="OpenTelemetrySDKRules_Name" />
     <Description Resource="OpenTelemetrySDKRules_Description" />
   </Localization>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="None" />
+    <Rule Id="CA1019" Action="None" />
+    <Rule Id="CA1032" Action="None" />
+    <Rule Id="CA1050" Action="None" />
+    <Rule Id="CA1051" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1063" Action="None" />
+    <Rule Id="CA1064" Action="None" />
+    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1307" Action="None" />
+    <Rule Id="CA1309" Action="None" />
+    <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA1809" Action="None" />
+    <Rule Id="CA1812" Action="None" />
+    <Rule Id="CA1813" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1822" Action="None" />
+    <Rule Id="CA1848" Action="None" />
+    <Rule Id="CA1849" Action="None" />
+    <Rule Id="CA1852" Action="None" />
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2008" Action="None" />
+    <Rule Id="CA2201" Action="None" />
+    <Rule Id="CA2213" Action="None" />
+    <Rule Id="CA5394" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA1401" Action="None" />

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
@@ -45,6 +45,9 @@ public class TestAWSECSResourceDetector : IDisposable
     public void Dispose()
     {
         this.ResetEnvironment();
+        var resourceAttributes = ecsResourceDetector.Detect();
+
+        Assert.Null(resourceAttributes); // will be null as it's not in ecs environment
     }
 
     [Fact]

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
@@ -45,15 +45,16 @@ public class TestAWSECSResourceDetector : IDisposable
     public void Dispose()
     {
         this.ResetEnvironment();
-        var resourceAttributes = ecsResourceDetector.Detect();
-
-        Assert.Null(resourceAttributes); // will be null as it's not in ecs environment
     }
 
     [Fact]
     public void TestNotOnEcs()
     {
-        Assert.Empty(new AWSECSResourceDetector().Detect().Attributes);
+        var ecsResourceDetector = new AWSECSResourceDetector();
+        var resourceAttributes = ecsResourceDetector.Detect();
+
+        Assert.NotNull(resourceAttributes);
+        Assert.Empty(resourceAttributes.Attributes);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSECSResourceDetector.cs
@@ -155,14 +155,14 @@ public class TestAWSECSResourceDetector : IDisposable
                         var content = await File.ReadAllTextAsync($"{Environment.CurrentDirectory}/Resources/{containerJsonPath}");
                         var data = Encoding.UTF8.GetBytes(content);
                         context.Response.ContentType = "application/json";
-                        await context.Response.Body.WriteAsync(data, 0, data.Length);
+                        await context.Response.Body.WriteAsync(data);
                     }
                     else if (context.Request.Method == HttpMethods.Get && context.Request.Path == "/task")
                     {
                         var content = await File.ReadAllTextAsync($"{Environment.CurrentDirectory}/Resources/{taskJsonPath}");
                         var data = Encoding.UTF8.GetBytes(content);
                         context.Response.ContentType = "application/json";
-                        await context.Response.Body.WriteAsync(data, 0, data.Length);
+                        await context.Response.Body.WriteAsync(data);
                     }
                     else
                     {

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEKSResourceDetector.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/TestAWSEKSResourceDetector.cs
@@ -28,7 +28,11 @@ public class TestAWSEKSResourceDetector
     [Fact]
     public void TestDetect()
     {
-        Assert.Empty(new AWSEKSResourceDetector().Detect().Attributes); // will be null as it's not in eks environment
+        var eksResourceDetector = new AWSEKSResourceDetector();
+        var resourceAttributes = eksResourceDetector.Detect();
+
+        Assert.NotNull(resourceAttributes);
+        Assert.Empty(resourceAttributes.Attributes);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Trace/TestAWSXRayPropagator.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Trace/TestAWSXRayPropagator.cs
@@ -29,11 +29,7 @@ public class TestAWSXRayPropagator
     private const string TraceId = "5759e988bd862e3fe1be46a994272793";
     private const string ParentId = "53995c3f42cd8ad8";
 
-#if NETFRAMEWORK
-    private static readonly string[] Empty = new string[0];
-#else
     private static readonly string[] Empty = Array.Empty<string>();
-#endif
 
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
     {


### PR DESCRIPTION
## Changes

- Enable `AnalysisLevel` at `latest-All`.
- Add relevant suppressions for test projects.

Resolves #950.

Depends on:

- #951
- #952
- #953
- #954
- #955
- #956
- #957
- #958
- #959
- #960
- #961
- #962
- #963
- #964
- #965
- #966
- #967
- #968
- #1043
- #1061
