### PR TITLE
[ResourceDetectors.Azure] Update AzureVmMetaDataRequestor [Add timeout for HttpClient]

### DIFF
--- a/src/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetaDataRequestor.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetaDataRequestor.cs
@@ -28,7 +28,7 @@ internal static class AzureVmMetaDataRequestor
 
     public static AzureVmMetadataResponse? GetAzureVmMetaDataResponseDefault()
     {
-        using var httpClient = new HttpClient();
+        using var httpClient = new HttpClient() { Timeout = TimeSpan.FromSeconds(2)};
 
         httpClient.DefaultRequestHeaders.Add("Metadata", "True");
         var res = httpClient.GetStringAsync(AzureVmMetadataEndpointURL).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/src/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetaDataRequestor.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Azure/AzureVmMetaDataRequestor.cs
@@ -28,7 +28,7 @@ internal static class AzureVmMetaDataRequestor
 
     public static AzureVmMetadataResponse? GetAzureVmMetaDataResponseDefault()
     {
-        using var httpClient = new HttpClient() { Timeout = TimeSpan.FromSeconds(2)};
+        using var httpClient = new HttpClient() { Timeout = TimeSpan.FromSeconds(2) };
 
         httpClient.DefaultRequestHeaders.Add("Metadata", "True");
         var res = httpClient.GetStringAsync(AzureVmMetadataEndpointURL).ConfigureAwait(false).GetAwaiter().GetResult();


### PR DESCRIPTION
Fixes #.

## Changes

Adding a timeout to reduce start up time when the application is not running on Azure VM.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
