### PR TITLE
Remove Moq from ResourceDetectors.AWS.Tests

### DIFF
--- a/test/OpenTelemetry.ResourceDetectors.AWS.Tests/Http/ServerCertificateValidationProviderTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.AWS.Tests/Http/ServerCertificateValidationProviderTests.cs
@@ -4,7 +4,6 @@
 #if !NETFRAMEWORK
 
 using System.Security.Cryptography.X509Certificates;
-using Moq;
 using OpenTelemetry.ResourceDetectors.AWS.Http;
 using Xunit;
 
@@ -12,7 +11,7 @@ namespace OpenTelemetry.ResourceDetectors.AWS.Tests.Http;
 
 public class ServerCertificateValidationProviderTests
 {
-    private const string InvalidCertificateName = "invalidcert";
+    private const string InvalidCertificateName = "invalidCert";
 
     [Fact]
     public void TestValidCertificate()
@@ -54,7 +53,7 @@ public class ServerCertificateValidationProviderTests
             ServerCertificateValidationProvider.FromCertificateFile(certificateUploader.FilePath);
 
         Assert.NotNull(serverCertificateValidationProvider);
-        Assert.False(serverCertificateValidationProvider.ValidationCallback(this, null, Mock.Of<X509Chain>(), default));
+        Assert.False(serverCertificateValidationProvider.ValidationCallback(this, null, new X509Chain(), default));
     }
 
     [Fact]
@@ -67,7 +66,7 @@ public class ServerCertificateValidationProviderTests
             ServerCertificateValidationProvider.FromCertificateFile(certificateUploader.FilePath);
 
         Assert.NotNull(serverCertificateValidationProvider);
-        Assert.False(serverCertificateValidationProvider.ValidationCallback(this, Mock.Of<X509Certificate2>(), null, default));
+        Assert.False(serverCertificateValidationProvider.ValidationCallback(this, new X509Certificate2(certificateUploader.FilePath), null, default));
     }
 }
 

--- a/test/OpenTelemetry.ResourceDetectors.AWS.Tests/OpenTelemetry.ResourceDetectors.AWS.Tests.csproj
+++ b/test/OpenTelemetry.ResourceDetectors.AWS.Tests/OpenTelemetry.ResourceDetectors.AWS.Tests.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="$(MoqPkgVer)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.ResourceDetectors.AWS\OpenTelemetry.ResourceDetectors.AWS.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1467

Remove the Moq library from the ResourceDetectors.AWS.Tests project.

## Changes


- Updated unit tests
- Removed Moq dependency