### PR TITLE
[OneCollector] Integration tests prep

### DIFF
--- a/.github/workflows/ci-Exporter.OneCollector-Integration.yml
+++ b/.github/workflows/ci-Exporter.OneCollector-Integration.yml
@@ -1,0 +1,57 @@
+name: Integration Build OpenTelemetry.Exporter.OneCollector
+
+permissions:
+  contents: read
+
+on:
+  pull_request_target: # Allows secret access from forks see: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
+    branches: [ 'main*', 'exporter*' ]
+    paths:
+    - '*/OpenTelemetry.Exporter.OneCollector*/**'
+    - 'build/**'
+    - '!**.md'
+
+env:
+  PROJECT: OpenTelemetry.Exporter.OneCollector
+
+jobs:
+  authorize:
+    environment: # Run external PRs from forks on the "external"" environment which requires approval
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ✓
+
+  build-integration-test:
+    needs: authorize
+
+    strategy:
+      fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+        version: [ net462, net6.0, net7.0 ]
+        exclude:
+        - os: ubuntu-latest
+          version: net462
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.ref }} # Run on the fork branch once approved
+
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+
+    - name: dotnet restore build/Projects/${{env.PROJECT}}.proj
+      run: dotnet restore build/Projects/${{env.PROJECT}}.proj
+
+    - name: dotnet build build/Projects/${{env.PROJECT}}.proj
+      run: dotnet build build/Projects/${{env.PROJECT}}.proj --configuration Release --no-restore
+
+    - name: dotnet test test/${{env.PROJECT}}.Tests
+      run: dotnet test test/${{env.PROJECT}}.Tests --filter CategoryName=OneCollectorIntegrationTests --framework ${{ matrix.version }} --configuration Release --no-restore --no-build --logger:"console;verbosity=detailed"
+      env:
+        OTEL_ONECOLLECTOR_INSTRUMENTATION_KEY: ${{ secrets.OTEL_ONECOLLECTOR_INSTRUMENTATION_KEY }}

--- a/build/Projects/OpenTelemetry.Exporter.OneCollector.proj
+++ b/build/Projects/OpenTelemetry.Exporter.OneCollector.proj
@@ -1,0 +1,27 @@
+<Project>
+
+  <PropertyGroup>
+    <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.Parent.FullName)</RepoRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OneCollector\OpenTelemetry.Exporter.OneCollector.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.Exporter.OneCollector.Tests\OpenTelemetry.Exporter.OneCollector.Tests.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.Exporter.OneCollector.Benchmarks\OpenTelemetry.Exporter.OneCollector.Benchmarks.csproj" />
+
+    <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OneCollector\OpenTelemetry.Exporter.OneCollector.csproj" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <MSBuild Projects="@(SolutionProjects)" Targets="Build" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(SolutionProjects)" Targets="Restore" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="Pack">
+    <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+</Project>

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\assign-reviewers.yml = .github\workflows\assign-reviewers.yml
 		.github\workflows\ci-aot.yml = .github\workflows\ci-aot.yml
+		.github\workflows\ci-Exporter.OneCollector-Integration.yml = .github\workflows\ci-Exporter.OneCollector-Integration.yml
+		.github\workflows\ci-Instrumentation.Process.yml = .github\workflows\ci-Instrumentation.Process.yml
 		.github\workflows\ci-md.yml = .github\workflows\ci-md.yml
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
@@ -205,7 +207,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Instrumentati
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AspNet", "AspNet", "{2B6D0764-5E66-423A-9943-B3A72FF181EA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.AspNet", "examples\AspNet\Examples.AspNet.csproj", "{9A4E3A68-904B-4835-A3C8-F664B73098DB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.AspNet", "examples\AspNet\Examples.AspNet.csproj", "{9A4E3A68-904B-4835-A3C8-F664B73098DB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "runtime-instrumentation", "examples\runtime-instrumentation\runtime-instrumentation.csproj", "{9FF9B46A-AD93-4B3F-92DA-6FDCC98FEA91}"
 EndProject

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -299,6 +299,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{9B
 		examples\Directory.Build.targets = examples\Directory.Build.targets
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{D1D1B96A-77E5-443E-8B5C-93D6CE5F5337}"
+	ProjectSection(SolutionItems) = preProject
+		build\Projects\OpenTelemetry.Exporter.OneCollector.proj = build\Projects\OpenTelemetry.Exporter.OneCollector.proj
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -707,6 +712,7 @@ Global
 		{B4951583-D432-4E87-85CF-498FDD6A35E6} = {2D354354-BAFB-490B-A26F-6A16A52A1A45}
 		{31937862-0C88-41C0-AFD6-F97A7BF803A9} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 		{9B30F5FD-3309-49CB-9CAD-D3372FAFD796} = {824BD1DE-3FA8-4FE0-823A-FD365EAC78AF}
+		{D1D1B96A-77E5-443E-8B5C-93D6CE5F5337} = {824BD1DE-3FA8-4FE0-823A-FD365EAC78AF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}


### PR DESCRIPTION
## Changes

* Adds a new workflow for running OneCollector integration tests. Those tests are being added on #1347

## Details

The goal is simple: We have a secret defined `OTEL_ONECOLLECTOR_INSTRUMENTATION_KEY` to set as an environment variable of the same name when running the tests.

Turns out this is not super easy to do!

A workflow defined as...

```yaml
on:
  pull_request:
```

...when opened from a fork does NOT see secrets.

There is a special trigger for this: [pull_request_target](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks).

But the problem with `pull_request_target` is, it runs on the targert repo, not the fork. That means the integration tests won't run with the code being PRed (which is what we want).

The reason for this is, there is an attack vector: [pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).

I did a bunch of reading on this and decided to try the [approach iterative took](https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets). Their approach is to require a human to approve these runs presumably after they have verified the code which will be run is safe. I think the manual approval approach is fine for these integration tests. I set up an environment called "external" which any approver or maintainer group member can approve.

So why is this PR happening? I can't get this `pull_request_target` workflow to run as part of #1347. It seems it needs to be part of the repo first. **Assuming no one objects, what I would like to do is merge this PR so I can try it out in action on #1347.** It is a bit of an experiment and might be reverted. This is either crazy or brilliant 🤣 