### PR TITLE
[OpenTelemetry.Instrumentation.AWSLambda]: consider two sources when setting http.method and http.target: original request and request context.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -44,7 +44,7 @@ internal class AWSLambdaHttpUtils
         {
             case APIGatewayProxyRequest request:
                 httpScheme = AWSLambdaUtils.GetHeaderValues(request, HeaderXForwardedProto)?.LastOrDefault();
-                httpTarget = string.Concat(request.RequestContext?.Path ?? string.Empty, GetQueryString(request));
+                httpTarget = string.Concat(request.RequestContext?.Path ?? request.Path ?? string.Empty, GetQueryString(request));
                 httpMethod = request.HttpMethod;
                 var hostHeader = AWSLambdaUtils.GetHeaderValues(request, HeaderHost)?.LastOrDefault();
                 (hostName, hostPort) = GetHostAndPort(httpScheme, hostHeader);

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -44,9 +44,9 @@ internal class AWSLambdaHttpUtils
         {
             case APIGatewayProxyRequest request:
                 httpScheme = AWSLambdaUtils.GetHeaderValues(request, HeaderXForwardedProto)?.LastOrDefault();
-                var path = request.Path ?? request.RequestContext?.Path ?? string.Empty;
+                var path = request.RequestContext?.Path ?? request.Path ?? string.Empty;
                 httpTarget = string.Concat(path, GetQueryString(request));
-                httpMethod = request.HttpMethod ?? request.RequestContext?.HttpMethod;
+                httpMethod = request.RequestContext?.HttpMethod ?? request.HttpMethod;
                 var hostHeader = AWSLambdaUtils.GetHeaderValues(request, HeaderHost)?.LastOrDefault();
                 (hostName, hostPort) = GetHostAndPort(httpScheme, hostHeader);
                 break;

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -44,8 +44,9 @@ internal class AWSLambdaHttpUtils
         {
             case APIGatewayProxyRequest request:
                 httpScheme = AWSLambdaUtils.GetHeaderValues(request, HeaderXForwardedProto)?.LastOrDefault();
-                httpTarget = string.Concat(request.RequestContext?.Path ?? request.Path ?? string.Empty, GetQueryString(request));
-                httpMethod = request.HttpMethod;
+                var path = request.Path ?? request.RequestContext?.Path ?? string.Empty;
+                httpTarget = string.Concat(path, GetQueryString(request));
+                httpMethod = request.HttpMethod ?? request.RequestContext?.HttpMethod;
                 var hostHeader = AWSLambdaUtils.GetHeaderValues(request, HeaderHost)?.LastOrDefault();
                 (hostName, hostPort) = GetHostAndPort(httpScheme, hostHeader);
                 break;

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
@@ -64,6 +64,28 @@ public class AWSLambdaHttpUtilsTests
     }
 
     [Fact]
+    public void GetHttpTags_APIGatewayProxyRequestWithEmptyContext_ReturnsCorrectHttpTarget()
+    {
+        var request = new APIGatewayProxyRequest
+        {
+            MultiValueQueryStringParameters = new Dictionary<string, IList<string>>
+            {
+                { "q1", new[] { "value1" } },
+            },
+            Path = "/path/test",
+        };
+
+        var actualTags = AWSLambdaHttpUtils.GetHttpTags(request);
+
+        var expectedTags = new Dictionary<string, object>
+        {
+            { "http.target", "/path/test?q1=value1" },
+        };
+
+        AssertTags(expectedTags, actualTags);
+    }
+
+    [Fact]
     public void GetHttpTags_APIGatewayProxyRequestWithMultiValueHeader_UsesLastValue()
     {
         var request = new APIGatewayProxyRequest

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
@@ -38,12 +38,15 @@ public class AWSLambdaHttpUtilsTests
                 { "X-Forwarded-Proto", new List<string> { "https" } },
                 { "Host", new List<string> { "localhost:1234" } },
             },
-            HttpMethod = "GET",
             MultiValueQueryStringParameters = new Dictionary<string, IList<string>>
             {
                 { "q1", new[] { "value1" } },
             },
-            Path = "/path/test",
+            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
+            {
+                HttpMethod = "GET",
+                Path = "/path/test",
+            },
         };
 
         var actualTags = AWSLambdaHttpUtils.GetHttpTags(request);
@@ -61,7 +64,7 @@ public class AWSLambdaHttpUtilsTests
     }
 
     [Fact]
-    public void GetHttpTags_APIGatewayProxyRequestWithContext_ReturnsTagsFromContext()
+    public void GetHttpTags_APIGatewayProxyRequestWithEmptyContext_ReturnsTagsFromRequest()
     {
         var request = new APIGatewayProxyRequest
         {
@@ -69,11 +72,8 @@ public class AWSLambdaHttpUtilsTests
             {
                 { "q1", new[] { "value1" } },
             },
-            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
-            {
-                HttpMethod = "POST",
-                Path = "/path/test",
-            },
+            HttpMethod = "POST",
+            Path = "/path/test",
         };
 
         var actualTags = AWSLambdaHttpUtils.GetHttpTags(request);

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
@@ -43,10 +43,7 @@ public class AWSLambdaHttpUtilsTests
             {
                 { "q1", new[] { "value1" } },
             },
-            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
-            {
-                Path = "/path/test",
-            },
+            Path = "/path/test",
         };
 
         var actualTags = AWSLambdaHttpUtils.GetHttpTags(request);
@@ -64,7 +61,7 @@ public class AWSLambdaHttpUtilsTests
     }
 
     [Fact]
-    public void GetHttpTags_APIGatewayProxyRequestWithEmptyContext_ReturnsCorrectHttpTarget()
+    public void GetHttpTags_APIGatewayProxyRequestWithContext_ReturnsTagsFromContext()
     {
         var request = new APIGatewayProxyRequest
         {
@@ -72,13 +69,18 @@ public class AWSLambdaHttpUtilsTests
             {
                 { "q1", new[] { "value1" } },
             },
-            Path = "/path/test",
+            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
+            {
+                HttpMethod = "POST",
+                Path = "/path/test",
+            },
         };
 
         var actualTags = AWSLambdaHttpUtils.GetHttpTags(request);
 
         var expectedTags = new Dictionary<string, object>
         {
+            { "http.method", "POST" },
             { "http.target", "/path/test?q1=value1" },
         };
 


### PR DESCRIPTION
**Problem**

For AWS Lambda functions (V1 only) invoked via HTTP depending on setup there might be different sources for setting http.method and http.target: original request (APIGatewayProxyRequest) and request context (ProxyRequestContext) defined inside of the request.

**Fix**

Consider Path and HttpMethod properties of APIGatewayProxyRequest and APIGatewayProxyRequest.ProxyRequestContext when setting http.target and http.method. Request context should be prioritised over request while setting http.target and http.method
