### PR TITLE
Updated AWSSDK, Amazon packages to support newer versions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.24" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.27" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.26" />
+    <PackageReference Include="AWSSDK.Core" Version="[3.5.1.24,4.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.5.0.27,4.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.5.0.26, 4.0)" />
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.1" />
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="[2.4.1, 3.0)" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="[1.2.0,3.0)" />
+    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="[2.0.0, 3.0)" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="[2.1.0, 3.0)" />
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
The Instrumentation.AWS SDK packages are quite old (3 years) and using this package in most projects creates alot of warnings. I think the "[legacy, next_ver)" format will fix this (not certain). If not, perhaps they could just be updated the 3.7 generation.

## Changes

In OpenTelemetry.Instrumentation.AWS:
Updated AWSSDK.Core to accept versions 3.5.1.24 up to 4.x
Updated AWSSDK.SimpleNotificationService to accept versions 3.5.0.27 up to 4.x
Updated AWSSDK.SQS to accept versions 3.5.0.26 up to 4.x

In OpenTelemetry.Instrumentation.AWSLambda:
Updated Amazon.Lambda.APIGatewayEvents to accept versions 2.4.1 up to 3.x
Updated Amazon.Lambda.Core to accept versions 1.2.0 up to 3.x
Updated Amazon.Lambda.SNSEvents to accept versions 2.0.0 up to 3.x
Updated Amazon.Lambda.SQSEvents to accept versions 2.1..0 up to 3.x

