### PR TITLE
[AzureMonitor] Add ApplicationInsightsSamplerOptions to improve Dependency Injection support

### DIFF
--- a/src/OpenTelemetry.Extensions.AzureMonitor/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler
-OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ApplicationInsightsSampler(float samplingRatio) -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ApplicationInsightsSampler(OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions! options) -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.ApplicationInsightsSamplerOptions() -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.SamplingRatio.get -> float
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.SamplingRatio.set -> void
 override OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult

--- a/src/OpenTelemetry.Extensions.AzureMonitor/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler
-OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ApplicationInsightsSampler(float samplingRatio) -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ApplicationInsightsSampler(OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions! options) -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.ApplicationInsightsSamplerOptions() -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.SamplingRatio.get -> float
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.SamplingRatio.set -> void
 override OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult

--- a/src/OpenTelemetry.Extensions.AzureMonitor/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler
-OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ApplicationInsightsSampler(float samplingRatio) -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ApplicationInsightsSampler(OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions! options) -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.ApplicationInsightsSamplerOptions() -> void
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.SamplingRatio.get -> float
+OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSamplerOptions.SamplingRatio.set -> void
 override OpenTelemetry.Extensions.AzureMonitor.ApplicationInsightsSampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult

--- a/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSampler.cs
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSampler.cs
@@ -33,18 +33,19 @@ public class ApplicationInsightsSampler : Sampler
     /// <summary>
     /// Initializes a new instance of the <see cref="ApplicationInsightsSampler"/> class.
     /// </summary>
-    /// <param name="samplingRatio">
-    /// Ratio of telemetry that should be sampled.
-    /// For example; Specifying 0.4F means 40% of traces are sampled and 60% are dropped.
+    /// <param name="options">
+    /// <see cref="ApplicationInsightsSamplerOptions"/> for configuring the ApplicationInsightsSampler.
     /// </param>
-    public ApplicationInsightsSampler(float samplingRatio)
+    public ApplicationInsightsSampler(ApplicationInsightsSamplerOptions options)
     {
-        // Ensure passed ratio is between 0 and 1, inclusive
-        Guard.ThrowIfOutOfRange((double)samplingRatio, min: 0.0, max: 1.0);
+        Guard.ThrowIfNull(options);
 
-        this.samplingRatio = samplingRatio;
-        this.Description = "ApplicationInsightsSampler{" + samplingRatio + "}";
-        var sampleRate = (float)Math.Round(samplingRatio * 100);
+        // Ensure passed ratio is between 0 and 1, inclusive
+        Guard.ThrowIfOutOfRange((double)options.SamplingRatio, min: 0.0, max: 1.0);
+
+        this.samplingRatio = options.SamplingRatio;
+        this.Description = "ApplicationInsightsSampler{" + options.SamplingRatio + "}";
+        var sampleRate = (float)Math.Round(options.SamplingRatio * 100);
         this.recordAndSampleSamplingResult = new SamplingResult(
             SamplingDecision.RecordAndSample,
             new Dictionary<string, object>

--- a/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSamplerOptions.cs
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/ApplicationInsightsSamplerOptions.cs
@@ -1,0 +1,30 @@
+// <copyright file="ApplicationInsightsSamplerOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Extensions.AzureMonitor;
+
+/// <summary>
+/// Options for configuring an <see cref="ApplicationInsightsSampler"/> to customize
+/// its sampling behavior.
+/// </summary>
+public class ApplicationInsightsSamplerOptions
+{
+    /// <summary>
+    /// Gets or sets the ratio of telemetry items to be sampled. The value must be between 0.0F and 1.0F, inclusive.
+    /// For example, specifying 0.4 means that 40% of traces are sampled and 60% are dropped.
+    /// </summary>
+    public float SamplingRatio { get; set; }
+}

--- a/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AzureMonitor/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Updated `ApplicationInsightsSampler` constructor to accept
+  `ApplicationInsightsSamplerOptions` instead of a float `samplingRatio`, and
+  introduced `ApplicationInsightsSamplerOptions` for Dependency Injection
+  support.
+
 ## 1.0.0-beta.3
 
 Released 2023-Feb-07

--- a/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.AzureMonitor.Tests/ApplicationInsightsSamplerTests.cs
@@ -49,18 +49,18 @@ public class ApplicationInsightsSamplerTests
         SamplingParameters testParams2 = new SamplingParameters(parentContext, testId2, "TestActivity", ActivityKind.Internal);
 
         // Verify sample ratio: 0
-        ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(samplingRatio: 0);
+        ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 0 });
         Assert.Equal(SamplingDecision.RecordOnly, zeroSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordOnly, zeroSampler.ShouldSample(testParams2).Decision);
 
         // Verify sample ratio: 1
-        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(samplingRatio: 1);
+        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 1 });
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, oneSampler.ShouldSample(testParams2).Decision);
 
         // Verify sample ratio: 0.5.
         // This is below the sample score for testId2, but strict enough to drop testId1
-        ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(samplingRatio: 0.5f);
+        ApplicationInsightsSampler ratioSampler = new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 0.5f });
         Assert.Equal(SamplingDecision.RecordOnly, ratioSampler.ShouldSample(testParams1).Decision);
         Assert.Equal(SamplingDecision.RecordAndSample, ratioSampler.ShouldSample(testParams2).Decision);
     }
@@ -68,27 +68,27 @@ public class ApplicationInsightsSamplerTests
     [Fact]
     public void ApplicationInsightsSamplerGoodArgs()
     {
-        ApplicationInsightsSampler pointFiveSampler = new ApplicationInsightsSampler(0.5f);
+        ApplicationInsightsSampler pointFiveSampler = new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 0.5f });
         Assert.NotNull(pointFiveSampler);
 
-        ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(0f);
+        ApplicationInsightsSampler zeroSampler = new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 0f });
         Assert.NotNull(zeroSampler);
 
-        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(1f);
+        ApplicationInsightsSampler oneSampler = new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 1f });
         Assert.NotNull(oneSampler);
     }
 
     [Fact]
     public void ApplicationInsightsSamplerBadArgs()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ApplicationInsightsSampler(-2f));
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ApplicationInsightsSampler(2f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = -2f }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 2f }));
     }
 
     [Fact]
     public void GetDescriptionMatchesSpec()
     {
         var expectedDescription = "ApplicationInsightsSampler{0.5}";
-        Assert.Equal(expectedDescription, new ApplicationInsightsSampler(0.5f).Description);
+        Assert.Equal(expectedDescription, new ApplicationInsightsSampler(new ApplicationInsightsSamplerOptions { SamplingRatio = 0.5f }).Description);
     }
 }


### PR DESCRIPTION
Fixes #.

## Changes
Please provide a brief description of the changes here.

This PR updates the `ApplicationInsightsSampler` constructor to accept an `ApplicationInsightsSamplerOptions` object instead of a float sampling ratio and introduces the `ApplicationInsightsSamplerOptions` class for providing Dependency Injection support for the sampler configuration.

```C#
.SetSampler(sp =>
{
   var options = sp.GetRequiredService<IOptionsMonitor<ApplicationInsightsSamplerOptions>>().Get(Options.DefaultName);
   return new ApplicationInsightsSampler(options);
})


builder.Services.Configure<ApplicationInsightsSamplerOptions>(options => { options.SamplingRatio = 1.0F; });
```

For significant contributions please make sure you have completed the following items:

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [X] Changes in public API reviewed
