### PR TITLE
[Instrumentation.AspNet] Fix activity being closed before processing completes

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -131,8 +131,6 @@ internal static class ActivityHelper
         Debug.Assert(context.Items[ContextKey] is ContextHolder, "Context item is not an ContextHolder instance.");
 
         var currentActivity = Activity.Current;
-
-        aspNetActivity.Stop();
         context.Items[ContextKey] = null;
 
         try
@@ -144,6 +142,7 @@ internal static class ActivityHelper
             AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, "OnStopped", callbackEx);
         }
 
+        aspNetActivity.Stop();
         AspNetTelemetryEventSource.Log.ActivityStopped(aspNetActivity);
 
         if (textMapPropagator is not TraceContextPropagator)

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fixed an issue where activities were stopped incorrectly before calling Enrich callbacks.
+* Fixed an issue where activities were stopped incorrectly before processing completed.
   Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
   ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fixed an issue where activities were closed incorrectly before processing completed.
+* Fixed an issue where activities were stopped incorrectly before calling Enrich callbacks.
   Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
   ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed an issue where activities were closed incorrectly before processing completed.
+  Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
+  ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
+
 * Update `OpenTelemetry.Api` to `1.6.0`.
   ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Release together with `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`.
+  Fixed an issue where activities were closed incorrectly before processing completed.
+  Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
+  ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
+
 ## 1.0.0-rc9.9
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Release together with `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`.
-  Fixed an issue where activities were closed incorrectly before processing completed.
+  Fixed an issue where activities were stopped incorrectly before processing completed.
   Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
   ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
 


### PR DESCRIPTION
Fixes #1138.

## Findings

This PR implements the fix suggested by @jdaigle.

I have tested this on an a .NET Framework 4.8 ASP MVC application I've been maintaining.

I ran into this issue trying to modify the span name to be prefixed by the http method as [recommended by the spec](<https://github.com/open-telemetry/semantic-conventions/blob/4040095eda0159e38edfe7084ed32d3077a6ffb0/docs/http/http-spans.md?plain=1#L70>). The problem I ran into was the `HttpInListener` overriding whatever changes the processor made to the span name.

It also seems odd to me that the activity is closed and *then* updated (through `HttpInListener.OnStopActivity`). I think there is a race condition with exporters here. I was able to trigger this by setting a breakpoint before `onRequestStoppedCallback` is called; sometimes the exported span would have the pre-callback display name and sometimes it would have the post-callback display name. This is due to the exporters being processors, and processors are triggered on stopping the activity (?). This of course depends on you're using the simple exporter or a batched one.

This is how I think it works (pre-patch):

- `aspNetActivity.Stop()` is called.
- Processors run (including exporters)
- `HttpInListener.OnStopActivity` is called (through `onRequestStoppedCallback`.

I'm still pretty new to OTEL in dotnet, so I might be missing something here, but this seems like a problem to me.

## Questions

- [x] Should the `content.Items[ContextKey] = null`  be moved as well, as the context is cleared out now before `asnNetActivity.Stop()` is called?

## Changes

This changes the point at which the activity is stopped to after the `onRequestStoppedCallback` function is called.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
