### PR TITLE
[Instana Exporter] Wrong JSON format for serialized spans

### DIFF
--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Wrong JSON for serialized spans was generated after last changes fixed
+* Fixes issue in span serialization process introduced in 1.0.2 version.
+  ([#979](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/979))
 * Update OTel SDK version to `1.3.2`.
   ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
 

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Wrong JSON for serialized spans was generated after last changes fixed
 * Update OTel SDK version to `1.3.2`.
   ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
 

--- a/src/OpenTelemetry.Exporter.Instana/Implementation/InstanaSpanSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Instana/Implementation/InstanaSpanSerializer.cs
@@ -46,17 +46,6 @@ internal class InstanaSpanSerializer
         return instanaSpan.Data.Events.GetEnumerator();
     }
 
-    internal async Task<byte[]> SerializeToByteArrayAsync(InstanaSpan instanaSpan)
-    {
-        using var stream = new MemoryStream();
-        using var writer = new StreamWriter(stream);
-
-        await this.SerializeToStreamWriterAsync(instanaSpan, writer);
-
-        await writer.FlushAsync();
-        return stream.ToArray();
-    }
-
     internal async Task SerializeToStreamWriterAsync(InstanaSpan instanaSpan, StreamWriter writer)
     {
         await writer.WriteAsync(OPEN_BRACE);

--- a/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
+++ b/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 	<PackageTags>Instana Tracing APM</PackageTags>
+	  <LangVersion>latest</LangVersion>
 	<Description>Instana .NET Exporter for OpenTelemetry</Description>
 	<MinVerTagPrefix>Exporter.Instana-</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
+++ b/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 	<PackageTags>Instana Tracing APM</PackageTags>
-	  <LangVersion>latest</LangVersion>
 	<Description>Instana .NET Exporter for OpenTelemetry</Description>
 	<MinVerTagPrefix>Exporter.Instana-</MinVerTagPrefix>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #.

## Changes

Instana backend reported generated JSON by InstanaExporter as wrong. 
JSON should contains spans node as a root but it was not a case.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
