### PR TITLE
[Instrumentation.Runtime] Release Runtime instrumentation version 1.5.1

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.5.1
+
+Released 2023-Sep-06
+
 * Add a metric `process.runtime.dotnet.gc.duration` for total paused duration in
   GC for .NET 7 and greater versions
   ([#1239](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1239))


### PR DESCRIPTION
Release Runtime instrumentation version `1.5.1` to release the `process.runtime.dotnet.gc.duration` metric.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* [ ] Changes in public API reviewed
