### PR TITLE
Add settings for VS Code build support.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "davidanson.vscode-markdownlint",
+    "ms-dotnettools.csharp",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+  "tasks": [
+    {
+      "args": [
+        "build",
+        "${workspaceFolder}/opentelemetry-dotnet-contrib.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "command": "dotnet",
+      "group": {
+        "isDefault": true,
+        "kind": "build"
+      },
+      "label": "build",
+      "problemMatcher": "$msCompile",
+      "type": "process"
+    },
+    {
+      "args": [
+        "test",
+        "${workspaceFolder}/opentelemetry-dotnet-contrib.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "command": "dotnet",
+      "group": {
+        "isDefault": true,
+        "kind": "test"
+      },
+      "label": "test",
+      "problemMatcher": "$msCompile",
+      "type": "process"
+    }
+  ],
+  "version": "2.0.0"
+}


### PR DESCRIPTION
## Changes

- Add `extensions.json` to match [the main `opentelemetry-dotnet` project](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.vscode/extensions.json).
- Add `tasks.json` to execute the build and test from inside VS Code.

This should make it easier for VS Code folks to iterate in their workflow.