### PR TITLE
[Instrumentation.AspNet] Update CHANGELOG for 1.7.0-beta.1 release

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.7.0-beta.1
 
-Released 2023-Dec-19
+Released 2023-Dec-20
 
 * Update `OpenTelemetry.Api` to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.0-beta.1
+
+Released 2023-Dec-19
+
 * Update `OpenTelemetry.Api` to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.7.0-beta.1
 
-Released 2023-Dec-19
+Released 2023-Dec-20
 
 * Added enrich functionality to metric instrumentation
   ([#1407](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1407)).

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.0-beta.1
+
+Released 2023-Dec-19
+
 * Added enrich functionality to metric instrumentation
   ([#1407](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1407)).
 


### PR DESCRIPTION
Update CHANGELOG for AspNet and AspNet.TelemetryHttpModule instrumentation to 1.7.0-beta.1.

- Followed pattern from previous release PR [here](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1427).
- Primary reason for requesting a release is to enable the currently unreleased Enrich() functionality tracked in this issue: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1226
