### PR TITLE
[Exporter.Geneva] Remove EventSource attribute from EtwDataTransport

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/EtwDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/EtwDataTransport.cs
@@ -19,8 +19,7 @@ using System.Diagnostics.Tracing;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
-[EventSource(Name = "OpenTelemetry")]
-internal class EtwEventSource : EventSource
+internal sealed class EtwEventSource : EventSource
 {
     public EtwEventSource(string providerName)
         : base(providerName, EventSourceSettings.EtwManifestEventFormat)
@@ -50,7 +49,7 @@ internal class EtwEventSource : EventSource
     }
 }
 
-internal class EtwDataTransport : IDataTransport, IDisposable
+internal sealed class EtwDataTransport : IDataTransport, IDisposable
 {
     public EtwDataTransport(string providerName)
     {
@@ -72,20 +71,12 @@ internal class EtwDataTransport : IDataTransport, IDisposable
 
     public void Dispose()
     {
-        this.Dispose(true);
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
         if (this.m_disposed)
         {
             return;
         }
 
-        if (disposing)
-        {
-            this.m_eventSource.Dispose();
-        }
+        this.m_eventSource.Dispose();
 
         this.m_disposed = true;
     }


### PR DESCRIPTION
## Changes
- Remove `EventSource` attribute from `EtwDataTransport` as it was only required for older targets (e.g net452). The `EventSource` ctor overload which takes the sourceName as a parameter is available on all the supported targets now
- Minor refactoring