### PR TITLE
Instrumentation.AWSLambda: Upgrade & explicitly depend on Newtonsoft.Json

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+* Add explicit dependency on Newtonsoft.Json, upgrading the minimum version.
+
+  This resolves a warning that some dependency analyzers may produce where this
+  package would transitively depend on a vulnerable version of Newtonsoft.Json
+  through [Amazon.Lambda.APIGatewayEvents][].
+
+  This also avoids a potential issue where the instrumentation would try to call
+  a Newtonsoft.Json function when no other package nor the app itself depends on
+  Newtonsoft.Json, since the transitive dependency would be ignored unless using
+  application were compiled against a TargetFramework older than Core 3.1.
+
+[Amazon.Lambda.APIGatewayEvents]: https://www.nuget.org/packages/Amazon.Lambda.APIGatewayEvents/2.4.1#dependencies-body-tab
+
 ## 1.1.0-beta.3
 
 Released 2023-Jun-13

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
     <PackageReference Include="OpenTelemetry" Version="1.1.0" />
     <PackageReference Include="OpenTelemetry.Contrib.Extensions.AWSXRay" Version="1.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSMessagingUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSMessagingUtilsTests.cs
@@ -83,6 +83,8 @@ public class AWSMessagingUtilsTests : IDisposable
                 new SQSMessage
                 {
                     MessageAttributes = new(),
+
+#pragma warning disable format // dotnet-format butchers the raw string & all following code (use dotnet format instead?)
                     Body = /*lang=json,strict*/ """
                     {
                       "Type" : "Notification",

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSMessagingUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSMessagingUtilsTests.cs
@@ -72,6 +72,45 @@ public class AWSMessagingUtilsTests : IDisposable
         Assert.Equal(2, links.Count());
     }
 
+    [Fact]
+    public void ExtractParentContext_SetParentFromMessageBatchIsEnabled_ParentIsSetFromSnsMessage()
+    {
+        AWSMessagingUtils.SetParentFromMessageBatch = true;
+        var sqsEvent = new SQSEvent
+        {
+            Records = new List<SQSMessage>
+            {
+                new SQSMessage
+                {
+                    MessageAttributes = new(),
+                    Body = /*lang=json,strict*/ """
+                    {
+                      "Type" : "Notification",
+                      "MessageId" : "f91f7f8e-77cc-51e7-ad08-231055044066",
+                      "TopicArn" : "arn:aws:sqs:us-east-1:123456789012:foo-bar-test-queue",
+                      "Subject" : "testsub",
+                      "Message" : "{\"This JSON string\": \"is in the SNS body\"}",
+                      "Timestamp" : "2023-03-29T11:27:04.056Z",
+                      "SignatureVersion" : "1",
+                      "Signature" : "base64string/redacted",
+                      "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-1234567abc123def1234567890123467.pem",
+                      "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sqs:us-east-1:123456789012:foo-bar-test-queue:123abcde-1234-1abc-1234-123456abcdef",
+                      "MessageAttributes" : {
+                        "traceparent" : {"Type":"String","Value":"00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-00"}
+                      }
+                    }
+                    """,
+                },
+            },
+        };
+
+        (PropagationContext parentContext, IEnumerable<ActivityLink> links) = AWSMessagingUtils.ExtractParentContext(sqsEvent);
+
+        Assert.NotEqual(default, parentContext);
+        Assert.Equal(SpanId1, parentContext.ActivityContext.SpanId.ToHexString());
+        Assert.Single(links);
+    }
+
     private static SQSEvent CreateSqsEventWithMessages(string[] spans)
     {
         var @event = new SQSEvent { Records = new List<SQSMessage>() };


### PR DESCRIPTION
Closes #1270 (alternative to that PR).

Related to a similar change in the XRay dependency: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1092

## Changes

Quoting the CHANGELOG:

* Add explicit dependency on Newtonsoft.Json, upgrading the mimimum version.

  This resolves a warning that some dependency analyzers may produce where this
  package would transitively depend on a vulnerable version of Newtonsoft.Json
  through [Amazon.Lambda.APIGatewayEvents][].

  This also avoids a potential issue where the instrumentation would try to call
  a Newtonsoft.Json function when no other package nor the app itself depends on
  Newtonsoft.Json, since the transitive dependency would be ignored unless using
  application were compiled against a TargetFramework older than Core 3.1.

[Amazon.Lambda.APIGatewayEvents]: https://www.nuget.org/packages/Amazon.Lambda.APIGatewayEvents/2.4.1#dependencies-body-tab

For significant contributions please make sure you have completed the following items:

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~ N/A
* ~~[ ] Changes in public API reviewed~~ N/A
