### PR TITLE
First step towards decoupling the CI

### DIFF
--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ 'main*' ]
     paths:
-    - '.github/workflows/ci-Instrumentation.Process.yml'
     - 'src/OpenTelemetry.Instrumentation.Process/**'
     - 'test/OpenTelemetry.Instrumentation.Process.Tests/**'
 

--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         dotnet-version: '7.0.x'
 
-    - name: Build
+    - name: Build OpenTelemetry.Instrumentation.Process
       run: dotnet build --configuration Release test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
 
     - name: Test ${{ matrix.version }}

--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -1,14 +1,18 @@
 name: Build
 
 on:
-  push:
-    branches: [ 'main*', 'instrumentation*', 'exporter*', 'extensions*' ]
-    paths-ignore:
-    - '**.md'
   pull_request:
-    branches: [ 'main*', 'instrumentation*', 'exporter*', 'extensions*' ]
-    paths-ignore:
-    - '**.md'
+    branches: [ 'main*', 'instrumentation*' ]
+    paths:
+    - '.github/**'
+    - 'build/**'
+    - 'src/OpenTelemetry.Instrumentation.Process.Tests/**'
+    - 'src/OpenTelemetry.Internal/**'
+    - 'src/Directory.Build.props'
+    - 'src/Directory.Build.targets'
+    - 'test/OpenTelemetry.Instrumentation.Process.Tests/**'
+    - 'global.json'
+    - 'NuGet.config'
 
 jobs:
   build-test:
@@ -36,11 +40,9 @@ jobs:
       with:
         dotnet-version: '7.0.x'
 
-    - name: Install dependencies
-      run: dotnet restore
-
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
 
     - name: Test ${{ matrix.version }}
-      run: dotnet test **/bin/**/${{ matrix.version }}/*.Tests.dll --logger:"console;verbosity=detailed"
+      run: dotnet test test/OpenTelemetry.Instrumentatio
+  n.Process.Tests/bin/Release/${{ matrix.version }}/OpenTelemetry.Instrumentation.Process.Tests.dll --logger:"console;verbosity=detailed"

--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -4,15 +4,8 @@ on:
   pull_request:
     branches: [ 'main*', 'instrumentation*' ]
     paths:
-    - '.github/**'
-    - 'build/**'
     - 'src/OpenTelemetry.Instrumentation.Process.Tests/**'
-    - 'src/OpenTelemetry.Internal/**'
-    - 'src/Directory.Build.props'
-    - 'src/Directory.Build.targets'
     - 'test/OpenTelemetry.Instrumentation.Process.Tests/**'
-    - 'global.json'
-    - 'NuGet.config'
 
 jobs:
   build-test:

--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build OpenTelemetry.Instrumentation.Process
 
 on:
   pull_request:

--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -1,10 +1,11 @@
-name: Build OpenTelemetry.Instrumentation.Process
+name: OpenTelemetry.Instrumentation.Process
 
 on:
   pull_request:
-    branches: [ 'main*', 'instrumentation*' ]
+    branches: [ 'main*' ]
     paths:
-    - 'src/OpenTelemetry.Instrumentation.Process.Tests/**'
+    - '.github/workflows/ci-Instrumentation.Process.yml'
+    - 'src/OpenTelemetry.Instrumentation.Process/**'
     - 'test/OpenTelemetry.Instrumentation.Process.Tests/**'
 
 jobs:

--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         dotnet-version: '7.0.x'
 
-    - name: Build OpenTelemetry.Instrumentation.Process
+    - name: Build
       run: dotnet build --configuration Release test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
 
     - name: Test ${{ matrix.version }}

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-TBD
-
 ## 1.0.0-alpha.6
 
 Released 2023-Feb-13

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+TBD
+
 ## 1.0.0-alpha.6
 
 Released 2023-Feb-13


### PR DESCRIPTION
As more components being added, CI is getting slower.
This PR is the first step exploring a per-component CI approach.

Here are my thoughts:
* A catch-all CI would still exist, and will only be triggered for any one of the following conditions:
  * The trigger is a pull (PR), and it includes changes to a global file (e.g. CI rules, shared files such as https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Internal
  * The trigger is a push (push should run all the tests)
* If a pull request does not include global changes, it should not trigger the catch-all CI; instead, it will only trigger a component specific CI which saves execution time