### PR TITLE
Create GitHub releases

### DIFF
--- a/.github/workflows/package-Exporter.Geneva.yml
+++ b/.github/workflows/package-Exporter.Geneva.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Exporter.Geneva
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Exporter.Geneva.yml
+++ b/.github/workflows/package-Exporter.Geneva.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Exporter.Instana.yml
+++ b/.github/workflows/package-Exporter.Instana.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Exporter.Instana.yml
+++ b/.github/workflows/package-Exporter.Instana.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Exporter.Instana
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Exporter.Stackdriver.yml
+++ b/.github/workflows/package-Exporter.Stackdriver.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Exporter.Stackdriver.yml
+++ b/.github/workflows/package-Exporter.Stackdriver.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Exporter.Stackdriver
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.AWSXRay.yml
+++ b/.github/workflows/package-Extensions.AWSXRay.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.AWSXRay.yml
+++ b/.github/workflows/package-Extensions.AWSXRay.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Contrib.Extensions.AWSXRay
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.AzureMonitor.yml
+++ b/.github/workflows/package-Extensions.AzureMonitor.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.AzureMonitor.yml
+++ b/.github/workflows/package-Extensions.AzureMonitor.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Extensions.AzureMonitor
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.Docker.yml
+++ b/.github/workflows/package-Extensions.Docker.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.Docker.yml
+++ b/.github/workflows/package-Extensions.Docker.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Extensions.Docker
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
@@ -51,7 +51,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.Abstractions.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Extensions.PersistentStorage.Abstractions
 
@@ -48,3 +50,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.PersistentStorage.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.PersistentStorage.yml
+++ b/.github/workflows/package-Extensions.PersistentStorage.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Extensions.PersistentStorage
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.yml
+++ b/.github/workflows/package-Extensions.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Extensions.yml
+++ b/.github/workflows/package-Extensions.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Extensions
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AWS.yml
+++ b/.github/workflows/package-Instrumentation.AWS.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AWS.yml
+++ b/.github/workflows/package-Instrumentation.AWS.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Contrib.Instrumentation.AWS
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AWSLambda.yml
+++ b/.github/workflows/package-Instrumentation.AWSLambda.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AWSLambda.yml
+++ b/.github/workflows/package-Instrumentation.AWSLambda.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.AWSLambda
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AspNet.TelemetryHttpModule.yml
+++ b/.github/workflows/package-Instrumentation.AspNet.TelemetryHttpModule.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AspNet.TelemetryHttpModule.yml
+++ b/.github/workflows/package-Instrumentation.AspNet.TelemetryHttpModule.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AspNet.yml
+++ b/.github/workflows/package-Instrumentation.AspNet.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.AspNet.yml
+++ b/.github/workflows/package-Instrumentation.AspNet.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.AspNet
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Elasticsearch.yml
+++ b/.github/workflows/package-Instrumentation.Elasticsearch.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Elasticsearch.yml
+++ b/.github/workflows/package-Instrumentation.Elasticsearch.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.ElasticsearchClient
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
+++ b/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
+++ b/.github/workflows/package-Instrumentation.EntityFrameworkCore.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.EntityFrameworkCore
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.EventCounters.yml
+++ b/.github/workflows/package-Instrumentation.EventCounters.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.EventCounters
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.EventCounters.yml
+++ b/.github/workflows/package-Instrumentation.EventCounters.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.GrpcCore.yml
+++ b/.github/workflows/package-Instrumentation.GrpcCore.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.GrpcCore.yml
+++ b/.github/workflows/package-Instrumentation.GrpcCore.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.GrpcCore
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Hangfire.yml
+++ b/.github/workflows/package-Instrumentation.Hangfire.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Hangfire.yml
+++ b/.github/workflows/package-Instrumentation.Hangfire.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.Hangfire
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.MySqlData.yml
+++ b/.github/workflows/package-Instrumentation.MySqlData.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.MySqlData.yml
+++ b/.github/workflows/package-Instrumentation.MySqlData.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.MySqlData
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Owin.yml
+++ b/.github/workflows/package-Instrumentation.Owin.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Owin.yml
+++ b/.github/workflows/package-Instrumentation.Owin.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.Owin
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Process.yml
+++ b/.github/workflows/package-Instrumentation.Process.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.Process
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Process.yml
+++ b/.github/workflows/package-Instrumentation.Process.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Quartz.yml
+++ b/.github/workflows/package-Instrumentation.Quartz.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Quartz.yml
+++ b/.github/workflows/package-Instrumentation.Quartz.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.Quartz
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Runtime.yml
+++ b/.github/workflows/package-Instrumentation.Runtime.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Runtime.yml
+++ b/.github/workflows/package-Instrumentation.Runtime.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.Runtime
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
+++ b/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
+++ b/.github/workflows/package-Instrumentation.StackExchangeRedis.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.StackExchangeRedis
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Wcf.yml
+++ b/.github/workflows/package-Instrumentation.Wcf.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-Instrumentation.Wcf.yml
+++ b/.github/workflows/package-Instrumentation.Wcf.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.Instrumentation.Wcf
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-ResourceDetectors.Azure.yml
+++ b/.github/workflows/package-ResourceDetectors.Azure.yml
@@ -54,7 +54,14 @@ jobs:
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+    - name: Create GitHub Prerelease
+      if: ${{ (contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create GitHub Release
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      if: ${{ !(contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.')) }}
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --notes "See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/${{ github.ref_name }}/src/${{env.PROJECT}}/CHANGELOG.md) for details." --latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-ResourceDetectors.Azure.yml
+++ b/.github/workflows/package-ResourceDetectors.Azure.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-test-pack:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     env:
       PROJECT: OpenTelemetry.ResourceDetectors.Azure
 
@@ -51,3 +53,8 @@ jobs:
     - name: Publish Nuget
       run: |
         nuget push **/${{env.PROJECT}}/bin/**/*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
+
+    - name: Create GitHub Release
+      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --verify-tag --draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -34,7 +34,7 @@ on the `main` branch is the one which added/updated the Changelog to
 the project being released. *This latest commit will be tagged on the release.*
 
 1. Create and push git tag for the project and the version of the project
-you want to release. The version shoud the one used in the **Pre-steps** to
+you want to release. The version should be the one used in the **Pre-steps** to
 update the Changelog.
 
     ```powershell
@@ -74,9 +74,4 @@ release page.
 3. Validate that the new version (as specified in step 1) of the project is
 successfully published to nuget.org under OpenTelemetry owner.
 
-4. Publish a release in GitHub:
-
-   - Use draft created by "Pack YOUR_PROJECT_NAME" GitHub workflow.
-   - Use the appropriate CHANGELOG.md content in the description.
-   - Set as a pre-release if it not stable release.
-   - Set as the latest release if you releasing stable version.
+4. Validate that the new version was published in GitHub.

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -68,7 +68,15 @@ update the Changelog.
 2. Navigate to the
 [**Actions**](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions)
 tab on the repo and monitor the "Pack YOUR_PROJECT_NAME" workflow. The last step
-in the workflow is to publish to Nuget.org.
+in the workflow is to publish to Nuget.org and prepare corresponding github
+release page.
 
-3. Validate that the new version (as specified in step1) of the project is
+3. Validate that the new version (as specified in step 1) of the project is
 successfully published to nuget.org under OpenTelemetry owner.
+
+4. Publish a release in GitHub:
+
+   - Use draft created by "Pack YOUR_PROJECT_NAME" GitHub workflow.
+   - Use the appropriate CHANGELOG.md content in the description.
+   - Set as a pre-release if it not stable release.
+   - Set as the latest release if you releasing stable version.


### PR DESCRIPTION
Fixes N/A

## Changes

Extend releasing process.
Automate creating GitHub releases for each package.
Current, tags-only approach does not create GitHub notifications about new releases. 
On the GitHub you can subscribe for the new releases
![image](https://user-images.githubusercontent.com/5972917/217743718-564b150f-aff3-426d-a636-66571cd8007c.png)

Tested on my fork with disabled nuget.org step:
![image](https://user-images.githubusercontent.com/5972917/217743355-34cd5668-54f3-4b52-ba29-294071bf2266.png)


For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
