### PR TITLE
Activities were getting closed with incorrect duration

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -133,12 +133,7 @@ internal static class ActivityHelper
         var currentActivity = Activity.Current;
         context.Items[ContextKey] = null;
 
-        // Make sure that the activity has a proper end time before onRequestStoppedCallback is called.
-        // Note that the activity must not be stopped before the callback is called.
-        if (aspNetActivity.Duration == TimeSpan.Zero)
-        {
-            aspNetActivity.SetEndTime(DateTime.UtcNow);
-        }
+        aspNetActivity.Stop();
 
         try
         {
@@ -149,7 +144,6 @@ internal static class ActivityHelper
             AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, "OnStopped", callbackEx);
         }
 
-        aspNetActivity.Stop();
         AspNetTelemetryEventSource.Log.ActivityStopped(aspNetActivity);
 
         if (textMapPropagator is not TraceContextPropagator)


### PR DESCRIPTION
## Context  
  
While using @qhris (thank you 🙏 ) work before it was published, we started to notice a weird pattern for the metrics.  
Our current setup has a .NET Framework ASP.NET application instrumented with OpenTelemetry dotnet client, and we needed to have the metrics tagged with route information, so that we are able to support grafana dashboards over it (we haven't found a way to do it over trace information). We are also using OTEL to feed the connected App Insights instance.    
  
As soon as we packed and deployed the code, due to the high load the system is subjected to (10M+ requests/day) we noticed a saw tooth pattern on the reported graphs in AppInsights and Grafana.  

![Screenshot 2023-11-10 at 15 53 55](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/assets/93126068/d0ccc6a9-f3b3-434f-8477-823a604a41bd)
![Screenshot 2023-11-10 at 15 54 20](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/assets/93126068/43ed5ba5-f073-4ecd-9c98-824da0e26acc)  
  
As you can see on the above, we have several thousand requests being saved with a duration of ~1ms. We also have the following:  
![Screenshot 2023-11-14 at 15 00 41](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/assets/93126068/82a13ca2-5c17-4851-b600-e0a80242155f)
![Screenshot 2023-11-14 at 15 02 58](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/assets/93126068/982c8092-9668-420a-bba5-e120e6ba1f0a)
Sorry for the redacted services names.  
  
Fixes #1431 .

## Changes

I reverted `ActivityHelper` to 895a9c7626ecad59b84d5886a5b82c547a209d08.  
Since this breaks the enrichment logic developed in #1407 (this was already address in #1425 ), I've added the duration computation logic into the `HttpInMetricsListener` (not the best place I know, but). I've tried to "import" most of the code from `Activity`, to have high precision.  

## Next steps
I would like to further improve the code and add unit tests, but to be clear my knowledge on this (ASP.NET lifecycle pipelines) is very limited to what Microsoft (still) has on their documentation pages, so I would request aid to understand the unit test case and to work on it.  
  

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue #
* [ ] Changes in public API reviewed
