### PR TITLE
[Instrumentation.Wcf] Release 1.0.0-rc.13

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc.13
+
+Released 2023-Oct-30
+
 * Update OpenTelemetry SDK version to `1.6.0`.
   ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 * Fixed span hierarchy when hosted in ASP.NET


### PR DESCRIPTION
[Instrumentation.Wcf] Release 1.0.0-rc.13

## Changes

* Update OpenTelemetry SDK version to `1.6.0`.
  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
* Fixed span hierarchy when hosted in ASP.NET
  ([#1342](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1342))
* **Breaking Change** `TelemetryClientMessageInspector` and `TelemetryDispatchMessageInspector`
  changed from public to internal
  ([#1376](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1376))
* Added support for `IRequestSessionChannel` and `IDuplexChannel` channel shapes
  ([#1374](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1374))

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~

## Notes

Planned to adjust Automatic Instrumentation to these changes.