### PR TITLE
[Exporter.Geneva] Can configure metrics namespace per Meter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsPartAName = 1 -> OpenT
 OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.MeterNamespaceOverrides.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.MeterNamespaceOverrides.set -> void
 static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
 static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder

--- a/src/OpenTelemetry.Exporter.Geneva/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/AssemblyInfo.cs
@@ -21,12 +21,15 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Geneva.Benchmark" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Geneva.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Geneva.Stress" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]
 
 internal static class AssemblyInfo
 {
 #if SIGNED
     public const string PublicKey = ", PublicKey=002400000480000094000000060200000024000052534131000400000100010051C1562A090FB0C9F391012A32198B5E5D9A60E9B80FA2D7B434C9E5CCB7259BD606E66F9660676AFC6692B8CDC6793D190904551D2103B7B22FA636DCBB8208839785BA402EA08FC00C8F1500CCEF28BBF599AA64FFB1E1D5DC1BF3420A3777BADFE697856E9D52070A50C3EA5821C80BEF17CA3ACFFA28F89DD413F096F898";
+    public const string MoqPublicKey = ", PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7";
 #else
     public const string PublicKey = "";
+    public const string MoqPublicKey = "";
 #endif
 }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
@@ -24,6 +24,7 @@ namespace OpenTelemetry.Exporter.Geneva;
 public class GenevaMetricExporterOptions
 {
     private IReadOnlyDictionary<string, object> _prepopulatedMetricDimensions;
+    private IReadOnlyDictionary<string, string> _meterNamespaceOverrides;
     private int _metricExporterIntervalMilliseconds = 60000;
 
     /// <summary>
@@ -94,6 +95,36 @@ public class GenevaMetricExporterOptions
             }
 
             this._prepopulatedMetricDimensions = copy;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the per Meter namespace override.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> MeterNamespaceOverrides
+    {
+        get
+        {
+            return this._meterNamespaceOverrides;
+        }
+
+        set
+        {
+            Guard.ThrowIfNull(value);
+
+            var copy = new Dictionary<string, string>(value.Count);
+
+            foreach (var entry in value)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Value))
+                {
+                    throw new ArgumentException($"Value provided for the meter: {entry.Key} is null or consists exclusively of white-space characters.");
+                }
+
+                copy[entry.Key] = entry.Value;
+            }
+
+            this._meterNamespaceOverrides = copy;
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -220,6 +220,10 @@ is 20000 milliseconds.
 This is a collection of the dimensions that will be applied to _every_ metric
 exported by the exporter.
 
+#### `MeterNamespaceOverrides` (optional)
+
+This is a collection of the Namespace overrides per Meter.
+
 ## Troubleshooting
 
 Before digging into a problem, check if you hit a known issue by looking at the

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
@@ -91,4 +91,35 @@ public class GenevaMetricExporterOptionsTests
 
         Assert.Null(exception);
     }
+
+    [Fact]
+    public void InvalidMeterNamespaceOverrides()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+        {
+            var exporterOptions = new GenevaMetricExporterOptions { MeterNamespaceOverrides = null };
+        });
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var exporterOptions = new GenevaMetricExporterOptions
+            {
+                MeterNamespaceOverrides = new Dictionary<string, string>
+                {
+                    ["Meter"] = null,
+                },
+            };
+        });
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var exporterOptions = new GenevaMetricExporterOptions
+            {
+                MeterNamespaceOverrides = new Dictionary<string, string>
+                {
+                    ["Meter"] = " ",
+                },
+            };
+        });
+    }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Unit test project for Geneva Exporters for OpenTelemetry</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
+    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes #.

## Changes

Add support in metrics for namespace configuration per meter.

Example scenario: two services report metrics into their own namespaces, but common metrics, like metrics from HTTP client and ASP.NET Core, to a shared namespace.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
