### PR TITLE
[redis] Switch CHANGELOG to use version rc9.9

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.0.0-rc11
+## 1.0.0-rc9.9
 
 Released 2023-May-25
 


### PR DESCRIPTION
Relates to #1207

## Changes

* Switch CHANGELOG for Redis from `1.0.0-rc11` to `1.0.0-rc9.9` because `rc11` doesn't resolve correctly with all the previous ~mistakes~ releases 🤣 