### PR TITLE
[repo] Use project files for tests in dedicated CI flows

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -47,8 +47,8 @@ jobs:
     - name: dotnet build build/Projects/${{ inputs.project-name }}.proj
       run: dotnet build build/Projects/${{ inputs.project-name }}.proj --configuration Release --no-restore
 
-    - name: dotnet test test/${{ inputs.project-name }}.Tests
-      run: dotnet test test/${{ inputs.project-name }}.Tests --collect:"Code Coverage" --results-directory:TestResults --framework ${{ matrix.version }} --configuration Release --no-restore --no-build --logger:"console;verbosity=detailed" -- RunConfiguration.DisableAppDomain=true
+    - name: dotnet test build/Projects/${{ inputs.project-name }}.proj
+      run: dotnet test build/Projects/${{ inputs.project-name }}.proj --collect:"Code Coverage" --results-directory:TestResults --framework ${{ matrix.version }} --configuration Release --no-restore --no-build --logger:"console;verbosity=detailed" -- RunConfiguration.DisableAppDomain=true
 
     - name: Install coverage tool
       run: dotnet tool install -g dotnet-coverage

--- a/.github/workflows/Component.Package.yml
+++ b/.github/workflows/Component.Package.yml
@@ -32,11 +32,11 @@ jobs:
     - name: dotnet build build/Projects/${{ inputs.project-name }}.proj
       run: dotnet build build/Projects/${{ inputs.project-name }}.proj --configuration Release --no-restore -p:Deterministic=true
 
-    - name: dotnet test test/${{ inputs.project-name }}.Tests
-      run: dotnet test test/${{ inputs.project-name }}.Tests --configuration Release --no-restore --no-build
+    - name: dotnet test build/Projects/${{ inputs.project-name }}.proj
+      run: dotnet test build/Projects/${{ inputs.project-name }}.proj --configuration Release --no-restore --no-build
 
     - name: dotnet pack build/Projects/${{ inputs.project-name }}.proj
-      run: dotnet pack build/Projects/${{ inputs.project-name }}.proj --configuration Release --no-build --no-restore
+      run: dotnet pack build/Projects/${{ inputs.project-name }}.proj --configuration Release --no-restore --no-build
 
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3

--- a/build/Projects/OpenTelemetry.Exporter.Geneva.proj
+++ b/build/Projects/OpenTelemetry.Exporter.Geneva.proj
@@ -11,6 +11,8 @@
     <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Geneva.Stress\OpenTelemetry.Exporter.Geneva.Stress.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Geneva\OpenTelemetry.Exporter.Geneva.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Geneva.Tests\OpenTelemetry.Exporter.Geneva.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
@@ -23,6 +25,10 @@
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>

--- a/build/Projects/OpenTelemetry.Exporter.OneCollector.proj
+++ b/build/Projects/OpenTelemetry.Exporter.OneCollector.proj
@@ -10,6 +10,8 @@
     <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.Exporter.OneCollector.Benchmarks\OpenTelemetry.Exporter.OneCollector.Benchmarks.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OneCollector\OpenTelemetry.Exporter.OneCollector.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Exporter.OneCollector.Tests\OpenTelemetry.Exporter.OneCollector.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
@@ -22,6 +24,10 @@
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>

--- a/build/Projects/OpenTelemetry.Instrumentation.AspNet.proj
+++ b/build/Projects/OpenTelemetry.Instrumentation.AspNet.proj
@@ -13,6 +13,8 @@
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj" />
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.AspNet*.Tests\*.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
@@ -25,6 +27,10 @@
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>

--- a/build/Projects/OpenTelemetry.Instrumentation.Owin.proj
+++ b/build/Projects/OpenTelemetry.Instrumentation.Owin.proj
@@ -10,6 +10,8 @@
     <SolutionProjects Include="$(RepoRoot)\examples\owin\**\*.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Owin\OpenTelemetry.Instrumentation.Owin.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.Owin.Tests\OpenTelemetry.Instrumentation.Owin.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
@@ -22,6 +24,10 @@
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>

--- a/build/Projects/OpenTelemetry.Instrumentation.Process.proj
+++ b/build/Projects/OpenTelemetry.Instrumentation.Process.proj
@@ -10,6 +10,8 @@
     <SolutionProjects Include="$(RepoRoot)\examples\process-instrumentation\**\*.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Process\OpenTelemetry.Instrumentation.Process.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.Process.Tests\OpenTelemetry.Instrumentation.Process.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
@@ -22,6 +24,10 @@
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>

--- a/build/Projects/OpenTelemetry.Instrumentation.StackExchangeRedis.proj
+++ b/build/Projects/OpenTelemetry.Instrumentation.StackExchangeRedis.proj
@@ -10,6 +10,8 @@
     <SolutionProjects Include="$(RepoRoot)\examples\redis\**\*.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.StackExchangeRedis\OpenTelemetry.Instrumentation.StackExchangeRedis.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.StackExchangeRedis.Tests\OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
@@ -22,6 +24,10 @@
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>

--- a/build/Projects/OpenTelemetry.Instrumentation.Wcf.proj
+++ b/build/Projects/OpenTelemetry.Instrumentation.Wcf.proj
@@ -10,6 +10,8 @@
     <SolutionProjects Include="$(RepoRoot)\examples\wcf\**\*.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Wcf\OpenTelemetry.Instrumentation.Wcf.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.Wcf.Tests\OpenTelemetry.Instrumentation.Wcf.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
@@ -22,6 +24,10 @@
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -303,6 +303,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{04
 	ProjectSection(SolutionItems) = preProject
 		build\Projects\OpenTelemetry.Exporter.Geneva.proj = build\Projects\OpenTelemetry.Exporter.Geneva.proj
 		build\Projects\OpenTelemetry.Exporter.OneCollector.proj = build\Projects\OpenTelemetry.Exporter.OneCollector.proj
+		build\Projects\OpenTelemetry.Instrumentation.AspNet.proj = build\Projects\OpenTelemetry.Instrumentation.AspNet.proj
 		build\Projects\OpenTelemetry.Instrumentation.Owin.proj = build\Projects\OpenTelemetry.Instrumentation.Owin.proj
 		build\Projects\OpenTelemetry.Instrumentation.Process.proj = build\Projects\OpenTelemetry.Instrumentation.Process.proj
 		build\Projects\OpenTelemetry.Instrumentation.StackExchangeRedis.proj = build\Projects\OpenTelemetry.Instrumentation.StackExchangeRedis.proj


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1386#issuecomment-1755893651

## Changes

#1386 combined Instrumentation.AspNet + Instrumentation.AspNet.TelemetryHttpModule into the same CI & release workflows but only the tests for Instrumentation.AspNet were being run. This PR changes the workflows to use the project files which now have targets for testing.
