### PR TITLE
[Instrumentation.Runtime] Update CHANGELOG for 1.4.0 release

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.4.0
+
+Released 2023-Jun-01
+
 ## 1.1.0-rc.2
 
 Released 2023-Feb-27

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Released 2023-Jun-01
 
+* Bumped the version to `1.4.0` to keep it in sync with the release versions of
+  `OpenTelemetry.API`. This makes it more intuitive for the users to figure out
+  what version of core packages would work with a given version of this package.
+
 ## 1.1.0-rc.2
 
 Released 2023-Feb-27


### PR DESCRIPTION
This is to avoid confusion and make it easy for users to understand what version of core packages this would work with.

## Changes
- Update CHANGELOG for 1.4.0 release
