### PR TITLE
Remove netcore3.1 from CI jobs

### DIFF
--- a/.github/workflows/ci-md.yml
+++ b/.github/workflows/ci-md.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        version: [ net462, netcoreapp3.1, net6.0, net7.0 ]
+        version: [ net462, net6.0, net7.0 ]
         exclude:
         - os: ubuntu-latest
           version: net462

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        version: [ net462, netcoreapp3.1, net6.0, net7.0 ]
+        version: [ net462, net6.0, net7.0 ]
         exclude:
         - os: ubuntu-latest
           version: net462
@@ -25,11 +25,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-
-    - name: Install .NET 3.1 SDK
-      uses: actions/setup-dotnet@v3.0.3
-      with:
-        dotnet-version: '3.1.x'
 
     - name: Install .NET 7 SDK
       uses: actions/setup-dotnet@v3.0.3


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/791 but only removing from CI. (to make CIs run a bit faster).

Actual removal from projects is to be separately done.