### PR TITLE
[Instrumentation.MySqlData,Instrumentation.StackExchangeRedis] Avoid SetStatus(Unset)

### DIFF
--- a/src/OpenTelemetry.Instrumentation.MySqlData/MySqlDataInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/MySqlDataInstrumentation.cs
@@ -168,17 +168,7 @@ internal class MySqlDataInstrumentation : DefaultTraceListener
             return;
         }
 
-        try
-        {
-            if (activity.IsAllDataRequested)
-            {
-                activity.SetStatus(Status.Unset);
-            }
-        }
-        finally
-        {
-            activity.Stop();
-        }
+        activity.Stop();
     }
 
     private void BeforeExecuteCommand(MySqlDataTraceCommand command)

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -107,8 +107,6 @@ internal static class RedisProfilerEntryToActivityConverter
             // Total:
             // command.ElapsedTime;             // 00:00:32.4988020
 
-            activity.SetStatus(Status.Unset);
-
             activity.SetTag(StackExchangeRedisCallsInstrumentation.RedisFlagsKeyName, command.Flags.ToString());
 
             if (options.SetVerboseDatabaseStatements)


### PR DESCRIPTION
Fixes N/A.

## Changes

Remove calls Activity.SetStatus(Unset)
It is probably leftover from older OTel SDK/API or older DiagnosticSource package.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
