### PR TITLE
[EventCounters] fix deadlock

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.5.1-rc.1
+
+Released 2023-Jun-29
+
 * Added support for sending common schema extensions using `ext.[name].[field]`
   syntax.
   ([#1073](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1073))

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Added a static constructor to ensure `EventCountersInstrumentationEventSource`
+got initialized when `EventCountersMetrics` was accessed for the first time to
+prevent potential deadlock;
+e.g.: <https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1024>.
+  ([#1260](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1260))
+
 * Update OpenTelemetry.Api to 1.5.1.
   ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -46,6 +46,7 @@ internal sealed class EventCountersMetrics : EventListener
     /// <param name="options">The options to define the metrics.</param>
     public EventCountersMetrics(EventCountersInstrumentationOptions options)
     {
+        _ = EventCountersInstrumentationEventSource.Log;
         lock (this.preInitEventSources)
         {
             this.options = options;

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -40,13 +40,20 @@ internal sealed class EventCountersMetrics : EventListener
     private readonly ConcurrentDictionary<(string, string), double> values = new();
     private bool isDisposed;
 
+    static EventCountersMetrics()
+    {
+        // Ensure EventCountersInstrumentationEventSource got initialized when the class was accessed for the first time
+        // to prevent potential deadlock:
+        // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1024.
+        _ = EventCountersInstrumentationEventSource.Log;
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EventCountersMetrics"/> class.
     /// </summary>
     /// <param name="options">The options to define the metrics.</param>
     public EventCountersMetrics(EventCountersInstrumentationOptions options)
     {
-        _ = EventCountersInstrumentationEventSource.Log;
         lock (this.preInitEventSources)
         {
             this.options = options;


### PR DESCRIPTION
Mitigates https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1024.

## Changes
Below is an example of when the deadlock can occur:

|                 | Thread 1 | Thread 2 |  locks acquired at this timestamp|
| ---------- | ----------|-----------|-----------|
| Time **↓**| call ctor of `EventCountersMetrics` | | |
|                 | [lock](https://github.com/Yun-Ting/opentelemetry-dotnet-contrib/blob/3e2015dd2a2884b1c89e596bcb53d599b6f961f4/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs#L50C1-L50C40) `preInitEventSources` |  | lock on `preInitEventSources` object by thread 1|
|                | iterate through the HashSet of `EventSources` [AND enable](https://github.com/Yun-Ting/opentelemetry-dotnet-contrib/blob/3e2015dd2a2884b1c89e596bcb53d599b6f961f4/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs#L58C1-L58C52) them  | | [lock](https://github.com/Yun-Ting/opentelemetry-dotnet-contrib/blob/3e2015dd2a2884b1c89e596bcb53d599b6f961f4/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs#L58C1-L58C52) on `EventSource`  by thread 1 |
|               |     | `EventSourceA` got enabled by thread 1 | |
|               |     | `OnEventWritten` callback fired on receiving an event | | 
|               |     | `EventCountersInstrumentationEventSource` got [lazy-init](https://github.com/Yun-Ting/opentelemetry-dotnet-contrib/blob/3e2015dd2a2884b1c89e596bcb53d599b6f961f4/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs#L127C13-L127C101) | lock on `EventSource` by thread 2 |
|               |     | `OnEventSourceCreated` callback fired  | |
|               |     |  [lock](https://github.com/Yun-Ting/opentelemetry-dotnet-contrib/blob/3e2015dd2a2884b1c89e596bcb53d599b6f961f4/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs#L96C8-L96C40) `preInitEventSouces` |  lock on `preInitEventSouces` by thread 2 | 

## Discussion

1. Better way to mitigate this issue could be, use an assistive dictionary to keep track of whether a particular eventSource should be enabled in a lock, and a flag (for example, shouldEnable) before releasing the lock. Outside of the lock, when the flag was set to true earlier, enable that eventSource. This approach should be more performant as compared to the current implementation. For example: https://github.com/dotnet/runtime/blob/84fd85932fd3b371cad69cc2412404ea50158c63/src/libraries/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs#L84C1-L93C14
2. The locks on `preInitEventSources` were added in this [PR](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/703) to address the issue -
"As OnEventSourceCreated can run before the constructor is done, you can run into a situation where you fail to enable an EventSource instance."
@MihaZupan: Instead of the current locking mechanism, Is it possible in `OnEventSourceCreated`, we use Spinlock to wait until `this.options` was set to ensure that `OnEventSourceCreated` will be triggered only after the `ctor` got executed? Too hacky?

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
