### PR TITLE
[PersistentStorage.FileSystem] fix directory size bug

### DIFF
--- a/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 1.0.0-beta.2 (Unreleased)
 
+* Fix a bug affecting the directory size when multiple `FileBlobProvider`s
+  were in a single process. [()]()
+
 * `FileBlobProvider` will now use the path provided during initialization as is
-* for storing blobs, without adding additional hash of current user and process.
+for storing blobs, without adding additional hash of current user and process.
 ([#1110](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1110))
 
 * Going forward the NuGet package will be

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/DirectorySizeTracker.cs
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/DirectorySizeTracker.cs
@@ -1,0 +1,86 @@
+// <copyright file="DirectorySizeTracker.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Threading;
+
+namespace OpenTelemetry.PersistentStorage.FileSystem;
+
+/// <summary>
+/// Tracks the available storage in a specified directory.
+/// </summary>
+internal class DirectorySizeTracker
+{
+    private readonly long maxSizeInBytes;
+    private readonly string path;
+    private long directoryCurrentSizeInBytes;
+
+    public DirectorySizeTracker(long maxSizeInBytes, string path)
+    {
+        this.maxSizeInBytes = maxSizeInBytes;
+        this.path = path;
+        this.directoryCurrentSizeInBytes = CalculateFolderSize(path);
+    }
+
+    public void FileAdded(long fileSizeInBytes) => Interlocked.Add(ref this.directoryCurrentSizeInBytes, fileSizeInBytes);
+
+    public void FileRemoved(long fileSizeInBytes) => Interlocked.Add(ref this.directoryCurrentSizeInBytes, fileSizeInBytes * -1);
+
+    public bool IsSpaceAvailable(out long currentSizeInBytes)
+    {
+        currentSizeInBytes = Interlocked.Read(ref this.directoryCurrentSizeInBytes);
+        return currentSizeInBytes < this.maxSizeInBytes;
+    }
+
+    public void RecountCurrentSize()
+    {
+        var size = CalculateFolderSize(this.path);
+        Interlocked.Exchange(ref this.directoryCurrentSizeInBytes, size);
+    }
+
+    internal static long CalculateFolderSize(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return 0;
+        }
+
+        long directorySize = 0;
+        try
+        {
+            foreach (string file in Directory.EnumerateFiles(path))
+            {
+                if (File.Exists(file))
+                {
+                    FileInfo fileInfo = new FileInfo(file);
+                    directorySize += fileInfo.Length;
+                }
+            }
+
+            foreach (string dir in Directory.GetDirectories(path))
+            {
+                directorySize += CalculateFolderSize(dir);
+            }
+        }
+        catch (Exception ex)
+        {
+            PersistentStorageEventSource.Log.PersistentStorageException(nameof(PersistentStorageHelper), "Error calculating folder size", ex);
+        }
+
+        return directorySize;
+    }
+}

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/FileBlobProvider.cs
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/FileBlobProvider.cs
@@ -94,7 +94,7 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
 
         // TODO: Validate time period values
         this.DirectoryPath = PersistentStorageHelper.CreateSubdirectory(path);
-        this.directorySizeTracker = new(maxSizeInBytes, path);
+        this.directorySizeTracker = new DirectorySizeTracker(maxSizeInBytes, path);
         this.retentionPeriodInMilliseconds = retentionPeriodInMilliseconds;
         this.writeTimeoutInMilliseconds = writeTimeoutInMilliseconds;
 

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/FileBlobProvider.cs
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/FileBlobProvider.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.PersistentStorage.FileSystem;
 public class FileBlobProvider : PersistentBlobProvider, IDisposable
 {
     internal readonly string DirectoryPath;
-    private readonly long maxSizeInBytes;
+    private readonly DirectorySizeTracker directorySizeTracker;
     private readonly long retentionPeriodInMilliseconds;
     private readonly int writeTimeoutInMilliseconds;
     private readonly Timer maintenanceTimer;
@@ -94,7 +94,7 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
 
         // TODO: Validate time period values
         this.DirectoryPath = PersistentStorageHelper.CreateSubdirectory(path);
-        this.maxSizeInBytes = maxSizeInBytes;
+        this.directorySizeTracker = new(maxSizeInBytes, path);
         this.retentionPeriodInMilliseconds = retentionPeriodInMilliseconds;
         this.writeTimeoutInMilliseconds = writeTimeoutInMilliseconds;
 
@@ -132,7 +132,7 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
             DateTime fileDateTime = PersistentStorageHelper.GetDateTimeFromBlobName(file);
             if (fileDateTime > retentionDeadline)
             {
-                yield return new FileBlob(file);
+                yield return new FileBlob(file, this.directorySizeTracker);
             }
         }
     }
@@ -174,12 +174,14 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
         }
 
         PersistentStorageHelper.RemoveExpiredBlobs(this.DirectoryPath, this.retentionPeriodInMilliseconds, this.writeTimeoutInMilliseconds);
+
+        // It is faster to calculate the directory size, instead of removing length of expired files.
+        this.directorySizeTracker.RecountCurrentSize();
     }
 
     private bool CheckStorageSize()
     {
-        var size = PersistentStorageHelper.GetDirectorySize();
-        if (size >= this.maxSizeInBytes)
+        if (!this.directorySizeTracker.IsSpaceAvailable(out long size))
         {
             // TODO: check accuracy of size reporting.
             PersistentStorageEventSource.Log.PersistentStorageWarning(
@@ -201,7 +203,7 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
         try
         {
             var blobFilePath = Path.Combine(this.DirectoryPath, PersistentStorageHelper.GetUniqueFileName(".blob"));
-            var blob = new FileBlob(blobFilePath);
+            var blob = new FileBlob(blobFilePath, this.directorySizeTracker);
 
             if (blob.TryWrite(buffer, leasePeriodMilliseconds))
             {

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/DirectorySizeTrackerTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/DirectorySizeTrackerTests.cs
@@ -1,0 +1,60 @@
+// <copyright file="DirectorySizeTrackerTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.IO;
+using Xunit;
+
+namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
+
+public class DirectorySizeTrackerTests
+{
+    [Fact]
+    public void VerifyDirectorySizeTracker()
+    {
+        var testDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+        testDirectory.Create();
+
+        var directorySizeTracker = new DirectorySizeTracker(maxSizeInBytes: 100, path: testDirectory.FullName);
+
+        // new directory, expected to have space
+        Assert.True(directorySizeTracker.IsSpaceAvailable(out long currentSize1));
+        Assert.Equal(0, currentSize1);
+
+        // add a file and check current space.
+        directorySizeTracker.FileAdded(30);
+        Assert.True(directorySizeTracker.IsSpaceAvailable(out long currentSize2));
+        Assert.Equal(30, currentSize2);
+
+        // add a file and check current space. Here we've exceeded the configured max size
+        directorySizeTracker.FileAdded(100);
+        Assert.False(directorySizeTracker.IsSpaceAvailable(out long currentSize3));
+        Assert.Equal(130, currentSize3);
+
+        // remove a file and check current space.
+        directorySizeTracker.FileRemoved(50);
+        Assert.True(directorySizeTracker.IsSpaceAvailable(out long currentSize4));
+        Assert.Equal(80, currentSize4);
+
+        // since we haven't actually written any files to disk,
+        // Recount will reset to zero.
+        directorySizeTracker.RecountCurrentSize();
+        Assert.True(directorySizeTracker.IsSpaceAvailable(out long currentSize5));
+        Assert.Equal(0, currentSize5);
+
+        // cleanup
+        testDirectory.Delete();
+    }
+}

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
@@ -64,13 +64,14 @@ public class FileBlobProviderTests
         testDirectory.Delete(true);
     }
 
-    [Fact(Skip = "Unstable")]
-    public void FileBlobProvider_CreateBlobReturnsNullIfblobProviderIsFull()
+    [Fact]
+    public void FileBlobProvider_CreateBlobReturnsNullIfBlobProviderIsFull()
     {
         var testDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
-        using var blobProvider = new FileBlobProvider(testDirectory.FullName, 10000);
+        using var blobProvider = new FileBlobProvider(testDirectory.FullName, 100);
 
-        PersistentStorageHelper.UpdateDirectorySize(10000);
+        // write a file to fill up the configured max space.
+        Assert.True(blobProvider.TryCreateBlob(new byte[100], out _));
 
         var data = Encoding.UTF8.GetBytes("Hello, World!");
 


### PR DESCRIPTION
Previously the directory size counter was a static long on a static helper class (PersistentStorageHelper.directorySize).
If a process contained multiple `FileBlobProvider`s, they would use the same counter and the value would be incorrect. 
This could block new files to be written to a directory.

## Changes
- New class `DirectorySizeTracker` which encapsulates the counter and all necessary math.
  - Most methods are moved from the `PersistentStorageHelper`.
  - An instance of this class in created in the `FileBlobProvider` ctor.
  - This replaces `FileBlobProvider.maxSizeInBytes` and `PersistentStorageHelper.directorySize`.
- edit `FileBlob` to take a refence to `DirectorySizeTracker`.
  This is necessary because any instance of `FileBlob` can perform a Write or Delete action and MUST update the counter.
  Previously this was done in the `PersistentStorageHelper`.



Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
