### PR TITLE
Bump test dependencies

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -24,14 +24,13 @@
     <CoverletCollectorPkgVer>[3.2.0,4.0.0)</CoverletCollectorPkgVer>
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
     <MicrosoftExtensionsLoggingPkgVer>[5.0.0,7.0)</MicrosoftExtensionsLoggingPkgVer>
-    <MicrosoftNETTestSdkPkgVer>[17.3.2,18.0)</MicrosoftNETTestSdkPkgVer>
-    <MoqPkgVer>[4.18.3,5.0)</MoqPkgVer>
-    <MoqNet45PkgVer>[4.17.2,5.0)</MoqNet45PkgVer>
+    <MicrosoftNETTestSdkPkgVer>[17.5.0,18.0)</MicrosoftNETTestSdkPkgVer>
+    <MoqPkgVer>[4.18.4,5.0)</MoqPkgVer>
     <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryCoreLatestVersion)</OpenTelemetryExporterInMemoryPkgVer>
     <OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>$(OpenTelemetryCoreLatestPrereleaseVersion)</OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>
-    <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>
+    <XUnitRunnerVisualStudioPkgVer>[2.4.5,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.4.2,3.0)</XUnitPkgVer>
-    <WiremockNetPkgVer>[1.5.20,2.0)</WiremockNetPkgVer>
+    <WiremockNetPkgVer>[1.5.21,2.0)</WiremockNetPkgVer>
 </PropertyGroup>
 
 </Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -27,7 +27,7 @@
       Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
     -->
     <MinVerPkgVer>[4.2.0,5.0)</MinVerPkgVer>
-    <MicrosoftCodeCoveragePkgVer>[17.3.2]</MicrosoftCodeCoveragePkgVer>
+    <MicrosoftCodeCoveragePkgVer>[17.5.0]</MicrosoftCodeCoveragePkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,5.0)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsOptionsPkgVer>[3.1.0,)</MicrosoftExtensionsOptionsPkgVer>
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.3,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>

--- a/build/process-codecoverage.ps1
+++ b/build/process-codecoverage.ps1
@@ -6,7 +6,7 @@ $files = Get-ChildItem "TestResults" -Filter "*.coverage" -Recurse
 Write-Host $env:USERPROFILE
 foreach ($file in $files)
 {
-    $command = $env:USERPROFILE+ '\.nuget\packages\microsoft.codecoverage\' + $microsoftCodeCoveragePkgVer + '\build\netstandard1.0\CodeCoverage\CodeCoverage.exe analyze /output:' + $file.DirectoryName + '\' + $file.Name + '.xml '+ $file.FullName
+    $command = $env:USERPROFILE+ '\.nuget\packages\microsoft.codecoverage\' + $microsoftCodeCoveragePkgVer + '\build\netstandard2.0\CodeCoverage\CodeCoverage.exe analyze /output:' + $file.DirectoryName + '\' + $file.Name + '.xml '+ $file.FullName
     Write-Host $command
     Invoke-Expression $command
 }

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/OpenTelemetry.Contrib.Instrumentation.AWS.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.5.1.24" />
     <PackageReference Include="AWSSDK.SQS" Version="3.5.0.26" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.2" />
-    <PackageReference Include="Moq" Version="$(MoqNet45PkgVer)" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Fixes #.

## Changes

As there is no more project referencing .NET Framework 4.5.2 packages can be updated (including Moq and xunit.runner).

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
