### PR TITLE
Disable flaky tests

### DIFF
--- a/test/OpenTelemetry.Extensions.Tests/Trace/AutoFlushActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/AutoFlushActivityProcessorTests.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Extensions.Tests.Trace;
 
 public class AutoFlushActivityProcessorTests
 {
-    [Fact]
+    [Fact(Skip = "Unstable")]
     public void AutoFlushActivityProcessor_FlushAfterLocalServerSideRootSpans_EndMatchingSpan_Flush()
     {
         var mockExporting = new Mock<BaseProcessor<Activity>>();

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -53,7 +53,7 @@ public class EventCountersMetricsTests
         Assert.Equal(1997.0202, GetActualValue(metric));
     }
 
-    [Fact]
+    [Fact(Skip = "Unstable")]
     public void IncrementingEventCounter()
     {
         // Arrange
@@ -81,7 +81,7 @@ public class EventCountersMetricsTests
         Assert.Equal(3, GetActualValue(metric));
     }
 
-    [Fact]
+    [Fact(Skip = "Unstable")]
     public void PollingCounter()
     {
         // Arrange
@@ -107,7 +107,7 @@ public class EventCountersMetricsTests
         Assert.Equal(10, GetActualValue(metric));
     }
 
-    [Fact]
+    [Fact(Skip = "Unstable")]
     public void IncrementingPollingCounter()
     {
         // Arrange


### PR DESCRIPTION
Addressing https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/977 and https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/941 as unstable tests are really affecting overall CI health.