### PR TITLE
[Exporter.Geneva] Add Exemplar support back

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -35,7 +35,7 @@
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTelemetryCoreLatestVersion>[1.5.1,2.0)</OpenTelemetryCoreLatestVersion>
-    <OpenTelemetryCoreLatestPrereleaseVersion>[1.5.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
+    <OpenTelemetryCoreLatestPrereleaseVersion>[1.6.0-alpha.1]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Update OpenTelemetry SDK version to `1.6.0-alpha.1`.
+  ([#1264](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1264))
+
+* Add back support for exporting `Exemplar`.
+  ([#1264](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1264))
+
 ## 1.5.1
 
 Released 2023-Jun-29

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -122,7 +122,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
             {
                 try
                 {
-                    // var exemplars = metricPoint.GetExemplars();
+                    var exemplars = metricPoint.GetExemplars();
 
                     switch (metric.MetricType)
                     {
@@ -136,6 +136,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(), // Using the endTime here as the timestamp as Geneva Metrics only allows for one field for timestamp
                                     metricPoint.Tags,
                                     metricData,
+                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -155,6 +156,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -174,6 +176,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -191,6 +194,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -207,6 +211,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -232,6 +237,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     count,
                                     min,
                                     max,
+                                    exemplars,
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -295,6 +301,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         long timestamp,
         in ReadOnlyTagCollection tags,
         MetricData value,
+        Exemplar[] exemplars,
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -321,7 +328,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                 out monitoringAccount,
                 out metricNamespace);
 
-            // SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
+            SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -354,6 +361,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         uint count,
         double min,
         double max,
+        Exemplar[] exemplars,
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -380,7 +388,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                 out monitoringAccount,
                 out metricNamespace);
 
-            // SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
+            SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -425,7 +433,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         MetricSerializer.SerializeString(buffer, ref bufferIndex, monitoringAccount);
     }
 
-    /* Commenting out Exemplar related code as it's removed from `1.5.0` stable version of OpenTelemetry SDK
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeExemplars(Exemplar[] exemplars, byte[] buffer, ref int bufferIndex)
     {
@@ -541,7 +548,6 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         var exemplarLength = bufferIndex - bufferIndexForLength + 1;
         MetricSerializer.SerializeByte(buffer, ref bufferIndexForLength, (byte)exemplarLength);
     }
-    */
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeNonHistogramMetricData(MetricEventType eventType, MetricData value, long timestamp, byte[] buffer, ref int bufferIndex)

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -245,7 +245,11 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
         }
 
         // Part B
+
+        // `LogRecord.LogLevel` was marked Obsolete in https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568
+#pragma warning disable 0618
         var logLevel = logRecord.LogLevel;
+#pragma warning restore 0618
 
         cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "severityText");
         cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, logLevels[(int)logLevel]);

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
@@ -293,7 +293,12 @@ internal sealed class TldLogExporter : TldExporter, IDisposable
         byte partBFieldsCount = 4;
         var partBFieldsCountPatch = eb.AddStruct("PartB", partBFieldsCount); // We at least have three fields in Part B: _typeName, severityText, severityNumber, name
         eb.AddCountedString("_typeName", "Log");
+
+        // `LogRecord.LogLevel` was marked Obsolete in https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568
+#pragma warning disable 0618
         var logLevel = logRecord.LogLevel;
+#pragma warning restore 0618
+
         eb.AddCountedString("severityText", logLevels[(int)logLevel]);
         eb.AddUInt8("severityNumber", GetSeverityNumber(logLevel));
         eb.AddCountedAnsiString("name", categoryName, Encoding.UTF8);

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
@@ -566,6 +566,7 @@ public class MetricExporterBenchmarks
             this.counterMetricPointWith3Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith3Dimensions.Tags,
             this.counterMetricDataWith3Dimensions,
+            Array.Empty<Exemplar>(),
             out _,
             out _);
     }
@@ -579,6 +580,7 @@ public class MetricExporterBenchmarks
             this.counterMetricPointWith4Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith4Dimensions.Tags,
             this.counterMetricDataWith4Dimensions,
+            Array.Empty<Exemplar>(),
             out _,
             out _);
     }
@@ -607,6 +609,7 @@ public class MetricExporterBenchmarks
             this.histogramCountWith3Dimensions,
             this.histogramMinWith3Dimensions,
             this.histogramMaxWith3Dimensions,
+            Array.Empty<Exemplar>(),
             out _,
             out _);
     }
@@ -623,6 +626,7 @@ public class MetricExporterBenchmarks
             this.histogramCountWith4Dimensions,
             this.histogramMinWith4Dimensions,
             this.histogramMaxWith4Dimensions,
+            Array.Empty<Exemplar>(),
             out _,
             out _);
     }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -1352,8 +1352,12 @@ public class GenevaLogExporterTests
         }
 
         // Part B fields
+
+        // `LogRecord.LogLevel` was marked Obsolete in https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568
+#pragma warning disable 0618
         Assert.Equal(logRecord.LogLevel.ToString(), mapping["severityText"]);
         Assert.Equal((byte)(((int)logRecord.LogLevel * 4) + 1), mapping["severityNumber"]);
+#pragma warning restore 0618
 
         Assert.Equal(logRecord.CategoryName, mapping["name"]);
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -196,13 +196,14 @@ public class GenevaMetricExporterTests
                 var metricDataValue = Convert.ToUInt64(metricPoint.GetSumLong());
                 var metricData = new MetricData { UInt64Value = metricDataValue };
 
-                // var exemplars = metricPoint.GetExemplars();
+                var exemplars = metricPoint.GetExemplars();
                 var bodyLength = exporter.SerializeMetricWithTLV(
                     MetricEventType.ULongMetric,
                     metric.Name,
                     metricPoint.EndTime.ToFileTime(),
                     metricPoint.Tags,
                     metricData,
+                    exemplars,
                     out _,
                     out _);
 
@@ -353,7 +354,7 @@ public class GenevaMetricExporterTests
 
         if (hasExemplars)
         {
-            // meterProviderBuilder.SetExemplarFilter(new AlwaysOnExemplarFilter());
+            meterProviderBuilder.SetExemplarFilter(new AlwaysOnExemplarFilter());
         }
 
         if (hasFilteredTagsForExemplars)
@@ -949,7 +950,7 @@ public class GenevaMetricExporterTests
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
 
-        // var exemplars = metricPoint.GetExemplars();
+        var exemplars = metricPoint.GetExemplars();
 
         List<TlvField> fields = null;
 
@@ -964,6 +965,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -989,6 +991,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -1016,6 +1019,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -1043,6 +1047,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -1077,6 +1082,7 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
+                exemplars,
                 out _,
                 out _);
 
@@ -1115,7 +1121,6 @@ public class GenevaMetricExporterTests
             Assert.Equal(bodyLength, data.LenBody);
         }
 
-        /*
         if (exemplars.Length > 0)
         {
             var validExemplars = exemplars.Where(exemplar => exemplar.Timestamp != default).ToList();
@@ -1137,7 +1142,6 @@ public class GenevaMetricExporterTests
                 AssertExemplarFilteredTagSerialization(expectedExemplar, serializedExemplar);
             }
         }
-        */
 
         // Check metric name, account, and namespace
         var connectionStringBuilder = new ConnectionStringBuilder(exporterOptions.ConnectionString);
@@ -1210,7 +1214,6 @@ public class GenevaMetricExporterTests
         Assert.Equal(dimensionsCount, dimensions.NumDimensions);
     }
 
-    /*
     private static void AssertExemplarFilteredTagSerialization(Exemplar expectedExemplar, SingleExemplar serializedExemplar)
     {
         var serializedExemplarBody = serializedExemplar.Body;
@@ -1260,7 +1263,6 @@ public class GenevaMetricExporterTests
             }
         }
     }
-    */
 
     private static UserdataV2 GetSerializedData(Metric metric, GenevaMetricExporter exporter)
     {
@@ -1269,7 +1271,7 @@ public class GenevaMetricExporterTests
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
 
-        // var exemplars = metricPoint.GetExemplars();
+        var exemplars = metricPoint.GetExemplars();
         UserdataV2 result = null;
 
         if (metricType == MetricType.LongSum)
@@ -1282,6 +1284,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -1300,6 +1303,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -1320,6 +1324,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -1340,6 +1345,7 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+                exemplars,
                 out _,
                 out _);
 
@@ -1367,6 +1373,7 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
+                exemplars,
                 out _,
                 out _);
 


### PR DESCRIPTION
Compare with #1238 which removed Exemplar support

## Changes
- Update OTel SDK version to `1.6.0-alpha.1`
- Add back Exemplar support
- Suppress warnings about `LogRecord.LogLevel` being Obsolete

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
