### PR TITLE
Export metrics to InfluxDB at a configurable interval

### DIFF
--- a/src/OpenTelemetry.Exporter.InfluxDB/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.InfluxDB/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Endpoint.set -> v
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.FlushInterval.get -> int
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.FlushInterval.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.InfluxDBMetricsExporterOptions() -> void
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricExportIntervalMilliseconds.get -> int
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricExportIntervalMilliseconds.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricsSchema.get -> OpenTelemetry.Exporter.InfluxDB.MetricsSchema
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricsSchema.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Org.get -> string?

--- a/src/OpenTelemetry.Exporter.InfluxDB/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.InfluxDB/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Endpoint.set -> v
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.FlushInterval.get -> int
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.FlushInterval.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.InfluxDBMetricsExporterOptions() -> void
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricExportIntervalMilliseconds.get -> int
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricExportIntervalMilliseconds.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricsSchema.get -> OpenTelemetry.Exporter.InfluxDB.MetricsSchema
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricsSchema.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Org.get -> string?

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Updates to 1.6.0 of OpenTelemetry SDK.
   ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+* Support for a configurable export interval in OpenTelemetry.Exporter.InfluxDB.
+  ([#1394](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1394))
 
 ## 1.0.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExporterExtensions.cs
@@ -62,7 +62,7 @@ public static class InfluxDBExporterExtensions
             });
             var metricsWriter = CreateMetricsWriter(options.MetricsSchema);
             var exporter = new InfluxDBMetricsExporter(metricsWriter, influxDbClient, writeApi);
-            return new PeriodicExportingMetricReader(exporter)
+            return new PeriodicExportingMetricReader(exporter, options.MetricExportIntervalMilliseconds)
             {
                 TemporalityPreference = MetricReaderTemporalityPreference.Cumulative,
             };

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporterOptions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.InfluxDB;
 
@@ -23,6 +24,8 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 /// </summary>
 public class InfluxDBMetricsExporterOptions
 {
+    private int metricExportIntervalMilliseconds = 60000;
+
     /// <summary>
     /// Gets or sets HTTP/S destination for line protocol.
     /// </summary>
@@ -52,4 +55,17 @@ public class InfluxDBMetricsExporterOptions
     /// Gets or sets the time to wait at most (milliseconds) with the write.
     /// </summary>
     public int FlushInterval { get; set; } = 1000;
+
+    /// <summary>
+    /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
+    /// </summary>
+    public int MetricExportIntervalMilliseconds
+    {
+        get => this.metricExportIntervalMilliseconds;
+        set
+        {
+            Guard.ThrowIfOutOfRange(value, min: 1000);
+            this.metricExportIntervalMilliseconds = value;
+        }
+    }
 }


### PR DESCRIPTION
## Changes

`InfluxDBExporterExtensions.AddInfluxDBMetricsExporter(MeterProviderBuilder, Action<InfluxDBMetricsExporterOptions>)` uses a `PeriodicExportingMetricReader` instance to pass the metrics to the InfluxDB exporter at an interval.  However, the extension method provides no means to make this interval user-configurable.

This PR introduces a new property, `MetricExportIntervalMilliseconds`, to `InfluxDBMetricsExporterOptions` to configure the said interval.  The property value is then passed as an argument to the `exportIntervalMilliseconds` parameter in the `PeriodicExportingMetricReader` constructor.

The default value for `InfluxDBMetricsExporterOptions.MetricExportIntervalMilliseconds` is set to 60000, matching the default that's specified with `PeriodicExportingMetricReader.DefaultExportIntervalMilliseconds`.
