### PR TITLE
Bump coverlet.collector from 3.2.0 to 6.0.0

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -21,7 +21,7 @@
       Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
     -->
     <BenchmarkDotNetPkgVer>[0.13.6,0.14)</BenchmarkDotNetPkgVer>
-    <CoverletCollectorPkgVer>[3.2.0,4.0.0)</CoverletCollectorPkgVer>
+    <CoverletCollectorPkgVer>[6.0.0,7.0.0)</CoverletCollectorPkgVer>
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
     <MicrosoftExtensionsLoggingPkgVer>[5.0.0,7.0)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftNETTestSdkPkgVer>[17.6.3,18.0)</MicrosoftNETTestSdkPkgVer>


### PR DESCRIPTION
## Changes

Bump coverlet.collector from 3.2.0 to 6.0.0

Huge version bump due to changes in versioning strategy https://github.com/coverlet-coverage/coverlet/releases/tag/v6.0.0

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
