### PR TITLE
An example / proof of concept for stratified sampling in OpenTelemetry.NET

### DIFF
--- a/examples/sampling/stratified-sampling/Examples.StratifiedSamplingByQueryType.csproj
+++ b/examples/sampling/stratified-sampling/Examples.StratifiedSamplingByQueryType.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0-rc.1" />
+  </ItemGroup>
+
+</Project>

--- a/examples/sampling/stratified-sampling/Program.cs
+++ b/examples/sampling/stratified-sampling/Program.cs
@@ -1,0 +1,72 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace StratifiedSamplingByQueryTypeDemo;
+
+internal class Program
+{
+    private static readonly ActivitySource MyActivitySource = new("StratifiedSampling.POC");
+
+    public static void Main(string[] args)
+    {
+        // We wrap the stratified sampler within a parentbased sampler.
+        // This is to enable downstream participants (i.e., the non-root spans) to have
+        // the same consistent sampling decision as the root span (that uses the stratified sampler).
+        // Such downstream participants may not have access to the same attributes that were used to
+        // make the stratified sampling decision at the root.
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .SetSampler(new ParentBasedSampler(new StratifiedSampler()))
+            .AddSource("StratifiedSampling.POC")
+            .AddConsoleExporter()
+            .Build();
+
+        var random = new Random(2357);
+        var tagsList = new List<KeyValuePair<string, object?>>(1);
+
+        // Generate some spans
+        for (var i = 0; i < 20; i++)
+        {
+            // Simulate a mix of user-initiated (25%) and programmatic (75%) queries
+            var randomValue = random.Next(4);
+            switch (randomValue)
+            {
+                case 0:
+                    tagsList.Add(new KeyValuePair<string, object?>("queryType", "userInitiated"));
+                    break;
+                default:
+                    tagsList.Add(new KeyValuePair<string, object?>("queryType", "programmatic"));
+                    break;
+            }
+
+            // Note that the queryType attribute here is present as part of the tags list when the activity is started.
+            // We are using this attribute value to achieve stratified sampling.
+            using (var activity = MyActivitySource.StartActivity(ActivityKind.Internal, parentContext: default, tags: tagsList))
+            {
+                activity?.SetTag("foo", "bar");
+                using (var activity2 = MyActivitySource.StartActivity(ActivityKind.Internal, parentContext: default, tags: tagsList))
+                {
+                    activity2?.SetTag("foo", "child");
+                }
+            }
+
+            tagsList.Clear();
+        }
+    }
+}

--- a/examples/sampling/stratified-sampling/README.md
+++ b/examples/sampling/stratified-sampling/README.md
@@ -1,21 +1,25 @@
 # StratifiedSampling in OpenTelemetry .NET - Example
 
-This is a proof of concept for how we can achieve stratified sampling in OpenTelemetry.
-This is based on an example scenario of requiring different sampling rates depending on
-whether the query is user-initiated or programmatic query.
+This is a proof of concept for how we can achieve stratified sampling in
+OpenTelemetry. This is based on an example scenario of requiring different
+sampling rates depending on whether the query is user-initiated or
+programmatic query.
 
-Stratified sampling is a way to divide a population (e.g., "all queries to a service") into mutually
-exclusive sub-populations aka "strata". For example, the strata here are "all user-initiated queries",
-"all programmatic queries". Each stratum is then sampled using a probabilistic sampling method.
-This ensures that all sub-populations are represented.
+Stratified sampling is a way to divide a population into mutually exclusive
+sub-populations aka "strata". For example, the strata for a population of
+"queries" could be "user-initiated queries" and "programmatic queries". Each
+stratum is then sampled using a probabilistic sampling method. This ensures
+that all sub-populations are represented.
 
-We use disproportionate stratified sampling here - i.e., the sample size of each sub-population here
-is not proportionate to their occurrence in the overall population - in this example, we want to ensure
-that all user-initiated queries are represented, so we use a 100% sampling rate for it, while the sampling
+We use disproportionate stratified sampling here - i.e., the sample size of
+each sub-population is not proportionate to their occurrence in the overall
+population. In this example, we want to ensure that all user initiated queries
+are represented, so we use a 100% sampling rate for it, while the sampling
 rate chosen for programmatic queries is much lower.
 
-You should see the following output on the Console when you run this application. This shows that the
-two sub-populations (strata) are being sampled independently.
+You should see the following output on the Console when you run this
+application. This shows that the two sub-populations (strata) are being
+sampled independently.
 
 ```text
 StratifiedSampler handling userinitiated query

--- a/examples/sampling/stratified-sampling/README.md
+++ b/examples/sampling/stratified-sampling/README.md
@@ -1,0 +1,215 @@
+# StratifiedSampling in OpenTelemetry .NET - Example
+
+This is a proof of concept for how we can achieve stratified sampling in OpenTelemetry.
+This is based on an example scenario of requiring different sampling rates depending on
+whether the query is user-initiated or programmatic query.
+
+Stratified sampling is a way to divide a population (e.g., "all queries to a service") into mutually
+exclusive sub-populations aka "strata". For example, the strata here are "all user-initiated queries",
+"all programmatic queries". Each stratum is then sampled using a probabilistic sampling method.
+This ensures that all sub-populations are represented.
+
+We use disproportionate stratified sampling here - i.e., the sample size of each sub-population here
+is not proportionate to their occurrence in the overall population - in this example, we want to ensure
+that all user-initiated queries are represented, so we use a 100% sampling rate for it, while the sampling
+rate chosen for programmatic queries is much lower.
+
+You should see the following output on the Console when you run this application. This shows that the
+two sub-populations (strata) are being sampled independently.
+
+```text
+StratifiedSampler handling userinitiated query
+Activity.TraceId:            1a122d63e5f8d32cb8ebd3e402eb5389
+Activity.SpanId:             83bdc6bbebea1df8
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       1ddd00d845ad645e
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.8156879Z
+Activity.Duration:           00:00:00.0008656
+Activity.Tags:
+    queryType: userInitiated
+    foo: child
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+Activity.TraceId:            1a122d63e5f8d32cb8ebd3e402eb5389
+Activity.SpanId:             1ddd00d845ad645e
+Activity.TraceFlags:         Recorded
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.8115186Z
+Activity.Duration:           00:00:00.0424036
+Activity.Tags:
+    queryType: userInitiated
+    foo: bar
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+Activity.TraceId:            03cddefbc0e0f61851135f814522a2df
+Activity.SpanId:             8d4fa3e27a12f666
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       8c46e4dc6d0f418c
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.8553756Z
+Activity.Duration:           00:00:00.0000019
+Activity.Tags:
+    queryType: programmatic
+    foo: child
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+Activity.TraceId:            03cddefbc0e0f61851135f814522a2df
+Activity.SpanId:             8c46e4dc6d0f418c
+Activity.TraceFlags:         Recorded
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.8553725Z
+Activity.Duration:           00:00:00.0069444
+Activity.Tags:
+    queryType: programmatic
+    foo: bar
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+StratifiedSampler handling programmatic query
+Activity.TraceId:            10f215a7ee6407da59d2601e39592c2a
+Activity.SpanId:             ec3e18694b8cd7cc
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       4df9f9b40b3d009b
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.8851028Z
+Activity.Duration:           00:00:00.0000013
+Activity.Tags:
+    queryType: programmatic
+    foo: child
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+Activity.TraceId:            10f215a7ee6407da59d2601e39592c2a
+Activity.SpanId:             4df9f9b40b3d009b
+Activity.TraceFlags:         Recorded
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.8850839Z
+Activity.Duration:           00:00:00.0099928
+Activity.Tags:
+    queryType: programmatic
+    foo: bar
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+Activity.TraceId:            e8659bfb274033b680783301ba46d406
+Activity.SpanId:             e03667a2841594b5
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       99888344a37cb573
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.9198094Z
+Activity.Duration:           00:00:00.0000006
+Activity.Tags:
+    queryType: programmatic
+    foo: child
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+Activity.TraceId:            e8659bfb274033b680783301ba46d406
+Activity.SpanId:             99888344a37cb573
+Activity.TraceFlags:         Recorded
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.9198062Z
+Activity.Duration:           00:00:00.0091424
+Activity.Tags:
+    queryType: programmatic
+    foo: bar
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+Activity.TraceId:            e80614a36538d9c101d39dc2c449cde6
+Activity.SpanId:             729f8c6d00b7dd4c
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       f76127b28c07d082
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.9485531Z
+Activity.Duration:           00:00:00.0000009
+Activity.Tags:
+    queryType: programmatic
+    foo: child
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+Activity.TraceId:            e80614a36538d9c101d39dc2c449cde6
+Activity.SpanId:             f76127b28c07d082
+Activity.TraceFlags:         Recorded
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.9485488Z
+Activity.Duration:           00:00:00.0078570
+Activity.Tags:
+    queryType: programmatic
+    foo: bar
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling userinitiated query
+Activity.TraceId:            8a5894524f1bea2a7bd8271fef9ec22d
+Activity.SpanId:             94b5b004287bd678
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       99600e9fe011c1cc
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.9660777Z
+Activity.Duration:           00:00:00.0000005
+Activity.Tags:
+    queryType: userInitiated
+    foo: child
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+Activity.TraceId:            8a5894524f1bea2a7bd8271fef9ec22d
+Activity.SpanId:             99600e9fe011c1cc
+Activity.TraceFlags:         Recorded
+Activity.ActivitySourceName: StratifiedSampling.POC
+Activity.DisplayName:        Main
+Activity.Kind:               Internal
+Activity.StartTime:          2023-02-09T05:19:30.9660744Z
+Activity.Duration:           00:00:00.0230182
+Activity.Tags:
+    queryType: userInitiated
+    foo: bar
+Resource associated with Activity:
+    service.name: unknown_service:Examples.StratifiedSamplingByQueryType
+
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+StratifiedSampler handling programmatic query
+```

--- a/examples/sampling/stratified-sampling/StratifiedSampler.cs
+++ b/examples/sampling/stratified-sampling/StratifiedSampler.cs
@@ -1,0 +1,89 @@
+// <copyright file="StratifiedSampler.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Trace;
+
+namespace StratifiedSamplingByQueryTypeDemo;
+
+// This is a Proof of Concept of a composite sampler that can used to
+// achieve stratified sampling. It shows how to use one or more span attributes
+// (that need to be available at the start of an activity) to perform stratified sampling.
+// Important considerations:
+// 1. This should be used as a root sampler in a ParentBasedSampler.
+// 2. This approach will work only when you have control over the root span creation
+// and you are able to pass the required span attributes. Instead, if the root span was
+// be created by an instrumentation library, this example, as currently authored,
+// cannot be used.
+internal class StratifiedSampler : Sampler
+{
+    // For this POC, we have two groups.
+    // 0 is the group corresponding to user-initiated queries where we want a 100% sampling rate.
+    // 1 is the group corresponding to programmatic queries where we want a lower sampling rate, say 10%
+    private const int NumGroups = 2;
+    private const string QueryTypeTag = "queryType";
+    private const string QueryTypeUserInitiated = "userInitiated";
+    private const string QueryTypeProgrammatic = "programmatic";
+
+    private readonly Dictionary<int, double> samplingRatios = new();
+    private readonly List<Sampler> samplers = new();
+
+    public StratifiedSampler()
+    {
+        // Initialize sampling ratios for different groups
+        this.samplingRatios[0] = 1.0;
+        this.samplingRatios[1] = 0.2;
+
+        for (var i = 0; i < NumGroups; i++)
+        {
+            this.samplers.Add(new TraceIdRatioBasedSampler(this.samplingRatios[i]));
+        }
+    }
+
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    {
+        if (samplingParameters.Tags != null)
+        {
+            foreach (var tag in samplingParameters.Tags)
+            {
+                if (tag.Key.Equals(QueryTypeTag, StringComparison.OrdinalIgnoreCase))
+                {
+                    var queryType = tag.Value as string;
+                    if (queryType == null)
+                    {
+                        continue;
+                    }
+
+                    if (queryType.Equals(QueryTypeUserInitiated, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Console.WriteLine($"StratifiedSampler handling userinitiated query");
+                        return this.samplers[0].ShouldSample(samplingParameters);
+                    }
+                    else if (queryType.Equals(QueryTypeProgrammatic, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Console.WriteLine($"StratifiedSampler handling programmatic query");
+                        return this.samplers[1].ShouldSample(samplingParameters);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Unexpected query type");
+                    }
+                }
+            }
+        }
+
+        return new SamplingResult(SamplingDecision.Drop);
+    }
+}

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -239,6 +239,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "process-instrumentation", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.EventCounters", "examples\event-counters\Examples.EventCounters\Examples.EventCounters.csproj", "{BA58CC8B-F5CA-4DC7-A3A8-D01B2E10731E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sampling", "sampling", "{622F0CF0-3844-4D0B-B1B4-23FA04BFC66F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stratified-sampling", "stratified-sampling", "{C48EADD1-A889-4678-946E-70572F7B99EC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.StratifiedSamplingByQueryType", "examples\sampling\stratified-sampling\Examples.StratifiedSamplingByQueryType.csproj", "{63E17627-FE07-47BC-A5A8-A30B4198A0FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -501,6 +507,10 @@ Global
 		{BA58CC8B-F5CA-4DC7-A3A8-D01B2E10731E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA58CC8B-F5CA-4DC7-A3A8-D01B2E10731E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA58CC8B-F5CA-4DC7-A3A8-D01B2E10731E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63E17627-FE07-47BC-A5A8-A30B4198A0FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63E17627-FE07-47BC-A5A8-A30B4198A0FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63E17627-FE07-47BC-A5A8-A30B4198A0FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63E17627-FE07-47BC-A5A8-A30B4198A0FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -578,6 +588,9 @@ Global
 		{B40B975E-78B2-4712-8B4D-BADA67DF0C0A} = {22DF5DC0-1290-4E83-A9D8-6BB7DE3B3E63}
 		{C3B3BBAF-CC38-4D5C-AFA2-33184D07BF75} = {B75EE478-97F7-4E9F-9A5A-DB3D0988EDEA}
 		{BA58CC8B-F5CA-4DC7-A3A8-D01B2E10731E} = {B75EE478-97F7-4E9F-9A5A-DB3D0988EDEA}
+		{622F0CF0-3844-4D0B-B1B4-23FA04BFC66F} = {B75EE478-97F7-4E9F-9A5A-DB3D0988EDEA}
+		{C48EADD1-A889-4678-946E-70572F7B99EC} = {622F0CF0-3844-4D0B-B1B4-23FA04BFC66F}
+		{63E17627-FE07-47BC-A5A8-A30B4198A0FE} = {C48EADD1-A889-4678-946E-70572F7B99EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}


### PR DESCRIPTION
This is an example / proof of concept for a basic stratified sampling in OpenTelemetry.NET. 

Fixes #984 .

## Changes

Certain customers using OpenTelemetry want to do achieve stratified sampling. Stratified sampling is a way to divide a population (e.g., "all queries to a service") into mutually exclusive sub-populations aka "strata". For example, the strata here could be "all user-initiated queries", "all programmatic queries". Each stratum is then sampled using a probabilistic sampling method. This ensures that all sub-populations are represented. 

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
