### PR TITLE
[OneCollector] Registration extension + tenant token tweaks

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -2,8 +2,6 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
@@ -15,7 +13,15 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.BatchOptions.
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.get -> string!
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorLogExporterOptions() -> void
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -2,8 +2,6 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
@@ -15,7 +13,15 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.BatchOptions.
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.get -> string!
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorLogExporterOptions() -> void
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Unshipped.txt
@@ -2,8 +2,6 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
@@ -15,7 +13,15 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.BatchOptions.
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.get -> string!
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorLogExporterOptions() -> void
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,8 +2,6 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
@@ -15,7 +13,15 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.BatchOptions.
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.get -> string!
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorLogExporterOptions() -> void
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -2,8 +2,6 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TenantToken.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
@@ -15,7 +13,15 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.BatchOptions.
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.get -> string!
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorLogExporterOptions() -> void
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Tenant token is no longer exposed on `OneCollectorExporterOptions` and will be
+  set automatically from the instrumentation key. Added new registration
+  overloads and a builder to help with configuration.
+  ([#XXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXX))
+
 ## 0.1.0-alpha.1
 
 Released 2023-Feb-16

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Tenant token is no longer exposed on `OneCollectorExporterOptions` and will be
   set automatically from the instrumentation key. Added new registration
   overloads and a builder to help with configuration.
-  ([#XXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXX))
+  ([#1032](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1032))
 
 ## 0.1.0-alpha.1
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterBuilder.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterBuilder.cs
@@ -1,0 +1,118 @@
+// <copyright file="OneCollectorLogExporterBuilder.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Exporter.OneCollector;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Logs;
+
+/// <summary>
+/// Contains methods for building <see cref="OneCollectorLogExporterOptions"/> instances.
+/// </summary>
+public sealed class OneCollectorLogExporterBuilder
+{
+    internal OneCollectorLogExporterBuilder(string? instrumentationKey)
+    {
+        this.Options = new()
+        {
+            InstrumentationKey = instrumentationKey,
+        };
+    }
+
+    internal OneCollectorLogExporterBuilder(IConfiguration configuration)
+        : this(instrumentationKey: null)
+    {
+        Debug.Assert(configuration != null, "configuration was null");
+
+        configuration.Bind(this.Options);
+    }
+
+    internal OneCollectorLogExporterOptions Options { get; }
+
+    /// <summary>
+    /// Register a callback action for configuring the batch options of <see
+    /// cref="OneCollectorLogExporterOptions"/>.
+    /// </summary>
+    /// <param name="configure">Callback action for configuring <see
+    /// cref="BatchExportProcessorOptions{T}"/>.</param>
+    /// <returns>The supplied <see cref="OneCollectorLogExporterBuilder"/> for
+    /// call chaining.</returns>
+    public OneCollectorLogExporterBuilder ConfigureBatchOptions(Action<BatchExportProcessorOptions<LogRecord>> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        configure(this.Options.BatchOptions);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Register a callback action for configuring the transport options of <see
+    /// cref="OneCollectorLogExporterOptions"/>.
+    /// </summary>
+    /// <param name="configure">Callback action for configuring <see
+    /// cref="OneCollectorExporterTransportOptions"/>.</param>
+    /// <returns>The supplied <see cref="OneCollectorLogExporterBuilder"/> for
+    /// call chaining.</returns>
+    public OneCollectorLogExporterBuilder ConfigureTransportOptions(Action<OneCollectorExporterTransportOptions> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        configure(this.Options.TransportOptions);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the <see cref="OneCollectorLogExporterOptions.DefaultEventName"/>
+    /// property. Default value: <c>Log</c>.
+    /// </summary>
+    /// <remarks><inheritdoc
+    /// cref="OneCollectorLogExporterOptions.DefaultEventName"
+    /// path="/remarks"/></remarks>
+    /// <param name="defaultEventName">Default event name.</param>
+    /// <returns>The supplied <see cref="OneCollectorLogExporterBuilder"/> for
+    /// call chaining.</returns>
+    public OneCollectorLogExporterBuilder SetDefaultEventName(string defaultEventName)
+    {
+        Guard.ThrowIfNullOrWhitespace(defaultEventName);
+
+        this.Options.DefaultEventName = defaultEventName;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the <see cref="OneCollectorExporterOptions.InstrumentationKey"/>
+    /// property.
+    /// </summary>
+    /// <remarks><inheritdoc
+    /// cref="OneCollectorExporterOptions.InstrumentationKey"
+    /// path="/remarks"/></remarks>
+    /// <param name="instrumentationKey">Instrumentation key.</param>
+    /// <returns>The supplied <see cref="OneCollectorLogExporterBuilder"/> for
+    /// call chaining.</returns>
+    public OneCollectorLogExporterBuilder SetInstrumentationKey(string instrumentationKey)
+    {
+        Guard.ThrowIfNullOrWhitespace(instrumentationKey);
+
+        this.Options.InstrumentationKey = instrumentationKey;
+
+        return this;
+    }
+}

--- a/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterOptions.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Exporter.OneCollector;
 public sealed class OneCollectorLogExporterOptions : OneCollectorExporterOptions, ISinkFactory<LogRecord>
 {
     /// <summary>
-    /// Gets or sets the default event name. Default value: Log.
+    /// Gets or sets the default event name. Default value: <c>Log</c>.
     /// </summary>
     /// <remarks>
     /// Note: The default event name is used when an <see
@@ -41,7 +41,7 @@ public sealed class OneCollectorLogExporterOptions : OneCollectorExporterOptions
 
     /// <summary>
     /// Gets or sets the default event namespace. Default value:
-    /// OpenTelemetry.Logs.
+    /// <c>OpenTelemetry.Logs</c>.
     /// </summary>
     /// <remarks>
     /// Note: The default event namespace is used if a <see

--- a/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterOptions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System.ComponentModel.DataAnnotations;
+
 namespace OpenTelemetry.Exporter.OneCollector;
 
 /// <summary>
@@ -26,13 +28,12 @@ public abstract class OneCollectorExporterOptions
     }
 
     /// <summary>
-    /// Gets or sets the OneCollector tenant token.
-    /// </summary>
-    public string? TenantToken { get; set; }
-
-    /// <summary>
     /// Gets or sets the OneCollector instrumentation key.
     /// </summary>
+    /// <remarks>
+    /// Note: Instrumentation key is required.
+    /// </remarks>
+    [Required]
     public string? InstrumentationKey { get; set; }
 
     /// <summary>
@@ -40,17 +41,29 @@ public abstract class OneCollectorExporterOptions
     /// </summary>
     public OneCollectorExporterTransportOptions TransportOptions { get; } = new();
 
+    /// <summary>
+    /// Gets the OneCollector tenant token.
+    /// </summary>
+    internal string? TenantToken { get; private set; }
+
     internal virtual void Validate()
     {
-        if (string.IsNullOrWhiteSpace(this.TenantToken))
-        {
-            throw new InvalidOperationException($"{nameof(this.TenantToken)} was not specified on {this.GetType().Name} options.");
-        }
-
         if (string.IsNullOrWhiteSpace(this.InstrumentationKey))
         {
             throw new InvalidOperationException($"{nameof(this.InstrumentationKey)} was not specified on {this.GetType().Name} options.");
         }
+
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        var positionOfFirstDash = this.InstrumentationKey.IndexOf('-', StringComparison.OrdinalIgnoreCase);
+#else
+        var positionOfFirstDash = this.InstrumentationKey!.IndexOf('-');
+#endif
+        if (positionOfFirstDash < 0)
+        {
+            throw new InvalidOperationException($"{nameof(this.InstrumentationKey)} specified on {this.GetType().Name} options is invalid.");
+        }
+
+        this.TenantToken = this.InstrumentationKey.Substring(0, positionOfFirstDash);
 
         this.TransportOptions.Validate();
     }

--- a/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterTransportOptions.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterTransportOptions.cs
@@ -33,7 +33,7 @@ public sealed class OneCollectorExporterTransportOptions
 
     /// <summary>
     /// Gets or sets OneCollector endpoint address. Default value:
-    /// https://mobile.events.data.microsoft.com/OneCollector/1.0/.
+    /// <c>https://mobile.events.data.microsoft.com/OneCollector/1.0/</c>.
     /// </summary>
     public Uri Endpoint { get; set; } = new Uri(DefaultOneCollectorEndpoint);
 
@@ -45,7 +45,7 @@ public sealed class OneCollectorExporterTransportOptions
 
     /// <summary>
     /// Gets or sets the maximum request payload size in bytes when sending data
-    /// to OneCollector. Default value: 4,194,304.
+    /// to OneCollector. Default value: <c>4,194,304</c>.
     /// </summary>
     /// <remarks>
     /// Note: Set to -1 for unlimited request payload size.
@@ -54,7 +54,7 @@ public sealed class OneCollectorExporterTransportOptions
 
     /// <summary>
     /// Gets or sets the maximum number of items per request payload when
-    /// sending data to OneCollector. Default value: 1500.
+    /// sending data to OneCollector. Default value: <c>1500</c>.
     /// </summary>
     /// <remarks>
     /// Note: Set to -1 for unlimited number of items per request payload.

--- a/src/OpenTelemetry.Exporter.OneCollector/README.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/README.md
@@ -23,11 +23,7 @@ using var logFactory = LoggerFactory.Create(builder => builder
     {
         builder.ParseStateValues = true;
         builder.IncludeScopes = true;
-        builder.AddOneCollectorExporter(o =>
-        {
-            o.TenantToken = "tenant-token-here";
-            o.InstrumentationKey = "instrumentation-key-here";
-        });
+        builder.AddOneCollectorExporter("instrumentation-key-here");
     }));
 
 var logger = logFactory.CreateLogger<MyService>();

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
@@ -1,0 +1,52 @@
+// <copyright file="OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.OneCollector.Tests;
+
+public class OneCollectorOpenTelemetryLoggerOptionsExtensionsTests
+{
+    [Fact]
+    public void InstrumentationKeyAndTenantTokenValidationTest()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(builder =>
+                {
+                    builder.AddOneCollectorExporter(options => { });
+                }));
+        });
+
+        using var loggerFactory = LoggerFactory.Create(builder => builder
+            .AddOpenTelemetry(builder =>
+            {
+                builder.AddOneCollectorExporter("token-extrainformation");
+            }));
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(builder =>
+                {
+                    builder.AddOneCollectorExporter("invalidinstrumentationkey");
+                }));
+        });
+    }
+}


### PR DESCRIPTION
## Changes

* Tenant token is now parsed automatically from the instrumentation key
* Registration extensions now operate on a builder instead of options directly. This is kind of a WIP I think it will make things easier as more and more features get added. But it may be removed before stable.
 
## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
