### PR TITLE
Add EventCounters to AotCompatibility.Test

### DIFF
--- a/.github/workflows/ci-aot.yml
+++ b/.github/workflows/ci-aot.yml
@@ -13,6 +13,8 @@ on:
     paths:
     - 'src/OpenTelemetry.Instrumentation.Runtime/**'
     - '!src/OpenTelemetry.Instrumentation.Runtime/README.md'
+    - 'src/OpenTelemetry.Instrumentation.EventCounters/**'
+    - '!src/OpenTelemetry.Instrumentation.EventCounters/README.md'
 
 jobs:
   aot-test:

--- a/.github/workflows/ci-aot.yml
+++ b/.github/workflows/ci-aot.yml
@@ -6,6 +6,8 @@ on:
     paths:
     - 'src/OpenTelemetry.Instrumentation.Runtime/**'
     - '!src/OpenTelemetry.Instrumentation.Runtime/README.md'
+    - 'src/OpenTelemetry.Instrumentation.EventCounters/**'
+    - '!src/OpenTelemetry.Instrumentation.EventCounters/README.md'
   pull_request:
     branches: [ 'main*' ]
     paths:

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.Runtime" />
+    <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.EventCounters" />
 
     <TrimmerRootAssembly Update="@(TrimmerRootAssembly)" Path="$(RepoRoot)\src\%(Identity)\%(Identity).csproj" />
     <ProjectReference Include="@(TrimmerRootAssembly->'%(Path)')" />


### PR DESCRIPTION
This ensures that the OpenTelemetry.Instrumentation.EventCounters library stays AOT-compatible.

Contributes to https://github.com/open-telemetry/opentelemetry-dotnet/issues/3429

cc @Yun-Ting 