### PR TITLE
[Instrumentation.GrpcCore] Update minimal Google.Protobuf to 3.15.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#483](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/483))
 * Update OpenTelemetry.Api to 1.6.0.
   ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
-* **Breaking Change** Drop Support to `Google.Protobuf` older than `3.15.0`.
+*  Update minimal supported  version of `Google.Protobuf` to `3.15.0`.
   ([#1456](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1456))
 
 ## 1.0.0-beta.5

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#483](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/483))
 * Update OpenTelemetry.Api to 1.6.0.
   ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
-*  Update minimal supported  version of `Google.Protobuf` to `3.15.0`.
+* Update minimal supported  version of `Google.Protobuf` to `3.15.0`.
   ([#1456](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1456))
 
 ## 1.0.0-beta.5

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#483](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/483))
 * Update OpenTelemetry.Api to 1.6.0.
   ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+* **Breaking Change** Drop Support to `Google.Protobuf` older than `3.15.0`.
+  ([#1456](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1456))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -7,7 +7,7 @@
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="[3.6.1,4.0)" />
+    <PackageReference Include="Google.Protobuf" Version="[3.15.0,4.0)" />
     <PackageReference Include="Grpc.Core.Api" Version="[2.23.0,3.0)" />
     <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-77rm-9x9h-xj3g - detected by .NET8 local update

## Changes

Update minimal Google.Protobuf to 3.15.0

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
