### PR TITLE
[Exporter.Geneva] Update publicAPI files for GenevaExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Shipped.txt
@@ -1,4 +1,7 @@
 Microsoft.Extensions.Logging.GenevaLoggingExtensions
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
 OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>
 OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>.GenevaBaseExporter() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
@@ -7,6 +10,8 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> stri
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string>
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.GenevaExporterOptions() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -1,4 +1,7 @@
 Microsoft.Extensions.Logging.GenevaLoggingExtensions
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
 OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>
 OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>.GenevaBaseExporter() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
@@ -7,6 +10,8 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> stri
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string>
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.GenevaExporterOptions() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,4 +1,7 @@
 Microsoft.Extensions.Logging.GenevaLoggingExtensions
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
 OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>
 OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>.GenevaBaseExporter() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
@@ -7,6 +10,8 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> stri
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string>
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.GenevaExporterOptions() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set -> void


### PR DESCRIPTION
## Changes
- Update publicAPI files for GenevaExporter for the stable release 1.4.0
