### PR TITLE
[Exporter.Geneva] Update OTel SDK version to 1.5.0 and remove Exemplars support

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Update OpenTelemetry SDK version to `1.5.0`.
   ([#1238](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1238))
 
+* Removed support for exporting `Exemplars`. This would be added back in the
+  `1.6.*` prerelease versions right after `1.5.0` stable version is released.
+  ([#1238](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1238))
+
+
 * Add named options support for `GenevaTraceExporter` and
   `GenevaMetricExporter`.
   ([#1218](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1218))

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -9,7 +9,6 @@
   `1.6.*` prerelease versions right after `1.5.0` stable version is released.
   ([#1238](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1238))
 
-
 * Add named options support for `GenevaTraceExporter` and
   `GenevaMetricExporter`.
   ([#1218](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1218))

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry SDK version to `1.5.0`.
+  ([#1238](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1238))
+
 * Add named options support for `GenevaTraceExporter` and
   `GenevaMetricExporter`.
   ([#1218](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1218))

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -122,7 +122,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
             {
                 try
                 {
-                    var exemplars = metricPoint.GetExemplars();
+                    // var exemplars = metricPoint.GetExemplars();
 
                     switch (metric.MetricType)
                     {
@@ -136,7 +136,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(), // Using the endTime here as the timestamp as Geneva Metrics only allows for one field for timestamp
                                     metricPoint.Tags,
                                     metricData,
-                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -156,7 +155,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -176,7 +174,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -194,7 +191,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -211,7 +207,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -237,7 +232,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     count,
                                     min,
                                     max,
-                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -301,7 +295,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         long timestamp,
         in ReadOnlyTagCollection tags,
         MetricData value,
-        Exemplar[] exemplars,
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -328,7 +321,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                 out monitoringAccount,
                 out metricNamespace);
 
-            SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
+            // SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -361,7 +354,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         uint count,
         double min,
         double max,
-        Exemplar[] exemplars,
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -388,7 +380,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                 out monitoringAccount,
                 out metricNamespace);
 
-            SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
+            // SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -433,6 +425,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         MetricSerializer.SerializeString(buffer, ref bufferIndex, monitoringAccount);
     }
 
+    /* Commenting out Exemplar related code as it's removed from `1.5.0` stable version of OpenTelemetry SDK
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeExemplars(Exemplar[] exemplars, byte[] buffer, ref int bufferIndex)
     {
@@ -548,6 +541,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         var exemplarLength = bufferIndex - bufferIndexForLength + 1;
         MetricSerializer.SerializeByte(buffer, ref bufferIndexForLength, (byte)exemplarLength);
     }
+    */
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeNonHistogramMetricData(MetricEventType eventType, MetricData value, long timestamp, byte[] buffer, ref int bufferIndex)

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.0-beta.3
+
+Released 2023-Jun-13
+
 * Add HTTP server span attributes for API Gateway triggers
   ([#626](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/626))
 * Removes `AddAWSLambdaConfigurations` method with default configure parameter.

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
@@ -566,7 +566,6 @@ public class MetricExporterBenchmarks
             this.counterMetricPointWith3Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith3Dimensions.Tags,
             this.counterMetricDataWith3Dimensions,
-            Array.Empty<Exemplar>(),
             out _,
             out _);
     }
@@ -580,7 +579,6 @@ public class MetricExporterBenchmarks
             this.counterMetricPointWith4Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith4Dimensions.Tags,
             this.counterMetricDataWith4Dimensions,
-            Array.Empty<Exemplar>(),
             out _,
             out _);
     }
@@ -609,7 +607,6 @@ public class MetricExporterBenchmarks
             this.histogramCountWith3Dimensions,
             this.histogramMinWith3Dimensions,
             this.histogramMaxWith3Dimensions,
-            Array.Empty<Exemplar>(),
             out _,
             out _);
     }
@@ -626,7 +623,6 @@ public class MetricExporterBenchmarks
             this.histogramCountWith4Dimensions,
             this.histogramMinWith4Dimensions,
             this.histogramMaxWith4Dimensions,
-            Array.Empty<Exemplar>(),
             out _,
             out _);
     }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -196,14 +196,13 @@ public class GenevaMetricExporterTests
                 var metricDataValue = Convert.ToUInt64(metricPoint.GetSumLong());
                 var metricData = new MetricData { UInt64Value = metricDataValue };
 
-                var exemplars = metricPoint.GetExemplars();
+                // var exemplars = metricPoint.GetExemplars();
                 var bodyLength = exporter.SerializeMetricWithTLV(
                     MetricEventType.ULongMetric,
                     metric.Name,
                     metricPoint.EndTime.ToFileTime(),
                     metricPoint.Tags,
                     metricData,
-                    exemplars,
                     out _,
                     out _);
 
@@ -354,7 +353,7 @@ public class GenevaMetricExporterTests
 
         if (hasExemplars)
         {
-            meterProviderBuilder.SetExemplarFilter(new AlwaysOnExemplarFilter());
+            // meterProviderBuilder.SetExemplarFilter(new AlwaysOnExemplarFilter());
         }
 
         if (hasFilteredTagsForExemplars)
@@ -949,7 +948,8 @@ public class GenevaMetricExporterTests
         var metricPointsEnumerator = metric.GetMetricPoints().GetEnumerator();
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
-        var exemplars = metricPoint.GetExemplars();
+
+        // var exemplars = metricPoint.GetExemplars();
 
         List<TlvField> fields = null;
 
@@ -964,7 +964,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -990,7 +989,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -1018,7 +1016,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -1046,7 +1043,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -1081,7 +1077,6 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
-                exemplars,
                 out _,
                 out _);
 
@@ -1120,6 +1115,7 @@ public class GenevaMetricExporterTests
             Assert.Equal(bodyLength, data.LenBody);
         }
 
+        /*
         if (exemplars.Length > 0)
         {
             var validExemplars = exemplars.Where(exemplar => exemplar.Timestamp != default).ToList();
@@ -1141,6 +1137,7 @@ public class GenevaMetricExporterTests
                 AssertExemplarFilteredTagSerialization(expectedExemplar, serializedExemplar);
             }
         }
+        */
 
         // Check metric name, account, and namespace
         var connectionStringBuilder = new ConnectionStringBuilder(exporterOptions.ConnectionString);
@@ -1213,6 +1210,7 @@ public class GenevaMetricExporterTests
         Assert.Equal(dimensionsCount, dimensions.NumDimensions);
     }
 
+    /*
     private static void AssertExemplarFilteredTagSerialization(Exemplar expectedExemplar, SingleExemplar serializedExemplar)
     {
         var serializedExemplarBody = serializedExemplar.Body;
@@ -1262,6 +1260,7 @@ public class GenevaMetricExporterTests
             }
         }
     }
+    */
 
     private static UserdataV2 GetSerializedData(Metric metric, GenevaMetricExporter exporter)
     {
@@ -1269,7 +1268,8 @@ public class GenevaMetricExporterTests
         var metricPointsEnumerator = metric.GetMetricPoints().GetEnumerator();
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
-        var exemplars = metricPoint.GetExemplars();
+
+        // var exemplars = metricPoint.GetExemplars();
         UserdataV2 result = null;
 
         if (metricType == MetricType.LongSum)
@@ -1282,7 +1282,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -1301,7 +1300,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -1322,7 +1320,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -1343,7 +1340,6 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-                exemplars,
                 out _,
                 out _);
 
@@ -1371,7 +1367,6 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
-                exemplars,
                 out _,
                 out _);
 


### PR DESCRIPTION
## Changes
- Update OTel SDK version to 1.5.0
- Remove Exemplars support

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
