### PR TITLE
Drop netcoreapp3.1 from CI & update testing framework in Instrumentation.GrpcCore to net6.0

### DIFF
--- a/.github/workflows/ci-Instrumentation.Process.yml
+++ b/.github/workflows/ci-Instrumentation.Process.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install .NET 3.1 SDK
-      uses: actions/setup-dotnet@v3.2.0
-      with:
-        dotnet-version: '3.1.x'
-
     - name: Install .NET 7 SDK
       uses: actions/setup-dotnet@v3.2.0
       with:

--- a/.github/workflows/ci-md.yml
+++ b/.github/workflows/ci-md.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        version: [ net462, netcoreapp3.1, net6.0, net7.0 ]
+        version: [ net462, net6.0, net7.0 ]
         exclude:
         - os: ubuntu-latest
           version: net462

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        version: [ net462, netcoreapp3.1, net6.0, net7.0 ]
+        version: [ net462, net6.0, net7.0 ]
         exclude:
         - os: ubuntu-latest
           version: net462
@@ -25,11 +25,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-
-    - name: Install .NET 3.1 SDK
-      uses: actions/setup-dotnet@v3.2.0
-      with:
-        dotnet-version: '3.1.x'
 
     - name: Install .NET 7 SDK
       uses: actions/setup-dotnet@v3.2.0

--- a/.github/workflows/integration-md.yml
+++ b/.github/workflows/integration-md.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp3.1,net6.0,net7.0]
+        version: [net6.0,net7.0]
     steps:
       - run: 'echo "No build required"'
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp3.1,net6.0,net7.0]
+        version: [net6.0,net7.0]
     steps:
       - uses: actions/checkout@v3
 

--- a/build/docker-compose.netcoreapp3.1.yml
+++ b/build/docker-compose.netcoreapp3.1.yml
@@ -1,9 +1,0 @@
-version: '3.7'
-
-services:
-  tests:
-    build:
-      args:
-        PUBLISH_FRAMEWORK: netcoreapp3.1
-        TEST_SDK_VERSION: 3.1
-        BUILD_SDK_VERSION: 7.0

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -74,7 +74,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{824BD1DE
 		build\debug.snk = build\debug.snk
 		build\docker-compose.net6.0.yml = build\docker-compose.net6.0.yml
 		build\docker-compose.net7.0.yml = build\docker-compose.net7.0.yml
-		build\docker-compose.netcoreapp3.1.yml = build\docker-compose.netcoreapp3.1.yml
 		build\opentelemetry-icon-color.png = build\opentelemetry-icon-color.png
 		build\OpenTelemetryContrib.prod.ruleset = build\OpenTelemetryContrib.prod.ruleset
 		build\OpenTelemetryContrib.test.ruleset = build\OpenTelemetryContrib.test.ruleset

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptorOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptorOptions.cs
@@ -35,7 +35,7 @@ public class ClientTracingInterceptorOptions
     public TextMapPropagator Propagator { get; internal set; } = Propagators.DefaultTextMapPropagator;
 
     /// <summary>
-    /// Gets or sets a custom identfier used during unit testing.
+    /// Gets or sets a custom identifier used during unit testing.
     /// </summary>
     internal Guid ActivityIdentifierValue { get; set; }
 }

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
@@ -23,7 +23,7 @@ using Google.Protobuf;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 
-namespace OpenTelemetry.Instrumentation.GrpcCore.Test;
+namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
 
 /// <summary>
 /// Test implementation of foobar.

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -25,7 +25,7 @@ using Moq;
 using OpenTelemetry.Context.Propagation;
 using Xunit;
 
-namespace OpenTelemetry.Instrumentation.GrpcCore.Test;
+namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
 
 /// <summary>
 /// Grpc Core client interceptor tests.
@@ -333,7 +333,7 @@ public class GrpcCoreClientInterceptorTests
         // TagObjects contain non string values
         // Tags contains only string values
         Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcSystem && (string)t.Value == "grpc");
-        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcService && (string)t.Value == "OpenTelemetry.Instrumentation.GrpcCore.Test.Foobar");
+        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcService && (string)t.Value == "OpenTelemetry.Instrumentation.GrpcCore.Tests.Foobar");
         Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcMethod);
         Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcGrpcStatusCode && (int)t.Value == (int)expectedStatusCode);
 

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -42,6 +42,11 @@ public class GrpcCoreClientInterceptorTests
     /// </summary>
     private static readonly Func<Metadata> DefaultMetadataFunc = () => new Metadata { new Metadata.Entry("foo", "bar") };
 
+    public GrpcCoreClientInterceptorTests()
+    {
+        System.Diagnostics.Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+    }
+
     /// <summary>
     /// Validates a successful AsyncUnary call.
     /// </summary>

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -440,8 +440,11 @@ public class GrpcCoreClientInterceptorTests
             Assert.Equal(originalMetadataCount, additionalMetadata.Count);
 
             // There was no parent activity, so these will be default
-            Assert.Equal(default, capturedPropagationContext.ActivityContext.TraceId);
-            Assert.Equal(default, capturedPropagationContext.ActivityContext.SpanId);
+            Assert.NotEqual(default, capturedPropagationContext.ActivityContext.TraceId);
+            Assert.NotEqual(default, capturedPropagationContext.ActivityContext.SpanId);
+            Assert.Null(activity.Parent);
+            Assert.Equal(activity.TraceId, capturedPropagationContext.ActivityContext.TraceId);
+            Assert.Equal(activity.SpanId, capturedPropagationContext.ActivityContext.SpanId);
 
             // Sanity check a valid metadata injection setter.
             Assert.NotEmpty(capturedCarrier);

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -42,11 +42,6 @@ public class GrpcCoreClientInterceptorTests
     /// </summary>
     private static readonly Func<Metadata> DefaultMetadataFunc = () => new Metadata { new Metadata.Entry("foo", "bar") };
 
-    public GrpcCoreClientInterceptorTests()
-    {
-        System.Diagnostics.Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-    }
-
     /// <summary>
     /// Validates a successful AsyncUnary call.
     /// </summary>

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -21,7 +21,7 @@ using Grpc.Core;
 using OpenTelemetry.Context.Propagation;
 using Xunit;
 
-namespace OpenTelemetry.Instrumentation.GrpcCore.Test;
+namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
 
 /// <summary>
 /// Grpc Core server interceptor tests.

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/InterceptorActivityListener.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/InterceptorActivityListener.cs
@@ -18,7 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 
-namespace OpenTelemetry.Instrumentation.GrpcCore.Test;
+namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
 
 /// <summary>
 /// This class listens for a single Activity created by the Grpc Core interceptors.

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorPkgVer)" />

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
@@ -14,7 +14,7 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetXUnitCliVer)" />
     <PackageReference Include="Grpc.Tools" Version="1.17.0" />
-    <PackageReference Include="Grpc" Version="[2.32.0,3.0)" />
+    <PackageReference Include="Grpc" Version="[2.46.6,3.0)" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="proto/*.proto" />

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/proto/foobar.proto
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/proto/foobar.proto
@@ -1,5 +1,5 @@
-﻿syntax = "proto3";
-package OpenTelemetry.Instrumentation.GrpcCore.Test;
+syntax = "proto3";
+package OpenTelemetry.Instrumentation.GrpcCore.Tests;
 
 service Foobar {
   rpc Unary (FoobarRequest) returns (FoobarResponse) {}


### PR DESCRIPTION
Towards #1031

## Changes

* update testing framework in Instrumentation.GrpcCore from netcoreapp3.1 to net6.0
  * after changes test was failing due to https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/default-activityidformat-changed
* Bum `Grpc` package in test to latest released. It is currently obsolete, unmaintained package so update to the latest release seems to be reasonable
  * mitigation of Unable to load shared library 'libdl.so' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: liblibdl.so: cannot open shared object file: No such file or directory 
* Drop netcoreapp3.1 from CI
* Minor opportunistic changes

As part of working on this `redis-test (netcoreapp3.1)` was removed from required builds

While reviewing consider to review each commit separately. History is more descriptive.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
