### PR TITLE
[onecollector] Remove ext.dt.traceFlags

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -15,6 +15,10 @@
   `{OriginalFormat}` key or `LogRecord.Body`).
   ([#1321](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1321))
 
+* Removed `traceFlags` from the common schema `dt` (Distributed Tracing)
+  extension because it is not currently supported by the OneCollector service.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.5.1
 
 Released 2023-Aug-07

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Removed `traceFlags` from the common schema `dt` (Distributed Tracing)
   extension because it is not currently supported by the OneCollector service.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1345](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1345))
 
 ## 1.5.1
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/LogRecordCommonSchemaJsonSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/LogRecordCommonSchemaJsonSerializer.cs
@@ -32,7 +32,6 @@ internal sealed class LogRecordCommonSchemaJsonSerializer : CommonSchemaJsonSeri
     private static readonly JsonEncodedText DistributedTraceExtensionProperty = JsonEncodedText.Encode("dt");
     private static readonly JsonEncodedText DistributedTraceExtensionTraceIdProperty = JsonEncodedText.Encode("traceId");
     private static readonly JsonEncodedText DistributedTraceExtensionSpanIdProperty = JsonEncodedText.Encode("spanId");
-    private static readonly JsonEncodedText DistributedTraceExtensionTraceFlagsProperty = JsonEncodedText.Encode("traceFlags");
     private static readonly JsonEncodedText ExceptionExtensionProperty = JsonEncodedText.Encode("ex");
     private static readonly JsonEncodedText ExceptionExtensionTypeProperty = JsonEncodedText.Encode("type");
     private static readonly JsonEncodedText ExceptionExtensionMessageProperty = JsonEncodedText.Encode("msg");
@@ -215,7 +214,12 @@ internal sealed class LogRecordCommonSchemaJsonSerializer : CommonSchemaJsonSeri
             writer.WriteStartObject(DistributedTraceExtensionProperty);
             writer.WriteString(DistributedTraceExtensionTraceIdProperty, item.TraceId.ToHexString());
             writer.WriteString(DistributedTraceExtensionSpanIdProperty, item.SpanId.ToHexString());
-            writer.WriteNumber(DistributedTraceExtensionTraceFlagsProperty, (int)item.TraceFlags);
+            /*
+             * Note: OneCollector does not currently support traceFlags. See:
+             * https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1313
+             *
+             * writer.WriteNumber(DistributedTraceExtensionTraceFlagsProperty, (int)item.TraceFlags);
+             */
             writer.WriteEndObject();
         }
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
@@ -209,7 +209,7 @@ public class LogRecordCommonSchemaJsonSerializerTests
         });
 
         Assert.Equal(
-            $"{{\"ver\":\"4.0\",\"name\":\"Namespace.Name\",\"time\":\"2032-01-18T10:11:12Z\",\"iKey\":\"o:tenant-token\",\"data\":{{\"severityText\":\"Trace\",\"severityNumber\":1}},\"ext\":{{\"dt\":{{\"traceId\":\"{traceId}\",\"spanId\":\"{spanId}\",\"traceFlags\":1}}}}}}\n",
+            $"{{\"ver\":\"4.0\",\"name\":\"Namespace.Name\",\"time\":\"2032-01-18T10:11:12Z\",\"iKey\":\"o:tenant-token\",\"data\":{{\"severityText\":\"Trace\",\"severityNumber\":1}},\"ext\":{{\"dt\":{{\"traceId\":\"{traceId}\",\"spanId\":\"{spanId}\"}}}}}}\n",
             json);
     }
 


### PR DESCRIPTION
Fixes #1313

## Changes

* Removes `ext.dt.traceFlags` because it isn't currently supported by OneCollector 

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
