### PR TITLE
[Exporter.Geneva] Update GenevaLogExporter to export eventName

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 OpenTelemetry.Exporter.Geneva.EventNameExportMode
-OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsField = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsPartAName = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsField = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 OpenTelemetry.Exporter.Geneva.EventNameExportMode
-OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsField = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsPartAName = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsField = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsField = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
-OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsTableName = 2 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 OpenTelemetry.Exporter.Geneva.EventNameExportMode
-OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsField = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsPartAName = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsField = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsTableName = 2 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -7,7 +7,7 @@
   ([#1134](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1134))
 
 * Update GenevaLogExporter to export `eventId.Name` as the value for Part A
-  `name` field when the `EventNameExportMode` option is set to `ExportAsField`.
+  `name` field when the `EventNameExportMode` option is set to `ExportAsPartAName`.
   ([#1135](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1135))
 
 ## 1.4.1

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Update GenevaLogExporter to export `eventId.Name` when the
+  `EventNameExportMode` option is set to `ExportAsField`.
+  ([#1135](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1135))
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-29

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update GenevaLogExporter to export `eventId.Name` when the
-  `EventNameExportMode` option is set to `ExportAsField`.
+* Update GenevaLogExporter to export `eventId.Name` as the value for Part A
+  `name` field when the `EventNameExportMode` option is set to `ExportAsField`.
   ([#1135](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1135))
 
 ## 1.5.0-alpha.2

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -17,7 +17,6 @@ Released 2023-Mar-29
 * Relaxed table name mapping validation rules to restore the previous behavior
   from version 1.3.0.
   ([#1120](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1120))
->>>>>>> origin/main
 
 ## 1.5.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
@@ -22,13 +22,13 @@ namespace OpenTelemetry.Exporter.Geneva;
 public enum EventNameExportMode
 {
     /// <summary>
-    /// GenevaExporter will not export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.id">eventId.Id</a>
+    /// GenevaExporter will not export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.name">eventId.Name</a>
     /// if the enum instance has no other flag selected.
     /// </summary>
     None = 0,
 
     /// <summary>
-    /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.id">eventId.Id</a>
+    /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.name">eventId.Name</a>
     /// as an individual field with the name `eventName` when this flag is selected. There is no de-duplication of fields. If `eventName`
     /// is also present in the log message or scopes, all the `eventName` fields are exported.
     /// </summary>
@@ -36,7 +36,7 @@ public enum EventNameExportMode
 
     /* Note: This might be added in future.
     /// <summary>
-    /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.id">eventId.Id</a>
+    /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.name">eventId.Name</a>
     /// as the table name when this flag is selected.
     /// </summary>
     ExportAsTableName = 2,

--- a/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
@@ -29,8 +29,7 @@ public enum EventNameExportMode
 
     /// <summary>
     /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.name">eventId.Name</a>
-    /// as an individual field with the name `eventName` when this flag is selected. There is no de-duplication of fields. If `eventName`
-    /// is also present in the log message or scopes, all the `eventName` fields are exported.
+    /// as Part A name field when this flag is selected.
     /// </summary>
     ExportAsField = 1,
 

--- a/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
@@ -31,7 +31,7 @@ public enum EventNameExportMode
     /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.name">eventId.Name</a>
     /// as Part A name field when this flag is selected.
     /// </summary>
-    ExportAsField = 1,
+    ExportAsPartAName = 1,
 
     /* Note: This might be added in future.
     /// <summary>

--- a/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
@@ -1,0 +1,44 @@
+// <copyright file="EventNameExportMode.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.Exporter.Geneva;
+
+[Flags]
+public enum EventNameExportMode
+{
+    /// <summary>
+    /// GenevaExporter will not export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.id">eventId.Id</a>
+    /// if the enum instance has no other flag selected.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.id">eventId.Id</a>
+    /// as an individual field with the name `eventName` when this flag is selected. There is no de-duplication of fields. If `eventName`
+    /// is also present in the log message or scopes, all the `eventName` fields are exported.
+    /// </summary>
+    ExportAsField = 1,
+
+    /* Note: This might be added in future.
+    /// <summary>
+    /// GenevaExporter will export <a href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.eventid.id">eventId.Id</a>
+    /// as the table name when this flag is selected.
+    /// </summary>
+    ExportAsTableName = 2,
+    */
+}

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -36,6 +36,8 @@ public class GenevaExporterOptions
 
     public ExceptionStackExportMode ExceptionStackExportMode { get; set; }
 
+    public EventNameExportMode EventNameExportMode { get; set; }
+
     public IReadOnlyDictionary<string, string> TableNameMappings
     {
         get => this._tableNameMappings;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -1019,8 +1019,8 @@ public class GenevaLogExporterTests
     [Theory]
     [InlineData(EventNameExportMode.None, false)]
     [InlineData(EventNameExportMode.None, true)]
-    [InlineData(EventNameExportMode.ExportAsField, false)]
-    [InlineData(EventNameExportMode.ExportAsField, true)]
+    [InlineData(EventNameExportMode.ExportAsPartAName, false)]
+    [InlineData(EventNameExportMode.ExportAsPartAName, true)]
     public void SerializationTestForEventName(EventNameExportMode eventNameExportMode, bool hasTableNameMapping)
     {
         // ARRANGE
@@ -1094,7 +1094,7 @@ public class GenevaLogExporterTests
             object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var eventName = GetField(fluentdData, "env_name");
 
-            if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsField))
+            if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsPartAName))
             {
                 Assert.Equal("TestEventNameWithLogMethod", eventName);
             }
@@ -1114,7 +1114,7 @@ public class GenevaLogExporterTests
             fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             eventName = GetField(fluentdData, "env_name");
 
-            if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsField))
+            if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsPartAName))
             {
                 Assert.Equal("TestEventNameWithLogExtensionMethod", eventName);
             }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -51,6 +51,13 @@ public class GenevaLogExporterTests
     }
 
     [Fact]
+    public void ExportEventNameDefaultIsNone()
+    {
+        GenevaExporterOptions exporterOptions = new GenevaExporterOptions();
+        Assert.Equal(EventNameExportMode.None, exporterOptions.EventNameExportMode);
+    }
+
+    [Fact]
     public void SpecialCharactersInTableNameMappings()
     {
         Assert.Throws<ArgumentException>(() =>
@@ -995,6 +1002,124 @@ public class GenevaLogExporterTests
             var exceptionMessage = GetField(fluentdData, "env_ex_msg");
             Assert.Equal("System.Exception", exceptionType);
             Assert.Equal("Exception Message", exceptionMessage);
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(EventNameExportMode.None)]
+    [InlineData(EventNameExportMode.ExportAsField)]
+    public void SerializationTestForEventName(EventNameExportMode eventNameExportMode)
+    {
+        // ARRANGE
+        string path = string.Empty;
+        Socket server = null;
+        var logRecordList = new List<LogRecord>();
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions();
+            exporterOptions.EventNameExportMode = eventNameExportMode;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GenerateTempFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(options =>
+                {
+                    options.AddGenevaLogExporter(options =>
+                    {
+                        options.ConnectionString = exporterOptions.ConnectionString;
+                        options.EventNameExportMode = exporterOptions.EventNameExportMode;
+                    });
+                    options.AddInMemoryExporter(logRecordList);
+                }));
+
+            // Create a test exporter to get MessagePack byte data to validate if the data was serialized correctly.
+            using var exporter = new MsgPackLogExporter(exporterOptions);
+
+            // Emit a LogRecord and grab a copy of the LogRecord from the collection passed to InMemoryExporter
+            var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
+
+            // ACT
+            // This is treated as structured logging as the state can be converted to IReadOnlyList<KeyValuePair<string, object>>
+
+            #region Test for `ILogger.Log`
+            logger.Log<object>(
+                logLevel: LogLevel.Information,
+                eventId: new EventId(1, "TestEventNameWithLogMethod"),
+                state: null,
+                exception: new Exception("Exception Message"),
+                formatter: null);
+
+            // VALIDATE
+            Assert.Single(logRecordList);
+            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
+            _ = exporter.SerializeLogRecord(logRecordList[0]);
+            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            var eventName = GetField(fluentdData, "eventName");
+
+            if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsField))
+            {
+                Assert.Equal("TestEventNameWithLogMethod", eventName);
+            }
+            else
+            {
+                Assert.Null(eventName);
+            }
+
+            #endregion
+
+            logRecordList.Clear();
+
+            #region Test for extension method
+            logger.LogInformation(eventId: new EventId(1, "TestEventNameWithLogExtensionMethod"), "Hello from {Name} {Price}.", "tomato", 2.99);
+
+            _ = exporter.SerializeLogRecord(logRecordList[0]);
+            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            eventName = GetField(fluentdData, "eventName");
+
+            if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsField))
+            {
+                Assert.Equal("TestEventNameWithLogExtensionMethod", eventName);
+            }
+            else
+            {
+                Assert.Null(eventName);
+            }
+            #endregion
+
+            logRecordList.Clear();
+
+            #region Test with eventName as null
+            logger.LogInformation(eventId: 1, "Hello from {Name} {Price}.", "tomato", 2.99);
+
+            _ = exporter.SerializeLogRecord(logRecordList[0]);
+            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            eventName = GetField(fluentdData, "eventName");
+            Assert.Null(eventName); // The exporter should not export eventName when it's null
+            #endregion
+
         }
         finally
         {


### PR DESCRIPTION
Towards #584 

This PR adds a new option called `EventNameExportMode` which can be used to export `eventId.Name`. When this option is set to `EventNameExportMode.ExportAsField`, GenevaLogExporter would export `eventId.Name` as a value for the field `env_name`.

### Default behavior

```csharp
public class Program
{
    public static void Main()
    {
        using var loggerFactory = LoggerFactory.Create(builder =>
        {
            builder.AddOpenTelemetry(options =>
            {
                options.AddGenevaLogExporter(options =>
                {
                    options.ConnectionString = "EtwSession=OpenTelemetry;";
                });
            });
        });

        // Creates a logger with the Category name as "Program"
        // GenevaExporter exports Category name under the column `name`
        var logger = loggerFactory.CreateLogger<Program>();

        logger.LogInformation(new EventId(100, "CustomEventName"), "Hello from log with EventId {food} {price}.", "tomato", 2.99);
    }
}
```

**What gets exported?**
TableName: "Log"

|    env_name |                     name |  eventId |    food |   price |   severityNumber | severityText |
|------------ |------------------------- |---------:|-------- |--------:|-----------------:|------------- |
| Log (this is same as the table name)        |Program                   |      100 |  tomato |    2.99 |                9 | Information  |

### With this PR

Users can set the `EventNameExportMode` option to `EventNameExportMode.ExportAsField` to export `eventId.Name` as a value for the field `env_name`.

```csharp
public class Program
{
    public static void Main()
    {
        using var loggerFactory = LoggerFactory.Create(builder =>
        {
            builder.AddOpenTelemetry(options =>
            {
                options.AddGenevaLogExporter(options =>
                {
                    options.ConnectionString = "EtwSession=OpenTelemetry;";
                    options.EventNameExportMode = EventNameExportMode.ExportAsField;
                });
            });
        });

        // Creates a logger with the Category name as "Program"
        // GenevaExporter exports Category name under the column `name`
        var logger = loggerFactory.CreateLogger<Program>();

        logger.LogInformation(new EventId(100, "CustomEventName"), "Hello from log with EventId {food} {price}.", "tomato", 2.99);
    }
}
```

**What gets exported?**
TableName: "Log"

|    env_name |                     name |  eventId |    food |   price |   severityNumber | severityText |
|------------ |------------------------- |---------:|-------- |--------:|-----------------:|------------- |
| CustomEventName         |Program                   |      100 |  tomato |    2.99 |                9 | Information  |


For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
