### PR TITLE
[GenevaExporter] Remove extra table name mapping validation

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Relaxed table name mapping validation rules to restore the previous behavior
+  from version 1.3.0.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/XXXX))
+
 ## 1.5.0-alpha.1
 
 Released 2023-Mar-13

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -62,6 +62,7 @@ public class GenevaExporterOptions
                     throw new ArgumentException($"The table name mapping value '{entry.Value}' provided for key '{entry.Key}' contained non-ASCII characters.", nameof(this.TableNameMappings));
                 }
 
+                /* Note: Validation disabled because it broke previously released versions.
                 if (entry.Value != "*")
                 {
                     if (!TableNameSerializer.IsValidTableName(entry.Value))
@@ -73,7 +74,7 @@ public class GenevaExporterOptions
                     {
                         throw new ArgumentException($"The table name mapping value '{entry.Value}' provided for key '{entry.Key}' is reserved and cannot be specified.", nameof(this.TableNameMappings));
                     }
-                }
+                }*/
 
                 copy[entry.Key] = entry.Value;
             }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -135,6 +135,7 @@ public class GenevaLogExporterTests
     [InlineData("categoryB", "TableB")]
     [InlineData("categoryA", "TableA", "categoryB", "TableB")]
     [InlineData("categoryA", "TableA", "*", "CatchAll")]
+    [InlineData("Example.DefaultService", "myTableName")]
     [InlineData(null)]
     public void TableNameMappingTest(params string[] category)
     {


### PR DESCRIPTION
Relates to #1105

[Note: I plan to make a hotfix branch for 1.4 once this goes in.]

## Changes

* Removes the extra validation added in 1.4 which was breaking for some folks.

## TODOs

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes

