### PR TITLE
Updated projects to build better with VS Code / OmniSharp on Mac

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "cSpell.words": [
-        "fluentdData"
+        "awsx",
+        "fluentddata",
+        "otel",
+        "protobuf",
+        "traceparent",
+        "xunit"
     ]
 }

--- a/examples/wcf/shared/Examples.Wcf.Shared.csproj
+++ b/examples/wcf/shared/Examples.Wcf.Shared.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/OpenTelemetry.Contrib.Extensions.AWSXRay.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS X-Ray.</Description>
     <MinVerTagPrefix>Extensions.AWSXRay-</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/OpenTelemetry.Contrib.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/OpenTelemetry.Contrib.Instrumentation.AWS.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <Description>AWS client instrumentation for OpenTelemetry .NET</Description>
 	<MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -5,6 +5,7 @@
     <Description>An OpenTelemetry .NET exporter that exports to local ETW or UDS</Description>
     <Authors>OpenTelemetry Authors</Authors>
     <NoWarn>$(NoWarn),CS1591,SA1123,SA1310,CA1810,CA1822,CA2000,CA2208,SA1201,SA1202,SA1308,SA1309,SA1311,SA1402,SA1602,SA1649</NoWarn>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <MinVerTagPrefix>Exporter.Geneva-</MinVerTagPrefix>

--- a/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
+++ b/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-	<PackageTags>Instana Tracing APM</PackageTags>
-	<Description>Instana .NET Exporter for OpenTelemetry</Description>
-	<MinVerTagPrefix>Exporter.Instana-</MinVerTagPrefix>
+    <PackageTags>Instana Tracing APM</PackageTags>
+    <Description>Instana .NET Exporter for OpenTelemetry</Description>
+    <MinVerTagPrefix>Exporter.Instana-</MinVerTagPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">

--- a/src/OpenTelemetry.Exporter.Stackdriver/OpenTelemetry.Exporter.Stackdriver.csproj
+++ b/src/OpenTelemetry.Exporter.Stackdriver/OpenTelemetry.Exporter.Stackdriver.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Description>Stackdriver .NET Exporter for OpenTelemetry.</Description>
     <PackageTags>$(PackageTags);Stackdriver;Google;GCP;distributed-tracing</PackageTags>

--- a/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/OpenTelemetry.Extensions.AzureMonitor.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">net6.0;$(TargetFrameworks)</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
     <MinVerTagPrefix>Extensions.AzureMonitor-</MinVerTagPrefix>
     <EnableAnalysis>true</EnableAnalysis>
   </PropertyGroup>

--- a/src/OpenTelemetry.Extensions.Docker/OpenTelemetry.Extensions.Docker.csproj
+++ b/src/OpenTelemetry.Extensions.Docker/OpenTelemetry.Extensions.Docker.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Description>OpenTelemetry Extensions - Container Resource Detector from Docker environment.</Description>
     <MinVerTagPrefix>Extensions.Docker-</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/OpenTelemetry.Extensions.PersistentStorage.Abstractions/OpenTelemetry.Extensions.PersistentStorage.Abstractions.csproj
+++ b/src/OpenTelemetry.Extensions.PersistentStorage.Abstractions/OpenTelemetry.Extensions.PersistentStorage.Abstractions.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">net6.0;$(TargetFrameworks)</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
     <Description>OpenTelemetry Persistent Storage Abstractions</Description>
     <MinVerTagPrefix>Extensions.PersistentStorage.Abstractions-</MinVerTagPrefix>
     <NoWarn>$(NoWarn),CA1031</NoWarn>

--- a/src/OpenTelemetry.Extensions.PersistentStorage/OpenTelemetry.Extensions.PersistentStorage.csproj
+++ b/src/OpenTelemetry.Extensions.PersistentStorage/OpenTelemetry.Extensions.PersistentStorage.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">net6.0;$(TargetFrameworks)</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
     <Description>OpenTelemetry Persistent Storage</Description>
     <MinVerTagPrefix>Extensions.PersistentStorage-</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
+++ b/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(TargetFrameworks);net6.0</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>netstandard2.0;net462;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">net6.0;$(TargetFrameworks)</TargetFrameworks> <!-- Added just to get proper nullable analysis in IDE -->
     <Description>OpenTelemetry .NET SDK preview features and extensions</Description>
     <MinVerTagPrefix>Extensions-</MinVerTagPrefix>
     <Nullable>enable</Nullable>

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/OpenTelemetry.Instrumentation.ElasticsearchClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/OpenTelemetry.Instrumentation.ElasticsearchClient.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Description>Elasticsearch instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/AsyncStreamReaderProxy.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/AsyncStreamReaderProxy.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using global::Grpc.Core;
+using Grpc.Core;
 
 namespace OpenTelemetry.Instrumentation.GrpcCore;
 
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 /// https://github.com/opentracing-contrib/csharp-grpc/blob/master/src/OpenTracing.Contrib.Grpc/Streaming/TracingAsyncStreamReader.cs.
 /// </remarks>
 /// <typeparam name="T">The message type.</typeparam>
-/// <seealso cref="global::Grpc.Core.IAsyncStreamReader{T}" />
+/// <seealso cref="IAsyncStreamReader{T}" />
 internal class AsyncStreamReaderProxy<T> : IAsyncStreamReader<T>
 {
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientStreamWriterProxy.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientStreamWriterProxy.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Threading.Tasks;
-using global::Grpc.Core;
+using Grpc.Core;
 
 namespace OpenTelemetry.Instrumentation.GrpcCore;
 
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 /// https://github.com/opentracing-contrib/csharp-grpc/blob/master/src/OpenTracing.Contrib.Grpc/Streaming/TracingClientStreamWriter.cs.
 /// </remarks>
 /// <typeparam name="T">The message type.</typeparam>
-/// <seealso cref="global::Grpc.Core.IClientStreamWriter{T}" />
+/// <seealso cref="IClientStreamWriter{T}" />
 internal class ClientStreamWriterProxy<T> : IClientStreamWriter<T>
 {
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
@@ -17,8 +17,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using global::Grpc.Core;
-using global::Grpc.Core.Interceptors;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 /// <summary>
 /// A client interceptor that starts and stops an Activity for each outbound RPC.
 /// </summary>
-/// <seealso cref="global::Grpc.Core.Interceptors.Interceptor" />
+/// <seealso cref="Interceptor" />
 public class ClientTracingInterceptor : Interceptor
 {
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -18,8 +18,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
-using global::Grpc.Core;
 using Google.Protobuf;
+using Grpc.Core;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.GrpcCore;
@@ -197,7 +197,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
             this.activity.SetTag(SemanticConventions.AttributeRpcGrpcStatusCode, statusCode);
             if (statusDescription != null)
             {
-                this.activity.SetStatus(OpenTelemetry.Trace.Status.Error.WithDescription(statusDescription));
+                this.activity.SetStatus(Trace.Status.Error.WithDescription(statusDescription));
             }
 
             this.activity.Stop();

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerStreamWriterProxy.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerStreamWriterProxy.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Threading.Tasks;
-using global::Grpc.Core;
+using Grpc.Core;
 
 namespace OpenTelemetry.Instrumentation.GrpcCore;
 
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 /// https://github.com/opentracing-contrib/csharp-grpc/blob/master/src/OpenTracing.Contrib.Grpc/Streaming/TracingServerStreamWriter.cs.
 /// </remarks>
 /// <typeparam name="T">The message type.</typeparam>
-/// <seealso cref="global::Grpc.Core.IServerStreamWriter{T}" />
+/// <seealso cref="IServerStreamWriter{T}" />
 internal class ServerStreamWriterProxy<T> : IServerStreamWriter<T>
 {
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
@@ -19,8 +19,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using global::Grpc.Core;
-using global::Grpc.Core.Interceptors;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 /// <summary>
 /// A service interceptor that starts and stops an Activity for each inbound RPC.
 /// </summary>
-/// <seealso cref="global::Grpc.Core.Interceptors.Interceptor" />
+/// <seealso cref="Interceptor" />
 public class ServerTracingInterceptor : Interceptor
 {
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
@@ -126,7 +126,7 @@ internal class HangfireInstrumentationJobFilterAttribute : JobFilterAttribute, I
         return telemetryData.ContainsKey(key) ? new[] { telemetryData[key] } : Enumerable.Empty<string>();
     }
 
-    private void SetStatusAndRecordException(Activity activity, System.Exception exception)
+    private void SetStatusAndRecordException(Activity activity, Exception exception)
     {
         activity.SetStatus(ActivityStatusCode.Error, exception.Message);
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
     <Description>dotnet runtime instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);runtime</PackageTags>
     <MinVerTagPrefix>Instrumentation.Runtime-</MinVerTagPrefix>

--- a/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
+++ b/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Description>OpenTelemetry instrumentation for WCF</Description>
     <PackageTags>$(PackageTags);distributed-tracing;WCF</PackageTags>
     <MinVerTagPrefix>Instrumentation.Wcf-</MinVerTagPrefix>

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Unit test project for AWS X-Ray for OpenTelemetry</Description>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net452</TargetFrameworks>
   </PropertyGroup>

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqNet45PkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/Http/TestServerCertificateValidationProvider.cs
+++ b/test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/Resources/Http/TestServerCertificateValidationProvider.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using OpenTelemetry.Contrib.Extensions.AWSXRay.Resources.Http;
 using Xunit;
@@ -27,23 +28,27 @@ public class TestServerCertificateValidationProvider
     [Fact]
     public void TestValidCertificate()
     {
-        using (CertificateUploader certificateUploader = new CertificateUploader())
+        // This test fails on Linux in netcoreapp3.1, but passes in net6.0 and net7.0.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            certificateUploader.Create();
+            using (CertificateUploader certificateUploader = new CertificateUploader())
+            {
+                certificateUploader.Create();
 
-            // Loads the certificate to the trusted collection from the file
-            ServerCertificateValidationProvider serverCertificateValidationProvider =
-                ServerCertificateValidationProvider.FromCertificateFile(certificateUploader.FilePath);
+                // Loads the certificate to the trusted collection from the file
+                ServerCertificateValidationProvider serverCertificateValidationProvider =
+                    ServerCertificateValidationProvider.FromCertificateFile(certificateUploader.FilePath);
 
-            // Validates if the certificate loaded into the trusted collection.
-            Assert.True(serverCertificateValidationProvider.IsCertificateLoaded);
+                // Validates if the certificate loaded into the trusted collection.
+                Assert.True(serverCertificateValidationProvider.IsCertificateLoaded);
 
-            var certificate = new X509Certificate2(certificateUploader.FilePath);
-            X509Chain chain = new X509Chain();
-            chain.Build(certificate);
+                var certificate = new X509Certificate2(certificateUploader.FilePath);
+                X509Chain chain = new X509Chain();
+                chain.Build(certificate);
 
-            // validates if certificate is valid
-            Assert.True(serverCertificateValidationProvider.ValidationCallback(null, certificate, chain, System.Net.Security.SslPolicyErrors.None));
+                // validates if certificate is valid
+                Assert.True(serverCertificateValidationProvider.ValidationCallback(null, certificate, chain, System.Net.Security.SslPolicyErrors.None));
+            }
         }
     }
 

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.5.0.26" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.2" />
     <PackageReference Include="Moq" Version="$(MoqNet45PkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Unit test project for AWS client instrumentation for OpenTelemetry</Description>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net452</TargetFrameworks>
   </PropertyGroup>

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequest.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/MockHttpRequest.cs
@@ -212,7 +212,7 @@ internal class MockHttpRequest : IHttpRequest<HttpContent>
 
     public Task<HttpContent> GetRequestContentAsync()
     {
-        return Task.FromResult<HttpContent>(new HttpRequestMessage().Content);
+        return Task.FromResult(new HttpRequestMessage().Content);
     }
 
     public IWebResponseData GetResponse()
@@ -227,7 +227,7 @@ internal class MockHttpRequest : IHttpRequest<HttpContent>
     {
         this.GetResponseAction?.Invoke();
         var response = this.ResponseCreator(this);
-        return Task.FromResult<IWebResponseData>(CustomWebResponse.GenerateWebResponse(response));
+        return Task.FromResult(CustomWebResponse.GenerateWebResponse(response));
     }
 
     public void SetRequestHeaders(IDictionary<string, string> headers)

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
@@ -1,21 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-		<OutputType>Exe</OutputType>
-    	<!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
-        <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
-        <NoWarn>$(NoWarn),SA1201,SA1202,SA1204,SA1311,SA1123</NoWarn>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
+    <NoWarn>$(NoWarn),SA1201,SA1202,SA1204,SA1311,SA1123</NoWarn>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPkgVer)" />
-		<PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryLatestPreReleasePkgVer)" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPkgVer)" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryLatestPreReleasePkgVer)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\OpenTelemetry.Exporter.Geneva.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference
+      Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\OpenTelemetry.Exporter.Geneva.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
@@ -15,8 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference
-      Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\OpenTelemetry.Exporter.Geneva.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\OpenTelemetry.Exporter.Geneva.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
@@ -150,8 +150,15 @@ public class UnixDomainSocketDataTransportTests
                 serverSocket.Shutdown(SocketShutdown.Both);
                 serverSocket.Disconnect(false);
                 serverSocket.Dispose();
-                server.Shutdown(SocketShutdown.Both);
-                server.Disconnect(false);
+
+                if (server.Connected)
+                {
+                    // On MacOS the 'server' socket never shows up as connected
+                    // so trying to shutdown/disconnect throws an exception.
+                    server.Shutdown(SocketShutdown.Both);
+                    server.Disconnect(false);
+                }
+
                 server.Dispose();
                 try
                 {

--- a/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Exporter.Stackdriver.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Exporter.Stackdriver.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Extensions.AzureMonitor.Tests/OpenTelemetry.Extensions.AzureMonitor.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.AzureMonitor.Tests/OpenTelemetry.Extensions.AzureMonitor.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPkgVer)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Extensions.Docker.Tests/OpenTelemetry.Extensions.Docker.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Docker.Tests/OpenTelemetry.Extensions.Docker.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Extensions.Tests/OpenTelemetry.Extensions.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Tests/OpenTelemetry.Extensions.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/OpenTelemetry.Instrumentation.AWSLambda.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/OpenTelemetry.Instrumentation.AWSLambda.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/OpenTelemetry.Instrumentation.AspNet.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/OpenTelemetry.Instrumentation.AspNet.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/OpenTelemetry.Instrumentation.AspNet.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/OpenTelemetry.Instrumentation.AspNet.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/OpenTelemetry.Instrumentation.EventCounters.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/OpenTelemetry.Instrumentation.EventCounters.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
@@ -250,7 +250,7 @@ internal class FoobarService : Foobar.FoobarBase
     /// <summary>
     /// Wraps server shutdown with an IDisposable pattern.
     /// </summary>
-    /// <seealso cref="System.IDisposable" />
+    /// <seealso cref="IDisposable" />
     public sealed class DisposableServer : IDisposable
     {
         /// <summary>

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -245,7 +245,7 @@ public class GrpcCoreClientInterceptorTests
                 Assert.True(Activity.Current.Source == GrpcCoreInstrumentation.ActivitySource);
                 Assert.Equal(parentActivity.Id, Activity.Current.ParentId);
 
-                // Set a tag on the Activity and make sure we can see it afterwardsd
+                // Set a tag on the Activity and make sure we can see it afterwards
                 Activity.Current.SetTag("foo", "bar");
                 return metadata;
             });

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -321,7 +321,7 @@ public class GrpcCoreClientInterceptorTests
     /// <param name="recordedMessages">if set to <c>true</c> [recorded messages].</param>
     internal static void ValidateCommonActivityTags(
         Activity activity,
-        Grpc.Core.StatusCode expectedStatusCode = Grpc.Core.StatusCode.OK,
+        StatusCode expectedStatusCode = StatusCode.OK,
         bool recordedMessages = false)
     {
         Assert.NotNull(activity);

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/OpenTelemetry.Instrumentation.Hangfire.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/OpenTelemetry.Instrumentation.Hangfire.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/OpenTelemetry.Instrumentation.Hangfire.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/OpenTelemetry.Instrumentation.Hangfire.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry Hangfire instrumentation</Description>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.MySqlData.Tests/OpenTelemetry.Instrumentation.MySqlData.Tests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPkgVer)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
         <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-        <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/OpenTelemetry.Instrumentation.Owin.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/OpenTelemetry.Instrumentation.Owin.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/OpenTelemetry.Instrumentation.Owin.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/OpenTelemetry.Instrumentation.Owin.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/OpenTelemetry.Instrumentation.Process.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryLatestPreReleasePkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Quartz.Tests/OpenTelemetry.Instrumentation.Quartz.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Quartz.Tests/OpenTelemetry.Instrumentation.Quartz.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
         <PackageReference Include="Quartz" Version="3.3.2" />
         <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-        <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Quartz.Tests/OpenTelemetry.Instrumentation.Quartz.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Quartz.Tests/OpenTelemetry.Instrumentation.Quartz.Tests.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <Description>Unit test project for OpenTelemetry Quartz.NET instrumentation</Description>
-        <TargetFrameworks>net7.0;net6.0;net472</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+        <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
         <IncludeSharedTestSource>true</IncludeSharedTestSource>
     </PropertyGroup>
 

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/OpenTelemetry.Instrumentation.Runtime.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/OpenTelemetry.Instrumentation.Runtime.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryLatestPreReleasePkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Changes

No actual _functional_ changes here, just changes to make VS Code / OmniSharp work a little better, particularly on MacOS.

- Update target framework monikers in projects to be descending - .NET Core, .NET Standard, .NET Desktop. OmniSharp uses the first one in the list and falls back. Ordering this way ensures the right analyzers, etc. will be in place. Includes standard comment to indicate the ordering is intentional.
- Fix IDE0001 warnings - The `.editorconfig` currently has these as warnings, so there were a few warnings showing up. Removing these warnings by simplifying names (basically removing unnecessary namespace prefixes) makes it easier to see what's actually going on.
- Spelling/dictionary updates - The `cSpell` dictionary got a couple additions so less is flagged as misspelled.
- .NET desktop framework tests (`net472`) only run on Windows - While MacOS and Linux can _compile_ stuff for `net472`, it can't _execute_. Updated the test fixtures for `net472` to only include a test adapter in those test projects if it's Windows.
- Enabled tests for non-Windows - For test projects that target .NET Core, you do need to include a test adapter (ie `xunit.runner.visualstudio`) or `dotnet test` doesn't know how to run the tests. Updated to remove the Windows-only testing on those projects.
- Fixed an `OpenTelemetry.Exporter.Geneva` test to pass on MacOS - The socket handling in these tests doesn't seem to work right on MacOS. I found one test that was failing because a socket was trying to be disposed but was getting disposed twice, which caused an exception. Doing a check before disposing allows the test to run and pass.

This fixes a lot, but doesn't fix everything.

- The `OpenTelemetry.Exporter.Geneva` tests are problematic - I got some to pass, but there is a lot of challenge with Unix sockets and MacOS. I haven't dived into that yet. These tests do fail on MacOS. I have seen a few issues with getting Unix sockets and .NET working with Mac, unsure if it overlaps with that.
- Hundreds of `info` messages - VS Code shows all the `info` messages ("suggested refactorings") by default. These are easy one-click fixes like "`using` statement can be simplified" or "Use compound assignment." It might be worth doing a bit of housekeeping to clean these up; or, alternatively, disable the info messages via `.editorconfig`.
- The `examples/AspNet` project is all red - At least on MacOS, this thing is all red because it's using the old project type and doesn't seem to include a reference to the .NET reference assemblies. I didn't dig in to see what can be done here, either.