### PR TITLE
[Exporter.Geneva] Perf improvement on .NET 8

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackExporter.cs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
 internal abstract class MsgPackExporter
 {
-    internal static readonly IReadOnlyDictionary<string, string> V40_PART_A_MAPPING = new Dictionary<string, string>
+    internal static readonly IReadOnlyDictionary<string, string> PART_A_MAPPING_DICTIONARY = new Dictionary<string, string>
     {
         // Part A
         [Schema.V40.PartA.IKey] = "env_iKey",
@@ -29,6 +32,12 @@ internal abstract class MsgPackExporter
         [Schema.V40.PartA.Extensions.Os.Name] = "env_os_name",
         [Schema.V40.PartA.Extensions.Os.Ver] = "env_os_ver",
     };
+
+#if NET8_0_OR_GREATER
+    internal static readonly IReadOnlyDictionary<string, string> V40_PART_A_MAPPING = PART_A_MAPPING_DICTIONARY.ToFrozenDictionary();
+#else
+    internal static readonly IReadOnlyDictionary<string, string> V40_PART_A_MAPPING = PART_A_MAPPING_DICTIONARY;
+#endif
 
     protected static int AddPartAField(byte[] buffer, int cursor, string name, object value)
     {

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -25,8 +28,15 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
 
     private readonly bool m_shouldExportEventName;
     private readonly TableNameSerializer m_tableNameSerializer;
+
+#if NET8_0_OR_GREATER
+    private readonly FrozenSet<string> m_customFields;
+    private readonly FrozenDictionary<string, object> m_prepopulatedFields;
+#else
     private readonly HashSet<string> m_customFields;
     private readonly Dictionary<string, object> m_prepopulatedFields;
+#endif
+
     private readonly ExceptionStackExportMode m_exportExceptionStack;
     private readonly List<string> m_prepopulatedFieldKeys;
     private readonly byte[] m_bufferEpilogue;
@@ -77,7 +87,11 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
                 this.m_prepopulatedFieldKeys.Add(kv.Key);
             }
 
+#if NET8_0_OR_GREATER
+            this.m_prepopulatedFields = tempPrepopulatedFields.ToFrozenDictionary(StringComparer.Ordinal);
+#else
             this.m_prepopulatedFields = tempPrepopulatedFields;
+#endif
         }
 
         // TODO: Validate custom fields (reserved name? etc).
@@ -89,7 +103,11 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
                 customFields.Add(name);
             }
 
+#if NET8_0_OR_GREATER
+            this.m_customFields = customFields.ToFrozenSet(StringComparer.Ordinal);
+#else
             this.m_customFields = customFields;
+#endif
         }
 
         var buffer = new byte[BUFFER_SIZE];

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -239,7 +242,11 @@ public class GenevaTraceExporterTests
             }
 
             using var exporter = new MsgPackTraceExporter(exporterOptions);
+#if NET8_0_OR_GREATER
+            var dedicatedFields = typeof(MsgPackTraceExporter).GetField("m_dedicatedFields", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(exporter) as FrozenSet<string>;
+#else
             var dedicatedFields = typeof(MsgPackTraceExporter).GetField("m_dedicatedFields", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(exporter) as HashSet<string>;
+#endif
             var CS40_PART_B_MAPPING = typeof(MsgPackTraceExporter).GetField("CS40_PART_B_MAPPING", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as IReadOnlyDictionary<string, string>;
             var m_buffer = typeof(MsgPackTraceExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(exporter) as ThreadLocal<byte[]>;
 
@@ -563,7 +570,9 @@ public class GenevaTraceExporterTests
         return callingMethodName;
     }
 
-    private void AssertFluentdForwardModeForActivity(GenevaExporterOptions exporterOptions, object fluentdData, Activity activity, IReadOnlyDictionary<string, string> CS40_PART_B_MAPPING, HashSet<string> dedicatedFields, Action<Dictionary<object, object>> customChecksForActivity)
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+    private void AssertFluentdForwardModeForActivity(GenevaExporterOptions exporterOptions, object fluentdData, Activity activity, IReadOnlyDictionary<string, string> CS40_PART_B_MAPPING, ISet<string> dedicatedFields, Action<Dictionary<object, object>> customChecksForActivity)
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
     {
         /* Fluentd Forward Mode:
         [


### PR DESCRIPTION
## Changes
- Use `FrozenSet` and `FrozenDictionary` on .NET 8 target

When the keys are known beforehand, `FrozenSet` and `FrozenDictioanry` offer better performance than `HashSet` and `Dictionary`. Check this blog post for more details: https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#frozen-collections

I did some benchmarking for both Activity and Logs with seven tags/attributes and GenevaExporter configured to have three `CustomFields`. Every tag/attribute has to be looked up against a dictionary to find out if it matches a dedicated field or one of the user-provided custom fields. For Logs, there is also a lookup cost for prepopulated fields and Part A names.

The below benchmarks provide a **~20%** improvement in serialization performance for seven tags/attributes. The perf improvement would be even more when there are more tags/attributes.

### Benchmark results

BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 7.0.14 (7.0.1423.51910), X64 RyuJIT AVX2
  Job-IUUTBF : .NET 7.0.14 (7.0.1423.51910), X64 RyuJIT AVX2
  Job-QQVGBM : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

<details>
<summary><b>Trace Benchmarks Code</b></summary>

```csharp
using System.Collections.Generic;
using System.Diagnostics;
using BenchmarkDotNet.Attributes;

namespace OpenTelemetry.Exporter.Geneva.Benchmark;

[MemoryDiagnoser]
public class TraceExporterBenchmarks
{
    private readonly Activity activity;
    private readonly MsgPackTraceExporter exporter;
    private readonly ActivitySource activitySource = new ActivitySource("OpenTelemetry.Exporter.Geneva.Benchmark");

    public TraceExporterBenchmarks()
    {
        Activity.DefaultIdFormat = ActivityIdFormat.W3C;

        #region Create activity to be used for Serialize and Export benchmark methods
        var activityListener = new ActivityListener
        {
            ActivityStarted = null,
            ActivityStopped = null,
            ShouldListenTo = (activitySource) => activitySource.Name == this.activitySource.Name,
            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
        };

        ActivitySource.AddActivityListener(activityListener);

        using (var testActivity = this.activitySource.StartActivity("Benchmark"))
        {
            this.activity = testActivity;
            this.activity.SetTag("tagKey1", "tagValue1");
            this.activity.SetTag("tagKey2", "tagValue2");
            this.activity.SetTag("tagKey3", "tagValue3");
            this.activity.SetTag("tagKey4", "tagValue4");
            this.activity.SetTag("tagKey5", "tagValue5");
            this.activity.SetTag("tagKey6", "tagValue6");
            this.activity.SetTag("tagKey7", "tagValue7");
        }

        activityListener.Dispose();
        #endregion

#pragma warning disable CA1861 // Avoid constant arrays as arguments
        this.exporter = new MsgPackTraceExporter(new GenevaExporterOptions
        {
            ConnectionString = "EtwSession=OpenTelemetry",
            PrepopulatedFields = new Dictionary<string, object>
            {
                ["cloud.role"] = "BusyWorker",
                ["cloud.roleInstance"] = "CY1SCH030021417",
                ["cloud.roleVer"] = "9.0.15289.2",
            },
            CustomFields = new string[] { "tagKey1", "tagKey2", "tagKey3" },
        });
#pragma warning restore CA1861 // Avoid constant arrays as arguments
    }

    [Benchmark]
    public void SerializeActivity()
    {
        this.exporter.SerializeActivity(this.activity);
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        this.activity.Dispose();
        this.activitySource.Dispose();
        this.exporter.Dispose();
    }
}
```
</details>

| Method            | Runtime  | Mean     | Error   | StdDev  | Ratio | Allocated |
|------------------ |--------- |---------:|--------:|--------:|------:|----------:|
| SerializeActivity | .NET 7.0 | 902.3 ns | 7.09 ns | 6.64 ns |  1.00 |         - | 
| SerializeActivity | .NET 8.0 | 728.8 ns | 3.77 ns | 2.94 ns |  0.81 |         - | 


<details>
<summary><b>Log Benchmarks Code</b></summary>

```csharp
using System.Collections.Generic;
using BenchmarkDotNet.Attributes;
using Microsoft.Extensions.Logging;
using OpenTelemetry.Logs;

namespace OpenTelemetry.Exporter.Geneva.Benchmark;

[MemoryDiagnoser]
public class LogExporterBenchmarks
{
    private readonly MsgPackLogExporter exporter;
    private readonly LogRecord logRecord;

    public LogExporterBenchmarks()
    {
        this.logRecord = GenerateTestLogRecord();

#pragma warning disable CA1861 // Avoid constant arrays as arguments
        this.exporter = new MsgPackLogExporter(new GenevaExporterOptions
        {
            ConnectionString = "EtwSession=OpenTelemetry",
            PrepopulatedFields = new Dictionary<string, object>
            {
                ["cloud.role"] = "BusyWorker",
                ["cloud.roleInstance"] = "CY1SCH030021417",
                ["cloud.roleVer"] = "9.0.15289.2",
            },
            CustomFields = new string[] { "Testkey1", "Testkey2", "Testkey3" },
        });
#pragma warning restore CA1861 // Avoid constant arrays as arguments
    }

    [Benchmark]
    public void SerializeLogRecord()
    {
        this.exporter.SerializeLogRecord(this.logRecord);
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        this.exporter.Dispose();
    }

    private static LogRecord GenerateTestLogRecord()
    {
        var items = new List<LogRecord>(1);
        using var factory = LoggerFactory.Create(builder => builder
            .AddOpenTelemetry(loggerOptions =>
            {
                loggerOptions.AddInMemoryExporter(items);
            }));

        var logger = factory.CreateLogger("TestLogger");
        LoggerTest.SayHello(logger, "testValue1", "testValue2", "testValue3", "testValue4", "testValue5", "testValue6", "testValue7");
        return items[0];
    }
}

#pragma warning disable SA1402 // File may only contain a single type
public static partial class LoggerTest
#pragma warning restore SA1402 // File may only contain a single type
{
    [LoggerMessage(
        EventId = 0,
        Level = LogLevel.Information,
        Message = "Hello from {Testkey1} {Testkey2} {Testkey3} {Testkey4} {Testkey5} {Testkey6} {Testkey7}.")]
    public static partial void SayHello(
        ILogger logger, string Testkey1, string Testkey2, string Testkey3, string Testkey4, string Testkey5, string Testkey6, string Testkey7);
}
```
</details>

| Method             | Runtime  | Mean       | Error   | StdDev  | Ratio | Allocated |
|------------------- |--------- |-----------:|--------:|--------:|------:|----------:|
| SerializeLogRecord | .NET 7.0 | 1,114.2 ns | 3.45 ns | 2.88 ns |  1.00 |         - |
| SerializeLogRecord | .NET 8.0 |   905.2 ns | 3.31 ns | 3.10 ns |  0.81 |         - |