### PR TITLE
[Instrumentation.AspNet] Update CHANGELOG for 1.6.0-beta.1 release

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.6.0-beta.1
+
+Released 2023-Oct-11
+
 * Fixed an issue where activities were stopped incorrectly before processing completed.
   Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
   ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -6,10 +6,14 @@
 
 Released 2023-Oct-11
 
-* Fixed an issue where activities were stopped incorrectly before processing
-  completed. Activity processor's `OnEnd` will now happen after
-  `AspNetInstrumentationOptions.Enrich`.
+* Updated `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule` dependency
+  to `1.6.0-beta.1` which brings in the following changes.:
+
+  * Fixed an issue where activities were stopped incorrectly before processing completed.
+  Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
   ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
+  * Update `OpenTelemetry.Api` to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-rc9.9
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 1.6.0-beta.1
 
 Released 2023-Oct-11

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## Unreleased
+## 1.6.0-beta.1
 
-* Release together with `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`.
-  Fixed an issue where activities were stopped incorrectly before processing completed.
-  Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
+Released 2023-Oct-11
+
+* Fixed an issue where activities were stopped incorrectly before processing
+  completed. Activity processor's `OnEnd` will now happen after
+  `AspNetInstrumentationOptions.Enrich`.
   ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
 
 ## 1.0.0-rc9.9

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -10,10 +10,10 @@ Released 2023-Oct-11
   to `1.6.0-beta.1` which brings in the following changes.:
 
   * Fixed an issue where activities were stopped incorrectly before processing completed.
-  Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
-  ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
+    Activity processor's `OnEnd` will now happen after `AspNetInstrumentationOptions.Enrich`.
+    ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388))
   * Update `OpenTelemetry.Api` to `1.6.0`.
-  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+    ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 ## 1.0.0-rc9.9
 


### PR DESCRIPTION
## Changes
- Bump up version to `1.6.0-beta.1` similar to instrumentation packages from main repo
- Update CHANGELOG for `1.6.0-beta.1` release