### PR TITLE
Remove Moq from Instrumentation.Wcf.Tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
@@ -11,10 +11,6 @@
     <EmbeddedResource Include="certificate.pfx" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.ServiceModel" />


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1467

Remove the Moq library from the Instrumentation.Wcf.Tests project.

## Changes

- Removed Moq dependency
