### PR TITLE
Hangfire: Downgrade OpenTelemetry.Api.ProviderBuilderExtensions to 1.6.0 to avoid MS.Extensions.* v8 dependencies

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Downgrade `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.6.0` to avoid
+  `Microsoft.Extensions.*` v8 dependencies.
+  ([#1502](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1502))
+
 * Update `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.7.0`.
   * Update `OpenTelemetry.Api` to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-* Update `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.7.0`.
-  * Update `OpenTelemetry.Api` to `1.7.0`.
-  ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
+* Update `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.6.0`.
+  * Update `OpenTelemetry.Api` to `1.6.0`.
+  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
 
 * Added overloads which accept a name to the `TracerProviderBuilder`
   `HangfireInstrumentationOptions` extension to allow for more fine-grained
@@ -13,10 +13,6 @@
 
 * Add Filter to HangfireInstrumentationOptions.
   ([#1440](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1440))
-
-* Downgrade `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.6.0`.
-  * Downgrade `OpenTelemetry.Api` to `1.6.0`.
-  ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1502))
 
 ## 1.5.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-* Downgrade `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.6.0` to avoid
-  `Microsoft.Extensions.*` v8 dependencies.
-  ([#1502](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1502))
-
 * Update `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.7.0`.
   * Update `OpenTelemetry.Api` to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
@@ -17,6 +13,10 @@
 
 * Add Filter to HangfireInstrumentationOptions.
   ([#1440](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1440))
+
+* Downgrade `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.6.0`.
+  * Downgrade `OpenTelemetry.Api` to `1.6.0`.
+  ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1502))
 
 ## 1.5.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Update `OpenTelemetry.Api.ProviderBuilderExtensions` to `1.6.0`.
   * Update `OpenTelemetry.Api` to `1.6.0`.
-  ([#1344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1344))
+  ([#1502](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1502))
 
 * Added overloads which accept a name to the `TracerProviderBuilder`
   `HangfireInstrumentationOptions` extension to allow for more fine-grained

--- a/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" Version="[1.7.0,1.9.0)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPkgVer)" />
-    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="[1.6.0,2.0)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />


### PR DESCRIPTION
Fixes #1500.

## Changes

Temporarily downgrading the OTel dependency. The version will be restored after the instrumentation release.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
