### PR TITLE
Bump OpenTelemetry to 1.5.1

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,7 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <!-- Uncomment following source, if you need to use nightly builds for OTel SDK/API
+    <!-- Uncomment following source, if you need to use nightly builds for OpenTelemetry SDK/API
       <add key="MyGet" value="https://www.myget.org/F/opentelemetry/api/v3/index.json" /> -->
   </packageSources>
   <disabledPackageSources />

--- a/build/Common.props
+++ b/build/Common.props
@@ -34,7 +34,7 @@
     <MicrosoftOwinPkgVer>[4.2.2,5.0)</MicrosoftOwinPkgVer>
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
-    <OpenTelemetryCoreLatestVersion>[1.5.0,2.0)</OpenTelemetryCoreLatestVersion>
+    <OpenTelemetryCoreLatestVersion>[1.5.1,2.0)</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.5.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>

--- a/examples/process-instrumentation/process-instrumentation.csproj
+++ b/examples/process-instrumentation/process-instrumentation.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.5.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Process\OpenTelemetry.Instrumentation.Process.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/runtime-instrumentation/runtime-instrumentation.csproj
+++ b/examples/runtime-instrumentation/runtime-instrumentation.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.5.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Runtime\OpenTelemetry.Instrumentation.Runtime.csproj" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
@@ -26,6 +26,8 @@
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
 * Extract AWS Resource Detectors to dedicated package `OpenTelemetry.ResourceDetectors.AWS`
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
+* Updates to 1.5.1 of OpenTelemetry SDK.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.2.0
 

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
@@ -11,8 +11,6 @@
   ([#875](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/875))
 * Replaced Newtonsoft.Json dependency with System.Text.Json
   ([#1092](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1092))
-* Updated OpenTelemetry SDK package version to 1.3.1
-  ([#875](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/875))
 * Enhancement - AWSECSResourceDetector - Implement `aws.{ecs.*,log.*}` resource
   attributes with data from ECS Metadata endpoint v4
   ([#875](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/875))

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Extract AWS Resource Detectors to dedicated package `OpenTelemetry.ResourceDetectors.AWS`
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
 * Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.2.0
 

--- a/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
+++ b/src/OpenTelemetry.Contrib.Extensions.AWSXRay/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updates to 1.5.0 of OpenTelemetry SDK.
-  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
+* Updates to 1.5.1 of OpenTelemetry SDK.
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 * Enhancement - AWSXRayIdGenerator - Generate X-Ray IDs with global Random
   instance instead of recreating with ThreadLocal
   ([#380](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/380))
@@ -11,7 +11,7 @@
   ([#875](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/875))
 * Replaced Newtonsoft.Json dependency with System.Text.Json
   ([#1092](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1092))
-* Updated OTel SDK package version to 1.3.1
+* Updated OpenTelemetry SDK package version to 1.3.1
   ([#875](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/875))
 * Enhancement - AWSECSResourceDetector - Implement `aws.{ecs.*,log.*}` resource
   attributes with data from ECS Metadata endpoint v4
@@ -26,8 +26,6 @@
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
 * Extract AWS Resource Detectors to dedicated package `OpenTelemetry.ResourceDetectors.AWS`
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
-* Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.2.0
 
@@ -45,7 +43,7 @@ Released 2022-May-18
 Released 2021-Sep-20
 
 * Added AWS resource detectors ([#149](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/149))
-* Updated OTel SDK package version to 1.1.0
+* Updated OpenTelemetry SDK package version to 1.1.0
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))
 
 ## 1.0.1

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -49,7 +49,7 @@ Released 2023-Jun-05
 * Add support for abstract domain sockets.
   ([#1199](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1199))
 
-* Update OTel SDK version to `1.5.0-rc.1`.
+* Update OpenTelemetry SDK version to `1.5.0-rc.1`.
   ([#1210](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1210))
 
 ## 1.5.0-alpha.3
@@ -109,7 +109,7 @@ Released 2023-Mar-13
   the connection.
   ([#935](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/935))
 
-* Update OTel SDK version to `1.5.0-alpha.1`.
+* Update OpenTelemetry SDK version to `1.5.0-alpha.1`.
 * Update GenevaMetricExporter to use TLV format serialization.
 * Add support for exporting exemplars.
   ([#1069](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1069))
@@ -242,9 +242,9 @@ Released 2022-Oct-17
   It will also not support string values that contain non-ASCII characters.
   [646](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/646)
 
-* Update OTel SDK version to `1.4.0-beta.2`. Add support for exporting Histogram
-  Min and Max. If the histogram does not contain min and max, the exporter
-  exports both the values as zero.
+* Update OpenTelemetry SDK version to `1.4.0-beta.2`. Add support for exporting
+  Histogram Min and Max. If the histogram does not contain min and max,
+  the exporter exports both the values as zero.
   [#704](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/704)
 
 ## 1.4.0-beta.1
@@ -266,7 +266,7 @@ Released 2022-Jul-28
 `GenevaMetricExporter`.
 [397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/397)
 
-* Update OTel SDK version to `1.3.0`.
+* Update OpenTelemetry SDK version to `1.3.0`.
 [427](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/427)
 
 * Remove support for .NET Framework 4.6.1. The minimum .NET Framework version
@@ -340,7 +340,7 @@ NuGet.
 [303](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/303)
 is the PR that introduced this bug to GenevaMetricExporterExtensions.cs
 
-* Update OTel SDK version to `1.2.0`.
+* Update OpenTelemetry SDK version to `1.2.0`.
 [319](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/319)
 
 ## 1.2.4 Broken
@@ -360,5 +360,5 @@ special casing "{OriginalFormat}" only.
 had a single KeyValuePair.
 [295](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/295)
 
-* Update OTel SDK version to `1.2.0-rc5`.
+* Update OpenTelemetry SDK version to `1.2.0-rc5`.
 [308](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/308)

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry SDK version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.5.0
 
 Released 2023-Jun-14

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update OpenTelemetry SDK version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.5.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -141,10 +141,8 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
         // `LogRecord.State` and `LogRecord.StateValues` were marked Obsolete in https://github.com/open-telemetry/opentelemetry-dotnet/pull/4334
 #pragma warning disable 0618
         IReadOnlyList<KeyValuePair<string, object>> listKvp;
-        if (logRecord.State == null)
+        if (logRecord.StateValues != null)
         {
-            // When State is null, OTel SDK guarantees StateValues is populated
-            // TODO: Debug.Assert?
             listKvp = logRecord.StateValues;
         }
         else

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
@@ -190,10 +190,8 @@ internal sealed class TldLogExporter : TldExporter, IDisposable
 
         // `LogRecord.State` and `LogRecord.StateValues` were marked Obsolete in https://github.com/open-telemetry/opentelemetry-dotnet/pull/4334
 #pragma warning disable 0618
-        if (logRecord.State == null)
+        if (logRecord.StateValues != null)
         {
-            // When State is null, OTel SDK guarantees StateValues is populated
-            // TODO: Debug.Assert?
             listKvp = logRecord.StateValues;
         }
         else

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updates to 1.5.1 of OpenTelemetry SDK.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-alpha.2
 
 Released 2023-Jun-20

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -8,7 +8,7 @@
   The lowest supported version is .NET Framework 4.6.2.
   ([#1050](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1050))
 * Update OTel SDK version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.3
 

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 ## Unreleased
 
-* Update OTel SDK version to `1.5.0`.
-  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
+* Update OpenTelemetry SDK version to `1.5.1`.
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 * Drop support for .NET Framework 4.6.1.
   The lowest supported version is .NET Framework 4.6.2.
   ([#1050](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1050))
-* Update OTel SDK version to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.3
 
@@ -16,7 +14,7 @@ Released 2023-Feb-21
 
 * Fixes issue in span serialization process introduced in 1.0.2 version.
   ([#979](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/979))
-* Update OTel SDK version to `1.3.2`.
+* Update OpenTelemetry SDK version to `1.3.2`.
   ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
 
 ## 1.0.2
@@ -37,7 +35,7 @@ Released 2022-Nov-02
   [376](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/376)
 * Application is crashing if environment variables are not defined
   [385](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/385)
-* Update OTel SDK version to `1.3.1`.
+* Update OpenTelemetry SDK version to `1.3.1`.
   ([#749](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/749))
 
 ## 1.0.0

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Drop support for .NET Framework 4.6.1.
   The lowest supported version is .NET Framework 4.6.2.
   ([#1050](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1050))
+* Update OTel SDK version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.0.3
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -19,7 +19,7 @@
   ([#1127](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1127))
 
 * Update OpenTelemetry to 1.5.1
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 0.1.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -18,6 +18,9 @@
   non-zero on `LogRecord`s.
   ([#1127](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1127))
 
+* Update OpenTelemetry to 1.5.1
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 0.1.0-alpha.2
 
 Released 2023-Mar-6

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/LogRecordCommonSchemaJsonSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/LogRecordCommonSchemaJsonSerializer.cs
@@ -133,11 +133,11 @@ internal sealed class LogRecordCommonSchemaJsonSerializer : CommonSchemaJsonSeri
 
         string? body = null;
 
-        if (item.StateValues != null)
+        if (item.Attributes != null)
         {
-            for (int i = 0; i < item.StateValues.Count; i++)
+            for (int i = 0; i < item.Attributes.Count; i++)
             {
-                var attribute = item.StateValues[i];
+                var attribute = item.Attributes[i];
 
                 if (string.IsNullOrEmpty(attribute.Key))
                 {

--- a/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
+++ b/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="[1.4.0,2.0.0)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPkgVer)" Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net6.0'" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Exporter.OneCollector/README.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/README.md
@@ -23,7 +23,6 @@ dotnet add package --prerelease OpenTelemetry.Exporter.OneCollector
 using var logFactory = LoggerFactory.Create(builder => builder
     .AddOpenTelemetry(builder =>
     {
-        builder.ParseStateValues = true;
         builder.IncludeScopes = true;
         builder.AddOneCollectorExporter("InstrumentationKey=instrumentation-key-here");
     }));

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Update OTel SDK version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Update OTel SDK version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Unreleased
 
-* Update OTel SDK version to `1.5.0`.
-  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
-* Update OTel SDK version to `1.5.1`.
+* Update OpenTelemetry SDK version to `1.5.1`.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.4
@@ -14,14 +12,14 @@ Released 2022-Dec-07
 * Fix the issue of incorrect handling of null attributes.
   ([#566](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/566))
 * Support for Google Cloud Dependencies up to 3.x.x
-  and OTel SDK package to 1.3.1
+  and OpenTelemetry SDK package to 1.3.1
   ([#794](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/794))
 
 ## 1.0.0-beta.3
 
 Released 2022-Jul-22
 
-* Updated OTel SDK package version to 1.2.0
+* Updated OpenTelemetry SDK package version to 1.2.0
 * Updated minimum full framework support to net462
 * Update Google.Cloud.Monitoring.V3 2.1.0 -> 2.6.0
 * Update Google.Cloud.Monitoring.V3 2.0.0 -> 2.3.0
@@ -45,10 +43,10 @@ Released 2022-Jul-22
 
 ## 1.0.0-beta1
 
-* Update OTel SDK package version to 1.1.0
+* Update OpenTelemetry SDK package version to 1.1.0
 * Log exceptions when failing to export data to stackdriver
 
 ## Initial Release
 
-* Updated OTel SDK package version to 1.1.0-beta1
+* Updated OpenTelemetry SDK package version to 1.1.0-beta1
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Update OTel SDK version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
+* Update OTel SDK version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add LogToActivityEventConversionOptions.Filter callback
   ([#1059](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1059))
 
-* Update OTel SDK version to `1.5.1`.
+* Update OpenTelemetry SDK version to `1.5.1`.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.4

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add LogToActivityEventConversionOptions.Filter callback
   ([#1059](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1059))
 
+* Update OTel SDK version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-beta.4
 
 Released 2023-Feb-27

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#1059](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1059))
 
 * Update OTel SDK version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
+++ b/src/OpenTelemetry.Extensions/Internal/ActivityEventAttachingLogProcessor.cs
@@ -78,17 +78,17 @@ internal sealed class ActivityEventAttachingLogProcessor : BaseProcessor<LogReco
 
             data.ForEachScope(ProcessScope, new State(tags, this));
 
-            if (data.StateValues != null)
+            if (data.Attributes != null)
             {
                 try
                 {
-                    this.options.StateConverter?.Invoke(tags, data.StateValues);
+                    this.options.StateConverter?.Invoke(tags, data.Attributes);
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
                 {
-                    OpenTelemetryExtensionsEventSource.Log.LogProcessorException($"Processing state of type [{data.State?.GetType().FullName}]", ex);
+                    OpenTelemetryExtensionsEventSource.Log.LogProcessorException($"Processing attributes for LogRecord with CategoryName [{data.CategoryName}]", ex);
                 }
             }
 

--- a/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
+++ b/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="[1.4.0,2.0.0)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update `OpenTelemetry.Api` to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-rc9.9
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update `OpenTelemetry.Api` to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-rc9.9
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Updates to 1.5.0 of OpenTelemetry SDK.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
+* Updates to 1.5.1 of OpenTelemetry SDK.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.0.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updates to 1.5.0 of OpenTelemetry SDK.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-* Updates to 1.5.0 of OpenTelemetry SDK.
-  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Updates to 1.5.1 of OpenTelemetry SDK.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Updated OTel SDK package version to 1.5.0
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
+* Updated OTel SDK package version to 1.5.1
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updated OTel SDK package version to 1.5.0
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Updated OTel SDK package version to 1.5.1
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -2,16 +2,14 @@
 
 ## Unreleased
 
-* Updated OTel SDK package version to 1.5.0
-  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
-* Updated OTel SDK package version to 1.5.1
+* Updated OpenTelemetry SDK package version to 1.5.1
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.4
 
 Released 2023-Mar-06
 
-* Updated OTel SDK package version to 1.4.0
+* Updated OpenTelemetry SDK package version to 1.4.0
   ([#1019](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1019))
 * Update minimum full framework support to net462
 * Requests that get an HTTP status code of 404 are not marked as an error span status
@@ -44,10 +42,10 @@ Released 2023-Mar-06
 
 Released 2021-June-17
 
-* Updated OTel SDK package version to 1.1.0-beta4
+* Updated OpenTelemetry SDK package version to 1.1.0-beta4
   ([#136](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/136))
 
 ## Initial Release
 
-* Updated OTel SDK package version to 1.1.0-beta1
+* Updated OpenTelemetry SDK package version to 1.1.0-beta1
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -7,7 +7,7 @@
   ([#1203](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1203))
 
 * Updated OTel SDK package version to 1.5.1
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.7
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -6,14 +6,14 @@
   enable filtering of instrumentation.
   ([#1203](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1203))
 
-* Updated OTel SDK package version to 1.5.1
+* Updated OpenTelemetry SDK package version to 1.5.1
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.7
 
 Released 2023-Jun-09
 
-* Updated OTel SDK package version to 1.5.0
+* Updated OpenTelemetry SDK package version to 1.5.0
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 
 ## 1.0.0-beta.6
@@ -29,14 +29,14 @@ Released 2023-Mar-13
 
 Released 2023-Feb-27
 
-* Updated OTel SDK package version to 1.4.0
+* Updated OpenTelemetry SDK package version to 1.4.0
   ([#1038](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1038))
 
 ## 1.0.0-beta.4
 
 Released 2023-Jan-25
 
-* Updated OTel SDK package version to 1.3.2
+* Updated OpenTelemetry SDK package version to 1.3.2
   ([#917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/917))
 
 * Update the `ActivitySource` name used to the assembly name:

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -6,6 +6,9 @@
   enable filtering of instrumentation.
   ([#1203](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1203))
 
+* Updated OTel SDK package version to 1.5.1
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-beta.7
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-* Update OpenTelemetry.Api to 1.5.0.
-  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Update OpenTelemetry.Api to 1.5.1.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Update OpenTelemetry.Api to 1.5.0.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
+* Update OpenTelemetry.Api to 1.5.1.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.0.0-alpha.2
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Update OpenTelemetry.Api to 1.5.0.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Update OpenTelemetry.Api to 1.5.1.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-alpha.2
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## 1.0.0-beta3
 
-* Updated OTel SDK package version to 1.1.0-beta1
+* Updated OpenTelemetry SDK package version to 1.1.0-beta1
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))
 
 * Do NOT mutate incoming call headers, copy them before propagation

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel API version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.5.0-beta.1
 
 Released 2023-Jun-23

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update OTel API version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.5.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.MassTransit/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MassTransit/CHANGELOG.md
@@ -23,10 +23,10 @@
 
 Released 2021-June-17
 
-* Updated OTel SDK package version to 1.1.0-beta4
+* Updated OpenTelemetry SDK package version to 1.1.0-beta4
   ([#136](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/136))
 
 ## Initial Release
 
-* Updated OTel SDK package version to 1.1.0-beta1
+* Updated OpenTelemetry SDK package version to 1.1.0-beta1
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))

--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update OTel API version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.7
 

--- a/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel API version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-beta.7
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 * Removes `AddOwinInstrumentation` method with default configure parameter.
   ([#929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/929))
+* Updated OpenTelemetry SDK to 1.5.1
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.0.0-rc.3
 

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Removes `AddOwinInstrumentation` method with default configure parameter.
   ([#929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/929))
 * Updated OpenTelemetry SDK to 1.5.1
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-rc.3
 

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry SDK to 1.5.0
-  ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
-* Removes `AddOwinInstrumentation` method with default configure parameter.
-  ([#929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/929))
 * Updated OpenTelemetry SDK to 1.5.1
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Removes `AddOwinInstrumentation` method with default configure parameter.
+  ([#929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/929))
 
 ## 1.0.0-rc.3
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry API to 1.5.1
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 0.5.0-beta.3
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update OpenTelemetry API to 1.5.1
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 0.5.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update OpenTelemetry.Api to 1.5.1.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-alpha.3
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry.Api to 1.5.1.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-alpha.3
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -7,7 +7,7 @@
   ([#1239](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1239))
 
 * Update OpenTelemetry API to 1.5.1
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.5.0
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -6,6 +6,9 @@
   GC for .NET 7 and greater versions
   ([#1239](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1239))
 
+* Update OpenTelemetry API to 1.5.1
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.5.0
 
 Released 2023-Jun-06

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -141,7 +141,7 @@ which are not .NET Runtime specific.
 
 ## 0.2.0-alpha.1
 
-* Updated OTel SDK package version to 1.3.0
+* Updated OpenTelemetry SDK package version to 1.3.0
   ([#411](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/411))
 * Fix some bugs in Runtime metrics
   ([#409](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/409))

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update OTel API version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-rc9.10
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel API version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-rc9.10
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OTel SDK version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-rc.10
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,21 +2,21 @@
 
 ## Unreleased
 
-* Update OTel SDK version to `1.5.1`.
+* Update OpenTelemetry SDK version to `1.5.1`.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-rc.10
 
 Released 2023-Jun-09
 
-* Update OTel SDK version to `1.5.0`.
+* Update OpenTelemetry SDK version to `1.5.0`.
   ([#1220](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1220))
 
 ## 1.0.0-rc.9
 
 Released 2023-Feb-27
 
-* Update OTel SDK version to `1.4.0`.
+* Update OpenTelemetry SDK version to `1.4.0`.
   ([#1038](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1038))
 * Removes `AddWcfInstrumentation` method with default configure parameter.
   ([#928](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/928))
@@ -25,7 +25,7 @@ Released 2023-Feb-27
 
 Released 2022-Dec-28
 
-* Update OTel SDK version to `1.3.1`.
+* Update OpenTelemetry SDK version to `1.3.1`.
   ([#631](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/631))
 * Change value `rpc.system` from `wcf` to `dotnet_wcf`.
   ([#837](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/837))
@@ -34,7 +34,7 @@ Released 2022-Dec-28
 
 Released 2022-Aug-23
 
-* Updated OTel SDK package version to 1.3.0
+* Updated OpenTelemetry SDK package version to 1.3.0
   ([#569](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/569))
 * Changed activity source name from `OpenTelemetry.WCF`
   to `OpenTelemetry.Instrumentation.Wcf`
@@ -103,7 +103,7 @@ Released 2021-Sep-13
 
 Released 2021-Jun-16
 
-* Updated OTel SDK package version to 1.1.0-beta1
+* Updated OpenTelemetry SDK package version to 1.1.0-beta1
   ([#100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/100))
 
 * Added enricher for WCF activity

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Update OTel SDK version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-rc.10
 

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -5,3 +5,6 @@
 * Initial release. Previously it was part of `OpenTelemetry.Contrib.Extensions.AWSXRay`
   package.
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
+
+* Update OTel SDK version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -6,5 +6,5 @@
   package.
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
 
-* Update OTel SDK version to `1.5.1`.
+* Update OpenTelemetry SDK version to `1.5.1`.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -7,4 +7,4 @@
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))
 
 * Update OTel SDK version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))

--- a/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updates to 1.5.1 of OpenTelemetry SDK.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-beta.4
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -9,4 +9,4 @@ Initial release of `OpenTelemetry.Sampler.AWS`.
    [#1124](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1124))
 
 * Update OTel SDK version to `1.5.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -8,5 +8,5 @@ Initial release of `OpenTelemetry.Sampler.AWS`.
   ([#1091](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1091),
    [#1124](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1124))
 
-* Update OTel SDK version to `1.5.1`.
+* Update OpenTelemetry SDK version to `1.5.1`.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -7,3 +7,6 @@ Initial release of `OpenTelemetry.Sampler.AWS`.
 * Feature - AWSXRayRemoteSampler - Add support for AWS X-Ray remote sampling
   ([#1091](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1091),
    [#1124](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1124))
+
+* Update OTel SDK version to `1.5.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
@@ -15,15 +15,32 @@
 // </copyright>
 
 using System.Diagnostics.Metrics;
+using System.Reflection;
 using OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using Xunit;
 
 namespace OpenTelemetry.Exporter.InfluxDB.Tests;
 
 public class InfluxDBMetricsExporterTests
 {
+    private static readonly string OpenTelemetrySdkVersion;
+
+#pragma warning disable CA1810 // Initialize reference type static fields inline
+    static InfluxDBMetricsExporterTests()
+#pragma warning restore CA1810 // Initialize reference type static fields inline
+    {
+        var sdkVersion = typeof(Sdk).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+        if (sdkVersion != null)
+        {
+            OpenTelemetrySdkVersion = Version.Parse(sdkVersion).ToString(3);
+        }
+        else
+        {
+            OpenTelemetrySdkVersion = "0.0.0";
+        }
+    }
+
     [Theory]
     [InlineData(MetricsSchema.TelegrafPrometheusV1, "test-gauge", "gauge")]
     [InlineData(MetricsSchema.TelegrafPrometheusV2, "prometheus", "test-gauge")]
@@ -440,7 +457,7 @@ public class InfluxDBMetricsExporterTests
             AssertUtils.HasTag("tag_key_2", "tag_value_2", 6, dataPoint.Tags);
             AssertUtils.HasTag("telemetry.sdk.language", "dotnet", 7, dataPoint.Tags);
             AssertUtils.HasTag("telemetry.sdk.name", "opentelemetry", 8, dataPoint.Tags);
-            AssertUtils.HasTag("telemetry.sdk.version", "1.5.0", 9, dataPoint.Tags);
+            AssertUtils.HasTag("telemetry.sdk.version", OpenTelemetrySdkVersion, 9, dataPoint.Tags);
         }
     }
 
@@ -490,6 +507,6 @@ public class InfluxDBMetricsExporterTests
         AssertUtils.HasTag("tag_key_2", "tag_value_2", 5, dataPoint.Tags);
         AssertUtils.HasTag("telemetry.sdk.language", "dotnet", 6, dataPoint.Tags);
         AssertUtils.HasTag("telemetry.sdk.name", "opentelemetry", 7, dataPoint.Tags);
-        AssertUtils.HasTag("telemetry.sdk.version", "1.5.0", 8, dataPoint.Tags);
+        AssertUtils.HasTag("telemetry.sdk.version", OpenTelemetrySdkVersion, 8, dataPoint.Tags);
     }
 }

--- a/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/LogRecordCommonSchemaJsonHttpPostBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/LogRecordCommonSchemaJsonHttpPostBenchmarks.cs
@@ -114,7 +114,7 @@ public class LogRecordCommonSchemaJsonHttpPostBenchmarks
                 logRecord.EventId = new EventId(1);
             }
 
-            logRecord.StateValues = new List<KeyValuePair<string, object?>>
+            logRecord.Attributes = new List<KeyValuePair<string, object?>>
             {
                 new KeyValuePair<string, object?>("userId", 18),
                 new KeyValuePair<string, object?>("greeting", "hello world"),

--- a/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
@@ -55,15 +55,14 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [InlineData(true, 18, true, true, true)]
-    [InlineData(true, 0, false, false, true, true)]
-    [InlineData(true, 18, true, true, true, false, true)]
-    [InlineData(true, 0, false, false, true, true, true)]
+    [InlineData(true, 18, true, true)]
+    [InlineData(true, 0, false, true, true)]
+    [InlineData(true, 18, true, true, false, true)]
+    [InlineData(true, 0, false, true, true, true)]
     public void AttachLogsToActivityEventTest(
         bool sampled,
         int eventId = 0,
         bool includeFormattedMessage = false,
-        bool parseStateValues = false,
         bool includeScopes = false,
         bool recordException = false,
         bool? filter = null)
@@ -76,7 +75,6 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
                 {
                     options.IncludeScopes = includeScopes;
                     options.IncludeFormattedMessage = includeFormattedMessage;
-                    options.ParseStateValues = parseStateValues;
                     options.AttachLogsToActivityEvent(x =>
                     {
                         x.Filter = filter switch
@@ -142,14 +140,7 @@ public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
                 Assert.DoesNotContain(tags, kvp => kvp.Key == nameof(LogRecord.FormattedMessage));
             }
 
-            if (parseStateValues)
-            {
-                Assert.Equal(8, tags["state.UserId"]);
-            }
-            else
-            {
-                Assert.DoesNotContain(tags, kvp => kvp.Key == "state.UserId");
-            }
+            Assert.Equal(8, tags["state.UserId"]);
 
             if (includeScopes)
             {


### PR DESCRIPTION
## Changes

* Bumps the repo `OpenTelemetryCoreLatestVersion` prop to 1.5.1
* Fixes code in `OpenTelemetry.Exporter.OneCollector` & `OpenTelemetry.Extensions` to build against 1.5.1
* Tweaks the `GenevaExporter` log code to prefer `StateValues` over `State`

## Merge checklist

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
