### PR TITLE
Remove Moq from Instrumentation.Cassandra.Tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Cassandra.Tests/OpenTelemetry.Instrumentation.Cassandra.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Cassandra.Tests/OpenTelemetry.Instrumentation.Cassandra.Tests.csproj
@@ -7,7 +7,6 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsOptionsPkgVer)" />


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1467

Remove the Moq library from the Instrumentation.Cassandra.Tests project.

## Changes

- Removed Moq dependency