### PR TITLE
[Exporter.Geneva] Update Benchmark results

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/LogExporterBenchmarks.cs
@@ -20,25 +20,25 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 
 /*
-BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.101
-  [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                    Method | IncludeFormattedMessage |       Mean |    Error |   StdDev |   Gen0 | Allocated |
-|-------------------------- |------------------------ |-----------:|---------:|---------:|-------:|----------:|
-| LoggerWithMessageTemplate |                   False | 1,221.9 ns | 17.52 ns | 15.53 ns | 0.0153 |     104 B |
-| LoggerWithDirectLoggerAPI |                   False | 1,109.6 ns | 22.14 ns | 34.47 ns | 0.0381 |     240 B |
-| LoggerWithSourceGenerator |                   False | 1,117.7 ns |  9.94 ns |  7.76 ns | 0.0095 |      64 B |
-|        SerializeLogRecord |                   False |   560.0 ns |  2.87 ns |  2.40 ns |      - |         - |
-|                    Export |                   False |   891.0 ns | 17.06 ns | 32.05 ns |      - |         - |
-| LoggerWithMessageTemplate |                    True | 1,243.7 ns | 24.79 ns | 35.55 ns | 0.0153 |     104 B |
-| LoggerWithDirectLoggerAPI |                    True | 1,090.8 ns | 12.85 ns | 10.04 ns | 0.0381 |     240 B |
-| LoggerWithSourceGenerator |                    True | 1,186.1 ns | 23.58 ns | 45.99 ns | 0.0095 |      64 B |
-|        SerializeLogRecord |                    True |   564.8 ns |  5.20 ns |  4.06 ns |      - |         - |
-|                    Export |                    True |   874.5 ns | 17.38 ns | 24.37 ns |      - |         - |
+| Method                    | IncludeFormattedMessage | Mean       | Error    | StdDev   | Median     | Gen0   | Allocated |
+|-------------------------- |------------------------ |-----------:|---------:|---------:|-----------:|-------:|----------:|
+| LoggerWithMessageTemplate | False                   | 1,119.7 ns | 22.42 ns | 29.15 ns | 1,110.3 ns | 0.0153 |     104 B |
+| LoggerWithDirectLoggerAPI | False                   | 1,358.0 ns | 26.31 ns | 33.28 ns | 1,346.6 ns | 0.0496 |     320 B |
+| LoggerWithSourceGenerator | False                   | 1,132.1 ns | 22.30 ns | 18.62 ns | 1,133.8 ns | 0.0095 |      64 B |
+| SerializeLogRecord        | False                   |   455.0 ns |  6.39 ns |  5.97 ns |   454.3 ns |      - |         - |
+| Export                    | False                   | 1,005.3 ns | 19.99 ns | 36.55 ns |   998.9 ns |      - |         - |
+| LoggerWithMessageTemplate | True                    | 1,153.7 ns | 16.13 ns | 14.30 ns | 1,153.6 ns | 0.0153 |     104 B |
+| LoggerWithDirectLoggerAPI | True                    | 1,342.0 ns | 26.39 ns | 29.33 ns | 1,335.7 ns | 0.0496 |     320 B |
+| LoggerWithSourceGenerator | True                    | 1,182.3 ns | 22.21 ns | 19.69 ns | 1,181.2 ns | 0.0095 |      64 B |
+| SerializeLogRecord        | True                    |   455.6 ns |  8.28 ns | 15.56 ns |   450.5 ns |      - |         - |
+| Export                    | True                    |   971.7 ns | 19.47 ns | 44.75 ns |   947.5 ns |      - |         - |
 */
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmark;

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/MetricExporterBenchmarks.cs
@@ -23,31 +23,31 @@ using BenchmarkDotNet.Attributes;
 using OpenTelemetry.Metrics;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23424.1000)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.203
-  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                                                   Method |      Mean |    Error |   StdDev | Allocated |
-|--------------------------------------------------------- |----------:|---------:|---------:|----------:|
-|                      InstrumentWithNoListener3Dimensions |  66.17 ns | 0.316 ns | 0.296 ns |         - |
-|                      InstrumentWithNoListener4Dimensions | 112.15 ns | 0.540 ns | 0.478 ns |         - |
-|                    InstrumentWithWithListener3Dimensions |  70.17 ns | 0.110 ns | 0.097 ns |         - |
-|                    InstrumentWithWithListener4Dimensions | 114.77 ns | 0.343 ns | 0.304 ns |         - |
-|                 InstrumentWithWithDummyReader3Dimensions | 192.32 ns | 0.369 ns | 0.288 ns |         - |
-|                 InstrumentWithWithDummyReader4Dimensions | 261.23 ns | 3.515 ns | 2.745 ns |         - |
-| InstrumentWithWithGenevaCounterMetricExporter3Dimensions | 198.50 ns | 1.153 ns | 1.022 ns |         - |
-| InstrumentWithWithGenevaCounterMetricExporter4Dimensions | 261.38 ns | 1.856 ns | 1.736 ns |         - |
-|                SerializeCounterMetricItemWith3Dimensions | 215.62 ns | 0.759 ns | 0.673 ns |         - |
-|                SerializeCounterMetricItemWith4Dimensions | 241.33 ns | 0.466 ns | 0.364 ns |         - |
-|                   ExportCounterMetricItemWith3Dimensions | 257.88 ns | 0.572 ns | 0.507 ns |         - |
-|                   ExportCounterMetricItemWith4Dimensions | 285.43 ns | 1.300 ns | 1.216 ns |         - |
-|              SerializeHistogramMetricItemWith3Dimensions | 380.58 ns | 6.226 ns | 5.823 ns |         - |
-|              SerializeHistogramMetricItemWith4Dimensions | 404.64 ns | 3.981 ns | 3.723 ns |         - |
-|                 ExportHistogramMetricItemWith3Dimensions | 438.35 ns | 2.442 ns | 2.040 ns |         - |
-|                 ExportHistogramMetricItemWith4Dimensions | 477.16 ns | 2.555 ns | 2.133 ns |         - |
+| Method                                                   | Mean      | Error     | StdDev    | Allocated |
+|--------------------------------------------------------- |----------:|----------:|----------:|----------:|
+| InstrumentWithNoListener3Dimensions                      |  23.83 ns |  0.080 ns |  0.075 ns |         - |
+| InstrumentWithNoListener4Dimensions                      |  56.71 ns |  0.730 ns |  0.647 ns |         - |
+| InstrumentWithWithListener3Dimensions                    |  24.46 ns |  0.257 ns |  0.215 ns |         - |
+| InstrumentWithWithListener4Dimensions                    |  59.02 ns |  0.501 ns |  0.444 ns |         - |
+| InstrumentWithWithDummyReader3Dimensions                 | 139.70 ns |  1.189 ns |  1.113 ns |         - |
+| InstrumentWithWithDummyReader4Dimensions                 | 184.76 ns |  2.012 ns |  1.680 ns |         - |
+| InstrumentWithWithGenevaCounterMetricExporter3Dimensions | 135.76 ns |  0.995 ns |  0.831 ns |         - |
+| InstrumentWithWithGenevaCounterMetricExporter4Dimensions | 193.14 ns |  1.507 ns |  1.336 ns |         - |
+| SerializeCounterMetricItemWith3Dimensions                | 165.27 ns |  1.000 ns |  0.887 ns |         - |
+| SerializeCounterMetricItemWith4Dimensions                | 191.13 ns |  1.201 ns |  1.003 ns |         - |
+| ExportCounterMetricItemWith3Dimensions                   | 657.63 ns | 13.019 ns | 13.369 ns |         - |
+| ExportCounterMetricItemWith4Dimensions                   | 682.76 ns | 13.598 ns | 32.318 ns |         - |
+| SerializeHistogramMetricItemWith3Dimensions              | 285.39 ns |  4.195 ns |  3.503 ns |         - |
+| SerializeHistogramMetricItemWith4Dimensions              | 303.15 ns |  3.834 ns |  3.587 ns |         - |
+| ExportHistogramMetricItemWith3Dimensions                 | 803.90 ns | 14.753 ns | 36.465 ns |         - |
+| ExportHistogramMetricItemWith4Dimensions                 | 810.62 ns | 14.445 ns | 11.278 ns |         - |
 */
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmark;

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/SerializationBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/SerializationBenchmarks.cs
@@ -21,25 +21,25 @@ using OpenTelemetry.Exporter.Geneva.External;
 using OpenTelemetry.Exporter.Geneva.TldExporter;
 
 /*
-BenchmarkDotNet=v0.13.3, OS=Windows 11 (10.0.22621.963)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.101
-  [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                         Method |      Mean |     Error |    StdDev | Allocated |
+| Method                         | Mean      | Error     | StdDev    | Allocated |
 |------------------------------- |----------:|----------:|----------:|----------:|
-|             TLD_SerializeUInt8 | 22.483 ns | 0.0216 ns | 0.0202 ns |         - |
-|         MsgPack_SerializeUInt8 |  7.360 ns | 0.0135 ns | 0.0127 ns |         - |
-|       TLD_SerializeAsciiString | 31.141 ns | 0.0210 ns | 0.0176 ns |         - |
-|   MsgPack_SerializeAsciiString | 19.580 ns | 0.0412 ns | 0.0385 ns |         - |
-|  TLD_SerializeUnicodeSubString | 41.064 ns | 0.0708 ns | 0.0662 ns |         - |
-|     TLD_SerializeUnicodeString | 41.889 ns | 0.0927 ns | 0.0868 ns |         - |
-| MsgPack_SerializeUnicodeString | 21.806 ns | 0.0281 ns | 0.0249 ns |         - |
-|          TLD_SerializeDateTime | 45.321 ns | 0.1321 ns | 0.1235 ns |         - |
-|      MsgPack_SerializeDateTime | 30.667 ns | 0.0401 ns | 0.0356 ns |         - |
-|                      TLD_Reset | 12.739 ns | 0.0351 ns | 0.0328 ns |         - |
+| TLD_SerializeUInt8             | 16.721 ns | 0.1541 ns | 0.1441 ns |         - |
+| MsgPack_SerializeUInt8         |  7.470 ns | 0.0854 ns | 0.0799 ns |         - |
+| TLD_SerializeAsciiString       | 25.828 ns | 0.3779 ns | 0.3535 ns |         - |
+| MsgPack_SerializeAsciiString   | 16.779 ns | 0.0421 ns | 0.0328 ns |         - |
+| TLD_SerializeUnicodeSubString  | 35.224 ns | 0.2928 ns | 0.2596 ns |         - |
+| TLD_SerializeUnicodeString     | 33.503 ns | 0.3786 ns | 0.3541 ns |         - |
+| MsgPack_SerializeUnicodeString | 19.173 ns | 0.1042 ns | 0.0924 ns |         - |
+| TLD_SerializeDateTime          | 36.896 ns | 0.2391 ns | 0.2119 ns |         - |
+| MsgPack_SerializeDateTime      | 30.335 ns | 0.1765 ns | 0.1651 ns |         - |
+| TLD_Reset                      |  7.856 ns | 0.0453 ns | 0.0379 ns |         - |
 */
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmark;

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDLogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDLogExporterBenchmarks.cs
@@ -22,19 +22,19 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
 
 /*
-BenchmarkDotNet=v0.13.3, OS=Windows 11 (10.0.22621.963)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.101
-  [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                     Method |     Mean |   Error |  StdDev | Allocated |
-|--------------------------- |---------:|--------:|--------:|----------:|
-| MsgPack_SerializeLogRecord | 560.9 ns | 2.92 ns | 2.44 ns |         - |
-|     TLD_SerializeLogRecord | 357.5 ns | 1.01 ns | 0.89 ns |         - |
-|    MsgPack_ExportLogRecord | 957.2 ns | 3.47 ns | 3.25 ns |         - |
-|        TLD_ExportLogRecord | 732.0 ns | 2.04 ns | 1.71 ns |         - |
+| Method                     | Mean       | Error    | StdDev   | Allocated |
+|--------------------------- |-----------:|---------:|---------:|----------:|
+| MsgPack_SerializeLogRecord |   441.4 ns |  3.19 ns |  2.99 ns |         - |
+| TLD_SerializeLogRecord     |   263.5 ns |  2.93 ns |  2.75 ns |         - |
+| MsgPack_ExportLogRecord    | 1,039.3 ns | 20.55 ns | 46.81 ns |         - |
+| TLD_ExportLogRecord        |   890.5 ns | 17.48 ns | 25.07 ns |         - |
 */
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmark;

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDTraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TLDTraceExporterBenchmarks.cs
@@ -21,19 +21,19 @@ using OpenTelemetry.Exporter.Geneva.TldExporter;
 using OpenTelemetry.Trace;
 
 /*
-BenchmarkDotNet=v0.13.3, OS=Windows 11 (10.0.22621.963)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.101
-  [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                    Method |     Mean |   Error |  StdDev | Allocated |
-|-------------------------- |---------:|--------:|--------:|----------:|
-| MsgPack_SerializeActivity | 300.3 ns | 1.14 ns | 1.07 ns |         - |
-|     TLD_SerializeActivity | 371.0 ns | 0.70 ns | 0.66 ns |         - |
-|    MsgPack_ExportActivity | 680.2 ns | 1.73 ns | 1.62 ns |         - |
-|        TLD_ExportActivity | 729.5 ns | 4.78 ns | 4.24 ns |         - |
+| Method                    | Mean     | Error    | StdDev   | Allocated |
+|-------------------------- |---------:|---------:|---------:|----------:|
+| MsgPack_SerializeActivity | 266.4 ns |  3.84 ns |  3.59 ns |         - |
+| TLD_SerializeActivity     | 298.9 ns |  1.99 ns |  1.66 ns |         - |
+| MsgPack_ExportActivity    | 787.3 ns | 15.70 ns | 31.71 ns |         - |
+| TLD_ExportActivity        | 878.6 ns |  9.84 ns |  9.20 ns |         - |
 */
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmark;

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmark/Exporter/TraceExporterBenchmarks.cs
@@ -20,18 +20,18 @@ using BenchmarkDotNet.Attributes;
 using OpenTelemetry.Trace;
 
 /*
-BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.101
-  [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                           Method |     Mean |    Error |   StdDev |   Median |   Gen0 | Allocated |
-|--------------------------------- |---------:|---------:|---------:|---------:|-------:|----------:|
-|                   ExportActivity | 566.3 ns |  3.13 ns |  2.44 ns | 565.9 ns |      - |         - |
-|                SerializeActivity | 313.3 ns |  1.71 ns |  1.60 ns | 313.0 ns |      - |         - |
-| CreateActivityWithGenevaExporter | 940.5 ns | 18.77 ns | 54.14 ns | 911.4 ns | 0.0648 |     416 B |
+| Method                           | Mean       | Error    | StdDev   | Gen0   | Allocated |
+|--------------------------------- |-----------:|---------:|---------:|-------:|----------:|
+| ExportActivity                   |   847.1 ns | 16.34 ns | 22.36 ns |      - |         - |
+| SerializeActivity                |   261.5 ns |  2.91 ns |  2.58 ns |      - |         - |
+| CreateActivityWithGenevaExporter | 1,066.0 ns | 20.98 ns | 56.35 ns | 0.0648 |     416 B |
 */
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmark;


### PR DESCRIPTION
## Changes
- Update Benchmark results

The benchmarks were run with an ETW listener running in parallel. This is done to measure the true cost of exporting telemetry.
