### PR TITLE
[Extensions.AWS, ResourceDetectors.AWS] Release 1.3.0-beta.1

### DIFF
--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.0-beta.1
+
+Released 2023-Aug-01
+
 * Rename package from `OpenTelemetry.Contrib.Extensions.AWSXRay`
   to `OpenTelemetry.Extensions.AWS`
   ([#1232](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1232))

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.3.0-beta.1
 
-Released 2023-Aug-01
+Released 2023-Aug-02
 
 * Rename package from `OpenTelemetry.Contrib.Extensions.AWSXRay`
   to `OpenTelemetry.Extensions.AWS`

--- a/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
+++ b/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS.</Description>
-    <MinVerTagPrefix>Extensions.AWSXRay-</MinVerTagPrefix>
+    <MinVerTagPrefix>Extensions.AWS-</MinVerTagPrefix>
     <Nullable>enable</Nullable>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
   </PropertyGroup>

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.0-beta.1
+
+Released 2023-Aug-01
+
 * Initial release. Previously it was part of `OpenTelemetry.Contrib.Extensions.AWSXRay`
   package.
   ([#1140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1140))

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.3.0-beta.1
 
-Released 2023-Aug-01
+Released 2023-Aug-02
 
 * Initial release. Previously it was part of `OpenTelemetry.Contrib.Extensions.AWSXRay`
   package.


### PR DESCRIPTION
Towards #1268

## Changes

Prerequisite to release another AWS packages.
Please check changes in changelog for details.

The question is if it should be released as 1.3.0-beta.1 (as we changed the package name) or it has to be major release (2.0.0-beta.1) for Extension package.
My recommendation is to use the same version for ResourceDetectors as it was extracted from the old package.
@srprash, @Oberon00, @rypdal, please let me know what do you think about versioning.

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~


