### PR TITLE
Updates for .NET 8 code analysis - Part 2

### DIFF
--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -31,8 +31,8 @@ namespace Examples.AspNet;
 public class WebApiApplication : HttpApplication
 #pragma warning restore SA1649 // File name should match first type name
 {
-    private IDisposable? tracerProvider;
-    private IDisposable? meterProvider;
+    private TracerProvider? tracerProvider;
+    private MeterProvider? meterProvider;
 
     protected void Application_Start()
     {

--- a/examples/wcf/server-aspnetframework/Global.asax.cs
+++ b/examples/wcf/server-aspnetframework/Global.asax.cs
@@ -29,7 +29,7 @@ namespace Examples.Wcf.Server.AspNetFramework;
 public class WebApiApplication : HttpApplication
 #pragma warning restore SA1649 // File name should match first type name
 {
-    private IDisposable? tracerProvider;
+    private TracerProvider? tracerProvider;
 
     protected void Application_Start()
     {

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/HttpJsonPostTransport.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/HttpJsonPostTransport.cs
@@ -17,6 +17,9 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Net;
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using System.Net.Http.Headers;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/IHttpClient.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/IHttpClient.cs
@@ -14,6 +14,10 @@
 // limitations under the License.
 // </copyright>
 
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+
 namespace OpenTelemetry.Exporter.OneCollector;
 
 internal interface IHttpClient

--- a/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExportProcessorBuilder.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExportProcessorBuilder.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter.OneCollector;
 using OpenTelemetry.Internal;

--- a/src/OpenTelemetry.Extensions/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions/TracerProviderBuilderExtensions.cs
@@ -47,10 +47,14 @@ public static class TracerProviderBuilderExtensions
         Func<Activity, bool> predicate,
         int timeoutMilliseconds = 10000)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(builder);
+#else
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
+#endif
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         return builder.AddProcessor(new AutoFlushActivityProcessor(predicate, timeoutMilliseconds));

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -124,7 +124,9 @@ internal class AWSLambdaHttpUtils
             return (null, null);
         }
 
+#pragma warning disable CA1861 // Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array
         var hostAndPort = hostHeader.Split(new char[] { ':' }, 2);
+#pragma warning restore CA1861 // Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array
         if (hostAndPort.Length > 1)
         {
             var host = hostAndPort[0];

--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
@@ -76,12 +76,12 @@ internal sealed class HangfireInstrumentationJobFilterAttribute : JobFilterAttri
     public void OnPerformed(PerformedContext performedContext)
     {
         // Short-circuit if nobody is listening
-        if (!HangfireInstrumentation.ActivitySource.HasListeners() || !performedContext.Items.ContainsKey(HangfireInstrumentationConstants.ActivityKey))
+        if (!HangfireInstrumentation.ActivitySource.HasListeners() || !performedContext.Items.TryGetValue(HangfireInstrumentationConstants.ActivityKey, out var value))
         {
             return;
         }
 
-        if (performedContext.Items[HangfireInstrumentationConstants.ActivityKey] is Activity activity)
+        if (value is Activity activity)
         {
             if (performedContext.Exception != null)
             {

--- a/src/OpenTelemetry.ResourceDetectors.AWS/AWSECSResourceDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/AWSECSResourceDetector.cs
@@ -106,7 +106,9 @@ public class AWSECSResourceDetector : IResourceDetector
 
         if (!clusterArn.StartsWith("arn:", StringComparison.Ordinal))
         {
+#pragma warning disable CA1865 // Use string.LastIndexOf(char) instead of string.LastIndexOf(string) when you have string with a single char
             var baseArn = containerArn.Substring(containerArn.LastIndexOf(":", StringComparison.Ordinal));
+#pragma warning restore CA1865 // Use string.LastIndexOf(char) instead of string.LastIndexOf(string) when you have string with a single char
             clusterArn = $"{baseArn}:cluster/{clusterArn}";
         }
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
@@ -25,6 +25,7 @@ namespace OpenTelemetry.Exporter.InfluxDB.Tests;
 public class InfluxDBMetricsExporterTests
 {
     private static readonly string OpenTelemetrySdkVersion;
+    private static readonly double[] TestBoundaries = new[] { 10D, 20D, 100D, 200D };
 
 #pragma warning disable CA1810 // Initialize reference type static fields inline
     static InfluxDBMetricsExporterTests()
@@ -312,7 +313,7 @@ public class InfluxDBMetricsExporterTests
             .AddMeter(meter.Name)
             .AddView("histogram_metric", new ExplicitBucketHistogramConfiguration
             {
-                Boundaries = new[] { 10D, 20D, 100D, 200D },
+                Boundaries = TestBoundaries,
                 RecordMinMax = true,
             })
             .ConfigureDefaultTestResource()
@@ -403,7 +404,7 @@ public class InfluxDBMetricsExporterTests
             .AddMeter(meter.Name)
             .AddView("histogram_metric", new ExplicitBucketHistogramConfiguration
             {
-                Boundaries = new[] { 10D, 20D, 100D, 200D },
+                Boundaries = TestBoundaries,
                 RecordMinMax = true,
             })
             .ConfigureDefaultTestResource()

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/LineProtocolParser.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/LineProtocolParser.cs
@@ -75,11 +75,13 @@ public class LineProtocolParser
             return boolValue;
         }
 
+#pragma warning disable CA1865 // Use char overload
         if (fieldValue.EndsWith("i", StringComparison.Ordinal)
             && long.TryParse(fieldValue.AsSpan(0, fieldValue.Length - 1).ToString(), out long intValue))
         {
             return intValue;
         }
+#pragma warning restore CA1865 // Use char overload
 
         if (double.TryParse(fieldValue, NumberStyles.Float, CultureInfo.InvariantCulture, out double doubleValue))
         {

--- a/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/LogRecordCommonSchemaJsonHttpPostBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/LogRecordCommonSchemaJsonHttpPostBenchmarks.cs
@@ -16,6 +16,9 @@
 
 using System.Diagnostics;
 using System.Net;
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging;

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/HttpJsonPostTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/HttpJsonPostTransportTests.cs
@@ -16,6 +16,9 @@
 
 using System.IO.Compression;
 using System.Net;
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using System.Text;
 using OpenTelemetry.Tests;
 using Xunit;

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Tools/MockWebResponse.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Tools/MockWebResponse.cs
@@ -115,7 +115,7 @@ internal class MockWebResponse
             }
         }
 
-        httpResponseMessage.StatusCode = statusCode;
+        httpResponseMessage!.StatusCode = statusCode;
         string dummyJson = "{\"key1\":\"value1\"}";
         httpResponseMessage.Content = new StringContent(body ?? dummyJson); // Content should be in Json format else we get exception from downstream unmarshalling
         return httpResponseMessage;
@@ -152,7 +152,9 @@ internal class MockWebResponse
                     break;
                 }
 
+#pragma warning disable CA1865 // Use char overload
                 var index = currentLine.IndexOf(":", StringComparison.Ordinal);
+#pragma warning restore CA1865 // Use char overload
                 if (index != -1)
                 {
                     var headerKey = currentLine.Substring(0, index);

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
@@ -40,7 +40,9 @@ public class AWSLambdaHttpUtilsTests
             },
             MultiValueQueryStringParameters = new Dictionary<string, IList<string>>
             {
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
                 { "q1", new[] { "value1" } },
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
             },
             RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
             {
@@ -70,7 +72,9 @@ public class AWSLambdaHttpUtilsTests
         {
             MultiValueQueryStringParameters = new Dictionary<string, IList<string>>
             {
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
                 { "q1", new[] { "value1" } },
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
             },
             HttpMethod = "POST",
             Path = "/path/test",
@@ -251,11 +255,13 @@ public class AWSLambdaHttpUtilsTests
 
     [Theory]
     [InlineData(null, "")]
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
     [InlineData(new string[] { }, "")]
     [InlineData(new[] { "value1" }, "?name=value1")]
     [InlineData(new[] { "value$a" }, "?name=value%24a")]
     [InlineData(new[] { "value 1" }, "?name=value+1")]
     [InlineData(new[] { "value1", "value2" }, "?name=value1&name=value2")]
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
     public void GetQueryString_APIGatewayProxyRequest_CorrectQueryString(IList<string> values, string expectedQueryString)
     {
         var request = new APIGatewayProxyRequest();

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -248,7 +248,7 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
 
     public void Dispose() => this.connection.Dispose();
 
-    private static DbConnection CreateInMemoryDatabase()
+    private static SqliteConnection CreateInMemoryDatabase()
     {
         var connection = new SqliteConnection("Filename=:memory:");
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation;
 public class RedisProfilerEntryToActivityConverterTests : IDisposable
 {
     private readonly ConnectionMultiplexer connection;
-    private readonly IDisposable tracerProvider;
+    private readonly TracerProvider tracerProvider;
 
     public RedisProfilerEntryToActivityConverterTests()
     {

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -108,7 +108,7 @@ public class StackExchangeRedisCallsInstrumentationTests
         };
         connectionOptions.EndPoints.Add(RedisEndPoint);
 
-        IConnectionMultiplexer? connection = null;
+        ConnectionMultiplexer? connection = null;
         var activityProcessor = new Mock<BaseProcessor<Activity>>();
         var sampler = new TestSampler();
         using (Sdk.CreateTracerProviderBuilder()

--- a/test/OpenTelemetry.ResourceDetectors.AWS.Tests/AWSECSResourceDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.AWS.Tests/AWSECSResourceDetectorTests.cs
@@ -91,10 +91,12 @@ public class AWSECSResourceDetectorTests : IDisposable
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskArn], "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskFamily], "curltest");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskRevision], "26");
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogGroupNames], new string[] { "/ecs/metadata" });
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogGroupArns], new string[] { "arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata" });
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogStreamNames], new string[] { "ecs/curl/8f03e41243824aea923aca126495f665" });
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogStreamArns], new string[] { "arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:log-stream:ecs/curl/8f03e41243824aea923aca126495f665" });
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
         }
     }
 
@@ -117,10 +119,12 @@ public class AWSECSResourceDetectorTests : IDisposable
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskArn], "arn:aws:ecs:us-west-2:111122223333:task/default/e9028f8d5d8e4f258373e7b93ce9a3c3");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskFamily], "curltest");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskRevision], "3");
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogGroupNames], new string[] { "/ecs/containerlogs" });
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogGroupArns], new string[] { "arn:aws:logs:us-west-2:111122223333:log-group:/ecs/containerlogs" });
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogStreamNames], new string[] { "ecs/curl/cd189a933e5849daa93386466019ab50" });
             Assert.NotStrictEqual(resourceAttributes[AWSSemanticConventions.AttributeLogStreamArns], new string[] { "arn:aws:logs:us-west-2:111122223333:log-group:/ecs/containerlogs:log-stream:ecs/curl/cd189a933e5849daa93386466019ab50" });
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
         }
     }
 


### PR DESCRIPTION
Towards #1437 

## Changes
- Fix the newer code analysis warnings from .NET 8 SDK
- Here a few common ones:
  - [CA1859](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859) Use concrete types when possible for improved performance
  - [CA1510](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1510) Use ArgumentNullException throw helper
