### PR TITLE
[Exporter.InfluxDB] Add support for Resources attributes

### DIFF
--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Support for Resource attributes in OpenTelemetry.Exporter.InfluxDB, allowing
+resource attributes to be passed as InfluxDB tags.
+  ([#1241](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1241))
 * Updates to 1.5.0 of OpenTelemetry SDK.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Support for Resource attributes in OpenTelemetry.Exporter.InfluxDB, allowing
-resource attributes to be passed as InfluxDB tags.
+  resource attributes to be passed as InfluxDB tags.
   ([#1241](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1241))
 * Updates to 1.5.0 of OpenTelemetry SDK.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
@@ -50,7 +50,7 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
         {
             foreach (var metric in batch)
             {
-                this.writer.Write(metric, this.writeApi);
+                this.writer.Write(metric, this.ParentProvider?.GetResource(), this.writeApi);
             }
 
             return ExportResult.Success;

--- a/src/OpenTelemetry.Exporter.InfluxDB/PointDataExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/PointDataExtensions.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.Generic;
 using InfluxDB.Client.Writes;
 
 namespace OpenTelemetry.Exporter.InfluxDB;
@@ -22,6 +23,21 @@ internal static class PointDataExtensions
 {
     public static PointData Tags(this PointData pointData, ReadOnlyTagCollection tags)
     {
+        foreach (var tag in tags)
+        {
+            pointData = pointData.Tag(tag.Key, tag.Value.ToString());
+        }
+
+        return pointData;
+    }
+
+    public static PointData Tags(this PointData pointData, IEnumerable<KeyValuePair<string, object>> tags)
+    {
+        if (tags == null)
+        {
+            return pointData;
+        }
+
         foreach (var tag in tags)
         {
             pointData = pointData.Tag(tag.Key, tag.Value.ToString());

--- a/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV1.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV1.cs
@@ -19,12 +19,13 @@ using InfluxDB.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
 {
-    public void Write(Metric metric, WriteApi writeApi)
+    public void Write(Metric metric, Resource resource, WriteApi writeApi)
     {
         var measurement = metric.Name;
 
@@ -38,6 +39,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Measurement(measurement)
                             .Field("gauge", dataPoint.GetGaugeLastValueLong())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -53,6 +55,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Measurement(measurement)
                             .Field("gauge", dataPoint.GetGaugeLastValueDouble())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -68,6 +71,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Measurement(measurement)
                             .Field("counter", dataPoint.GetSumLong())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -83,6 +87,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Measurement(measurement)
                             .Field("counter", dataPoint.GetSumDouble())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -98,6 +103,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Measurement(measurement)
                             .Field("gauge", dataPoint.GetSumLong())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -113,6 +119,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Measurement(measurement)
                             .Field("gauge", dataPoint.GetSumDouble())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -128,6 +135,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                         .Field("count", dataPoint.GetHistogramCount())
                         .Field("sum", dataPoint.GetHistogramSum())
                         .Tags(dataPoint.Tags)
+                        .Tags(resource?.Attributes)
                         .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
 
                     if (dataPoint.TryGetHistogramMinMaxValues(out double min, out double max))

--- a/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV2.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV2.cs
@@ -19,12 +19,13 @@ using InfluxDB.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
 {
-    public void Write(Metric metric, WriteApi writeApi)
+    public void Write(Metric metric, Resource resource, WriteApi writeApi)
     {
         var measurement = "prometheus";
         var metricName = metric.Name;
@@ -39,6 +40,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Measurement(measurement)
                             .Field(metricName, metricPoint.GetGaugeLastValueLong())
                             .Tags(metricPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -54,6 +56,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Measurement(measurement)
                             .Field(metricName, metricPoint.GetGaugeLastValueDouble())
                             .Tags(metricPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -69,6 +72,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Measurement(measurement)
                             .Field(metricName, metricPoint.GetSumLong())
                             .Tags(metricPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -84,6 +88,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Measurement(measurement)
                             .Field(metricName, metricPoint.GetSumDouble())
                             .Tags(metricPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -99,6 +104,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Measurement(measurement)
                             .Field(metricName, dataPoint.GetSumLong())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -114,6 +120,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Measurement(measurement)
                             .Field(metricName, dataPoint.GetSumDouble())
                             .Tags(dataPoint.Tags)
+                            .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
                         writeApi.WritePoint(pointData);
                     }
@@ -127,6 +134,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                     var basePoint = PointData
                         .Measurement(measurement)
                         .Tags(metricPoint.Tags)
+                        .Tags(resource?.Attributes)
                         .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
 
                     var headPoint = basePoint

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using Xunit;
 
 namespace OpenTelemetry.Exporter.InfluxDB.Tests;
@@ -36,6 +37,7 @@ public class InfluxDBMetricsExporterTests
 
         using var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.WithDefaultTestConfiguration();
@@ -61,9 +63,7 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(1, dataPoint.Fields.Count);
         AssertUtils.HasField(valueKey, 42L, dataPoint.Fields);
 
-        Assert.Equal(2, dataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, dataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, dataPoint.Tags);
+        AssertTags(dataPoint);
 
         Assert.InRange(dataPoint.Timestamp, before, after);
     }
@@ -81,6 +81,7 @@ public class InfluxDBMetricsExporterTests
 
         using var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.WithDefaultTestConfiguration();
@@ -106,9 +107,7 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(1, dataPoint.Fields.Count);
         AssertUtils.HasField(valueKey, 55.42D, dataPoint.Fields);
 
-        Assert.Equal(2, dataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, dataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, dataPoint.Tags);
+        AssertTags(dataPoint);
 
         Assert.InRange(dataPoint.Timestamp, before, after);
     }
@@ -126,6 +125,7 @@ public class InfluxDBMetricsExporterTests
 
         using var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.WithDefaultTestConfiguration();
@@ -149,9 +149,7 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(1, dataPoint.Fields.Count);
         AssertUtils.HasField(valueKey, 100L, dataPoint.Fields);
 
-        Assert.Equal(2, dataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, dataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, dataPoint.Tags);
+        AssertTags(dataPoint);
 
         Assert.InRange(dataPoint.Timestamp, before, after);
     }
@@ -169,6 +167,7 @@ public class InfluxDBMetricsExporterTests
 
         using var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.WithDefaultTestConfiguration();
@@ -192,9 +191,7 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(1, dataPoint.Fields.Count);
         AssertUtils.HasField(valueKey, 12.59D, dataPoint.Fields);
 
-        Assert.Equal(2, dataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, dataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, dataPoint.Tags);
+        AssertTags(dataPoint);
 
         Assert.InRange(dataPoint.Timestamp, before, after);
     }
@@ -212,6 +209,7 @@ public class InfluxDBMetricsExporterTests
 
         using var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.WithDefaultTestConfiguration();
@@ -236,9 +234,7 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(1, dataPoint.Fields.Count);
         AssertUtils.HasField(valueKey, -50L, dataPoint.Fields);
 
-        Assert.Equal(2, dataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, dataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, dataPoint.Tags);
+        AssertTags(dataPoint);
 
         Assert.InRange(dataPoint.Timestamp, before, after);
     }
@@ -256,6 +252,7 @@ public class InfluxDBMetricsExporterTests
 
         using var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.WithDefaultTestConfiguration();
@@ -280,9 +277,7 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(1, dataPoint.Fields.Count);
         AssertUtils.HasField(valueKey, -50.11D, dataPoint.Fields);
 
-        Assert.Equal(2, dataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, dataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, dataPoint.Tags);
+        AssertTags(dataPoint);
 
         Assert.InRange(dataPoint.Timestamp, before, after);
     }
@@ -303,6 +298,7 @@ public class InfluxDBMetricsExporterTests
                 Boundaries = new[] { 10D, 20D, 100D, 200D },
                 RecordMinMax = true,
             })
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.WithDefaultTestConfiguration();
@@ -337,9 +333,7 @@ public class InfluxDBMetricsExporterTests
         AssertUtils.HasField("200.00", 1L, dataPoint.Fields);
         AssertUtils.HasField("+Inf", 1L, dataPoint.Fields);
 
-        Assert.Equal(2, dataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, dataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, dataPoint.Tags);
+        AssertTags(dataPoint);
 
         Assert.InRange(dataPoint.Timestamp, before, after);
     }
@@ -395,6 +389,7 @@ public class InfluxDBMetricsExporterTests
                 Boundaries = new[] { 10D, 20D, 100D, 200D },
                 RecordMinMax = true,
             })
+            .ConfigureDefaultTestResource()
             .AddInfluxDBMetricsExporter(options =>
             {
                 options.Endpoint = influxServerEndpoint;
@@ -422,9 +417,8 @@ public class InfluxDBMetricsExporterTests
         AssertUtils.HasField("histogram_metric_sum", 550D, headDataPoint.Fields);
         AssertUtils.HasField("histogram_metric_min", 50D, headDataPoint.Fields);
         AssertUtils.HasField("histogram_metric_max", 250D, headDataPoint.Fields);
-        Assert.Equal(2, headDataPoint.Tags.Count);
-        AssertUtils.HasTag("tag_key_1", "tag_value_1", 0, headDataPoint.Tags);
-        AssertUtils.HasTag("tag_key_2", "tag_value_2", 1, headDataPoint.Tags);
+
+        AssertTags(headDataPoint);
         Assert.InRange(headDataPoint.Timestamp, before, after);
 
         AssertBucketDataPoint(influxServer.ReadPoint(), "10.00", 0);
@@ -438,8 +432,15 @@ public class InfluxDBMetricsExporterTests
             Assert.Equal("prometheus", dataPoint.Measurement);
             AssertUtils.HasField("histogram_metric_bucket", count, dataPoint.Fields);
             AssertUtils.HasTag("le", bound, 0, dataPoint.Tags);
-            AssertUtils.HasTag("tag_key_1", "tag_value_1", 1, dataPoint.Tags);
-            AssertUtils.HasTag("tag_key_2", "tag_value_2", 2, dataPoint.Tags);
+            AssertUtils.HasTag("service.instance.id", "my-service-id", 1, dataPoint.Tags);
+            AssertUtils.HasTag("service.name", "my-service", 2, dataPoint.Tags);
+            AssertUtils.HasTag("service.namespace", "my-service-namespace", 3, dataPoint.Tags);
+            AssertUtils.HasTag("service.version", "1.0", 4, dataPoint.Tags);
+            AssertUtils.HasTag("tag_key_1", "tag_value_1", 5, dataPoint.Tags);
+            AssertUtils.HasTag("tag_key_2", "tag_value_2", 6, dataPoint.Tags);
+            AssertUtils.HasTag("telemetry.sdk.language", "dotnet", 7, dataPoint.Tags);
+            AssertUtils.HasTag("telemetry.sdk.name", "opentelemetry", 8, dataPoint.Tags);
+            AssertUtils.HasTag("telemetry.sdk.version", "1.5.0", 9, dataPoint.Tags);
         }
     }
 
@@ -476,5 +477,19 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal("prometheus", pointData.Measurement);
         Assert.DoesNotContain("histogram_metric_min", pointData.Fields);
         Assert.DoesNotContain("histogram_metric_max", pointData.Fields);
+    }
+
+    private static void AssertTags(PointData dataPoint)
+    {
+        Assert.Equal(9, dataPoint.Tags.Count);
+        AssertUtils.HasTag("service.instance.id", "my-service-id", 0, dataPoint.Tags);
+        AssertUtils.HasTag("service.name", "my-service", 1, dataPoint.Tags);
+        AssertUtils.HasTag("service.namespace", "my-service-namespace", 2, dataPoint.Tags);
+        AssertUtils.HasTag("service.version", "1.0", 3, dataPoint.Tags);
+        AssertUtils.HasTag("tag_key_1", "tag_value_1", 4, dataPoint.Tags);
+        AssertUtils.HasTag("tag_key_2", "tag_value_2", 5, dataPoint.Tags);
+        AssertUtils.HasTag("telemetry.sdk.language", "dotnet", 6, dataPoint.Tags);
+        AssertUtils.HasTag("telemetry.sdk.name", "opentelemetry", 7, dataPoint.Tags);
+        AssertUtils.HasTag("telemetry.sdk.version", "1.5.0", 8, dataPoint.Tags);
     }
 }

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/MeterProviderBuilderTestExtensions.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/MeterProviderBuilderTestExtensions.cs
@@ -1,4 +1,4 @@
-// <copyright file="IMetricsWriter.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterProviderBuilderTestExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +14,19 @@
 // limitations under the License.
 // </copyright>
 
-using InfluxDB.Client;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 
-namespace OpenTelemetry.Exporter.InfluxDB;
+namespace OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 
-internal interface IMetricsWriter
+public static class MeterProviderBuilderTestExtensions
 {
-    void Write(Metric metric, Resource resource, WriteApi writeApi);
+    public static MeterProviderBuilder ConfigureDefaultTestResource(this MeterProviderBuilder meterProviderBuilder)
+    {
+        return meterProviderBuilder.ConfigureResource(builder => builder.AddService(
+            serviceName: "my-service",
+            serviceNamespace: "my-service-namespace",
+            serviceVersion: "1.0",
+            serviceInstanceId: "my-service-id"));
+    }
 }


### PR DESCRIPTION
Fixes #1206.

## Changes

This PR introduces support for Resource attributes in OpenTelemetry.Exporter.InfluxDB. With this change, resource attributes will now be passed as InfluxDB tags.

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
~~* [ ] Design discussion issue #~~
~~* [ ] Changes in public API reviewed~~
