### PR TITLE
Fix ActivityTraceFlags assertion

### DIFF
--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -323,9 +323,8 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
             modelBuilder.Entity<Item>(
                 b =>
                 {
-                    b.Property("Id");
-                    b.HasKey("Id");
                     b.Property(e => e.Name);
+                    b.HasKey("Name");
                 });
         }
     }

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -153,7 +153,7 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         var activity = (Activity)activityProcessor.Invocations[1].Arguments[0];
 
         Assert.False(activity.IsAllDataRequested);
-        Assert.True(activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.None));
+        Assert.False(activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded));
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         var activity = (Activity)activityProcessor.Invocations[1].Arguments[0];
 
         Assert.False(activity.IsAllDataRequested);
-        Assert.True(activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.None));
+        Assert.False(activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #.

## Changes

This is always `true`
```c#
Assert.True(activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.None));
```
This is a correct assertion

```c#
Assert.False(activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded));
```

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
