### PR TITLE
[redis] Append options name to the background thread

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -21,7 +21,7 @@
 * When using named options the name will now be applied to the background thread
   created for each instrumented connection in the format
   `OpenTelemetry.Redis{OPTIONS_NAME_HERE}`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1205](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1205))
 
 ## 1.0.0-rc9.8
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -18,6 +18,11 @@
   `TracerProvider` has been created.
   ([#1193](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1193))
 
+* When using named options the name will now be applied to the background thread
+  created for each instrumented connection in the format
+  `OpenTelemetry.Redis{OPTIONS_NAME_HERE}`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-rc9.8
 
 Released 2023-Feb-27

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -53,8 +53,12 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
     /// Initializes a new instance of the <see cref="StackExchangeRedisConnectionInstrumentation"/> class.
     /// </summary>
     /// <param name="connection"><see cref="IConnectionMultiplexer"/> to instrument.</param>
+    /// <param name="name">Optional name for the connection.</param>
     /// <param name="options">Configuration options for redis instrumentation.</param>
-    public StackExchangeRedisConnectionInstrumentation(IConnectionMultiplexer connection, StackExchangeRedisInstrumentationOptions options)
+    public StackExchangeRedisConnectionInstrumentation(
+        IConnectionMultiplexer connection,
+        string? name,
+        StackExchangeRedisInstrumentationOptions options)
     {
         Guard.ThrowIfNull(connection);
 
@@ -62,7 +66,7 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
 
         this.drainThread = new Thread(this.DrainEntries)
         {
-            Name = "OpenTelemetry.Redis",
+            Name = string.IsNullOrWhiteSpace(name) ? "OpenTelemetry.Redis" : $"OpenTelemetry.Redis{{{name}}}",
             IsBackground = true,
         };
         this.drainThread.Start();

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentation.cs
@@ -58,7 +58,7 @@ public sealed class StackExchangeRedisInstrumentation : IDisposable
 
         lock (this.InstrumentedConnections)
         {
-            var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, options);
+            var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, name, options);
 
             this.InstrumentedConnections.Add(instrumentation);
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -158,7 +158,7 @@ public class StackExchangeRedisCallsInstrumentationTests
 
         var connection = ConnectionMultiplexer.Connect(connectionOptions);
 
-        using var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, new StackExchangeRedisInstrumentationOptions());
+        using var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, name: null, new StackExchangeRedisInstrumentationOptions());
         var profilerFactory = instrumentation.GetProfilerSessionsFactory();
         var first = profilerFactory();
         var second = profilerFactory();
@@ -236,7 +236,7 @@ public class StackExchangeRedisCallsInstrumentationTests
 
         var connection = ConnectionMultiplexer.Connect(connectionOptions);
 
-        using var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, new StackExchangeRedisInstrumentationOptions());
+        using var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, name: null, new StackExchangeRedisInstrumentationOptions());
         var profilerFactory = instrumentation.GetProfilerSessionsFactory();
 
         // start a root level activity
@@ -276,7 +276,7 @@ public class StackExchangeRedisCallsInstrumentationTests
 
         var connection = ConnectionMultiplexer.Connect(connectionOptions);
 
-        using var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, new StackExchangeRedisInstrumentationOptions());
+        using var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, name: null, new StackExchangeRedisInstrumentationOptions());
         var profilerFactory = instrumentation.GetProfilerSessionsFactory();
 
         // start a root level activity


### PR DESCRIPTION
Following up on https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1193#discussion_r1201616561

## Changes

* Append the name of the options (when used) to the background thread responsible for draining Redis profiling sessions.

## TODOs

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
