### PR TITLE
[Instrumentation.AspNet] Adjust start and stop activity to be invoked after request start/stop callbacks

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -142,6 +142,11 @@ internal static class ActivityHelper
 
         context.Items[ContextKey] = null;
 
+        if (aspNetActivity.Duration == TimeSpan.Zero)
+        {
+            aspNetActivity.SetEndTime(DateTime.UtcNow);
+        }
+
         try
         {
             onRequestStoppedCallback?.Invoke(aspNetActivity, context);

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -78,7 +78,7 @@ internal static class ActivityHelper
 
         PropagationContext propagationContext = textMapPropagator.Extract(default, context.Request, HttpRequestHeaderValuesGetter);
 
-        Activity activity = AspNetSource.StartActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext);
+        Activity activity = AspNetSource.CreateActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext);
 
         if (activity != null)
         {
@@ -101,6 +101,8 @@ internal static class ActivityHelper
             {
                 AspNetTelemetryEventSource.Log.CallbackException(activity, "OnStarted", callbackEx);
             }
+
+            activity.Start();
 
             AspNetTelemetryEventSource.Log.ActivityStarted(activity);
         }
@@ -138,7 +140,6 @@ internal static class ActivityHelper
 
         var currentActivity = Activity.Current;
 
-        aspNetActivity.Stop();
         context.Items[ContextKey] = null;
 
         try
@@ -149,6 +150,8 @@ internal static class ActivityHelper
         {
             AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, "OnStopped", callbackEx);
         }
+
+        aspNetActivity.Stop();
 
         AspNetTelemetryEventSource.Log.ActivityStopped(currentActivity);
 


### PR DESCRIPTION
Adjust start and stop activity to be invoked after request start/stop callbacks

Fixes #701

## Changes

As some implementations (including custom ones) of BaseProcessor<T> can handle OnStart and OnStop instantly, start and stop events should be fired after activities are enriched with request/response data.

