### PR TITLE
Increase reliability of WCF HTTP tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForHttpTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForHttpTests.cs
@@ -254,8 +254,8 @@ public class TelemetryBindingElementForHttpTests : IDisposable
                 else
                 {
                     Assert.Equal(2, stoppedActivities.Count);
-                    Assert.Equal("DownstreamInstrumentation", stoppedActivities[0].OperationName);
-                    Assert.Equal(WcfInstrumentationActivitySource.OutgoingRequestActivityName, stoppedActivities[1].OperationName);
+                    Assert.NotNull(stoppedActivities.SingleOrDefault(activity => activity.OperationName == "DownstreamInstrumentation"));
+                    Assert.NotNull(stoppedActivities.SingleOrDefault(activity => activity.OperationName == WcfInstrumentationActivitySource.OutgoingRequestActivityName));
                 }
             }
             else


### PR DESCRIPTION
Fixes #1325

## Changes
Increase reliability of WCF HTTP tests - do not assume the order of the stopped activities

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
