### PR TITLE
Request to release OpenTelemetry.Instrumentation.AWS package

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.0-beta.2
+
+Released 2023-Dec-04
+
 * Updated dependency on AWS .NET SDK to version 3.7.100.
   ([#1454](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1454))
 

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.1.0-beta.2
 
-Released 2023-Dec-04
+Released 2023-Dec-01
 
 * Updated dependency on AWS .NET SDK to version 3.7.100.
   ([#1454](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1454))


### PR DESCRIPTION
## Changes
Requesting to release OpenTelemetry.Instrumentation.AWS. I need the change to continue some experimenting work I'm trying to do with the new .NET Aspire project with AWS and the AWS .NET SDK.

@open-telemetry/dotnet-contrib-maintainers

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
