### PR TITLE
Improve OWIN server metric precision

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
@@ -226,7 +226,7 @@ internal sealed class DiagnosticsMiddleware : OwinMiddleware
         {
             var endTimestamp = Stopwatch.GetTimestamp();
             var duration = endTimestamp - startTimestamp;
-            var durationS = duration / Stopwatch.Frequency;
+            var durationS = duration / (double)Stopwatch.Frequency;
 
             OwinInstrumentationMetrics.HttpServerDuration.Record(
                 durationS,


### PR DESCRIPTION
## Changes

Without the cast to double, precision of the HTTP server duration is lower.

For significant contributions please make sure you have completed the following items:

* ~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~
* ~[ ] Design discussion issue #~
* ~[ ] Changes in public API reviewed~
