### PR TITLE
[Instrumentation.AWS] Update AWS SDK references

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated dependency on AWS .NET SDK to version 3.7.100.
+  ([#1454](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1454))
+
 ## 1.1.0-beta.1
 
 Released 2023-Aug-07

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.24" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.27" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.26" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.100" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.100" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100" />
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.1.2" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100" />
     <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes
Update the AWS .NET SDK dependencies for the OpenTelemetry.Instrumentation.AWS package. This is needed because the version that was previously had a max range cap of `3.6` but the SDK has been on version `3.7` since 2021. Without this change users are getting restore warnings whenever they are using an SDK versions released in the last 2 years.

For background purposes I'm a developer of the AWS .NET SDK.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
