### PR TITLE
[Instrumentation.Process] Exposed required metric `process.cpu.count` for computing CPU utilization in the backend.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,4 @@ For significant contributions please make sure you have completed the following 
 
 * [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
 * [ ] Design discussion issue #
+* [ ] Changes in public API reviewed

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `process.cpu.count` metric.
+  ([#981](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/981))
+
 ## 1.0.0-alpha.6
 
 Released 2023-Feb-13

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Removed CPU utilization metric `process.cpu.utilization`.
+  ([#972](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/972))
+
 * Removed `ProcessInstrumentationOptions` and
   `AddProcessInstrumentation(this MeterProviderBuilder builder,`
   `Action<ProcessInstrumentationOptions>? configure)`

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `process.cpu.count` metric.
+  ([#981](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/981))
+
 * Removed CPU utilization metric `process.cpu.utilization`.
   ([#972](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/972))
 

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -66,13 +66,13 @@ internal sealed class ProcessMetrics
             description: "Total CPU seconds broken down by different states.");
 
         MeterInstance.CreateObservableUpDownCounter(
-            "process.processor.count",
+            "process.processors",
             () =>
             {
                 return Environment.ProcessorCount;
             },
             unit: "{processors}",
-            description: "Processor count.");
+            description: "Process processors count.");
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.threads",

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -16,7 +16,6 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Reflection;
@@ -24,25 +23,16 @@ using Diagnostics = System.Diagnostics;
 
 namespace OpenTelemetry.Instrumentation.Process;
 
-internal sealed class ProcessMetrics : IDisposable
+internal sealed class ProcessMetrics
 {
     internal static readonly AssemblyName AssemblyName = typeof(ProcessMetrics).Assembly.GetName();
     internal static readonly string MeterName = AssemblyName.Name;
 
-    private readonly Meter meterInstance = new(MeterName, AssemblyName.Version.ToString());
+    private static readonly Meter MeterInstance = new(MeterName, AssemblyName.Version.ToString());
 
-    // vars for calculating CPU utilization
-    private DateTime lastCollectionTimeUtc;
-    private double lastCollectedUserProcessorTime;
-    private double lastCollectedPrivilegedProcessorTime;
-
-    public ProcessMetrics(ProcessInstrumentationOptions options)
+    static ProcessMetrics()
     {
-        this.lastCollectionTimeUtc = DateTime.UtcNow;
-        this.lastCollectedUserProcessorTime = Diagnostics.Process.GetCurrentProcess().UserProcessorTime.TotalSeconds;
-        this.lastCollectedPrivilegedProcessorTime = Diagnostics.Process.GetCurrentProcess().PrivilegedProcessorTime.TotalSeconds;
-
-        this.meterInstance.CreateObservableUpDownCounter(
+        MeterInstance.CreateObservableUpDownCounter(
             "process.memory.usage",
             () =>
             {
@@ -51,7 +41,7 @@ internal sealed class ProcessMetrics : IDisposable
             unit: "By",
             description: "The amount of physical memory allocated for this process.");
 
-        this.meterInstance.CreateObservableUpDownCounter(
+        MeterInstance.CreateObservableUpDownCounter(
             "process.memory.virtual",
             () =>
             {
@@ -60,7 +50,7 @@ internal sealed class ProcessMetrics : IDisposable
             unit: "By",
             description: "The amount of committed virtual memory for this process.");
 
-        this.meterInstance.CreateObservableCounter(
+        MeterInstance.CreateObservableCounter(
             "process.cpu.time",
             () =>
             {
@@ -74,16 +64,7 @@ internal sealed class ProcessMetrics : IDisposable
             unit: "s",
             description: "Total CPU seconds broken down by different states.");
 
-        this.meterInstance.CreateObservableGauge(
-            "process.cpu.utilization",
-            () =>
-            {
-                return this.GetCpuUtilization();
-            },
-            unit: "1",
-            description: "Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process.");
-
-        this.meterInstance.CreateObservableUpDownCounter(
+        MeterInstance.CreateObservableUpDownCounter(
             "process.threads",
             () =>
             {
@@ -93,26 +74,7 @@ internal sealed class ProcessMetrics : IDisposable
             description: "Process threads count.");
     }
 
-    public void Dispose()
+    public ProcessMetrics(ProcessInstrumentationOptions options)
     {
-        this.meterInstance.Dispose();
-    }
-
-    private IEnumerable<Measurement<double>> GetCpuUtilization()
-    {
-        var process = Diagnostics.Process.GetCurrentProcess();
-        var elapsedTimeForAllCpus = (DateTime.UtcNow - this.lastCollectionTimeUtc).TotalSeconds * Environment.ProcessorCount;
-        var userProcessorUtilization = (process.UserProcessorTime.TotalSeconds - this.lastCollectedUserProcessorTime) / elapsedTimeForAllCpus;
-        var privilegedProcessorUtilization = (process.PrivilegedProcessorTime.TotalSeconds - this.lastCollectedPrivilegedProcessorTime) / elapsedTimeForAllCpus;
-
-        this.lastCollectionTimeUtc = DateTime.UtcNow;
-        this.lastCollectedUserProcessorTime = process.UserProcessorTime.TotalSeconds;
-        this.lastCollectedPrivilegedProcessorTime = process.PrivilegedProcessorTime.TotalSeconds;
-
-        return new[]
-        {
-            new Measurement<double>(Math.Min(userProcessorUtilization, 1D), new KeyValuePair<string, object?>("state", "user")),
-            new Measurement<double>(Math.Min(privilegedProcessorUtilization, 1D), new KeyValuePair<string, object?>("state", "system")),
-        };
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -66,13 +66,13 @@ internal sealed class ProcessMetrics
             description: "Total CPU seconds broken down by different states.");
 
         MeterInstance.CreateObservableUpDownCounter(
-            "process.processors",
+            "process.cpu.count",
             () =>
             {
                 return Environment.ProcessorCount;
             },
             unit: "{processors}",
-            description: "Process processors count.");
+            description: "The number of processors (CPU cores) available to the current process.");
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.threads",

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -16,6 +16,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Reflection;
@@ -63,6 +64,15 @@ internal sealed class ProcessMetrics
             },
             unit: "s",
             description: "Total CPU seconds broken down by different states.");
+
+        MeterInstance.CreateObservableUpDownCounter(
+            "process.processor.count",
+            () =>
+            {
+                return Environment.ProcessorCount;
+            },
+            unit: "{processors}",
+            description: "Processor count.");
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.threads",

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -92,6 +92,20 @@ Gets the user processor time for this process.
 * [Process.PrivilegedProcessorTime](https://learn.microsoft.com/dotnet/api/system.diagnostics.process.privilegedprocessortime):
 Gets the privileged processor time for this process.
 
+### process.processors
+
+Process threads count.
+
+| Units         | Instrument Type         | Value Type |
+|---------------|-------------------------|------------|
+| `{processors}`| ObservableUpDownCounter | `Int32`    |
+
+The API used to retrieve the value is:
+
+* [Process.processors](https://learn.microsoft.com/dotnet/api/system.environment.processorcount):
+Gets the number of processors available
+to the current process.
+
 ### process.threads
 
 Process threads count.

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -102,8 +102,8 @@ The number of processors (CPU cores) available to the current process.
 
 The API used to retrieve the value is [System.Environment.ProcessorCount](https://learn.microsoft.com/dotnet/api/system.environment.processorcount).
 
-Note:
-This metric is under [discussion][1] and not part of the
+> **Note**
+> This metric is under [discussion][1] and not part of the
 [Process Metrics Spec][2] at this time.
 
 [1]: https://github.com/open-telemetry/opentelemetry-specification/issues/3200

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -92,9 +92,9 @@ Gets the user processor time for this process.
 * [Process.PrivilegedProcessorTime](https://learn.microsoft.com/dotnet/api/system.diagnostics.process.privilegedprocessortime):
 Gets the privileged processor time for this process.
 
-### process.processors
+### process.cpu.count
 
-Process threads count.
+Process processor (CPU cores) count.
 
 | Units         | Instrument Type         | Value Type |
 |---------------|-------------------------|------------|

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -102,6 +102,10 @@ The number of processors (CPU cores) available to the current process.
 
 The API used to retrieve the value is [System.Environment.ProcessorCount](https://learn.microsoft.com/dotnet/api/system.environment.processorcount).
 
+Note:
+This metric is under [discussion](https://github.com/open-telemetry/opentelemetry-specification/issues/3200)
+and not part of the [Process Metrics Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md) at this time.
+
 ### process.threads
 
 Process threads count.

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -92,23 +92,6 @@ Gets the user processor time for this process.
 * [Process.PrivilegedProcessorTime](https://learn.microsoft.com/dotnet/api/system.diagnostics.process.privilegedprocessortime):
 Gets the privileged processor time for this process.
 
-### process.cpu.utilization
-
-Difference in process.cpu.time since the last measurement,
-divided by the elapsed time and number of CPUs available to the process.
-
-| Units | Instrument Type   | Value Type | Attribute Key(s) | Attribute Values |
-|-------|-------------------|------------|------------------|------------------|
-|  `1`  | ObservableCounter | `Double`   | state            | user, system     |
-
-The APIs used to retrieve the values are:
-
-* [Process.UserProcessorTime](https://learn.microsoft.com/dotnet/api/system.diagnostics.process.userprocessortime):
-Gets the user processor time for this process.
-
-* [Process.PrivilegedProcessorTime](https://learn.microsoft.com/dotnet/api/system.diagnostics.process.privilegedprocessortime):
-Gets the privileged processor time for this process.
-
 ### process.threads
 
 Process threads count.

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -94,7 +94,7 @@ Gets the privileged processor time for this process.
 
 ### process.cpu.count
 
-Process processor (CPU cores) count.
+Process processors (CPU cores) count.
 
 | Units         | Instrument Type         | Value Type |
 |---------------|-------------------------|------------|

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -103,8 +103,11 @@ The number of processors (CPU cores) available to the current process.
 The API used to retrieve the value is [System.Environment.ProcessorCount](https://learn.microsoft.com/dotnet/api/system.environment.processorcount).
 
 Note:
-This metric is under [discussion](https://github.com/open-telemetry/opentelemetry-specification/issues/3200)
-and not part of the [Process Metrics Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md) at this time.
+This metric is under [discussion][1] and not part of the
+[Process Metrics Spec][2] at this time.
+
+[1]: https://github.com/open-telemetry/opentelemetry-specification/issues/3200
+[2]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md
 
 ### process.threads
 

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -100,11 +100,7 @@ The number of processors (CPU cores) available to the current process.
 |---------------|-------------------------|------------|
 | `{processors}`| ObservableUpDownCounter | `Int32`    |
 
-The API used to retrieve the value is:
-
-* [Process.processors](https://learn.microsoft.com/dotnet/api/system.environment.processorcount):
-Gets the number of processors available
-to the current process.
+The API used to retrieve the value is [System.Environment.ProcessorCount](https://learn.microsoft.com/dotnet/api/system.environment.processorcount).
 
 ### process.threads
 

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -45,9 +45,9 @@ public class ProcessMetricsTests
         Assert.NotNull(virtualMemoryMetric);
         var cpuTimeMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.time");
         Assert.NotNull(cpuTimeMetric);
-        var processorCountMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.processors");
+        var processorCountMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.count");
         Assert.NotNull(processorCountMetric);
-        var threadMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.threads");
+        var threadMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.count");
         Assert.NotNull(threadMetric);
 
         exportedItemsA.Clear();
@@ -151,7 +151,7 @@ public class ProcessMetricsTests
         Assert.NotNull(virtualMemoryMetricA);
         var cpuTimeMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.time");
         Assert.NotNull(cpuTimeMetricA);
-        var processorCountMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.processors");
+        var processorCountMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.count");
         Assert.NotNull(processorCountMetricA);
         var threadMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.threads");
         Assert.NotNull(threadMetricA);
@@ -163,7 +163,7 @@ public class ProcessMetricsTests
         Assert.NotNull(virtualMemoryMetricB);
         var cpuTimeMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.cpu.time");
         Assert.NotNull(cpuTimeMetricB);
-        var processorCountMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.processors");
+        var processorCountMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.cpu.count");
         Assert.NotNull(processorCountMetricB);
         var threadMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.threads");
         Assert.NotNull(threadMetricB);

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -16,6 +16,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using OpenTelemetry.Metrics;
 using Xunit;
 
@@ -28,25 +30,44 @@ public class ProcessMetricsTests
     [Fact]
     public void ProcessMetricsAreCaptured()
     {
-        var exportedItems = new List<Metric>();
-        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+        var exportedItemsA = new List<Metric>();
+        var meterProviderA = Sdk.CreateMeterProviderBuilder()
             .AddProcessInstrumentation()
-            .AddInMemoryExporter(exportedItems)
+            .AddInMemoryExporter(exportedItemsA)
             .Build();
 
-        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+        meterProviderA.ForceFlush(MaxTimeToAllowForFlush);
 
-        Assert.True(exportedItems.Count == 5);
-        var physicalMemoryMetric = exportedItems.FirstOrDefault(i => i.Name == "process.memory.usage");
+        Assert.True(exportedItemsA.Count == 4);
+        var physicalMemoryMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetric);
-        var virtualMemoryMetric = exportedItems.FirstOrDefault(i => i.Name == "process.memory.virtual");
+        var virtualMemoryMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.virtual");
         Assert.NotNull(virtualMemoryMetric);
-        var cpuTimeMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.time");
+        var cpuTimeMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.time");
         Assert.NotNull(cpuTimeMetric);
-        var cpuUtilizationMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.utilization");
-        Assert.NotNull(cpuUtilizationMetric);
-        var threadMetric = exportedItems.FirstOrDefault(i => i.Name == "process.threads");
+        var threadMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.threads");
         Assert.NotNull(threadMetric);
+
+        exportedItemsA.Clear();
+
+        var exportedItemsB = new List<Metric>();
+
+        using var meterProviderB = Sdk.CreateMeterProviderBuilder()
+            .AddProcessInstrumentation()
+            .AddInMemoryExporter(exportedItemsA, metricReaderOptions =>
+            {
+                metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 1500;
+            })
+            .AddInMemoryExporter(exportedItemsB, metricReaderOptions =>
+            {
+                metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 5000;
+            })
+            .Build();
+
+        meterProviderB.ForceFlush(MaxTimeToAllowForFlush);
+
+        Assert.True(exportedItemsA.Count == 4);
+        Assert.True(exportedItemsB.Count == 4);
     }
 
     [Fact]
@@ -87,44 +108,62 @@ public class ProcessMetricsTests
     }
 
     [Fact]
-    public void CpuUtilizationMetricsAreCaptured()
+    public void ProcessMetricsAreCapturedWhenTasksOverlap()
     {
-        var exportedItems = new List<Metric>();
-        using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddProcessInstrumentation()
-            .AddInMemoryExporter(exportedItems)
-            .Build();
+        var exportedItemsA = new List<Metric>();
+        var exportedItemsB = new List<Metric>();
 
-        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-
-        var cpuUtilizationMetric = exportedItems.FirstOrDefault(i => i.Name == "process.cpu.utilization");
-        Assert.NotNull(cpuUtilizationMetric);
-
-        var userCpuUtilizationCaptured = false;
-        var systemCpuUtilizationCaptured = false;
-
-        var iter = cpuUtilizationMetric.GetMetricPoints().GetEnumerator();
-        while (iter.MoveNext() && (!userCpuUtilizationCaptured || !systemCpuUtilizationCaptured))
+        var tasks = new List<Task>()
         {
-            foreach (var tag in iter.Current.Tags)
+            Task.Run(() =>
             {
-                if (tag.Key == "state" && tag.Value.ToString() == "user")
-                {
-                    userCpuUtilizationCaptured = true;
-                }
-                else if (tag.Key == "state" && tag.Value.ToString() == "system")
-                {
-                    systemCpuUtilizationCaptured = true;
-                }
-            }
-        }
+                var meterProviderA = Sdk.CreateMeterProviderBuilder()
+                    .AddProcessInstrumentation()
+                    .AddInMemoryExporter(exportedItemsA)
+                    .Build();
 
-        Assert.True(userCpuUtilizationCaptured);
-        Assert.True(systemCpuUtilizationCaptured);
+                Thread.Sleep(3000); // increase the odds of 2 tasks overlaps
+
+                meterProviderA.ForceFlush(MaxTimeToAllowForFlush);
+            }),
+
+            Task.Run(() =>
+            {
+                var meterProviderB = Sdk.CreateMeterProviderBuilder()
+                    .AddProcessInstrumentation()
+                    .AddInMemoryExporter(exportedItemsB)
+                    .Build();
+
+                Thread.Sleep(3000); // increase the odds of 2 tasks overlaps
+
+                meterProviderB.ForceFlush(MaxTimeToAllowForFlush);
+            }),
+        };
+
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.True(exportedItemsA.Count == 4);
+        var physicalMemoryMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.usage");
+        Assert.NotNull(physicalMemoryMetricA);
+        var virtualMemoryMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.virtual");
+        Assert.NotNull(virtualMemoryMetricA);
+        var cpuTimeMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.time");
+        Assert.NotNull(cpuTimeMetricA);
+        var threadMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.threads");
+        Assert.NotNull(threadMetricA);
+
+        Assert.True(exportedItemsB.Count == 4);
+        var physicalMemoryMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.memory.usage");
+        Assert.NotNull(physicalMemoryMetricB);
+        var virtualMemoryMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.memory.virtual");
+        Assert.NotNull(virtualMemoryMetricB);
+        var cpuTimeMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.cpu.time");
+        Assert.NotNull(cpuTimeMetricB);
+        var threadMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.threads");
+        Assert.NotNull(threadMetricB);
     }
 
-    // See: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/831
-    [Fact(Skip = "There are known issues with this test.")]
+    [Fact]
     public void CheckValidGaugeValueWhen2MeterProviderInstancesHaveTheSameMeterName()
     {
         var exportedItemsA = new List<Metric>();
@@ -173,8 +212,6 @@ public class ProcessMetricsTests
 
         meterProviderA.ForceFlush(MaxTimeToAllowForFlush);
 
-        // Note: This fails due to:
-        // https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Metrics/MetricReaderExt.cs#L244-L249
         Assert.NotEmpty(exportedItemsA);
         Assert.Empty(exportedItemsB);
     }

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -38,13 +38,15 @@ public class ProcessMetricsTests
 
         meterProviderA.ForceFlush(MaxTimeToAllowForFlush);
 
-        Assert.True(exportedItemsA.Count == 4);
+        Assert.True(exportedItemsA.Count == 5);
         var physicalMemoryMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetric);
         var virtualMemoryMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.virtual");
         Assert.NotNull(virtualMemoryMetric);
         var cpuTimeMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.time");
         Assert.NotNull(cpuTimeMetric);
+        var processorCountMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.processors");
+        Assert.NotNull(processorCountMetric);
         var threadMetric = exportedItemsA.FirstOrDefault(i => i.Name == "process.threads");
         Assert.NotNull(threadMetric);
 
@@ -66,8 +68,8 @@ public class ProcessMetricsTests
 
         meterProviderB.ForceFlush(MaxTimeToAllowForFlush);
 
-        Assert.True(exportedItemsA.Count == 4);
-        Assert.True(exportedItemsB.Count == 4);
+        Assert.True(exportedItemsA.Count == 5);
+        Assert.True(exportedItemsB.Count == 5);
     }
 
     [Fact]
@@ -142,23 +144,27 @@ public class ProcessMetricsTests
 
         Task.WaitAll(tasks.ToArray());
 
-        Assert.True(exportedItemsA.Count == 4);
+        Assert.True(exportedItemsA.Count == 5);
         var physicalMemoryMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetricA);
         var virtualMemoryMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.virtual");
         Assert.NotNull(virtualMemoryMetricA);
         var cpuTimeMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.time");
         Assert.NotNull(cpuTimeMetricA);
+        var processorCountMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.processors");
+        Assert.NotNull(processorCountMetricA);
         var threadMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.threads");
         Assert.NotNull(threadMetricA);
 
-        Assert.True(exportedItemsB.Count == 4);
+        Assert.True(exportedItemsB.Count == 5);
         var physicalMemoryMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetricB);
         var virtualMemoryMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.memory.virtual");
         Assert.NotNull(virtualMemoryMetricB);
         var cpuTimeMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.cpu.time");
         Assert.NotNull(cpuTimeMetricB);
+        var processorCountMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.processors");
+        Assert.NotNull(processorCountMetricB);
         var threadMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.threads");
         Assert.NotNull(threadMetricB);
     }


### PR DESCRIPTION
Based on spec discussion: https://github.com/open-telemetry/opentelemetry-specification/pull/2392#discussion_r832488855
Related to: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/972.

## Changes

Exposed required metric `process.processors` for computing CPU utilization in the backend.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
