### PR TITLE
[Exporter.Instana] Bump OTel to 1.4.0

### DIFF
--- a/src/OpenTelemetry.Exporter.Instana/.publicApi/net461/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Instana/.publicApi/net461/PublicAPI.Shipped.txt
@@ -1,2 +1,0 @@
-OpenTelemetry.Exporter.Instana.TracerProviderBuilderExtensions
-static OpenTelemetry.Exporter.Instana.TracerProviderBuilderExtensions.AddInstanaExporter(this OpenTelemetry.Trace.TracerProviderBuilder options) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Instana/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Instana/.publicApi/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.Exporter.Instana.TracerProviderBuilderExtensions
+static OpenTelemetry.Exporter.Instana.TracerProviderBuilderExtensions.AddInstanaExporter(this OpenTelemetry.Trace.TracerProviderBuilder options) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Update OTel SDK version to `1.4.0`.
+  ([#1050](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1050))
+* Drop support for .NET Framework 4.6.1.
+  The lowest supported version is .NET Framework 4.6.2.
+  ([#1050](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1050))
+
 ## 1.0.3
 
 Released 2023-Feb-21

--- a/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
+++ b/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
@@ -8,22 +8,6 @@
     <MinVerTagPrefix>Exporter.Instana-</MinVerTagPrefix>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net461|AnyCPU'">
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.3.2" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
+++ b/src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageTags>Instana Tracing APM</PackageTags>
     <Description>Instana .NET Exporter for OpenTelemetry</Description>
     <MinVerTagPrefix>Exporter.Instana-</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.2" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Exporter.Instana/README.md
+++ b/src/OpenTelemetry.Exporter.Instana/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Instana.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Instana)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Instana.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Instana)
 
-The Instana Exporter exports telemetry to Instana backand.
+The Instana Exporter exports telemetry to Instana backend.
 
 ## Installation
 

--- a/src/OpenTelemetry.Exporter.Instana/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Instana/TracerProviderBuilderExtensions.cs
@@ -37,8 +37,6 @@ public static class TracerProviderBuilderExtensions
             throw new ArgumentNullException(nameof(options));
         }
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
         return options.AddProcessor(new BatchActivityExportProcessor(new InstanaExporter()));
-#pragma warning restore CA2000 // Dispose objects before losing scope
     }
 }

--- a/test/OpenTelemetry.Exporter.Instana.Tests/OpenTelemetry.Exporter.Instana.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Instana.Tests/OpenTelemetry.Exporter.Instana.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Exporter.Instana.Tests/OpenTelemetry.Exporter.Instana.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Instana.Tests/OpenTelemetry.Exporter.Instana.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
@@ -13,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" Condition="'$(TargetFramework)' == 'net462'"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up to #1038 where Instana was unpinned from $(OpenTelemetryCoreLatestVersion)
Towards #1031

## Changes

Bump OTel 1.4.0, as this version is not supporting .NET Framework 4.6.1 and .NET Core App 3.1
The package will produce libraries for .NET Framework 4.6.2 and test was switched to `net7.0;net.60;net462`

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
