### PR TITLE
Releases with OTel SDK/API 1.5.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-rc9.9
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Update `OpenTelemetry.Api` to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc9.9
+
+Released 2023-Jun-07
+
 * Update `OpenTelemetry.Api` to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-rc9.9
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Release together with `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`
   due to update `OpenTelemetry.Api` to `1.5.0`.

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 1.0.0-rc9.9
+
+Released 2023-Jun-07
+
+* Release together with `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`
+  due to update `OpenTelemetry.Api` to `1.5.0`.
+  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
+
 ## 1.0.0-rc9.8
 
 Released 2023-Feb-27

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.7
+
+Released 2023-Jun-07
+
 * Updated OTel SDK package version to 1.5.0
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-beta.7
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Updated OTel SDK package version to 1.5.0
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.7
+
+Released 2023-Jun-07
+
 * Update OTel API version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Removes `AddMySqlDataInstrumentation` method with default configure parameter.

--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-beta.7
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Update OTel API version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.5.0-beta.3
+
+Released 2023-Jun-07
+
 * Update OpenTelemetry API to 1.5.0
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.5.0-beta.3
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Update OpenTelemetry API to 1.5.0
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-alpha.3
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Update OpenTelemetry.Api to 1.5.0.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-alpha.3
+
+Released 2023-Jun-07
+
 * Update OpenTelemetry.Api to 1.5.0.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-rc9.10
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Update OTel API version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc9.10
+
+Released 2023-Jun-07
+
 * Update OTel API version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc.10
+
+Released 2023-Jun-07
+
 * Update OTel SDK version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-rc.10
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Update OTel SDK version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.4
+
+Released 2023-Jun-07
+
 * Updates to 1.5.0 of OpenTelemetry SDK.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-beta.4
 
-Released 2023-Jun-07
+Released 2023-Jun-09
 
 * Updates to 1.5.0 of OpenTelemetry SDK.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))


### PR DESCRIPTION
Fixes #.

## Changes

Releases with OTel SDK/API 1.5.0 for packages used by Automatic Instrumentation

Versioning - just bumping last version (as all of them are not stable yet).
Please let me know, if I should go with 1.5.0-[alpha|beta|rc].1

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
