### PR TITLE
[Extensions] Add LogToActivityEventConversionOptions.Filter callback

### DIFF
--- a/src/OpenTelemetry.Extensions/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions
 OpenTelemetry.Logs.LogToActivityEventConversionOptions
+OpenTelemetry.Logs.LogToActivityEventConversionOptions.Filter.get -> System.Func<OpenTelemetry.Logs.LogRecord!, bool>?
+OpenTelemetry.Logs.LogToActivityEventConversionOptions.Filter.set -> void
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.LogToActivityEventConversionOptions() -> void
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.ScopeConverter.get -> System.Action<System.Diagnostics.ActivityTagsCollection!, int, OpenTelemetry.Logs.LogRecordScope>!
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.ScopeConverter.set -> void

--- a/src/OpenTelemetry.Extensions/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions
 OpenTelemetry.Logs.LogToActivityEventConversionOptions
+OpenTelemetry.Logs.LogToActivityEventConversionOptions.Filter.get -> System.Func<OpenTelemetry.Logs.LogRecord!, bool>?
+OpenTelemetry.Logs.LogToActivityEventConversionOptions.Filter.set -> void
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.LogToActivityEventConversionOptions() -> void
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.ScopeConverter.get -> System.Action<System.Diagnostics.ActivityTagsCollection!, int, OpenTelemetry.Logs.LogRecordScope>!
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.ScopeConverter.set -> void

--- a/src/OpenTelemetry.Extensions/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions
 OpenTelemetry.Logs.LogToActivityEventConversionOptions
+OpenTelemetry.Logs.LogToActivityEventConversionOptions.Filter.get -> System.Func<OpenTelemetry.Logs.LogRecord!, bool>?
+OpenTelemetry.Logs.LogToActivityEventConversionOptions.Filter.set -> void
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.LogToActivityEventConversionOptions() -> void
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.ScopeConverter.get -> System.Action<System.Diagnostics.ActivityTagsCollection!, int, OpenTelemetry.Logs.LogRecordScope>!
 OpenTelemetry.Logs.LogToActivityEventConversionOptions.ScopeConverter.set -> void

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add LogToActivityEventConversionOptions.Filter callback
+  ([#1059](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1059))
+
 ## 1.0.0-beta.4
 
 Released 2023-Feb-27

--- a/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
+++ b/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
@@ -62,6 +62,7 @@ internal sealed class ActivityEventAttachingLogProcessor : BaseProcessor<LogReco
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 OpenTelemetryExtensionsEventSource.Log.LogProcessorException($"Processing filter of category [{data.CategoryName}]", ex);
+                return;
             }
 
             var tags = new ActivityTagsCollection

--- a/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
+++ b/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
@@ -50,6 +50,24 @@ internal sealed class ActivityEventAttachingLogProcessor : BaseProcessor<LogReco
 
         if (activity?.IsAllDataRequested == true)
         {
+            bool? filter;
+            try
+            {
+                filter = this.options.Filter?.Invoke(data);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                filter = null;
+                OpenTelemetryExtensionsEventSource.Log.LogProcessorException($"Processing filter of category [{data.CategoryName}]", ex);
+            }
+
+            if (filter == false)
+            {
+                return;
+            }
+
             var tags = new ActivityTagsCollection
             {
                 { nameof(data.CategoryName), data.CategoryName },

--- a/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
+++ b/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
@@ -61,7 +61,7 @@ internal sealed class ActivityEventAttachingLogProcessor : BaseProcessor<LogReco
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                OpenTelemetryExtensionsEventSource.Log.LogProcessorException($"Processing filter of category [{data.CategoryName}]", ex);
+                OpenTelemetryExtensionsEventSource.Log.LogRecordFilterException(data.CategoryName, ex);
                 return;
             }
 

--- a/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
+++ b/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
@@ -50,22 +50,18 @@ internal sealed class ActivityEventAttachingLogProcessor : BaseProcessor<LogReco
 
         if (activity?.IsAllDataRequested == true)
         {
-            bool? filter;
             try
             {
-                filter = this.options.Filter?.Invoke(data);
+                if (this.options.Filter?.Invoke(data) == false)
+                {
+                    return;
+                }
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                filter = null;
                 OpenTelemetryExtensionsEventSource.Log.LogProcessorException($"Processing filter of category [{data.CategoryName}]", ex);
-            }
-
-            if (filter == false)
-            {
-                return;
             }
 
             var tags = new ActivityTagsCollection

--- a/src/OpenTelemetry.Extensions/Internal/OpenTelemetryExtensionsEventSource.cs
+++ b/src/OpenTelemetry.Extensions/Internal/OpenTelemetryExtensionsEventSource.cs
@@ -42,4 +42,19 @@ internal sealed class OpenTelemetryExtensionsEventSource : EventSource
     {
         this.WriteEvent(1, @event, exception);
     }
+
+    [NonEvent]
+    public void LogRecordFilterException(string? categoryName, Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
+        {
+            this.LogRecordFilterException(categoryName, ex.ToInvariantString());
+        }
+    }
+
+    [Event(2, Message = "Filter threw an exception, request will not be collected. CategoryName: '{0}', Exception: {1}.", Level = EventLevel.Warning)]
+    public void LogRecordFilterException(string? categoryName, string exception)
+    {
+        this.WriteEvent(2, categoryName, exception);
+    }
 }

--- a/src/OpenTelemetry.Extensions/Internal/OpenTelemetryExtensionsEventSource.cs
+++ b/src/OpenTelemetry.Extensions/Internal/OpenTelemetryExtensionsEventSource.cs
@@ -52,7 +52,7 @@ internal sealed class OpenTelemetryExtensionsEventSource : EventSource
         }
     }
 
-    [Event(2, Message = "Filter threw an exception, request will not be collected. CategoryName: '{0}', Exception: {1}.", Level = EventLevel.Warning)]
+    [Event(2, Message = "Filter threw an exception, log record will not be attached to an activity. CategoryName: '{0}', Exception: {1}.", Level = EventLevel.Warning)]
     public void LogRecordFilterException(string? categoryName, string exception)
     {
         this.WriteEvent(2, categoryName, exception);

--- a/src/OpenTelemetry.Extensions/Internal/OpenTelemetryExtensionsEventSource.cs
+++ b/src/OpenTelemetry.Extensions/Internal/OpenTelemetryExtensionsEventSource.cs
@@ -52,7 +52,7 @@ internal sealed class OpenTelemetryExtensionsEventSource : EventSource
         }
     }
 
-    [Event(2, Message = "Filter threw an exception, log record will not be attached to an activity. CategoryName: '{0}', Exception: {1}.", Level = EventLevel.Warning)]
+    [Event(2, Message = "Filter threw an exception, log record will not be attached to an activity, the log record would flow to its pipeline unaffected. CategoryName: '{0}', Exception: {1}.", Level = EventLevel.Warning)]
     public void LogRecordFilterException(string? categoryName, string exception)
     {
         this.WriteEvent(2, categoryName, exception);

--- a/src/OpenTelemetry.Extensions/Logs/LogToActivityEventConversionOptions.cs
+++ b/src/OpenTelemetry.Extensions/Logs/LogToActivityEventConversionOptions.cs
@@ -43,7 +43,7 @@ public class LogToActivityEventConversionOptions
     /// processed logRecord and should return a boolean.
     /// <list type="bullet">
     /// <item>If filter returns <see langword="true"/> the event is collected.</item>
-    /// <item>If filter returns <see langword="false"/> the event is filtered out (NOT collected).</item>
+    /// <item>If filter returns <see langword="false"/> or throws an exception the event is filtered out (NOT collected).</item>
     /// </list>
     /// </remarks>
     public Func<LogRecord, bool>? Filter { get; set; }

--- a/src/OpenTelemetry.Extensions/Logs/LogToActivityEventConversionOptions.cs
+++ b/src/OpenTelemetry.Extensions/Logs/LogToActivityEventConversionOptions.cs
@@ -34,4 +34,17 @@ public class LogToActivityEventConversionOptions
     /// Gets or sets the callback action used to convert log scopes into <see cref="ActivityEvent"/> tags.
     /// </summary>
     public Action<ActivityTagsCollection, int, LogRecordScope> ScopeConverter { get; set; } = DefaultLogStateConverter.ConvertScope;
+
+    /// <summary>
+    /// Gets or sets the callback method allowing to filter out particular <see cref="LogRecord"/>.
+    /// </summary>
+    /// <remarks>
+    /// The filter callback receives the <see cref="LogRecord"/> for the
+    /// processed logRecord and should return a boolean.
+    /// <list type="bullet">
+    /// <item>If filter returns <see langword="true"/> the event is collected.</item>
+    /// <item>If filter returns <see langword="false"/> the event is filtered out (NOT collected).</item>
+    /// </list>
+    /// </remarks>
+    public Func<LogRecord, bool>? Filter { get; set; }
 }

--- a/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
@@ -57,13 +57,16 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
     [InlineData(false)]
     [InlineData(true, 18, true, true, true)]
     [InlineData(true, 0, false, false, true, true)]
+    [InlineData(true, 18, true, true, true, false, true)]
+    [InlineData(true, 0, false, false, true, true, true)]
     public void AttachLogsToActivityEventTest(
         bool sampled,
         int eventId = 0,
         bool includeFormattedMessage = false,
         bool parseStateValues = false,
         bool includeScopes = false,
-        bool recordException = false)
+        bool recordException = false,
+        bool? filter = null)
     {
         this.sampled = sampled;
 
@@ -74,7 +77,15 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
                     options.IncludeScopes = includeScopes;
                     options.IncludeFormattedMessage = includeFormattedMessage;
                     options.ParseStateValues = parseStateValues;
-                    options.AttachLogsToActivityEvent();
+                    options.AttachLogsToActivityEvent(x =>
+                    {
+                        x.Filter = filter switch
+                        {
+                            true => _ => true,
+                            false => _ => false,
+                            null => null,
+                        };
+                    });
                 });
                 builder.AddFilter(typeof(ActivityEventAttachingLogProcessorTests).FullName, LogLevel.Trace);
             });
@@ -174,6 +185,63 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
                 Assert.Equal("Goodbye OpenTelemetry.", exTags["exception.message"]);
                 Assert.Contains(exTags, kvp => kvp.Key == "exception.stacktrace");
             }
+        }
+        else
+        {
+            Assert.Empty(activity.Events);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [InlineData(true, 18, true, true, true)]
+    [InlineData(true, 0, false, false, true, true)]
+    public void AttachLogsToActivityEventTest_Filter(
+        bool sampled,
+        int eventId = 0,
+        bool includeFormattedMessage = false,
+        bool parseStateValues = false,
+        bool includeScopes = false,
+        bool recordException = false)
+    {
+        this.sampled = sampled;
+
+        using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeScopes = includeScopes;
+                    options.IncludeFormattedMessage = includeFormattedMessage;
+                    options.ParseStateValues = parseStateValues;
+                    options.AttachLogsToActivityEvent(x => x.Filter = _ => false);
+                });
+                builder.AddFilter(typeof(ActivityEventAttachingLogProcessorTests).FullName, LogLevel.Trace);
+            });
+
+        ILogger logger = loggerFactory.CreateLogger<ActivityEventAttachingLogProcessorTests>();
+        Activity activity = this.activitySource.StartActivity("Test");
+
+        using IDisposable scope = logger.BeginScope("{NodeId}", 99);
+
+        logger.LogInformation(eventId, "Hello OpenTelemetry {UserId}!", 8);
+
+        if (recordException)
+        {
+            var innerActivity = this.activitySource.StartActivity("InnerTest");
+
+            using IDisposable innerScope = logger.BeginScope("{RequestId}", "1234");
+
+            logger.LogError(new InvalidOperationException("Goodbye OpenTelemetry."), "Exception event.");
+
+            innerActivity.Dispose();
+        }
+
+        activity.Dispose();
+
+        if (sampled)
+        {
+            Assert.DoesNotContain(activity.Events, x => x.Name == "log");
         }
         else
         {

--- a/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
@@ -193,12 +193,17 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    [InlineData(true, 18, true, true, true)]
-    [InlineData(true, 0, false, false, true, true)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, true, 18, true, true, true)]
+    [InlineData(true, true, 0, false, false, true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, false, 18, true, true, true)]
+    [InlineData(true, false, 0, false, false, true, true)]
     public void AttachLogsToActivityEventTest_Filter(
         bool sampled,
+        bool filterThrows,
         int eventId = 0,
         bool includeFormattedMessage = false,
         bool parseStateValues = false,
@@ -214,7 +219,9 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
                     options.IncludeScopes = includeScopes;
                     options.IncludeFormattedMessage = includeFormattedMessage;
                     options.ParseStateValues = parseStateValues;
-                    options.AttachLogsToActivityEvent(x => x.Filter = _ => false);
+                    options.AttachLogsToActivityEvent(x => x.Filter = _ => filterThrows
+                        ? throw new Exception()
+                        : false);
                 });
                 builder.AddFilter(typeof(ActivityEventAttachingLogProcessorTests).FullName, LogLevel.Trace);
             });


### PR DESCRIPTION
## Changes

I found it useful to be able to filter which log message will be attached to an Activity. This PR adds a Filter callback which can simply filter out a log message.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
~~[ ] Design discussion issue~~
* [ ] Changes in public API reviewed
