### PR TITLE
Remove references to Jaeger exporter

### DIFF
--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -83,7 +83,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
   </ItemGroup>

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -42,13 +42,6 @@ public class WebApiApplication : HttpApplication
 
         switch (ConfigurationManager.AppSettings["UseExporter"].ToLowerInvariant())
         {
-            case "jaeger":
-                builder.AddJaegerExporter(jaegerOptions =>
-                 {
-                     jaegerOptions.AgentHost = ConfigurationManager.AppSettings["JaegerHost"];
-                     jaegerOptions.AgentPort = int.Parse(ConfigurationManager.AppSettings["JaegerPort"]);
-                 });
-                break;
             case "zipkin":
                 builder.AddZipkinExporter(zipkinOptions =>
                 {

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -7,8 +7,6 @@
 		<add key="UnobtrusiveJavaScriptEnabled" value="true"/>
 		<add key="UseExporter" value="console"/>
 		<add key="UseMetricsExporter" value="console"/>
-		<add key="JaegerHost" value="localhost"/>
-		<add key="JaegerPort" value="6831"/>
 		<add key="ZipkinEndpoint" value="http://localhost:9411/api/v2/spans"/>
 		<add key="OtlpEndpoint" value="http://localhost:4317"/>
 	</appSettings>

--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -57,8 +57,8 @@ following shows changes required to your `Web.config` when using IIS web server.
 
 ASP.NET instrumentation must be enabled at application startup. This is
 typically done in the `Global.asax.cs` as shown below. This example also sets up
-the OpenTelemetry Jaeger exporter, which requires adding the package
-[`OpenTelemetry.Exporter.Jaeger`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Jaeger/README.md)
+the OpenTelemetry OTLP exporter, which requires adding the package
+[`OpenTelemetry.Exporter.OpenTelemetryProtocol`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
 to the application.
 
 ```csharp
@@ -72,7 +72,7 @@ public class WebApiApplication : HttpApplication
     {
         this.tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddAspNetInstrumentation()
-            .AddJaegerExporter()
+            .AddOtlpExporter()
             .Build();
     }
     protected void Application_End()

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/README.md
@@ -23,8 +23,8 @@ ASP.NET Core instrumentation example:
 services.AddOpenTelemetry().WithTracing(x =>
 {
     x.AddElasticsearchClientInstrumentation();
-    x.UseJaegerExporter(config => {
-      // Configure Jaeger
+    x.AddOtlpExporter(config => {
+      // Configure OTLP
     });
 });
 ```

--- a/src/OpenTelemetry.Instrumentation.MassTransit/README.md
+++ b/src/OpenTelemetry.Instrumentation.MassTransit/README.md
@@ -52,8 +52,8 @@ services.AddMassTransitHostedService();
 services.AddOpenTelemetrySdk(x =>
 {
     x.AddMassTransitInstrumentation();
-    x.UseJaegerExporter(config => {
-      // Configure Jaeger
+    x.AddOtlpExporter(config => {
+      // Configure OTLP
     });
 });
 ```

--- a/src/OpenTelemetry.Instrumentation.Quartz/README.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/README.md
@@ -9,7 +9,7 @@ Automatically instruments the Quartz jobs from
 ## Supported Frameworks
 
 QuartzNET Instrumentation is only supported when using .NET Framework >=
-`net472` and netstandard >= `netstandard2.0`. Quartz`net461` support for
+`net472` and .NET Standard >= `netstandard2.0`. Quartz`net461` support for
 activity sources has been removed, more information can be found
 [here](https://www.quartz-scheduler.net/2021/04/07/quartznet-3-3-released/).
 
@@ -45,8 +45,8 @@ public void ConfigureServices(IServiceCollection services)
 services.AddOpenTelemetry().WithTracing(x =>
 {
     x.AddQuartzInstrumentation();
-    x.UseJaegerExporter(config => {
-      // Configure Jaeger
+    x.AddOtlpExporter(config => {
+      // Configure OTLP
     });
 });
 ```


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-specification/pull/2858

## Changes

Remove references to Jaeger exporter. Replace by OTLP for most cases.
It will be fully deprecated in July.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
