### PR TITLE
[OneCollectorExporter] Connection string design

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,11 +1,15 @@
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException() -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message) -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message, System.Exception? innerException) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter.OneCollectorLogExporter(OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions! options) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions
@@ -16,12 +20,12 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorL
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetConnectionString(string! connectionString) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
-OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,11 +1,15 @@
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException() -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message) -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message, System.Exception? innerException) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter.OneCollectorLogExporter(OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions! options) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions
@@ -16,12 +20,12 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorL
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetConnectionString(string! connectionString) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
-OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Unshipped.txt
@@ -1,11 +1,15 @@
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException() -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message) -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message, System.Exception? innerException) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter.OneCollectorLogExporter(OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions! options) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions
@@ -16,12 +20,12 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorL
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetConnectionString(string! connectionString) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
-OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,11 +1,15 @@
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException() -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message) -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message, System.Exception? innerException) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter.OneCollectorLogExporter(OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions! options) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions
@@ -16,12 +20,12 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorL
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetConnectionString(string! connectionString) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
-OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,11 +1,15 @@
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.get -> string?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.InstrumentationKey.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.TransportOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException() -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message) -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneCollectorExporterValidationException(string! message, System.Exception? innerException) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporter.OneCollectorLogExporter(OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions! options) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions
@@ -16,12 +20,12 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorL
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureBatchOptions(System.Action<OpenTelemetry.BatchExportProcessorOptions<OpenTelemetry.Logs.LogRecord!>!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
+OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetConnectionString(string! connectionString) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
-OpenTelemetry.Logs.OneCollectorLogExporterBuilder.SetInstrumentationKey(string! instrumentationKey) -> OpenTelemetry.Logs.OneCollectorLogExporterBuilder!
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
-static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! instrumentationKey, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExporterBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 * Switched to using a connection string design instead of passing
   instrumentation key directly.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1037](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1037))
 
 ## 0.1.0-alpha.1
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -7,6 +7,10 @@
   overloads and a builder to help with configuration.
   ([#1032](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1032))
 
+* Switched to using a connection string design instead of passing
+  instrumentation key directly.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 0.1.0-alpha.1
 
 Released 2023-Feb-16

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/ConnectionStringParser.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/ConnectionStringParser.cs
@@ -1,0 +1,76 @@
+// <copyright file="ConnectionStringParser.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Exporter.OneCollector;
+
+internal sealed class ConnectionStringParser
+{
+    public ConnectionStringParser(string connectionString)
+    {
+        Guard.ThrowIfNullOrWhitespace(connectionString);
+
+        const char Semicolon = ';';
+        const char EqualSign = '=';
+
+        foreach (var token in connectionString.Split(Semicolon))
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                continue;
+            }
+
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            var index = token.IndexOf(EqualSign, StringComparison.Ordinal);
+#else
+            var index = token.IndexOf(EqualSign);
+#endif
+            if (index == -1 || index != token.LastIndexOf(EqualSign))
+            {
+                continue;
+            }
+
+            var pair = token.Trim().Split(EqualSign);
+
+            var key = pair[0].Trim();
+            var value = pair[1].Trim();
+            if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException("Connection string cannot contain empty keys or values.", nameof(connectionString));
+            }
+
+            this.ParsedKeyValues[key] = value;
+        }
+
+        if (this.ParsedKeyValues.Count == 0)
+        {
+            throw new ArgumentException("Connection string is invalid.", nameof(connectionString));
+        }
+    }
+
+    public string? InstrumentationKey
+    {
+        get
+        {
+            this.ParsedKeyValues.TryGetValue(nameof(this.InstrumentationKey), out string? instrumentationKey);
+
+            return instrumentationKey;
+        }
+    }
+
+    internal Dictionary<string, string> ParsedKeyValues { get; } = new(StringComparer.Ordinal);
+}

--- a/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterBuilder.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterBuilder.cs
@@ -26,16 +26,16 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 public sealed class OneCollectorLogExporterBuilder
 {
-    internal OneCollectorLogExporterBuilder(string? instrumentationKey)
+    internal OneCollectorLogExporterBuilder(string? connectionString)
     {
         this.Options = new()
         {
-            InstrumentationKey = instrumentationKey,
+            ConnectionString = connectionString,
         };
     }
 
     internal OneCollectorLogExporterBuilder(IConfiguration configuration)
-        : this(instrumentationKey: null)
+        : this(connectionString: null)
     {
         Debug.Assert(configuration != null, "configuration was null");
 
@@ -79,6 +79,25 @@ public sealed class OneCollectorLogExporterBuilder
     }
 
     /// <summary>
+    /// Sets the <see cref="OneCollectorExporterOptions.ConnectionString"/>
+    /// property.
+    /// </summary>
+    /// <remarks><inheritdoc
+    /// cref="OneCollectorExporterOptions.ConnectionString"
+    /// path="/remarks"/></remarks>
+    /// <param name="connectionString">Connection string.</param>
+    /// <returns>The supplied <see cref="OneCollectorLogExporterBuilder"/> for
+    /// call chaining.</returns>
+    public OneCollectorLogExporterBuilder SetConnectionString(string connectionString)
+    {
+        Guard.ThrowIfNullOrWhitespace(connectionString);
+
+        this.Options.ConnectionString = connectionString;
+
+        return this;
+    }
+
+    /// <summary>
     /// Sets the <see cref="OneCollectorLogExporterOptions.DefaultEventName"/>
     /// property. Default value: <c>Log</c>.
     /// </summary>
@@ -93,25 +112,6 @@ public sealed class OneCollectorLogExporterBuilder
         Guard.ThrowIfNullOrWhitespace(defaultEventName);
 
         this.Options.DefaultEventName = defaultEventName;
-
-        return this;
-    }
-
-    /// <summary>
-    /// Sets the <see cref="OneCollectorExporterOptions.InstrumentationKey"/>
-    /// property.
-    /// </summary>
-    /// <remarks><inheritdoc
-    /// cref="OneCollectorExporterOptions.InstrumentationKey"
-    /// path="/remarks"/></remarks>
-    /// <param name="instrumentationKey">Instrumentation key.</param>
-    /// <returns>The supplied <see cref="OneCollectorLogExporterBuilder"/> for
-    /// call chaining.</returns>
-    public OneCollectorLogExporterBuilder SetInstrumentationKey(string instrumentationKey)
-    {
-        Guard.ThrowIfNullOrWhitespace(instrumentationKey);
-
-        this.Options.InstrumentationKey = instrumentationKey;
 
         return this;
     }

--- a/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExporterOptions.cs
@@ -68,7 +68,7 @@ public sealed class OneCollectorLogExporterOptions : OneCollectorExporterOptions
                 this.InstrumentationKey!,
                 transportOptions.Endpoint,
                 transportOptions.HttpCompression,
-                transportOptions.HttpClientFactory() ?? throw new InvalidOperationException($"{nameof(OneCollectorLogExporterOptions)} was missing HttpClientFactory or it returned null.")));
+                transportOptions.HttpClientFactory() ?? throw new OneCollectorExporterValidationException($"{nameof(OneCollectorLogExporterOptions)} was missing HttpClientFactory or it returned null.")));
 #pragma warning restore CA2000 // Dispose objects before losing scope
     }
 
@@ -76,12 +76,12 @@ public sealed class OneCollectorLogExporterOptions : OneCollectorExporterOptions
     {
         if (string.IsNullOrWhiteSpace(this.DefaultEventNamespace))
         {
-            throw new InvalidOperationException($"{nameof(this.DefaultEventNamespace)} was not specified on {nameof(OneCollectorLogExporterOptions)} options.");
+            throw new OneCollectorExporterValidationException($"{nameof(this.DefaultEventNamespace)} was not specified on {nameof(OneCollectorLogExporterOptions)} options.");
         }
 
         if (string.IsNullOrWhiteSpace(this.DefaultEventName))
         {
-            throw new InvalidOperationException($"{nameof(this.DefaultEventName)} was not specified on {nameof(OneCollectorLogExporterOptions)} options.");
+            throw new OneCollectorExporterValidationException($"{nameof(this.DefaultEventName)} was not specified on {nameof(OneCollectorLogExporterOptions)} options.");
         }
 
         base.Validate();

--- a/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorOpenTelemetryLoggerOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorOpenTelemetryLoggerOptionsExtensions.cs
@@ -53,7 +53,7 @@ public static class OneCollectorOpenTelemetryLoggerOptionsExtensions
     {
         Guard.ThrowIfNull(configure);
 
-        return AddOneCollectorExporter(options, instrumentationKey: null, configuration: null, configure);
+        return AddOneCollectorExporter(options, connectionString: null, configuration: null, configure);
     }
 
     /// <summary>
@@ -61,16 +61,16 @@ public static class OneCollectorOpenTelemetryLoggerOptionsExtensions
     /// cref="OpenTelemetryLoggerOptions"/>.
     /// </summary>
     /// <param name="options"><see cref="OpenTelemetryLoggerOptions"/>.</param>
-    /// <param name="instrumentationKey">OneCollector instrumentation key.</param>
+    /// <param name="connectionString">OneCollector connection string.</param>
     /// <returns>The supplied <see cref="OpenTelemetryLoggerOptions"/> for call
     /// chaining.</returns>
     public static OpenTelemetryLoggerOptions AddOneCollectorExporter(
         this OpenTelemetryLoggerOptions options,
-        string instrumentationKey)
+        string connectionString)
     {
-        Guard.ThrowIfNullOrWhitespace(instrumentationKey);
+        Guard.ThrowIfNullOrWhitespace(connectionString);
 
-        return AddOneCollectorExporter(options, instrumentationKey, configuration: null, configure: null);
+        return AddOneCollectorExporter(options, connectionString, configuration: null, configure: null);
     }
 
     /// <summary>
@@ -78,18 +78,18 @@ public static class OneCollectorOpenTelemetryLoggerOptionsExtensions
     /// cref="OpenTelemetryLoggerOptions"/>.
     /// </summary>
     /// <param name="options"><see cref="OpenTelemetryLoggerOptions"/>.</param>
-    /// <param name="instrumentationKey">OneCollector instrumentation key.</param>
+    /// <param name="connectionString">OneCollector connection string.</param>
     /// <param name="configure">Callback action for configuring <see cref="OneCollectorLogExporterBuilder"/>.</param>
     /// <returns>The supplied <see cref="OpenTelemetryLoggerOptions"/> for call
     /// chaining.</returns>
     public static OpenTelemetryLoggerOptions AddOneCollectorExporter(
         this OpenTelemetryLoggerOptions options,
-        string instrumentationKey,
+        string connectionString,
         Action<OneCollectorLogExporterBuilder> configure)
     {
-        Guard.ThrowIfNullOrWhitespace(instrumentationKey);
+        Guard.ThrowIfNullOrWhitespace(connectionString);
 
-        return AddOneCollectorExporter(options, instrumentationKey, configuration: null, configure);
+        return AddOneCollectorExporter(options, connectionString, configuration: null, configure);
     }
 
     /// <summary>
@@ -106,7 +106,7 @@ public static class OneCollectorOpenTelemetryLoggerOptionsExtensions
     {
         Guard.ThrowIfNull(configuration);
 
-        return AddOneCollectorExporter(options, instrumentationKey: null, configuration, configure: null);
+        return AddOneCollectorExporter(options, connectionString: null, configuration, configure: null);
     }
 
     /// <summary>
@@ -125,19 +125,19 @@ public static class OneCollectorOpenTelemetryLoggerOptionsExtensions
     {
         Guard.ThrowIfNull(configuration);
 
-        return AddOneCollectorExporter(options, instrumentationKey: null, configuration, configure);
+        return AddOneCollectorExporter(options, connectionString: null, configuration, configure);
     }
 
     internal static OpenTelemetryLoggerOptions AddOneCollectorExporter(
         this OpenTelemetryLoggerOptions options,
-        string? instrumentationKey,
+        string? connectionString,
         IConfiguration? configuration,
         Action<OneCollectorLogExporterBuilder>? configure)
     {
         Guard.ThrowIfNull(options);
 
         var builder = configuration == null
-            ? new OneCollectorLogExporterBuilder(instrumentationKey)
+            ? new OneCollectorLogExporterBuilder(connectionString)
             : new OneCollectorLogExporterBuilder(configuration);
 
         configure?.Invoke(builder);

--- a/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterOptions.cs
@@ -28,18 +28,23 @@ public abstract class OneCollectorExporterOptions
     }
 
     /// <summary>
-    /// Gets or sets the OneCollector instrumentation key.
+    /// Gets or sets the OneCollector connection string.
     /// </summary>
     /// <remarks>
-    /// Note: Instrumentation key is required.
+    /// Note: Connection string is required.
     /// </remarks>
     [Required]
-    public string? InstrumentationKey { get; set; }
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// Gets the OneCollector transport options.
     /// </summary>
     public OneCollectorExporterTransportOptions TransportOptions { get; } = new();
+
+    /// <summary>
+    /// Gets the OneCollector instrumentation key.
+    /// </summary>
+    internal string? InstrumentationKey { get; private set; }
 
     /// <summary>
     /// Gets the OneCollector tenant token.
@@ -48,9 +53,15 @@ public abstract class OneCollectorExporterOptions
 
     internal virtual void Validate()
     {
+        if (string.IsNullOrWhiteSpace(this.ConnectionString))
+        {
+            throw new OneCollectorExporterValidationException($"{nameof(this.ConnectionString)} was not specified on {this.GetType().Name} options.");
+        }
+
+        this.InstrumentationKey = new ConnectionStringParser(this.ConnectionString!).InstrumentationKey;
         if (string.IsNullOrWhiteSpace(this.InstrumentationKey))
         {
-            throw new InvalidOperationException($"{nameof(this.InstrumentationKey)} was not specified on {this.GetType().Name} options.");
+            throw new OneCollectorExporterValidationException("Instrumentation key was not specified on connection string.");
         }
 
 #if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -60,7 +71,7 @@ public abstract class OneCollectorExporterOptions
 #endif
         if (positionOfFirstDash < 0)
         {
-            throw new InvalidOperationException($"{nameof(this.InstrumentationKey)} specified on {this.GetType().Name} options is invalid.");
+            throw new OneCollectorExporterValidationException($"Instrumentation key specified as part of {nameof(this.ConnectionString)} on {this.GetType().Name} options is invalid.");
         }
 
         this.TenantToken = this.InstrumentationKey.Substring(0, positionOfFirstDash);

--- a/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterTransportOptions.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterTransportOptions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System.ComponentModel.DataAnnotations;
+
 namespace OpenTelemetry.Exporter.OneCollector;
 
 /// <summary>
@@ -35,6 +37,10 @@ public sealed class OneCollectorExporterTransportOptions
     /// Gets or sets OneCollector endpoint address. Default value:
     /// <c>https://mobile.events.data.microsoft.com/OneCollector/1.0/</c>.
     /// </summary>
+    /// <remarks>
+    /// Note: Endpoint is required.
+    /// </remarks>
+    [Required]
     public Uri Endpoint { get; set; } = new Uri(DefaultOneCollectorEndpoint);
 
     /// <summary>
@@ -88,22 +94,22 @@ public sealed class OneCollectorExporterTransportOptions
     {
         if (this.Endpoint == null)
         {
-            throw new InvalidOperationException($"{nameof(this.Endpoint)} was not specified on {this.GetType().Name} options.");
+            throw new OneCollectorExporterValidationException($"{nameof(this.Endpoint)} was not specified on {this.GetType().Name} options.");
         }
 
         if (this.HttpClientFactory == null)
         {
-            throw new InvalidOperationException($"{nameof(this.HttpClientFactory)} was not specified on {this.GetType().Name} options.");
+            throw new OneCollectorExporterValidationException($"{nameof(this.HttpClientFactory)} was not specified on {this.GetType().Name} options.");
         }
 
         if (this.MaxPayloadSizeInBytes <= 0 && this.MaxPayloadSizeInBytes != -1)
         {
-            throw new InvalidOperationException($"{nameof(this.MaxPayloadSizeInBytes)} was invalid on {this.GetType().Name} options.");
+            throw new OneCollectorExporterValidationException($"{nameof(this.MaxPayloadSizeInBytes)} was invalid on {this.GetType().Name} options.");
         }
 
         if (this.MaxNumberOfItemsPerPayload <= 0 && this.MaxNumberOfItemsPerPayload != -1)
         {
-            throw new InvalidOperationException($"{nameof(this.MaxNumberOfItemsPerPayload)} was invalid on {this.GetType().Name} options.");
+            throw new OneCollectorExporterValidationException($"{nameof(this.MaxNumberOfItemsPerPayload)} was invalid on {this.GetType().Name} options.");
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterValidationException.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterValidationException.cs
@@ -1,0 +1,61 @@
+// <copyright file="OneCollectorExporterValidationException.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Runtime.Serialization;
+
+namespace OpenTelemetry.Exporter.OneCollector;
+
+/// <summary>
+/// Represents errors that occur validating OneCollectorExporter configuration.
+/// </summary>
+[Serializable]
+public sealed class OneCollectorExporterValidationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OneCollectorExporterValidationException"/> class.
+    /// </summary>
+    public OneCollectorExporterValidationException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OneCollectorExporterValidationException"/> class.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    public OneCollectorExporterValidationException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see
+    /// cref="OneCollectorExporterValidationException"/> class.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the
+    /// exception.</param>
+    /// <param name="innerException">The exception that is the cause of the
+    /// current exception, or a <see langword="null"/> reference if no inner
+    /// exception is specified.</param>
+    public OneCollectorExporterValidationException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+
+    private OneCollectorExporterValidationException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        : base(serializationInfo, streamingContext)
+    {
+    }
+}

--- a/src/OpenTelemetry.Exporter.OneCollector/README.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/README.md
@@ -25,7 +25,7 @@ using var logFactory = LoggerFactory.Create(builder => builder
     {
         builder.ParseStateValues = true;
         builder.IncludeScopes = true;
-        builder.AddOneCollectorExporter("instrumentation-key-here");
+        builder.AddOneCollectorExporter("InstrumentationKey=instrumentation-key-here");
     }));
 
 var logger = logFactory.CreateLogger<MyService>();

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/ConnectionStringParserTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/ConnectionStringParserTests.cs
@@ -1,0 +1,59 @@
+// <copyright file="ConnectionStringParserTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+
+namespace OpenTelemetry.Exporter.OneCollector.Tests;
+
+public class ConnectionStringParserTests
+{
+    [Fact]
+    public void InvalidConnectionStringTest()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            new ConnectionStringParser("invalid-connection-string");
+        });
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            new ConnectionStringParser("Key=");
+        });
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            new ConnectionStringParser("Key1=Value1;Key2=");
+        });
+    }
+
+    [Fact]
+    public void ExtraDataIgnoredInConnectionStringTest()
+    {
+        var builder = new ConnectionStringParser("Key1=Value1;;;Key2;");
+
+        Assert.Single(builder.ParsedKeyValues);
+        Assert.Contains(builder.ParsedKeyValues, kvp => kvp.Key == "Key1" && kvp.Value == "Value1");
+    }
+
+    [Fact]
+    public void LastOneWinsInConnectionStringTest()
+    {
+        var builder = new ConnectionStringParser("Key1=Value1;Key1=Value2;");
+
+        Assert.Single(builder.ParsedKeyValues);
+        Assert.Contains(builder.ParsedKeyValues, kvp => kvp.Key == "Key1" && kvp.Value == "Value2");
+    }
+}

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
@@ -25,27 +25,46 @@ public class OneCollectorOpenTelemetryLoggerOptionsExtensionsTests
     [Fact]
     public void InstrumentationKeyAndTenantTokenValidationTest()
     {
-        Assert.Throws<InvalidOperationException>(() =>
         {
             using var loggerFactory = LoggerFactory.Create(builder => builder
                 .AddOpenTelemetry(builder =>
                 {
-                    builder.AddOneCollectorExporter(options => { });
+                    builder.AddOneCollectorExporter("InstrumentationKey=token-extrainformation");
+                }));
+        }
+
+        {
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(builder =>
+                {
+                    builder.AddOneCollectorExporter(configure => configure.SetConnectionString("InstrumentationKey=token-extrainformation"));
+                }));
+        }
+
+        Assert.Throws<OneCollectorExporterValidationException>(() =>
+        {
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(builder =>
+                {
+                    builder.AddOneCollectorExporter(configure => { });
                 }));
         });
 
-        using var loggerFactory = LoggerFactory.Create(builder => builder
-            .AddOpenTelemetry(builder =>
-            {
-                builder.AddOneCollectorExporter("token-extrainformation");
-            }));
-
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.Throws<OneCollectorExporterValidationException>(() =>
         {
             using var loggerFactory = LoggerFactory.Create(builder => builder
                 .AddOpenTelemetry(builder =>
                 {
-                    builder.AddOneCollectorExporter("invalidinstrumentationkey");
+                    builder.AddOneCollectorExporter("InstrumentationKey=invalidinstrumentationkey");
+                }));
+        });
+
+        Assert.Throws<OneCollectorExporterValidationException>(() =>
+        {
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(builder =>
+                {
+                    builder.AddOneCollectorExporter("UnknownKey=invalidinstrumentationkey");
                 }));
         });
     }


### PR DESCRIPTION
Follow-up to: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1032#discussion_r1114877266

## Changes

* Switch to a connection string design instead of passing instrumentation key directly.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
