### PR TITLE
[Instrumentation.Runtime] Add a metric for total paused duration in GC for .NET 7 and greater versions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add a metric for total paused duration in GC
+  ([#1239](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1239))
+
 ## 1.5.0
 
 Released 2023-Jun-06

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Add a metric for total paused duration in GC for .NET 7 and greater versions
+* Add a metric `process.runtime.dotnet.gc.duration` for total paused duration in
+  GC for .NET 7 and greater versions
   ([#1239](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1239))
 
 ## 1.5.0

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add a metric for total paused duration in GC
+* Add a metric for total paused duration in GC for .NET 7 and greater versions
   ([#1239](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1239))
 
 ## 1.5.0

--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -176,6 +176,22 @@ The API used to retrieve the value is:
 * [GCGenerationInfo.FragmentationAfterBytes Property](https://docs.microsoft.com/dotnet/api/system.gcgenerationinfo.fragmentationafterbytes)
   Gets the fragmentation in bytes on exit from the reported collection.
 
+#### process.runtime.dotnet.**gc.duration**
+
+The total amount of time paused in GC since the process start.
+
+> **Note**
+> This metric is only available when targeting .NET 7 or later.
+
+| Units | Instrument Type   | Value Type | Attribute Key(s) | Attribute Values |
+|-------|-------------------|------------|------------------|------------------|
+| `ns`  | ObservableCounter | `Int64`    | No Attributes    | N/A              |
+
+The API used to retrieve the value is:
+
+* [GC.GetTotalPauseDuration](https://learn.microsoft.com/dotnet/api/system.gc.gettotalpauseduration)
+  Gets the total amount of time paused in GC since the beginning of the process.
+
 ### JIT Compiler related metrics
 
 These metrics are only available when targeting .NET6 or later.

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -120,9 +120,9 @@ internal sealed class RuntimeMetrics
                 description: "The heap size (including fragmentation), as observed during the latest garbage collection. The value will be unavailable until at least one garbage collection has occurred.");
         }
 
-        // Not valid until .NET 7 where the bug in the API is fixed. See context in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/496
         if (Environment.Version.Major >= 7)
         {
+            // Not valid until .NET 7 where the bug in the API is fixed. See context in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/496
             MeterInstance.CreateObservableUpDownCounter(
                 "process.runtime.dotnet.gc.heap.fragmentation.size",
                 () =>
@@ -144,6 +144,18 @@ internal sealed class RuntimeMetrics
                 },
                 unit: "bytes",
                 description: "The heap fragmentation, as observed during the latest garbage collection. The value will be unavailable until at least one garbage collection has occurred.");
+
+            // GC.GetTotalPauseDuration() is not available until .NET 7. See context in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1163
+            var mi = typeof(GC).GetMethod("GetTotalPauseDuration", BindingFlags.Public | BindingFlags.Static);
+            var getTotalPauseDuration = mi?.CreateDelegate<Func<TimeSpan>>();
+            if (getTotalPauseDuration != null)
+            {
+                MeterInstance.CreateObservableCounter(
+                    "process.runtime.dotnet.gc.duration",
+                    () => getTotalPauseDuration().Ticks * NanosecondsPerTick,
+                    unit: "ns",
+                    description: "The total amount of time paused in GC since the process start.");
+            }
         }
 
         MeterInstance.CreateObservableCounter(

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -94,6 +94,9 @@ public class RuntimeMetricsTests
         {
             var gcHeapFragmentationSizeMetric = exportedItems.FirstOrDefault(i => i.Name == "process.runtime.dotnet.gc.heap.fragmentation.size");
             Assert.NotNull(gcHeapFragmentationSizeMetric);
+
+            var gcDurationMetric = exportedItems.FirstOrDefault(i => i.Name == "process.runtime.dotnet.gc.duration");
+            Assert.NotNull(gcDurationMetric);
         }
 #endif
     }


### PR DESCRIPTION
Fixes #1163.

## Changes

Add a new metric for total paused duration in GC `process.runtime.dotnet.gc.duration` with data from [GC.GetTotalPauseDuration Method](https://learn.microsoft.com/en-us/dotnet/api/system.gc.gettotalpauseduration?view=net-7.0).

It is recommended over the `time-in-gc` EventCounter in the [Well-known EventCounters in .NET](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/available-counters).

The metrics would show in the output of [Prometheus Exporter HttpListener](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md) (for how to set it up, follow [this getting-started guide](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/getting-started-prometheus-grafana)) like this:

```
# TYPE process_runtime_dotnet_gc_duration_ns counter
# UNIT process_runtime_dotnet_gc_duration_ns ns
# HELP process_runtime_dotnet_gc_duration_ns The total amount of time paused in GC since the process start.
process_runtime_dotnet_gc_duration_ns 8860000 1686806670504
```

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [X] Design discussion issue #1163
* [X] Changes in public API reviewed: N/A
