### PR TITLE
[OpenTelemetry.Exporter.Geneva] Release 1.4.0-rc.3

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.4.0-rc.3
+
 * Update OpenTelemetry to 1.4.0-rc.3
   ([#944](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/944))
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 1.4.0-rc.3
 
+Released 2023-Feb-08
+
 * Update OpenTelemetry to 1.4.0-rc.3
   ([#944](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/944))
 


### PR DESCRIPTION
Fixes N/A.

Based on [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md#how-to-request-for-release-of-package)

## Changes

Please provide a brief description of the changes here.

`OpenTelemetry.Exporter.Geneva` Release `1.4.0-rc.3`

To fix:

`error NU1608: Detected package version outside of dependency constraint: OpenTelemetry.Exporter.Geneva 1.4.0-rc.2 requires OpenTelemetry (= 1.4.0-rc.2) but version OpenTelemetry 1.4.0-rc.3 was resolved.`

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
