### PR TITLE
[Exporter.Stackdriver] Documentation - remove reference to metric exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Stackdriver/README.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/README.md
@@ -47,15 +47,6 @@ using (tracer.StartActiveSpan("/getuser", out TelemetrySpan span))
 }
 ```
 
-## Metrics
-
-```csharp
-var metricExporter = new StackdriverExporter(
-    "YOUR-GOOGLE-PROJECT-ID",
-    Stats.ViewManager);
-metricExporter.Start();
-```
-
 ## References
 
 * [stackdriver-trace-setup](https://cloud.google.com/trace/docs/setup/)


### PR DESCRIPTION
Update documentation for #1263.

## Changes
[Exporter.Stackdriver] Documentation - remove reference to metric exporterorter

which is not implemented

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
