### PR TITLE
[Exporter.Geneva] Add build time constant for experimental features

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
+++ b/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <OTelSdkVersion>$(OpenTelemetryCoreLatestPrereleaseVersion)</OTelSdkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(OTelSdkVersion.Contains('alpha')) OR $(OTelSdkVersion.Contains('beta')) OR $(OTelSdkVersion.Contains('rc'))">
+    <DefineConstants>$(DefineConstants);EXPOSE_EXPERIMENTAL_FEATURES</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -122,7 +122,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
             {
                 try
                 {
+#if EXPOSE_EXPERIMENTAL_FEATURES
                     var exemplars = metricPoint.GetExemplars();
+#endif
 
                     switch (metric.MetricType)
                     {
@@ -136,7 +138,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(), // Using the endTime here as the timestamp as Geneva Metrics only allows for one field for timestamp
                                     metricPoint.Tags,
                                     metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                                     exemplars,
+#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -156,7 +160,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                                     exemplars,
+#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -176,7 +182,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                                     exemplars,
+#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -194,7 +202,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                                     exemplars,
+#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -211,7 +221,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                                     exemplars,
+#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -237,7 +249,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                                     count,
                                     min,
                                     max,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                                     exemplars,
+#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -301,7 +315,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         long timestamp,
         in ReadOnlyTagCollection tags,
         MetricData value,
+#if EXPOSE_EXPERIMENTAL_FEATURES
         Exemplar[] exemplars,
+#endif
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -328,7 +344,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                 out monitoringAccount,
                 out metricNamespace);
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
             SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
+#endif
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -361,7 +379,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         uint count,
         double min,
         double max,
+#if EXPOSE_EXPERIMENTAL_FEATURES
         Exemplar[] exemplars,
+#endif
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -388,7 +408,9 @@ public class GenevaMetricExporter : BaseExporter<Metric>
                 out monitoringAccount,
                 out metricNamespace);
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
             SerializeExemplars(exemplars, this.buffer, ref bufferIndex);
+#endif
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -433,6 +455,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         MetricSerializer.SerializeString(buffer, ref bufferIndex, monitoringAccount);
     }
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeExemplars(Exemplar[] exemplars, byte[] buffer, ref int bufferIndex)
     {
@@ -548,6 +571,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
         var exemplarLength = bufferIndex - bufferIndexForLength + 1;
         MetricSerializer.SerializeByte(buffer, ref bufferIndexForLength, (byte)exemplarLength);
     }
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeNonHistogramMetricData(MetricEventType eventType, MetricData value, long timestamp, byte[] buffer, ref int bufferIndex)

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -13,7 +13,7 @@
     <EnableAnalysis>true</EnableAnalysis>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OTelSdkVersion)" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project=".\Common.GenevaExporter.props"/>
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -12,9 +13,9 @@
     <EnableAnalysis>true</EnableAnalysis>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
   </PropertyGroup>
-
+  
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestPrereleaseVersion)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OTelSdkVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
@@ -566,7 +566,9 @@ public class MetricExporterBenchmarks
             this.counterMetricPointWith3Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith3Dimensions.Tags,
             this.counterMetricDataWith3Dimensions,
+#if EXPOSE_EXPERIMENTAL_FEATURES
             Array.Empty<Exemplar>(),
+#endif
             out _,
             out _);
     }
@@ -580,7 +582,9 @@ public class MetricExporterBenchmarks
             this.counterMetricPointWith4Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith4Dimensions.Tags,
             this.counterMetricDataWith4Dimensions,
+#if EXPOSE_EXPERIMENTAL_FEATURES
             Array.Empty<Exemplar>(),
+#endif
             out _,
             out _);
     }
@@ -609,7 +613,9 @@ public class MetricExporterBenchmarks
             this.histogramCountWith3Dimensions,
             this.histogramMinWith3Dimensions,
             this.histogramMaxWith3Dimensions,
+#if EXPOSE_EXPERIMENTAL_FEATURES
             Array.Empty<Exemplar>(),
+#endif
             out _,
             out _);
     }
@@ -626,7 +632,9 @@ public class MetricExporterBenchmarks
             this.histogramCountWith4Dimensions,
             this.histogramMinWith4Dimensions,
             this.histogramMaxWith4Dimensions,
+#if EXPOSE_EXPERIMENTAL_FEATURES
             Array.Empty<Exemplar>(),
+#endif
             out _,
             out _);
     }

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\Common.GenevaExporter.props"/>
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
@@ -17,5 +18,5 @@
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\OpenTelemetry.Exporter.Geneva.csproj" />
   </ItemGroup>
-
+  
 </Project>

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\Common.GenevaExporter.props"/>
-  
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/OpenTelemetry.Exporter.Geneva.Benchmark.csproj
@@ -18,5 +18,5 @@
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\OpenTelemetry.Exporter.Geneva.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -196,14 +196,18 @@ public class GenevaMetricExporterTests
                 var metricDataValue = Convert.ToUInt64(metricPoint.GetSumLong());
                 var metricData = new MetricData { UInt64Value = metricDataValue };
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 var exemplars = metricPoint.GetExemplars();
+#endif
                 var bodyLength = exporter.SerializeMetricWithTLV(
                     MetricEventType.ULongMetric,
                     metric.Name,
                     metricPoint.EndTime.ToFileTime(),
                     metricPoint.Tags,
                     metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                     exemplars,
+#endif
                     out _,
                     out _);
 
@@ -950,7 +954,9 @@ public class GenevaMetricExporterTests
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
         var exemplars = metricPoint.GetExemplars();
+#endif
 
         List<TlvField> fields = null;
 
@@ -965,7 +971,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -991,7 +999,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1019,7 +1029,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1047,7 +1059,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1082,7 +1096,9 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1121,6 +1137,7 @@ public class GenevaMetricExporterTests
             Assert.Equal(bodyLength, data.LenBody);
         }
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
         if (exemplars.Length > 0)
         {
             var validExemplars = exemplars.Where(exemplar => exemplar.Timestamp != default).ToList();
@@ -1142,6 +1159,7 @@ public class GenevaMetricExporterTests
                 AssertExemplarFilteredTagSerialization(expectedExemplar, serializedExemplar);
             }
         }
+#endif
 
         // Check metric name, account, and namespace
         var connectionStringBuilder = new ConnectionStringBuilder(exporterOptions.ConnectionString);
@@ -1214,6 +1232,7 @@ public class GenevaMetricExporterTests
         Assert.Equal(dimensionsCount, dimensions.NumDimensions);
     }
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
     private static void AssertExemplarFilteredTagSerialization(Exemplar expectedExemplar, SingleExemplar serializedExemplar)
     {
         var serializedExemplarBody = serializedExemplar.Body;
@@ -1263,6 +1282,7 @@ public class GenevaMetricExporterTests
             }
         }
     }
+#endif
 
     private static UserdataV2 GetSerializedData(Metric metric, GenevaMetricExporter exporter)
     {
@@ -1284,7 +1304,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1303,7 +1325,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1324,7 +1348,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1345,7 +1371,9 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 
@@ -1373,7 +1401,9 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
+#if EXPOSE_EXPERIMENTAL_FEATURES
                 exemplars,
+#endif
                 out _,
                 out _);
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\Common.GenevaExporter.props"/>
 
   <PropertyGroup>
     <Description>Unit test project for Geneva Exporters for OpenTelemetry</Description>


### PR DESCRIPTION
## Changes
- Add a build time constant to check if experimental features should be set or not
- This helps in avoiding adding/commenting out Exemplar related code for every stable release
