### PR TITLE
[Instrumentation.AspNet] Fix metric http.server.duration always being zero

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -133,6 +133,13 @@ internal static class ActivityHelper
         var currentActivity = Activity.Current;
         context.Items[ContextKey] = null;
 
+        // Make sure that the activity has a proper end time before onRequestStoppedCallback is called.
+        // Note that the activity must not be stopped before the callback is called.
+        if (aspNetActivity.Duration == TimeSpan.Zero)
+        {
+            aspNetActivity.SetEndTime(DateTime.UtcNow);
+        }
+
         try
         {
             onRequestStoppedCallback?.Invoke(aspNetActivity, context);

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Fixed an issue that caused `http.server.duration` metric value to always be set to `0`. The issue exists in `1.6.0-beta.1` version.
+* Fixed an issue that caused `http.server.duration` metric value to always be set
+  to `0`. The issue exists in `1.6.0-beta.1` version.
   ([#1425](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1425))
 
 ## 1.6.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix for `http.server.duration` always being zero since `1.6.0-beta.1`.
+* Fixed an issue that caused `http.server.duration` metric value to always be set to `0`. The issue exists in `1.6.0-beta.1` version.
   ([#1425](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1425))
 
 ## 1.6.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix for `http.server.duration` being time always being zero since `1.6.0-beta.1`.
+* Fix for `http.server.duration` always being zero since `1.6.0-beta.1`.
   ([#1425](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1425))
 
 ## 1.6.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix for `http.server.duration` being time always being zero since
+  ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388)).
+
 ## 1.6.0-beta.1
 
 Released 2023-Oct-11

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Fix for `http.server.duration` being time always being zero since
-  ([#1388](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1388)).
+* Fix for `http.server.duration` being time always being zero since `1.6.0-beta.1`.
+  ([#1425](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1425))
 
 ## 1.6.0-beta.1
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -61,7 +61,7 @@ public class HttpInMetricsListenerTests
         Thread.Sleep(1); // Make sure duration is always greater than 0 to avoid flakiness.
         ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
 
-        Assert.True(duration > 0, "Metruc duration should be set.");
+        Assert.True(duration > 0, "Metric duration should be set.");
 
         meterProvider.ForceFlush();
 
@@ -69,7 +69,7 @@ public class HttpInMetricsListenerTests
         foreach (var p in exportedItems[0].GetMetricPoints())
         {
             metricPoints.Add(p);
-        } 
+        }
 
         Assert.Single(metricPoints);
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -60,8 +60,6 @@ public class HttpInMetricsListenerTests
         Thread.Sleep(1); // Make sure duration is always greater than 0 to avoid flakiness.
         ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
 
-        Assert.True(duration > 0, "Metric duration should be set.");
-
         meterProvider.ForceFlush();
 
         var metricPoints = new List<MetricPoint>();
@@ -81,6 +79,7 @@ public class HttpInMetricsListenerTests
         Assert.Equal("http.server.duration", exportedItems[0].Name);
         Assert.Equal(1L, count);
         Assert.Equal(duration, sum);
+        Assert.True(duration > 0, "Metric duration should be set.");
 
         Assert.Equal(3, metricPoints[0].Tags.Count);
         string? httpMethod = null;

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -16,6 +16,8 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Threading;
 using System.Web;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Metrics;
@@ -56,7 +58,10 @@ public class HttpInMetricsListenerTests
             .Build();
 
         var activity = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
+        Thread.Sleep(1); // Make sure duration is always greater than 0 to avoid flakiness.
         ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+
+        Assert.True(duration > 0, "Metruc duration should be set.");
 
         meterProvider.ForceFlush();
 
@@ -64,7 +69,7 @@ public class HttpInMetricsListenerTests
         foreach (var p in exportedItems[0].GetMetricPoints())
         {
             metricPoints.Add(p);
-        }
+        } 
 
         Assert.Single(metricPoints);
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -16,7 +16,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Web;
 using OpenTelemetry.Context.Propagation;


### PR DESCRIPTION
Fixes a bug introduced in #1388 as mentioned by @vishweshbankwar.

## Changes

- Explicitly set the end duration of the activity before `onRequestStoppedCallback` is called.
- Updated tests to catch this in the future.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes