### PR TITLE
[Instrumentation.AspNet] fix metric description

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
@@ -28,7 +28,7 @@ internal sealed class HttpInMetricsListener : IDisposable
 
     public HttpInMetricsListener(Meter meter)
     {
-        this.httpServerDuration = meter.CreateHistogram<double>("http.server.duration", "ms", "measures the duration of the inbound HTTP request");
+        this.httpServerDuration = meter.CreateHistogram<double>("http.server.duration", "ms", "Measures the duration of inbound HTTP requests.");
         TelemetryHttpModule.Options.OnRequestStoppedCallback += this.OnStopActivity;
     }
 


### PR DESCRIPTION
Fixes [#4169](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4169)
Is a continuation of [#4171](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4171)
Initiated by [this issue](https://github.com/open-telemetry/opentelemetry-demo/issues/737) on the OpenTelemetry Demo

## Changes

Fixes the metric description to conform with specifications and prevent errors from the Prometheus exporter in the collector.

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
