### PR TITLE
Add missing Binding Redirect for Examples.AspNet project

### DIFF
--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -57,6 +57,10 @@
         <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.2" newVersion="7.0.0.2"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Fixes #1417.

## Changes

Add missing binding redirect to web.config
