### PR TITLE
Bump OTel SDK/API to 1.6.0

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -35,7 +35,7 @@
     <MicrosoftOwinPkgVer>[4.2.2,5.0)</MicrosoftOwinPkgVer>
     <MicrosoftPublicApiAnalyzersPkgVer>[3.3.3]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
-    <OpenTelemetryCoreLatestVersion>[1.5.1,2.0)</OpenTelemetryCoreLatestVersion>
+    <OpenTelemetryCoreLatestVersion>[1.6.0,2.0)</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.6.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Updates to 1.6.0 of OpenTelemetry SDK.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OpenTelemetry SDK version to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OpenTelemetry SDK version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 * Drop support for .NET Framework 4.6.1.
   The lowest supported version is .NET Framework 4.6.2.
   ([#1050](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1050))

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry to 1.6.0
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+
 * Added support for receiving tranmission failures via the
   `RegisterPayloadTransmittedCallback` API.
   ([#1309](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1309))

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OpenTelemetry SDK version to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OpenTelemetry SDK version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updates to 1.6.0 of OpenTelemetry SDK.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+
 ## 1.3.0-beta.1
 
 Released 2023-Aug-02

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -5,8 +5,8 @@
 * Add LogToActivityEventConversionOptions.Filter callback
   ([#1059](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1059))
 
-* Update OpenTelemetry SDK version to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OpenTelemetry SDK version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update `OpenTelemetry.Api` to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update `OpenTelemetry.Api` to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-rc9.9
 

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Updates to 1.6.0 of OpenTelemetry SDK.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry SDK package version to 1.5.1
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Updated OpenTelemetry SDK package version to 1.6.0
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -6,8 +6,8 @@
   enable filtering of instrumentation.
   ([#1203](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1203))
 
-* Updated OpenTelemetry SDK package version to 1.5.1
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Updated OpenTelemetry SDK package version to 1.6.0
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-beta.7
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry.Api to 1.6.0.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+
 ## 1.5.1-alpha.1
 
 Released 2023-Jul-11

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Make the context propagation extraction case insensitive.
   ([#483](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/483))
+* Update OpenTelemetry.Api to 1.6.0.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="[3.6.1,4.0)" />
     <PackageReference Include="Grpc.Core.Api" Version="[2.23.0,3.0)" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.1.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OTel API version to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OTel API version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.5.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry SDK to 1.5.1
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Updated OpenTelemetry SDK to 1.6.0
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 * Removes `AddOwinInstrumentation` method with default configure parameter.
   ([#929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/929))
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OpenTelemetry API to 1.5.1
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OpenTelemetry API to 1.6.0
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 0.5.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OpenTelemetry.Api to 1.5.1.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OpenTelemetry.Api to 1.6.0.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-alpha.3
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry API to 1.6.0
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+
 ## 1.5.1
 
 Released 2023-Sep-06

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Update OTel API version to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OTel API version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-rc9.10
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry SDK version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+
 ## 1.0.0-rc.12
 
 Released 2023-Aug-30

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update OpenTelemetry SDK version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+
 ## 1.3.0-beta.1
 
 Released 2023-Aug-02

--- a/src/OpenTelemetry.ResourceDetectors.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Azure/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Updates to 1.6.0 of OpenTelemetry SDK.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 * Suppress instrumentation for outgoing http call made to metadata service
   during `Detect()`.
   ([#1297](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1297))

--- a/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updates to 1.5.1 of OpenTelemetry SDK.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Updates to 1.6.0 of OpenTelemetry SDK.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-beta.4
 

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -8,5 +8,5 @@ Initial release of `OpenTelemetry.Sampler.AWS`.
   ([#1091](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1091),
    [#1124](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1124))
 
-* Update OpenTelemetry SDK version to `1.5.1`.
-  ([#1255](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1255))
+* Update OpenTelemetry SDK version to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))


### PR DESCRIPTION
Fixes N/A.

## Changes

Bump OTel SDK/API to 1.6.0
Exporter.Geneva statys on 1.6.0-rc.1 as it depends on non-stable features.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[  ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
