### PR TITLE
Assign correct value to ext_dt_spanId in Tld Geneva exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* TldLogExporter to export `SpanId` value in `ext_dt_spanId` field instead of
+  `TraceId` value.
+  ([#1184](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1184))
+
 ## 1.5.0-alpha.3
 
 Released 2023-Apr-19

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
@@ -257,7 +257,7 @@ internal sealed class TldLogExporter : TldExporter, IDisposable
 
         if (logRecord.SpanId != default)
         {
-            eb.AddCountedString("ext_dt_spanId", logRecord.TraceId.ToHexString());
+            eb.AddCountedString("ext_dt_spanId", logRecord.SpanId.ToHexString());
             partAFieldsCount++;
         }
 


### PR DESCRIPTION
## Changes

I was testing the Geneva TldExporter locally (it produces very nice info into the EventSource) and I noticed the spanId value was too long and the same as traceId, so I looked in the code and noticed it was assigning the wrong property to the field.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
