### PR TITLE
Options to correctly parent WCF activities when hosted within ASP.NET

### DIFF
--- a/examples/wcf/Examples.Wcf.Server.AspNet/Examples.Wcf.Server.AspNet.csproj
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Examples.Wcf.Server.AspNet.csproj
@@ -1,0 +1,161 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{23AA75F6-403F-4867-BF0E-BAF0A44F9A7A}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Examples.Wcf.Server.AspNet</RootNamespace>
+    <AssemblyName>Examples.Wcf.Server.AspNet</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="StatusService.svc" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="StatusService.svc.cs">
+      <DependentUpon>StatusService.svc</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj">
+      <Project>{ec83d37a-3704-4515-8ee8-4d007cd9e0a8}</Project>
+      <Name>OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj">
+      <Project>{582b70b5-0067-4d9a-abf2-623f502be9a9}</Project>
+      <Name>OpenTelemetry.Instrumentation.AspNet</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\OpenTelemetry.Instrumentation.Wcf\OpenTelemetry.Instrumentation.Wcf.csproj">
+      <Project>{cad5c27a-d359-4086-9c4f-02204c084a8e}</Project>
+      <Name>OpenTelemetry.Instrumentation.Wcf</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\shared\Examples.Wcf.Shared.csproj">
+      <Project>{21716c26-3b2a-4208-bdfb-8e58e2af49ea}</Project>
+      <Name>Examples.Wcf.Shared</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry">
+      <Version>1.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="OpenTelemetry.Exporter.Console">
+      <Version>1.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol">
+      <Version>1.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Memory">
+      <Version>4.5.5</Version>
+    </PackageReference>
+    <PackageReference Include="System.ServiceModel.Primitives">
+      <Version>4.7.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Threading.Tasks">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Threading.Tasks.Extensions">
+      <Version>4.5.4</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>61494</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:61494/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="Examples.Wcf.Server.AspNet.WebApiApplication" Language="C#" %>

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax.cs
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax.cs
@@ -42,7 +42,7 @@ public class WebApiApplication : HttpApplication
             })
             .AddSource("StatusService")
             .AddWcfInstrumentation()
-            .AddAspNetInstrumentation();
+            .AddAspNetInstrumentation(options => options.SetActivityContextOnIncomingRequest = true);
 
         switch (ConfigurationManager.AppSettings["UseExporter"].ToLowerInvariant())
         {

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax.cs
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax.cs
@@ -1,0 +1,93 @@
+// <copyright file="Global.asax.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Configuration;
+using System.Web;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Examples.Wcf.Server.AspNet;
+
+#pragma warning disable SA1649 // File name should match first type name
+public class WebApiApplication : HttpApplication
+#pragma warning restore SA1649 // File name should match first type name
+{
+    private IDisposable tracerProvider;
+    private IDisposable meterProvider;
+
+    protected void Application_Start()
+    {
+        var builder = Sdk.CreateTracerProviderBuilder()
+            .ConfigureResource(resource =>
+            {
+                resource.AddTelemetrySdk();
+                resource.AddService("Examples.Wcf.Server.AspNet");
+            })
+            .AddSource("StatusService")
+            .AddWcfInstrumentation()
+            .AddAspNetInstrumentation();
+
+        switch (ConfigurationManager.AppSettings["UseExporter"].ToLowerInvariant())
+        {
+            case "otlp":
+                builder.AddOtlpExporter(otlpOptions =>
+                    {
+                        otlpOptions.Endpoint = new Uri(ConfigurationManager.AppSettings["OtlpEndpoint"]);
+                    });
+                break;
+            default:
+                builder.AddConsoleExporter(options => options.Targets = ConsoleExporterOutputTargets.Debug);
+                break;
+        }
+
+        this.tracerProvider = builder.Build();
+
+        // Metrics
+        // Note: Tracerprovider is needed for metrics to work
+        // https://github.com/open-telemetry/opentelemetry-dotnet/issues/2994
+
+        var meterBuilder = Sdk.CreateMeterProviderBuilder()
+             .AddAspNetInstrumentation();
+
+        switch (ConfigurationManager.AppSettings["UseMetricsExporter"].ToLowerInvariant())
+        {
+            case "otlp":
+                meterBuilder.AddOtlpExporter(otlpOptions =>
+                {
+                    otlpOptions.Endpoint = new Uri(ConfigurationManager.AppSettings["OtlpEndpoint"]);
+                });
+                break;
+            default:
+                meterBuilder.AddConsoleExporter((exporterOptions, metricReaderOptions) =>
+                {
+                    exporterOptions.Targets = ConsoleExporterOutputTargets.Debug;
+                });
+                break;
+        }
+
+        this.meterProvider = meterBuilder.Build();
+    }
+
+    protected void Application_End()
+    {
+        this.tracerProvider?.Dispose();
+        this.meterProvider?.Dispose();
+    }
+}

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax.cs
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Global.asax.cs
@@ -41,7 +41,7 @@ public class WebApiApplication : HttpApplication
                 resource.AddService("Examples.Wcf.Server.AspNet");
             })
             .AddSource("StatusService")
-            .AddWcfInstrumentation()
+            .AddWcfInstrumentation(options => options.ReadContextFromHttpHeaders = true)
             .AddAspNetInstrumentation(options => options.SetActivityContextOnIncomingRequest = true);
 
         switch (ConfigurationManager.AppSettings["UseExporter"].ToLowerInvariant())

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Properties/AssemblyInfo.cs
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Properties/AssemblyInfo.cs
@@ -1,0 +1,51 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Examples.Wcf.Server.AspNet")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Examples.Wcf.Server.AspNet")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("23aa75f6-403f-4867-bf0e-baf0a44f9a7a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/examples/wcf/Examples.Wcf.Server.AspNet/StatusService.svc
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/StatusService.svc
@@ -1,0 +1,1 @@
+﻿<%@ ServiceHost Language="C#" Debug="true" Service="Examples.Wcf.Server.AspNet.StatusService" CodeBehind="StatusService.svc.cs" %>

--- a/examples/wcf/Examples.Wcf.Server.AspNet/StatusService.svc.cs
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/StatusService.svc.cs
@@ -1,0 +1,38 @@
+// <copyright file="StatusService.svc.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Examples.Wcf.Server.AspNet
+{
+    public class StatusService : IStatusServiceContract
+    {
+        private static readonly ActivitySource activitySource = new(nameof(StatusService));
+
+        public Task<StatusResponse> PingAsync(StatusRequest request)
+        {
+            using var activity = activitySource.StartActivity();
+
+            return Task.FromResult(
+                new StatusResponse
+                {
+                    ServerTime = DateTimeOffset.UtcNow,
+                });
+        }
+    }
+}

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Web.Debug.config
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Web.Release.config
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/examples/wcf/Examples.Wcf.Server.AspNet/Web.config
+++ b/examples/wcf/Examples.Wcf.Server.AspNet/Web.config
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+
+<configuration>
+
+  <appSettings>
+    <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true" />
+    <add key="UseExporter" value="otlp" />
+    <add key="UseMetricsExporter" value="console" />
+    <add key="ZipkinEndpoint" value="http://localhost:9411/api/v2/spans" />
+    <add key="OtlpEndpoint" value="http://localhost:4317" />
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.8" />
+    <httpRuntime targetFramework="4.8" />
+  </system.web>
+  <system.serviceModel>
+    <behaviors>
+      <serviceBehaviors>
+        <behavior>
+          <!-- To avoid disclosing metadata information, set the values below to false before deployment -->
+          <serviceMetadata httpGetEnabled="true" httpsGetEnabled="true" />
+          <!-- To receive exception details in faults for debugging purposes, set the value below to true.  Set to false before deployment to avoid disclosing exception information -->
+          <serviceDebug includeExceptionDetailInFaults="false" />
+        </behavior>
+      </serviceBehaviors>
+      <endpointBehaviors>
+        <behavior name="telemetry">
+          <telemetryExtension />
+        </behavior>
+      </endpointBehaviors>
+    </behaviors>
+    <protocolMapping>
+      <add binding="basicHttpBinding" scheme="http" />
+    </protocolMapping>
+    <serviceHostingEnvironment aspNetCompatibilityEnabled="false" multipleSiteBindingsEnabled="true" />
+    <extensions>
+      <behaviorExtensions>
+        <add name="telemetryExtension"
+             type="OpenTelemetry.Instrumentation.Wcf.TelemetryEndpointBehaviorExtensionElement, OpenTelemetry.Instrumentation.Wcf" />
+      </behaviorExtensions>
+    </extensions>
+    <services>
+      <service name="Examples.Wcf.Server.AspNet.StatusService">
+        <endpoint bindingNamespace="http://opentelemetry.io/" behaviorConfiguration="telemetry"
+                  binding="basicHttpBinding" contract="Examples.Wcf.IStatusServiceContract" />
+      </service>
+    </services>
+  </system.serviceModel>
+  <system.webServer>
+    <modules runAllManagedModulesForAllRequests="true">
+      <add name="TelemetryHttpModule"
+           type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule,OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule"
+           preCondition="integratedMode,managedHandler" />
+    </modules>
+    <!--
+        To browse web app root directory during debugging, set the value below to true.
+        Set to false before deployment to avoid disclosing web app folder information.
+      -->
+    <directoryBrowse enabled="true" />
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a"
+                          culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/examples/wcf/client-netframework/App.config
+++ b/examples/wcf/client-netframework/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.serviceModel>
     <extensions>
@@ -26,6 +26,7 @@
       </netTcpBinding>
     </bindings>
     <client>
+      <endpoint address="http://localhost:61494/StatusService.svc" binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="Examples.Wcf.IStatusServiceContract" name="StatusService_AspNet" />
       <endpoint address="http://localhost:9009/Telemetry" binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="Examples.Wcf.IStatusServiceContract" name="StatusService_Http" />
       <endpoint address="net.tcp://localhost:9090/Telemetry" binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="Examples.Wcf.IStatusServiceContract" name="StatusService_Tcp" />
     </client>

--- a/examples/wcf/client-netframework/Program.cs
+++ b/examples/wcf/client-netframework/Program.cs
@@ -35,6 +35,7 @@ internal static class Program
 
         await CallService("StatusService_Http").ConfigureAwait(false);
         await CallService("StatusService_Tcp").ConfigureAwait(false);
+        await CallService("StatusService_AspNet").ConfigureAwait(false);
 
         Console.WriteLine("Press enter to exit.");
         Console.ReadLine();

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -288,13 +288,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetectors.AWS.Tests", "test\OpenTelemetry.ResourceDetectors.AWS.Tests\OpenTelemetry.ResourceDetectors.AWS.Tests.csproj", "{DE898A1E-920E-476F-B0DB-A98AFD6E3BF4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.Exporter.InfluxDB", "src\OpenTelemetry.Exporter.InfluxDB\OpenTelemetry.Exporter.InfluxDB.csproj", "{FD5E9AC8-DC05-4C64-BDC6-D26F5552808E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.InfluxDB", "src\OpenTelemetry.Exporter.InfluxDB\OpenTelemetry.Exporter.InfluxDB.csproj", "{FD5E9AC8-DC05-4C64-BDC6-D26F5552808E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.Exporter.InfluxDB.Tests", "test\OpenTelemetry.Exporter.InfluxDB.Tests\OpenTelemetry.Exporter.InfluxDB.Tests.csproj", "{4847A991-D0C3-4421-B0D3-EA189959E639}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.InfluxDB.Tests", "test\OpenTelemetry.Exporter.InfluxDB.Tests\OpenTelemetry.Exporter.InfluxDB.Tests.csproj", "{4847A991-D0C3-4421-B0D3-EA189959E639}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "InfluxDB", "InfluxDB", "{2D354354-BAFB-490B-A26F-6A16A52A1A45}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.InfluxDB", "examples\InfluxDB\Examples.InfluxDB\Examples.InfluxDB.csproj", "{B4951583-D432-4E87-85CF-498FDD6A35E6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.InfluxDB", "examples\InfluxDB\Examples.InfluxDB\Examples.InfluxDB.csproj", "{B4951583-D432-4E87-85CF-498FDD6A35E6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.Wcf.Server.AspNet", "examples\wcf\Examples.Wcf.Server.AspNet\Examples.Wcf.Server.AspNet.csproj", "{23AA75F6-403F-4867-BF0E-BAF0A44F9A7A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -622,6 +624,10 @@ Global
 		{B4951583-D432-4E87-85CF-498FDD6A35E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4951583-D432-4E87-85CF-498FDD6A35E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4951583-D432-4E87-85CF-498FDD6A35E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23AA75F6-403F-4867-BF0E-BAF0A44F9A7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23AA75F6-403F-4867-BF0E-BAF0A44F9A7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23AA75F6-403F-4867-BF0E-BAF0A44F9A7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23AA75F6-403F-4867-BF0E-BAF0A44F9A7A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -718,6 +724,7 @@ Global
 		{4847A991-D0C3-4421-B0D3-EA189959E639} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 		{2D354354-BAFB-490B-A26F-6A16A52A1A45} = {B75EE478-97F7-4E9F-9A5A-DB3D0988EDEA}
 		{B4951583-D432-4E87-85CF-498FDD6A35E6} = {2D354354-BAFB-490B-A26F-6A16A52A1A45}
+		{23AA75F6-403F-4867-BF0E-BAF0A44F9A7A} = {73474960-8F91-4EE5-8E3E-F7E7ADA99238}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -59,4 +59,10 @@ public class AspNetInstrumentationOptions
     /// See: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md"/>.
     /// </remarks>
     public bool RecordException { get; set; }
+
+    /// <summary>
+    /// Mutate incoming request headers to have context of activity started by AspNetInstrumentation.
+    /// Useful for downstream instrumentation.
+    /// </summary>
+    public bool SetActivityContextOnIncomingRequest { get; set; }
 }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfInstrumentationActivitySource.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfInstrumentationActivitySource.cs
@@ -45,6 +45,15 @@ internal static class WcfInstrumentationActivitySource
                 : new[] { request.Headers.GetHeader<string>(headerIndex) };
         };
 
+#if NETFRAMEWORK
+    public static Func<Message, string, IEnumerable<string>> HttpHeaderValuesGetter { get; }
+        = (request, name) =>
+        {
+            request.Properties.TryGetValue(HttpRequestMessageProperty.Name, out var prop);
+            return (prop as HttpRequestMessageProperty)?.Headers.GetValues(name);
+        };
+#endif
+
     public static Action<Message, string, string> MessageHeaderValueSetter { get; }
         = (request, name, value) => request.Headers.Add(MessageHeader.CreateHeader(name, "https://www.w3.org/TR/trace-context/", value, false));
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryDispatchMessageInspector.cs
@@ -63,7 +63,16 @@ public class TelemetryDispatchMessageInspector : IDispatchMessageInspector
         }
 
         var textMapPropagator = Propagators.DefaultTextMapPropagator;
-        var ctx = textMapPropagator.Extract(default, request, WcfInstrumentationActivitySource.MessageHeaderValuesGetter);
+
+        PropagationContext ctx;
+        if (WcfInstrumentationActivitySource.Options.ReadContextFromHttpHeaders)
+        {
+            ctx = textMapPropagator.Extract(default, request, WcfInstrumentationActivitySource.HttpHeaderValuesGetter);
+        }
+        else
+        {
+            ctx = textMapPropagator.Extract(default, request, WcfInstrumentationActivitySource.MessageHeaderValuesGetter);
+        }
 
         Activity activity = WcfInstrumentationActivitySource.ActivitySource.StartActivity(
             WcfInstrumentationActivitySource.IncomingRequestActivityName,

--- a/src/OpenTelemetry.Instrumentation.Wcf/WcfInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/WcfInstrumentationOptions.cs
@@ -62,4 +62,11 @@ public class WcfInstrumentationOptions
     /// Gets or sets a value indicating whether or not the SOAP message version should be added as the <see cref="WcfInstrumentationConstants.SoapMessageVersionTag"/> tag. Default value: False.
     /// </summary>
     public bool SetSoapMessageVersion { get; set; }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Read context from HTTP headers instead of from SOAP headers.
+    /// </summary>
+    public bool ReadContextFromHttpHeaders { get; set; }
+#endif
 }


### PR DESCRIPTION
Fixes #1243.

## Changes

- Added sample ASP.NET hosted WCF service to demonstrate the issue. This implements the same status service as existing sample WCF projects, and can be called by the same client.
- Added a new option `SetActivityContextOnIncomingRequest` to ASP.NET instrumentation. Setting this to true will cause incoming request headers to be mutated to contain the propagation context of activity just started by ASP.NET instrumentation. This is not great, but it is the only way to pass this context to WCF.
- Added new option `ReadContextFromHttpHeaders` to WCF instrumentation. Setting this to true will cause propagation context to be read from HTTP headers instead of SOAP headers. Besides being able to read parent activity from ASP.NET above, this also fixes context retrieval for non-SOAP HTTP requests.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
