### PR TITLE
Add atshaw43 as AWS components co-owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -5,9 +5,10 @@
 components:
   src/OpenTelemetry.Contrib.Extensions.AWSXRay/:
     - srprash
-    - lupengamzn
+    - atshaw43
   src/OpenTelemetry.Contrib.Instrumentation.AWS/:
     - srprash
+    - atshaw43
   src/OpenTelemetry.Exporter.Geneva/:
     - cijothomas
     - codeblanch
@@ -66,11 +67,13 @@ components:
     - iskiselev
   src/OpenTelemetry.Sampler.AWS/:
     - srprash
+    - atshaw43
   test/OpenTelemetry.Contrib.Extensions.AWSXRay.Tests/:
     - srprash
-    - lupengamzn
+    - atshaw43
   test/OpenTelemetry.Contrib.Instrumentation.AWS.Tests/:
     - srprash
+    - atshaw43
   test/OpenTelemetry.Exporter.Geneva.Benchmark/:
     - cijothomas
     - codeblanch
@@ -140,3 +143,4 @@ components:
     - iskiselev
   test/OpenTelemetry.Sampler.AWS.Tests/:
     - srprash
+    - atshaw43


### PR DESCRIPTION
## Changes
- Add @atshaw43 as a co-owner for AWS components.
- Remove @lupengamzn as he isn't on the project anymore.

