### PR TITLE
Fix AOT warnings in StackExchangeRedis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'azure')
       || contains(needs.detect-changes.outputs.changes, 'aottestapp')
       || contains(needs.detect-changes.outputs.changes, 'build')
+      || contains(needs.detect-changes.outputs.changes, 'redis')
       || contains(needs.detect-changes.outputs.changes, 'shared')
     uses: ./.github/workflows/verifyaotcompat.yml
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,22 @@
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation.AddConnection(StackExchange.Redis.IConnectionMultiplexer! connection) -> System.IDisposable!
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation.AddConnection(string! name, StackExchange.Redis.IConnectionMultiplexer! connection) -> System.IDisposable!
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation.Dispose() -> void
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity!, StackExchange.Redis.Profiling.IProfiledCommand!>?
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Enrich.set -> void
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.EnrichActivityWithTimingEvents.get -> bool
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.EnrichActivityWithTimingEvents.set -> void
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.FlushInterval.get -> System.TimeSpan
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.FlushInterval.set -> void
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.SetVerboseDatabaseStatements.get -> bool
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.SetVerboseDatabaseStatements.set -> void
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.StackExchangeRedisInstrumentationOptions() -> void
+OpenTelemetry.Trace.TracerProviderBuilderExtensions
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, StackExchange.Redis.IConnectionMultiplexer! connection) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, StackExchange.Redis.IConnectionMultiplexer! connection, System.Action<OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, string? name, StackExchange.Redis.IConnectionMultiplexer? connection, System.Action<OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.ConfigureRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.ConfigureRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<System.IServiceProvider!, OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Update OTel API version to `1.6.0`.
   ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
+* Add `net6.0` target framework and make library AOT and trimming compatible
+  ([#1415](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1415))
+
 ## 1.0.0-rc9.10
 
 Released 2023-Jun-09

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -20,16 +20,21 @@ using System.Reflection;
 using System.Reflection.Emit;
 using OpenTelemetry.Trace;
 using StackExchange.Redis.Profiling;
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+#endif
 
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation;
 
 internal static class RedisProfilerEntryToActivityConverter
 {
+    private const string ScriptEvalMessageTypeName = "StackExchange.Redis.RedisDatabase+ScriptEvalMessage";
+
     private static readonly Lazy<Func<object, (string?, string?)>> MessageDataGetter = new(() =>
     {
-        var redisAssembly = typeof(IProfiledCommand).Assembly;
-        Type profiledCommandType = redisAssembly.GetType("StackExchange.Redis.Profiling.ProfiledCommand");
-        Type scriptMessageType = redisAssembly.GetType("StackExchange.Redis.RedisDatabase+ScriptEvalMessage");
+        Type profiledCommandType = Type.GetType("StackExchange.Redis.Profiling.ProfiledCommand, StackExchange.Redis", throwOnError: true)!;
+        Type scriptMessageType = Type.GetType(ScriptEvalMessageTypeName + ", StackExchange.Redis", throwOnError: true)!;
 
         var messageDelegate = CreateFieldGetter<object>(profiledCommandType, "Message", BindingFlags.NonPublic | BindingFlags.Instance);
         var scriptDelegate = CreateFieldGetter<string>(scriptMessageType, "script", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -59,12 +64,27 @@ internal static class RedisProfilerEntryToActivityConverter
                 script = scriptDelegate?.Invoke(message);
             }
 
-            if (commandAndKeyFetcher.TryFetch(message, out var value))
+            if (GetCommandAndKey(commandAndKeyFetcher, message, out var value))
             {
                 return (value, script);
             }
 
             return (null, script);
+
+#if NET6_0_OR_GREATER
+            [DynamicDependency("CommandAndKey", ScriptEvalMessageTypeName, "StackExchange.Redis")]
+            [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The CommandAndKey property is preserved by the above DynamicDependency")]
+#endif
+            static bool GetCommandAndKey(
+                PropertyFetcher<string> commandAndKeyFetcher,
+                object message,
+#if NET6_0_OR_GREATER
+                [NotNullWhen(true)]
+#endif
+                out string? value)
+            {
+                return commandAndKeyFetcher.TryFetch(message, out value);
+            }
         });
     });
 
@@ -186,20 +206,37 @@ internal static class RedisProfilerEntryToActivityConverter
     /// Creates getter for a field defined in private or internal type
     /// represented with classType variable.
     /// </summary>
-    private static Func<object, TField>? CreateFieldGetter<TField>(Type classType, string fieldName, BindingFlags flags)
+    private static Func<object, TField?>? CreateFieldGetter<TField>(
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+#endif
+        Type classType,
+        string fieldName,
+        BindingFlags flags)
     {
-        FieldInfo field = classType.GetField(fieldName, flags);
+        FieldInfo? field = classType.GetField(fieldName, flags);
         if (field != null)
         {
-            string methodName = classType.FullName + ".get_" + field.Name;
-            DynamicMethod getterMethod = new DynamicMethod(methodName, typeof(TField), new[] { typeof(object) }, true);
-            ILGenerator generator = getterMethod.GetILGenerator();
-            generator.Emit(OpCodes.Ldarg_0);
-            generator.Emit(OpCodes.Castclass, classType);
-            generator.Emit(OpCodes.Ldfld, field);
-            generator.Emit(OpCodes.Ret);
+#if NET6_0_OR_GREATER
+            if (RuntimeFeature.IsDynamicCodeSupported)
+#endif
+            {
+                string methodName = classType.FullName + ".get_" + field.Name;
+                DynamicMethod getterMethod = new DynamicMethod(methodName, typeof(TField), new[] { typeof(object) }, true);
+                ILGenerator generator = getterMethod.GetILGenerator();
+                generator.Emit(OpCodes.Ldarg_0);
+                generator.Emit(OpCodes.Castclass, classType);
+                generator.Emit(OpCodes.Ldfld, field);
+                generator.Emit(OpCodes.Ret);
 
-            return (Func<object, TField>)getterMethod.CreateDelegate(typeof(Func<object, TField>));
+                return (Func<object, TField>)getterMethod.CreateDelegate(typeof(Func<object, TField>));
+            }
+#if NET6_0_OR_GREATER
+            else
+            {
+                return obj => (TField?)field.GetValue(obj);
+            }
+#endif
         }
 
         return null;

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
     <Description>StackExchange.Redis instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;Redis;StackExchange.Redis</PackageTags>
-    <IncludeSharedInstrumentationSource>true</IncludeSharedInstrumentationSource>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
     <MinVerTagPrefix>Instrumentation.StackExchangeRedis-</MinVerTagPrefix>
     <ImplicitUsings>true</ImplicitUsings>
@@ -12,6 +11,8 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.AOT.cs" Link="Includes\PropertyFetcher.AOT.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -31,9 +31,9 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
 {
     internal const string RedisDatabaseIndexKeyName = "db.redis.database_index";
     internal const string RedisFlagsKeyName = "db.redis.flags";
-    internal static readonly string ActivitySourceName = typeof(StackExchangeRedisConnectionInstrumentation).Assembly.GetName().Name;
+    internal static readonly string ActivitySourceName = typeof(StackExchangeRedisConnectionInstrumentation).Assembly.GetName().Name!;
     internal static readonly string ActivityName = ActivitySourceName + ".Execute";
-    internal static readonly Version Version = typeof(StackExchangeRedisConnectionInstrumentation).Assembly.GetName().Version;
+    internal static readonly Version Version = typeof(StackExchangeRedisConnectionInstrumentation).Assembly.GetName().Version!;
     internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
     internal static readonly IEnumerable<KeyValuePair<string, object?>> CreationTags = new[]
     {
@@ -137,7 +137,7 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
         }
     }
 
-    private void DrainEntries(object state)
+    private void DrainEntries(object? state)
     {
         while (true)
         {

--- a/src/Shared/PropertyFetcher.AOT.cs
+++ b/src/Shared/PropertyFetcher.AOT.cs
@@ -18,6 +18,7 @@
 
 // NOTE: This version of PropertyFetcher is AOT-compatible.
 // Usages of the non-AOT-compatible version can be moved over to this one when they need to support AOT/trimming.
+// Copied from https://github.com/open-telemetry/opentelemetry-dotnet/blob/86a6ba0b7f7ed1f5e84e5a6610e640989cd3ae9f/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs#L30
 
 #nullable enable
 

--- a/src/Shared/PropertyFetcher.AOT.cs
+++ b/src/Shared/PropertyFetcher.AOT.cs
@@ -1,0 +1,236 @@
+// <copyright file="PropertyFetcher.AOT.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable disable
+
+// NOTE: This version of PropertyFetcher is AOT-compatible.
+// Usages of the non-AOT-compatible version can be moved over to this one when they need to support AOT/trimming.
+
+#nullable enable
+
+#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.Reflection;
+
+namespace OpenTelemetry.Instrumentation;
+
+/// <summary>
+/// PropertyFetcher fetches a property from an object.
+/// </summary>
+/// <typeparam name="T">The type of the property being fetched.</typeparam>
+internal sealed class PropertyFetcher<T>
+{
+#if NET6_0_OR_GREATER
+    private const string TrimCompatibilityMessage = "PropertyFetcher is used to access properties on objects dynamically by design and cannot be made trim compatible.";
+#endif
+    private readonly string propertyName;
+    private PropertyFetch? innerFetcher;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyFetcher{T}"/> class.
+    /// </summary>
+    /// <param name="propertyName">Property name to fetch.</param>
+    public PropertyFetcher(string propertyName)
+    {
+        this.propertyName = propertyName;
+    }
+
+    public int NumberOfInnerFetchers => this.innerFetcher == null
+        ? 0
+        : 1 + this.innerFetcher.NumberOfInnerFetchers;
+
+    /// <summary>
+    /// Try to fetch the property from the object.
+    /// </summary>
+    /// <param name="obj">Object to be fetched.</param>
+    /// <param name="value">Fetched value.</param>
+    /// <returns><see langword= "true"/> if the property was fetched.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(TrimCompatibilityMessage)]
+#endif
+    public bool TryFetch(
+#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
+        [NotNullWhen(true)]
+#endif
+        object? obj,
+        out T? value)
+    {
+        var innerFetcher = this.innerFetcher;
+        if (innerFetcher is null)
+        {
+            return TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value);
+        }
+
+        return innerFetcher.TryFetch(obj, out value);
+    }
+
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(TrimCompatibilityMessage)]
+#endif
+    private static bool TryFetchRare(object? obj, string propertyName, ref PropertyFetch? destination, out T? value)
+    {
+        if (obj is null)
+        {
+            value = default;
+            return false;
+        }
+
+        var fetcher = PropertyFetch.Create(obj.GetType().GetTypeInfo(), propertyName);
+
+        if (fetcher is null)
+        {
+            value = default;
+            return false;
+        }
+
+        destination = fetcher;
+
+        return fetcher.TryFetch(obj, out value);
+    }
+
+    // see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(TrimCompatibilityMessage)]
+#endif
+    private abstract class PropertyFetch
+    {
+        public abstract int NumberOfInnerFetchers { get; }
+
+        public static PropertyFetch? Create(TypeInfo type, string propertyName)
+        {
+            var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase)) ?? type.GetProperty(propertyName);
+            return CreateFetcherForProperty(property);
+
+            static PropertyFetch? CreateFetcherForProperty(PropertyInfo? propertyInfo)
+            {
+                if (propertyInfo == null || !typeof(T).IsAssignableFrom(propertyInfo.PropertyType))
+                {
+                    // returns null and wait for a valid payload to arrive.
+                    return null;
+                }
+
+                var declaringType = propertyInfo.DeclaringType;
+                if (declaringType!.IsValueType)
+                {
+                    throw new NotSupportedException(
+                        $"Type: {declaringType.FullName} is a value type. PropertyFetcher can only operate on reference payload types.");
+                }
+
+                if (declaringType == typeof(object))
+                {
+                    // TODO: REMOVE this if branch when .NET 7 is out of support.
+                    // This branch is never executed and is only needed for .NET 7 AOT-compiler at trimming stage; i.e.,
+                    // this is not needed in .NET 8, because the compiler is improved and call into MakeGenericMethod will be AOT-compatible.
+                    // It is used to force the AOT compiler to create an instantiation of the method with a reference type.
+                    // The code for that instantiation can then be reused at runtime to create instantiation over any other reference.
+                    return CreateInstantiated<object>(propertyInfo);
+                }
+                else
+                {
+                    return DynamicInstantiationHelper(declaringType, propertyInfo);
+                }
+
+                // Separated as a local function to be able to target the suppression to just this call.
+                // IL3050 was generated here because of the call to MakeGenericType, which is problematic in AOT if one of the type parameters is a value type;
+                // because the compiler might need to generate code specific to that type.
+                // If the type parameter is a reference type, there will be no problem; because the generated code can be shared among all reference type instantiations.
+#if NET6_0_OR_GREATER
+                [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The code guarantees that all the generic parameters are reference types.")]
+#endif
+                static PropertyFetch? DynamicInstantiationHelper(Type declaringType, PropertyInfo propertyInfo)
+                {
+                    return (PropertyFetch?)typeof(PropertyFetch)
+                        .GetMethod(nameof(CreateInstantiated), BindingFlags.NonPublic | BindingFlags.Static)!
+                        .MakeGenericMethod(declaringType) // This is validated in the earlier call chain to be a reference type.
+                        .Invoke(null, new object[] { propertyInfo })!;
+                }
+            }
+        }
+
+        public abstract bool TryFetch(
+#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
+            [NotNullWhen(true)]
+#endif
+            object? obj,
+            out T? value);
+
+        // Goal: make PropertyFetcher AOT-compatible.
+        // AOT compiler can't guarantee correctness when call into MakeGenericType or MakeGenericMethod
+        // if one of the generic parameters is a value type (reference types are OK.)
+        // For PropertyFetcher, the decision was made to only support reference type payloads, i.e.:
+        // the object from which to get the property value MUST be a reference type.
+        // Create generics with the declared object type as a generic parameter is OK, but we need the return type
+        // of the property to be a value type (on top of reference types.)
+        // Normally, we would have a helper class like `PropertyFetchInstantiated` that takes 2 generic parameters,
+        // the declared object type, and the type of the property value.
+        // But that would mean calling MakeGenericType, with value type parameters which AOT won't support.
+        //
+        // As a workaround, Generic instantiation was split into:
+        // 1. The object type comes from the PropertyFetcher generic parameter.
+        //    Compiler supports it even if it is a value type; the type is known statically during compilation
+        //    since PropertyFetcher is used with it.
+        // 2. Then, the declared object type is passed as a generic parameter to a generic method on PropertyFetcher<T> (or nested type.)
+        //    Therefore, calling into MakeGenericMethod will only require specifying one parameter - the declared object type.
+        //    The declared object type is guaranteed to be a reference type (throw on value type.) Thus, MakeGenericMethod is AOT compatible.
+        private static PropertyFetch CreateInstantiated<TDeclaredObject>(PropertyInfo propertyInfo)
+            where TDeclaredObject : class
+            => new PropertyFetchInstantiated<TDeclaredObject>(propertyInfo);
+
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(TrimCompatibilityMessage)]
+#endif
+        private sealed class PropertyFetchInstantiated<TDeclaredObject> : PropertyFetch
+            where TDeclaredObject : class
+        {
+            private readonly string propertyName;
+            private readonly Func<TDeclaredObject, T> propertyFetch;
+            private PropertyFetch? innerFetcher;
+
+            public PropertyFetchInstantiated(PropertyInfo property)
+            {
+                this.propertyName = property.Name;
+                this.propertyFetch = (Func<TDeclaredObject, T>)property.GetMethod!.CreateDelegate(typeof(Func<TDeclaredObject, T>));
+            }
+
+            public override int NumberOfInnerFetchers => this.innerFetcher == null
+                ? 0
+                : 1 + this.innerFetcher.NumberOfInnerFetchers;
+
+            public override bool TryFetch(
+#if NETSTANDARD2_1_0_OR_GREATER || NET6_0_OR_GREATER
+                [NotNullWhen(true)]
+#endif
+                object? obj,
+                out T? value)
+            {
+                if (obj is TDeclaredObject o)
+                {
+                    value = this.propertyFetch(o);
+                    return true;
+                }
+
+                var innerFetcher = this.innerFetcher;
+                if (innerFetcher is null)
+                {
+                    return TryFetchRare(obj, this.propertyName, ref this.innerFetcher, out value);
+                }
+
+                return innerFetcher.TryFetch(obj, out value);
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.Runtime" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.EventCounters" />
+    <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.StackExchangeRedis" />
     <TrimmerRootAssembly Include="OpenTelemetry.ResourceDetectors.Azure" />
 
     <TrimmerRootAssembly Update="@(TrimmerRootAssembly)" Path="$(RepoRoot)\src\%(Identity)\%(Identity).csproj" />


### PR DESCRIPTION
- Add net6.0 target, so we can annotate the code correctly and use new APIs.
- Copy PropertyFetcher from open-telemetry/opentelemetry-dotnet which was made AOT compatible. Made a new shared version that other libraries can opt into using over time, so this change has no affect on other libraries.
- Add StackExchangeRedis to the AotCompatibility.TestApp.
- Address warnings to make the code work under AOT/trimmed.

Fix #1341

cc @Yun-Ting @utpilla @vitek-karas