### PR TITLE
Allow overriding the Part B "name" field value in GenevaLogExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Allow overriding the Part B "name" field value in GenevaLogExporter.
+  ([#1367](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1367))
+
 ## 1.6.0
 
 Released 2023-Sep-09

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -276,20 +276,26 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
                 bodyPopulated = true;
                 continue;
             }
-            else if (this.m_customFields == null || entry.Key == "name" || this.m_customFields.ContainsKey(entry.Key))
+            else if (this.m_customFields == null || this.m_customFields.ContainsKey(entry.Key))
             {
                 // TODO: the above null check can be optimized and avoided inside foreach.
                 if (entry.Value != null)
                 {
                     // null is not supported.
+                    if (string.Equals(entry.Key, "name", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!(entry.Value is string))
+                        {
+                            // name must be string according to Part B in Common Schema. Skip serializing this field otherwise
+                            continue;
+                        }
+
+                        namePopulated = true;
+                    }
+
                     cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
                     cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
                     cntFields += 1;
-
-                    if (entry.Key == "name")
-                    {
-                        namePopulated = true;
-                    }
                 }
             }
             else

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -282,7 +282,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
                 if (entry.Value != null)
                 {
                     // null is not supported.
-                    if (string.Equals(entry.Key, "name", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(entry.Key, "name", StringComparison.Ordinal))
                     {
                         if (!(entry.Value is string))
                         {

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
@@ -342,7 +342,7 @@ internal sealed class TldLogExporter : TldExporter, IDisposable
                 if (entry.Value != null)
                 {
                     // null is not supported.
-                    if (string.Equals(entry.Key, "name", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(entry.Key, "name", StringComparison.Ordinal))
                     {
                         if (entry.Value is string nameValue)
                         {

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldLogExporter.cs
@@ -336,16 +336,20 @@ internal sealed class TldLogExporter : TldExporter, IDisposable
                 bodyPopulated = true;
                 continue;
             }
-            else if (this.customFields == null || entry.Key == "name" || this.customFields.ContainsKey(entry.Key))
+            else if (this.customFields == null || this.customFields.ContainsKey(entry.Key))
             {
                 // TODO: the above null check can be optimized and avoided inside foreach.
                 if (entry.Value != null)
                 {
                     // null is not supported.
-                    if (entry.Key == "name" && entry.Value is string nameValue)
+                    if (string.Equals(entry.Key, "name", StringComparison.OrdinalIgnoreCase))
                     {
-                        eb.AddCountedAnsiString("name", nameValue, Encoding.UTF8);
-                        namePopulated = true;
+                        if (entry.Value is string nameValue)
+                        {
+                            // name must be string according to Part B in Common Schema. Skip serializing this field otherwise
+                            eb.AddCountedAnsiString("name", nameValue, Encoding.UTF8);
+                            namePopulated = true;
+                        }
                     }
                     else
                     {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -1136,9 +1136,11 @@ public class GenevaLogExporterTests
     [InlineData(false, false, "Custom name")]
     [InlineData(false, false, "")]
     [InlineData(false, false, null)]
-    [InlineData(false, false, 5)]
+    [InlineData(false, false, 12345)]
     [InlineData(true, false, "Custom name")]
     [InlineData(true, true, "Custom name")]
+    [InlineData(true, true, 12345)]
+    [InlineData(true, false, 12345)]
     public void SerializationTestForPartBName(bool hasCustomFields, bool hasNameInCustomFields, object customNameValue)
     {
         // ARRANGE
@@ -1240,7 +1242,14 @@ public class GenevaLogExporterTests
                 if (customNameValue != null)
                 {
                     var envProperties = mapping["env_properties"] as Dictionary<object, object>;
-                    Assert.True(Equals(envProperties["name"], customNameValue));
+                    if (customNameValue is int customNameNumber)
+                    {
+                        Assert.Equal(Convert.ToInt32(envProperties["name"]), customNameNumber);
+                    }
+                    else
+                    {
+                        Assert.Equal((string)envProperties["name"], (string)customNameValue);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #1186

## Changes

Allow overriding the "name" field in the Geneva Log Exporter
This allows big codebases to be migrated to OpenTelemetry while still maintaining back-compatibility of the emitted logs