### PR TITLE
Fix up Redis trimming annotations

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix an issue in the trimming annotations to refer to the correct Type
+  ([#1420](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1420))
+
 ## 1.0.0-rc9.11
 
 Released 2023-Oct-31

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -29,12 +29,10 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation;
 
 internal static class RedisProfilerEntryToActivityConverter
 {
-    private const string ScriptEvalMessageTypeName = "StackExchange.Redis.RedisDatabase+ScriptEvalMessage";
-
     private static readonly Lazy<Func<object, (string?, string?)>> MessageDataGetter = new(() =>
     {
         Type profiledCommandType = Type.GetType("StackExchange.Redis.Profiling.ProfiledCommand, StackExchange.Redis", throwOnError: true)!;
-        Type scriptMessageType = Type.GetType(ScriptEvalMessageTypeName + ", StackExchange.Redis", throwOnError: true)!;
+        Type scriptMessageType = Type.GetType("StackExchange.Redis.RedisDatabase+ScriptEvalMessage, StackExchange.Redis", throwOnError: true)!;
 
         var messageDelegate = CreateFieldGetter<object>(profiledCommandType, "Message", BindingFlags.NonPublic | BindingFlags.Instance);
         var scriptDelegate = CreateFieldGetter<string>(scriptMessageType, "script", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -72,7 +70,7 @@ internal static class RedisProfilerEntryToActivityConverter
             return (null, script);
 
 #if NET6_0_OR_GREATER
-            [DynamicDependency("CommandAndKey", ScriptEvalMessageTypeName, "StackExchange.Redis")]
+            [DynamicDependency("CommandAndKey", "StackExchange.Redis.Message", "StackExchange.Redis")]
             [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The CommandAndKey property is preserved by the above DynamicDependency")]
 #endif
             static bool GetCommandAndKey(


### PR DESCRIPTION
#1415 had an issue in it due to how the DynamicDependency attribute is written.

1. Referring to a nested type with `+` isn't correct in DynamicDependency attributes. You need to just use a normal `.`. The current code is producing a warning when using the .NET 8.0 SDK to publish for AOT. "warning IL2036: OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation.RedisProfilerEntryToActivityConverter.<.cctor>g__GetCommandAndKey|5_3(PropertyFetcher`1<String>,Object,String&): Unresolved type 'StackExchange.Redis.RedisDatabase+ScriptEvalMessage' in 'DynamicDependencyAttribute'."

This wasn't caught in our CI because we use the .NET 7.0 SDK to publish, which doesn't catch this bug.

2. The "CommandAndKey" property isn't on the nested ScriptEvalMessage type, but instead a virtual on the base Message class.

The fix here is to use the base Message class in the DynamicDependency. I've verified this works with a .NET 8.0 SDK.

cc @Yun-Ting @utpilla @vitek-karas