### PR TITLE
[Instrumentation.EventCounters] Release EventCounters instrumentation version 1.5.1-alpha.1

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.0.0-alpha.3
+## 1.5.1-alpha.1
 
 Released 2023-Jul-10
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-alpha.3
+
+Released 2023-Jul-10
+
 * Added a static constructor to ensure `EventCountersInstrumentationEventSource`
 got initialized when `EventCountersMetrics` was accessed for the first time to
 prevent potential deadlock;

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Released 2023-Jul-11
 
-* Bumped the package version to `1.5.0-alpha.1` to keep its major and minor
+* Bumped the package version to `1.5.1-alpha.1` to keep its major and minor
   version in sync with that of the core packages. This would make it more
   intuitive for users to figure out what version of core packages would work
   with a given version of this package.

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ## 1.5.1-alpha.1
 
-Released 2023-Jul-10
+Released 2023-Jul-11
+
+* Bumped the package version to `1.5.0-alpha.1` to keep its major and minor
+  version in sync with that of the core packages. This would make it more
+  intuitive for users to figure out what version of core packages would work
+  with a given version of this package.
 
 * Added a static constructor to ensure `EventCountersInstrumentationEventSource`
 got initialized when `EventCountersMetrics` was accessed for the first time to


### PR DESCRIPTION
## Changes

Release EventCounters instrumentation version 1.5.1-alpha.1
@open-telemetry/dotnet-contrib-maintainers 
For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
