### PR TITLE
[Geneva.Logs] Refine CustomFields documentation

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -95,6 +95,9 @@ On Windows the connection string has the format `EtwSession={ETW session}`.
 
 A list of fields which should be stored as individual table columns.
 
+* If null, all fields will be stored as individual columns.
+* If non-null, only those fields named in the list will be stored as individual columns.
+
 #### `PrepopulatedFields` (optional)
 
 This is a collection of fields that will be applied to all the Logs and Traces


### PR DESCRIPTION
Based on reading the code and talking with the authors inside of Microsoft, CustomFields is expected to have different behavior when set to null vs. non-null.

Capture this distinction in the README.