### PR TITLE
Remove Moq from Instrumentation.ElasticsearchClient.Tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="NEST" Version="7.9.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1467

Remove the Moq library from the Instrumentation.ElasticsearchClient.Tests project.

## Changes

- Updated unit tests
- Removed Moq dependency
