### PR TITLE
Allow subtypes of default AWS service clients to be instrumented

### DIFF
--- a/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
+++ b/src/OpenTelemetry.Contrib.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
@@ -39,7 +39,7 @@ internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
 
     public void Customize(Type serviceClientType, RuntimePipeline pipeline)
     {
-        if (serviceClientType.BaseType != typeof(AmazonServiceClient))
+        if (!typeof(AmazonServiceClient).IsAssignableFrom(serviceClientType))
         {
             return;
         }

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/TestAmazonDynamoDBClient.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/TestAmazonDynamoDBClient.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="TestAmazonDynamoDBClient.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Amazon;
+using Amazon.DynamoDBv2;
+using Amazon.Runtime;
+
+namespace OpenTelemetry.Contrib.Instrumentation.AWS.Tests;
+
+internal class TestAmazonDynamoDBClient : AmazonDynamoDBClient
+{
+    public TestAmazonDynamoDBClient(AWSCredentials credentials, RegionEndpoint region)
+        : base(credentials, region)
+    {
+    }
+}

--- a/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/TestAmazonDynamoDBClient.cs
+++ b/test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/Tools/TestAmazonDynamoDBClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestAmazonDynamoDBClient.cs" company="OpenTelemetry Authors">
+// <copyright file="TestAmazonDynamoDBClient.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Changes

Allow any type in `AmazonServiceClient` hierarchy to be instrumented rather than just direct subtypes.