### PR TITLE
[GenevaExporter] [1.4.0 hotfix] Backport remove extra table name mapping validation

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -7,8 +7,8 @@
 Released 2023-Mar-29
 
 * Relaxed table name mapping validation rules to restore the previous behavior
-  from version 1.3.0.
-  ([#1109](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1109))
+  from version 1.3.0. ([Issue
+  #1105](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1105))
 
 ## 1.4.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -8,7 +8,7 @@ Released 2023-Mar-29
 
 * Relaxed table name mapping validation rules to restore the previous behavior
   from version 1.3.0.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/XXXX))
+  ([#1109](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1109))
 
 ## 1.4.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 1.4.1
+
+Released 2023-Mar-29
+
+* Relaxed table name mapping validation rules to restore the previous behavior
+  from version 1.3.0.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/XXXX))
+
 ## 1.4.0
 
 Released 2023-Feb-27

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -62,6 +62,7 @@ public class GenevaExporterOptions
                     throw new ArgumentException($"The table name mapping value '{entry.Value}' provided for key '{entry.Key}' contained non-ASCII characters.", nameof(this.TableNameMappings));
                 }
 
+                /* Note: Validation disabled because it broke previously released versions.
                 if (entry.Value != "*")
                 {
                     if (!TableNameSerializer.IsValidTableName(entry.Value))
@@ -73,7 +74,7 @@ public class GenevaExporterOptions
                     {
                         throw new ArgumentException($"The table name mapping value '{entry.Value}' provided for key '{entry.Key}' is reserved and cannot be specified.", nameof(this.TableNameMappings));
                     }
-                }
+                }*/
 
                 copy[entry.Key] = entry.Value;
             }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/TableNameSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/TableNameSerializer.cs
@@ -49,7 +49,6 @@ internal sealed class TableNameSerializer
     {
         Debug.Assert(options != null, "options were null");
         Debug.Assert(!string.IsNullOrWhiteSpace(defaultTableName), "defaultEventName was null or whitespace");
-        Debug.Assert(IsValidTableName(defaultTableName), "defaultEventName was invalid");
 
         this.m_defaultTableName = BuildStr8BufferForAsciiString(defaultTableName);
 
@@ -81,45 +80,6 @@ internal sealed class TableNameSerializer
 
             this.m_tableMappings = tempTableMappings;
         }
-    }
-
-    public static bool IsReservedTableName(string tableName)
-    {
-        Debug.Assert(!string.IsNullOrWhiteSpace(tableName), "tableName was null or whitespace");
-
-        // TODO: Implement this if needed.
-
-        return false;
-    }
-
-    public static bool IsValidTableName(string tableName)
-    {
-        Debug.Assert(!string.IsNullOrWhiteSpace(tableName), "tableName was null or whitespace");
-
-        var length = tableName.Length;
-        if (length > MaxSanitizedCategoryNameLength)
-        {
-            return false;
-        }
-
-        char firstChar = tableName[0];
-        if (firstChar < 'A' || firstChar > 'Z')
-        {
-            return false;
-        }
-
-        for (int i = 1; i < length; i++)
-        {
-            char cur = tableName[i];
-            if ((cur >= 'a' && cur <= 'z') || (cur >= 'A' && cur <= 'Z') || (cur >= '0' && cur <= '9'))
-            {
-                continue;
-            }
-
-            return false;
-        }
-
-        return true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -135,6 +135,7 @@ public class GenevaLogExporterTests
     [InlineData("categoryB", "TableB")]
     [InlineData("categoryA", "TableA", "categoryB", "TableB")]
     [InlineData("categoryA", "TableA", "*", "CatchAll")]
+    [InlineData("Example.DefaultService", "myTableName")]
     [InlineData(null)]
     public void TableNameMappingTest(params string[] category)
     {


### PR DESCRIPTION
[Note: This is going into a branch I created off the GenevaExporter-1.4.0 tag.]

Fixes #1105

## Changes

* Backport the fix from #1109 for a 1.4.0 hotfix.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes

