### PR TITLE
[repo+ci] Use SDK dotnet format in CI

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -24,4 +24,4 @@ jobs:
       uses: actions/setup-dotnet@v3
 
     - name: dotnet format
-      run: dotnet format opentelemetry-dotnet-contrib.sln --no-restore --verify-no-changes
+      run: dotnet format opentelemetry-dotnet-contrib.sln --verify-no-changes

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -23,8 +23,5 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
 
-    - name: Install format tool
-      run: dotnet tool install -g dotnet-format
-
     - name: dotnet format
-      run: dotnet-format --folder --check
+      run: dotnet format opentelemetry-dotnet-contrib.sln --no-restore --verify-no-changes

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -27,8 +27,8 @@ jobs:
       run: dotnet restore
 
     - name: Protobuf compile
-      run: dotnet build -t:Protobuf_Compile
-      continue-on-error: true
+      run: dotnet build -t:Protobuf_Compile --no-restore
+      continue-on-error: true # Note: Projects without Grpc.Tools won't have the Protobuf_Compile target which generates an error
 
     - name: dotnet format
       run: dotnet format opentelemetry-dotnet-contrib.sln --no-restore --verify-no-changes

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -24,4 +24,4 @@ jobs:
       uses: actions/setup-dotnet@v3
 
     - name: dotnet format
-      run: dotnet format opentelemetry-dotnet-contrib.sln --verify-no-changes
+      run: dotnet format opentelemetry-dotnet-contrib.sln --verify-no-changes --verbosity diagnostic

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -23,5 +23,12 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
 
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Protobuf compile
+      run: dotnet build -t:Protobuf_Compile
+      continue-on-error: true
+
     - name: dotnet format
-      run: dotnet format opentelemetry-dotnet-contrib.sln --verify-no-changes --verbosity diagnostic
+      run: dotnet format opentelemetry-dotnet-contrib.sln --no-restore --verify-no-changes

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -13,7 +13,6 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)/OpenTelemetryContrib.prod.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn),1573,1712</NoWarn>
     <PackageOutputPath Condition="$(Build_ArtifactStagingDirectory) != ''">$(Build_ArtifactStagingDirectory)</PackageOutputPath>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--<MinVerVerbosity>detailed</MinVerVerbosity>-->
     <PackageTags>Observability;OpenTelemetry;Monitoring;Telemetry</PackageTags>
   </PropertyGroup>

--- a/build/Common.props
+++ b/build/Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.FullName)</RepoRoot>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)debug.snk</AssemblyOriginatorKeyFile>
@@ -10,7 +10,7 @@
     <NetMinimumSupportedVersion>net6.0</NetMinimumSupportedVersion>
     <NetStandardMinimumSupportedVersion>netstandard2.0</NetStandardMinimumSupportedVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AnalysisLevel>latest-All</AnalysisLevel>
+    <AnalysisLevel>latest-all</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/build/Common.targets
+++ b/build/Common.targets
@@ -1,7 +1,3 @@
 <Project>
 
-  <PropertyGroup Condition="'$(EnableAnalysis)'=='true' and '$(SkipAnalysis)'!='true'">
-    <AnalysisLevel>latest-all</AnalysisLevel>
-  </PropertyGroup>
-
 </Project>

--- a/examples/AspNet/App_Start/RouteConfig.cs
+++ b/examples/AspNet/App_Start/RouteConfig.cs
@@ -17,20 +17,19 @@
 using System.Web.Mvc;
 using System.Web.Routing;
 
-namespace Examples.AspNet
+namespace Examples.AspNet;
+
+public class RouteConfig
 {
-    public class RouteConfig
+    public static void RegisterRoutes(RouteCollection routes)
     {
-        public static void RegisterRoutes(RouteCollection routes)
-        {
-            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+        routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 
-            routes.MapMvcAttributeRoutes();
+        routes.MapMvcAttributeRoutes();
 
-            routes.MapRoute(
-                name: "Default",
-                url: "{controller}/{action}/{id}",
-                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional });
-        }
+        routes.MapRoute(
+            name: "Default",
+            url: "{controller}/{action}/{id}",
+            defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional });
     }
 }

--- a/examples/AspNet/Controllers/HomeController.cs
+++ b/examples/AspNet/Controllers/HomeController.cs
@@ -21,11 +21,13 @@ namespace Examples.AspNet.Controllers;
 public class HomeController : Controller
 {
     // For testing traditional routing. Ex: https://localhost:XXXX/
+    [HttpGet]
     public ActionResult Index()
     {
         return this.View();
     }
 
+    [HttpGet]
     [Route("about_attr_route/{customerId}")] // For testing attribute routing. Ex: https://localhost:XXXX/about_attr_route
     public ActionResult About(int? customerId)
     {

--- a/examples/AspNet/Controllers/WeatherForecastController.cs
+++ b/examples/AspNet/Controllers/WeatherForecastController.cs
@@ -57,7 +57,7 @@ public class WeatherForecastController : ApiController
     {
         if (customerId < 0)
         {
-            throw new ArgumentException();
+            throw new ArgumentOutOfRangeException(nameof(customerId));
         }
 
         // Making http calls here to serve as an example of
@@ -141,7 +141,7 @@ public class WeatherForecastController : ApiController
     {
         using var request = new HttpClient();
 
-        using var response = await request.GetAsync("http://www.google.com").ConfigureAwait(false);
+        using var response = await request.GetAsync(new Uri("http://www.google.com")).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
     }
@@ -149,7 +149,7 @@ public class WeatherForecastController : ApiController
     // Test dependency collection via legacy HttpWebRequest sync.
     private static void RequestGoogleHomPageViaHttpWebRequestLegacySync()
     {
-        var request = WebRequest.Create("http://www.google.com/?sync");
+        var request = WebRequest.Create(new Uri("http://www.google.com/?sync"));
 
         using var response = request.GetResponse();
     }
@@ -157,7 +157,7 @@ public class WeatherForecastController : ApiController
     // Test dependency collection via legacy HttpWebRequest async.
     private static async Task RequestGoogleHomPageViaHttpWebRequestLegacyAsync()
     {
-        var request = (HttpWebRequest)WebRequest.Create($"http://www.google.com/?async");
+        var request = (HttpWebRequest)WebRequest.Create(new Uri("http://www.google.com/?async"));
 
         using var response = await request.GetResponseAsync().ConfigureAwait(false);
     }
@@ -165,7 +165,7 @@ public class WeatherForecastController : ApiController
     // Test dependency collection via legacy HttpWebRequest IAsyncResult.
     private static void RequestGoogleHomPageViaHttpWebRequestLegacyAsyncResult()
     {
-        var request = (HttpWebRequest)WebRequest.Create($"http://www.google.com/?async");
+        var request = (HttpWebRequest)WebRequest.Create(new Uri("http://www.google.com/?async"));
 
         var asyncResult = request.BeginGetResponse(null, null);
 
@@ -181,7 +181,8 @@ public class WeatherForecastController : ApiController
 
             // This request is not available over SSL and will throw a handshake exception.
 
-            using var response = await request.GetAsync(this.Url.Content("~/subroute/10").Replace("http", "https")).ConfigureAwait(false);
+            using var response = await request.GetAsync(
+                new Uri(this.Url.Content("~/subroute/10").Replace("http", "https"))).ConfigureAwait(false);
 
             Debug.Fail("Unreachable");
         }
@@ -197,7 +198,8 @@ public class WeatherForecastController : ApiController
 
         // This request will return a 500 error because customerId should be >= 0;
 
-        using var response = await request.GetAsync(this.Url.Content("~/subroute/-1")).ConfigureAwait(false);
+        using var response = await request.GetAsync(
+            new Uri(this.Url.Content("~/subroute/-1"))).ConfigureAwait(false);
 
         Debug.Assert(response.StatusCode == HttpStatusCode.InternalServerError, "response.StatusCode is InternalServerError");
     }
@@ -209,7 +211,8 @@ public class WeatherForecastController : ApiController
 
         // This request will return successfully and cause a bunch of sub-spans;
 
-        using var response = await request.GetAsync(this.Url.Content("~/subroute/10")).ConfigureAwait(false);
+        using var response = await request.GetAsync(
+            new Uri(this.Url.Content("~/subroute/10"))).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
     }

--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -1,46 +1,19 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>
-    </ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{9A4E3A68-904B-4835-A3C8-F664B73098DB}</ProjectGuid>
-    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>OpenTelemetry.Exporter.AspNet</RootNamespace>
-    <AssemblyName>OpenTelemetry.Exporter.AspNet</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <UseIISExpress>true</UseIISExpress>
-    <Use64BitIISExpress />
-    <IISExpressSSLPort>
-    </IISExpressSSLPort>
-    <IISExpressAnonymousAuthentication />
-    <IISExpressWindowsAuthentication />
-    <IISExpressUseClassicPipelineMode />
-    <UseGlobalApplicationHostFile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <AppConfig>web.config</AppConfig>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+  <ItemGroup>
+    <ProjectCapability Include="DotNetCoreWeb" />
+    <ProjectCapability Include="SupportsSystemWeb" />
+    <ProjectCapability Include="LegacyRazorEditor" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Configuration" />
@@ -87,16 +60,13 @@
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.5.0-rc.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj">
-      <Project>{582b70b5-0067-4d9a-abf2-623f502be9a9}</Project>
-      <Name>OpenTelemetry.Instrumentation.AspNet</Name>
-    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="Exists('$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets')" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
     <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
@@ -109,22 +79,4 @@
     <BuildDependsOnOriginalValue>$(BuildDependsOn)</BuildDependsOnOriginalValue>
     <BuildDependsOn>SkipBuildWithoutVisualStudio</BuildDependsOn>
   </PropertyGroup>
-  <ProjectExtensions>
-    <VisualStudio>
-      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
-        <WebProjectProperties>
-          <UseIIS>True</UseIIS>
-          <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>0</DevelopmentServerPort>
-          <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:56171/</IISUrl>
-          <NTLMAuthentication>False</NTLMAuthentication>
-          <UseCustomServer>False</UseCustomServer>
-          <CustomServerUrl>
-          </CustomServerUrl>
-          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
-        </WebProjectProperties>
-      </FlavorProperties>
-    </VisualStudio>
-  </ProjectExtensions>
 </Project>

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -40,15 +40,15 @@ public class WebApiApplication : HttpApplication
              .AddAspNetInstrumentation()
              .AddHttpClientInstrumentation();
 
-        switch (ConfigurationManager.AppSettings["UseExporter"].ToLowerInvariant())
+        switch (ConfigurationManager.AppSettings["UseExporter"].ToUpperInvariant())
         {
-            case "zipkin":
+            case "ZIPKIN":
                 builder.AddZipkinExporter(zipkinOptions =>
                 {
                     zipkinOptions.Endpoint = new Uri(ConfigurationManager.AppSettings["ZipkinEndpoint"]);
                 });
                 break;
-            case "otlp":
+            case "OTLP":
                 builder.AddOtlpExporter(otlpOptions =>
                     {
                         otlpOptions.Endpoint = new Uri(ConfigurationManager.AppSettings["OtlpEndpoint"]);
@@ -68,15 +68,15 @@ public class WebApiApplication : HttpApplication
         var meterBuilder = Sdk.CreateMeterProviderBuilder()
              .AddAspNetInstrumentation();
 
-        switch (ConfigurationManager.AppSettings["UseMetricsExporter"].ToLowerInvariant())
+        switch (ConfigurationManager.AppSettings["UseMetricsExporter"].ToUpperInvariant())
         {
-            case "otlp":
+            case "OTLP":
                 meterBuilder.AddOtlpExporter(otlpOptions =>
                 {
                     otlpOptions.Endpoint = new Uri(ConfigurationManager.AppSettings["OtlpEndpoint"]);
                 });
                 break;
-            case "prometheus":
+            case "PROMETHEUS":
                 meterBuilder.AddPrometheusHttpListener();
                 break;
             default:

--- a/examples/AspNet/Properties/AssemblyInfo.cs
+++ b/examples/AspNet/Properties/AssemblyInfo.cs
@@ -14,37 +14,9 @@
 // limitations under the License.
 // </copyright>
 
-using System.Reflection;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Examples.AspNet")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Examples.AspNet")]
-[assembly: AssemblyCopyright("Copyright @ 2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("9a4e3a68-904b-4835-a3c8-f664b73098db")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/examples/AspNet/Properties/launchSettings.json
+++ b/examples/AspNet/Properties/launchSettings.json
@@ -1,0 +1,18 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:23307"
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -1,58 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<appSettings>
-		<add key="webpages:Version" value="3.0.0.0"/>
-		<add key="webpages:Enabled" value="false"/>
-		<add key="ClientValidationEnabled" value="true"/>
-		<add key="UnobtrusiveJavaScriptEnabled" value="true"/>
-		<add key="UseExporter" value="console"/>
-		<add key="UseMetricsExporter" value="console"/>
-		<add key="ZipkinEndpoint" value="http://localhost:9411/api/v2/spans"/>
-		<add key="OtlpEndpoint" value="http://localhost:4317"/>
-	</appSettings>
-	<system.web>
-		<compilation debug="true" targetFramework="4.8"/>
-		<httpRuntime targetFramework="4.8" maxRequestLength="2147483647" executionTimeout="300"/>
-	</system.web>
-	<system.webServer>
-		<handlers>
-			<remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-			<remove name="OPTIONSVerbHandler"/>
-			<remove name="TRACEVerbHandler"/>
-			<add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
-		</handlers>
-		<modules>
-			<add name="SuppressInstrumentationHttpModule" type="Examples.AspNet.SuppressInstrumentationHttpModule" preCondition="integratedMode,managedHandler"/>
-			<add name="TelemetryHttpModule" type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" preCondition="integratedMode,managedHandler"/>
-		</modules>
-		<security>
-			<requestFiltering>
-				<requestLimits maxAllowedContentLength="4294967295"/>
-			</requestFiltering>
-		</security>
-	</system.webServer>
-	<runtime>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-			</dependentAssembly>
-		</assemblyBinding>
-	</runtime>
+  <appSettings>
+    <add key="webpages:Version" value="3.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="UseExporter" value="console"/>
+    <add key="UseMetricsExporter" value="console"/>
+    <add key="ZipkinEndpoint" value="http://localhost:9411/api/v2/spans"/>
+    <add key="OtlpEndpoint" value="http://localhost:4317"/>
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.8"/>
+    <httpRuntime targetFramework="4.8" maxRequestLength="2147483647" executionTimeout="300"/>
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+    </handlers>
+    <modules>
+      <add name="SuppressInstrumentationHttpModule" type="Examples.AspNet.SuppressInstrumentationHttpModule" preCondition="integratedMode,managedHandler"/>
+      <add name="TelemetryHttpModule" type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" preCondition="integratedMode,managedHandler"/>
+    </modules>
+    <security>
+      <requestFiltering>
+        <requestLimits maxAllowedContentLength="4294967295"/>
+      </requestFiltering>
+    </security>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,3 +1,4 @@
 <Project>
+  <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'opentelemetry-dotnet-contrib.sln'))\build\Common.nonprod.props" />
 </Project>

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -291,6 +291,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.InfluxDB", "exampl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.AotCompatibility.TestApp", "test\OpenTelemetry.AotCompatibility.TestApp\OpenTelemetry.AotCompatibility.TestApp.csproj", "{31937862-0C88-41C0-AFD6-F97A7BF803A9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{9B30F5FD-3309-49CB-9CAD-D3372FAFD796}"
+	ProjectSection(SolutionItems) = preProject
+		examples\Directory.Build.props = examples\Directory.Build.props
+		examples\Directory.Build.targets = examples\Directory.Build.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -698,6 +704,7 @@ Global
 		{2D354354-BAFB-490B-A26F-6A16A52A1A45} = {B75EE478-97F7-4E9F-9A5A-DB3D0988EDEA}
 		{B4951583-D432-4E87-85CF-498FDD6A35E6} = {2D354354-BAFB-490B-A26F-6A16A52A1A45}
 		{31937862-0C88-41C0-AFD6-F97A7BF803A9} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
+		{9B30F5FD-3309-49CB-9CAD-D3372FAFD796} = {824BD1DE-3FA8-4FE0-823A-FD365EAC78AF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -10,7 +10,6 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <MinVerTagPrefix>Exporter.Geneva-</MinVerTagPrefix>
-    <EnableAnalysis>true</EnableAnalysis>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/OpenTelemetry.Exporter.InfluxDB.csproj
+++ b/src/OpenTelemetry.Exporter.InfluxDB/OpenTelemetry.Exporter.InfluxDB.csproj
@@ -7,7 +7,6 @@
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>$(NetMinimumSupportedVersion);$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <MinVerTagPrefix>Exporter.InfluxDB-</MinVerTagPrefix>
-    <EnableAnalysis>true</EnableAnalysis>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
+++ b/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
@@ -8,7 +8,6 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <MinVerTagPrefix>Exporter.OneCollector-</MinVerTagPrefix>
     <Nullable>enable</Nullable>
-    <EnableAnalysis>true</EnableAnalysis>
     <ImplicitUsings>true</ImplicitUsings>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
   </PropertyGroup>

--- a/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
+++ b/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
@@ -8,7 +8,6 @@
     <Description>OpenTelemetry .NET SDK preview features and extensions</Description>
     <MinVerTagPrefix>Extensions-</MinVerTagPrefix>
     <Nullable>enable</Nullable>
-    <EnableAnalysis>true</EnableAnalysis>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
@@ -4,7 +4,6 @@
         <Description>OpenTelemetry Metrics instrumentation for Dotnet EventCounters</Description>
         <PackageTags>$(PackageTags);metrics;eventcounters</PackageTags>
         <MinVerTagPrefix>Instrumentation.EventCounters-</MinVerTagPrefix>
-        <EnableAnalysis>true</EnableAnalysis>
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
+++ b/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
@@ -5,7 +5,6 @@
     <Description>OpenTelemetry instrumentation for OWIN</Description>
     <PackageTags>$(PackageTags);distributed-tracing;OWIN</PackageTags>
     <MinVerTagPrefix>Instrumentation.Owin-</MinVerTagPrefix>
-    <EnableAnalysis>true</EnableAnalysis>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
+++ b/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
@@ -4,7 +4,6 @@
     <Description>dotnet process instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);process</PackageTags>
     <MinVerTagPrefix>Instrumentation.Process-</MinVerTagPrefix>
-    <EnableAnalysis>true</EnableAnalysis>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -5,7 +5,6 @@
     <Description>dotnet runtime instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);runtime</PackageTags>
     <MinVerTagPrefix>Instrumentation.Runtime-</MinVerTagPrefix>
-    <EnableAnalysis>true</EnableAnalysis>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -8,7 +8,6 @@
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
     <MinVerTagPrefix>Instrumentation.StackExchangeRedis-</MinVerTagPrefix>
     <Nullable>enable</Nullable>
-    <EnableAnalysis>true</EnableAnalysis>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.PersistentStorage.Abstractions/OpenTelemetry.PersistentStorage.Abstractions.csproj
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/OpenTelemetry.PersistentStorage.Abstractions.csproj
@@ -10,7 +10,6 @@
     <MinVerTagPrefix>PersistentStorage.Abstractions-</MinVerTagPrefix>
     <NoWarn>$(NoWarn),1591</NoWarn>
     <Nullable>enable</Nullable>
-    <EnableAnalysis>true</EnableAnalysis>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.ResourceDetectors.Azure/OpenTelemetry.ResourceDetectors.Azure.csproj
+++ b/src/OpenTelemetry.ResourceDetectors.Azure/OpenTelemetry.ResourceDetectors.Azure.csproj
@@ -4,7 +4,6 @@
         <Description>OpenTelemetry Resource Detectors for Azure cloud environments</Description>
         <PackageTags>$(PackageTags);ResourceDetector</PackageTags>
         <MinVerTagPrefix>ResourceDetectors.Azure-</MinVerTagPrefix>
-        <EnableAnalysis>true</EnableAnalysis>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
+++ b/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
@@ -69,7 +69,7 @@ internal class AWSXRaySamplerClient : IDisposable
             catch (Exception ex)
             {
                 AWSSamplerEventSource.Log.FailedToDeserializeResponse(
-                    nameof(AWSXRaySamplerClient.GetSamplingRules),
+                    nameof(this.GetSamplingRules),
                     ex.Message);
             }
         }
@@ -98,7 +98,7 @@ internal class AWSXRaySamplerClient : IDisposable
         catch (Exception ex)
         {
             AWSSamplerEventSource.Log.FailedToDeserializeResponse(
-                    nameof(AWSXRaySamplerClient.GetSamplingTargets),
+                    nameof(this.GetSamplingTargets),
                     ex.Message);
         }
 

--- a/src/Shared/ExceptionExtensions.cs
+++ b/src/Shared/ExceptionExtensions.cs
@@ -16,7 +16,11 @@
 
 #nullable enable
 
+#pragma warning disable IDE0005 // Using directive is unnecessary. <- Projects with ImplicitUsings enabled don't need System or System.Threading
+using System;
 using System.Globalization;
+using System.Threading;
+#pragma warning restore IDE0005 // Using directive is unnecessary.
 
 namespace OpenTelemetry.Internal;
 
@@ -28,18 +32,18 @@ internal static class ExceptionExtensions
     /// </summary>
     /// <param name="exception">Exception to convert to string.</param>
     /// <returns>Exception as string with no culture.</returns>
-    public static string ToInvariantString(this System.Exception exception)
+    public static string ToInvariantString(this Exception exception)
     {
-        var originalUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+        var originalUICulture = Thread.CurrentThread.CurrentUICulture;
 
         try
         {
-            System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
             return exception.ToString();
         }
         finally
         {
-            System.Threading.Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>$(NetMinimumSupportedVersion)</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <EnableAnalysis>true</EnableAnalysis>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/OpenTelemetry.Exporter.OneCollector.Benchmarks.csproj
+++ b/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/OpenTelemetry.Exporter.OneCollector.Benchmarks.csproj
@@ -7,7 +7,6 @@
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <EnableAnalysis>true</EnableAnalysis>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OpenTelemetry.Exporter.OneCollector.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OpenTelemetry.Exporter.OneCollector.Tests.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <EnableAnalysis>true</EnableAnalysis>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #1274

## Changes

* Updates the `dotnet-format` ci workflow to use the SDK version
* Cleans up new warnings manifested by `dotnet format`
* Removes `EnableAnalysis` property as it is now globally enabled in common props
