### PR TITLE
[Exporter.Geneva] Update mapping for http tags

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Update Part B mapping to add Http related tags based on the new Semantic
+  Conventions.
+  ([#1402](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1402))
+
 * Fix serialization bug in `TldTraceExporter` and `TldLogExporter` when there
   are no Part C fields.
   ([#1396](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1396))

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackTraceExporter.cs
@@ -410,8 +410,11 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         ["db.statement"] = "dbStatement",
 
         ["http.method"] = "httpMethod",
+        ["http.request.method"] = "httpMethod",
         ["http.url"] = "httpUrl",
+        ["url.full"] = "httpUrl",
         ["http.status_code"] = "httpStatusCode",
+        ["http.response.status_code"] = "httpStatusCode",
 
         ["messaging.system"] = "messagingSystem",
         ["messaging.destination"] = "messagingDestination",

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/TldTraceExporter.cs
@@ -41,8 +41,11 @@ internal sealed class TldTraceExporter : TldExporter, IDisposable
         ["db.statement"] = "dbStatement",
 
         ["http.method"] = "httpMethod",
+        ["http.request.method"] = "httpMethod",
         ["http.url"] = "httpUrl",
+        ["url.full"] = "httpUrl",
         ["http.status_code"] = "httpStatusCode",
+        ["http.response.status_code"] = "httpStatusCode",
 
         ["messaging.system"] = "messagingSystem",
         ["messaging.destination"] = "messagingDestination",


### PR DESCRIPTION
## Changes
- Update mapping for http tags based on the new semantic conventions

https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/Shared/SemanticConventions.cs#L120-L121

https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/Shared/SemanticConventions.cs#L126

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
