### PR TITLE
[Exporter.Geneva] Update OTel SDK version and CHANGELOG for 1.6.0 release

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.6.0
+
+Released 2023-Sep-09
+
+* Update OpenTelemetry SDK version to `1.6.0`.
+  ([#1346](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1346))
+
 ## 1.6.0-rc.1
 
 Released 2023-Aug-28

--- a/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
+++ b/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <OTelSdkVersion>$(OpenTelemetryCoreLatestPrereleaseVersion)</OTelSdkVersion>
+    <OTelSdkVersion>$(OpenTelemetryCoreLatestVersion)</OTelSdkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(OTelSdkVersion.Contains('alpha')) OR $(OTelSdkVersion.Contains('beta')) OR $(OTelSdkVersion.Contains('rc'))">

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -358,7 +358,9 @@ public class GenevaMetricExporterTests
 
         if (hasExemplars)
         {
+#if EXPOSE_EXPERIMENTAL_FEATURES
             meterProviderBuilder.SetExemplarFilter(new AlwaysOnExemplarFilter());
+#endif
         }
 
         if (hasFilteredTagsForExemplars)
@@ -1291,7 +1293,10 @@ public class GenevaMetricExporterTests
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
         var exemplars = metricPoint.GetExemplars();
+#endif
+
         UserdataV2 result = null;
 
         if (metricType == MetricType.LongSum)


### PR DESCRIPTION
## Changes
- Update OTel SDK version to `1.6.0`
- Update CHANGELOG for 1.6.0 release