### PR TITLE
[Exporter.Geneva][TldLogExporter] Update TldLogExporter to log eventId.Id as a PartB field

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* TldLogExporter to export `eventId.Id` as a Part B field instead of Part C field.
+* TldLogExporter to export `eventId.Id` as a Part B field instead of Part C
+  field.
   ([#1134](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1134))
 
 ## 1.5.0-alpha.2

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* TldLogExporter to export `eventId.Id` as a Part B field instead of Part C field.
+  ([#1134](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1134))
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-29

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
@@ -296,6 +296,13 @@ internal sealed class TldLogExporter : TldExporter, IDisposable
         eb.AddUInt8("severityNumber", GetSeverityNumber(logLevel));
         eb.AddCountedAnsiString("name", categoryName, Encoding.UTF8);
 
+        var eventId = logRecord.EventId;
+        if (eventId != default)
+        {
+            eb.AddInt32("eventId", eventId.Id);
+            partBFieldsCount++;
+        }
+
         byte hasEnvProperties = 0;
         bool bodyPopulated = false;
 
@@ -393,13 +400,6 @@ internal sealed class TldLogExporter : TldExporter, IDisposable
             // named "env_properties".
             var serializedEnvPropertiesStringAsBytes = JsonSerializer.SerializeKeyValuePairsListAsBytes(envPropertiesList, out var count);
             eb.AddCountedAnsiString("env_properties", serializedEnvPropertiesStringAsBytes, 0, count);
-        }
-
-        var eventId = logRecord.EventId;
-        if (eventId != default)
-        {
-            eb.AddInt32("eventId", eventId.Id);
-            partCFieldsCount++;
         }
 
         eb.SetStructFieldCount(partCFieldsCountPatch, (byte)partCFieldsCount);


### PR DESCRIPTION
## Changes
- Update TldLogExporter to log `eventId.Id` as a PartB field

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
