### PR TITLE
ResourceDetectors - Process

### DIFF
--- a/.github/ISSUE_TEMPLATE/comp_resourcedetectors_process.md
+++ b/.github/ISSUE_TEMPLATE/comp_resourcedetectors_process.md
@@ -1,0 +1,41 @@
+---
+name: OpenTelemetry.ResourceDetectors.Process
+about: OpenTelemetry.ResourceDetectors.Process
+labels: comp:resourcedetectors.process
+---
+
+# Issue with OpenTelemetry.ResourceDetectors.Process
+
+List of [all OpenTelemetry NuGet
+packages](https://www.nuget.org/profiles/OpenTelemetry) and version that you are
+using (e.g. `OpenTelemetry 1.3.2`):
+
+* TBD
+
+Runtime version (e.g. `net462`, `net48`, `net6.0`, `net7.0` etc. You can
+find this information from the `*.csproj` file):
+
+* TBD
+
+**Is this a feature request or a bug?**
+
+* [ ] Feature Request
+* [ ] Bug
+
+**What is the expected behavior?**
+
+What do you expect to see?
+
+**What is the actual behavior?**
+
+What did you see instead? If you are reporting a bug, create a self-contained
+project using the template of your choice and apply the minimum required code to
+result in the issue you're observing. We will close this issue if:
+
+* The repro project you share with us is complex. We can't investigate custom
+  projects, so don't point us to such, please.
+* If we can not reproduce the behavior you're reporting.
+
+## Additional Context
+
+Add any other context about the feature request here.

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -99,6 +99,11 @@ flags:
     paths:
       - src/OpenTelemetry.ResourceDetectors.Azure
 
+  unittests-ResourceDetectors.Process:
+    carryforward: true
+    paths:
+      - src/OpenTelemetry.ResourceDetectors.Process
+
   unittests-ResourceDetectors.ProcessRuntime:
     carryforward: true
     paths:

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -65,6 +65,9 @@ components:
     - vishweshbankwar
   src/OpenTelemetry.ResourceDetectors.Container/:
     - iskiselev
+  src/OpenTelemetry.ResourceDetectors.Process/:
+    - Kielek
+    - lachmatt
   src/OpenTelemetry.ResourceDetectors.ProcessRuntime/:
     - Kielek
     - lachmatt
@@ -144,6 +147,9 @@ components:
     - vishweshbankwar
   test/OpenTelemetry.ResourceDetectors.Container.Tests/:
     - iskiselev
+  test/OpenTelemetry.ResourceDetectors.Process.Tests/:
+    - Kielek
+    - lachmatt
   test/OpenTelemetry.ResourceDetectors.ProcessRuntime.Tests/:
     - Kielek
     - lachmatt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
           owin: ['*/OpenTelemetry.Instrumentation.Owin*/**', 'examples/owin/**', '!**/*.md']
           persistentstorage: ['*/OpenTelemetry.PersistentStorage*/**', '!**/*.md']
           process: ['*/OpenTelemetry.Instrumentation.Process*/**', 'examples/process-instrumentation/**', '!**/*.md']
-          processruntime: ['*/OpenTelemetry.ResourceDetectors.ProcessRuntime*/**', '!**/*.md']
+          processdetector: ['*/OpenTelemetry.ResourceDetectors.Process/**', '*/OpenTelemetry.ResourceDetectors.Process.Tests/**', '!**/*.md']
+          processruntime: ['*/OpenTelemetry.ResourceDetectors.ProcessRuntime/**', '*/OpenTelemetry.ResourceDetectors.ProcessRuntime.Tests/**', '!**/*.md']
           redis: ['*/OpenTelemetry.Instrumentation.StackExchangeRedis*/**', 'examples/redis/**', '!**/*.md']
           runtime: ['*/OpenTelemetry.Instrumentation.Runtime*/**', 'examples/runtime-instrumentation/**', '!**/*.md']
           wcf: ['*/OpenTelemetry.Instrumentation.Wcf*/**', 'examples/wcf/**', '!**/*.md']
@@ -43,7 +44,10 @@ jobs:
             '!*/OpenTelemetry.Instrumentation.AspNet*/**',
             '!examples/AspNet/**',
             '!*/OpenTelemetry.ResourceDetectors.Azure*/**',
-            '!*/OpenTelemetry.ResourceDetectors.ProcessRuntime*/**',
+            '!*/OpenTelemetry.ResourceDetectors.Process/**',
+            '!*/OpenTelemetry.ResourceDetectors.Process.Tests/**',
+            '!*/OpenTelemetry.ResourceDetectors.ProcessRuntime/**',
+            '!*/OpenTelemetry.ResourceDetectors.ProcessRuntime.Tests/**',
             '!*/OpenTelemetry.Instrumentation.EventCounters*/**',
             '!examples/event-counters/**',
             '!*/OpenTelemetry.Extensions/**',
@@ -178,6 +182,17 @@ jobs:
       project-name: OpenTelemetry.Instrumentation.Process
       code-cov-name: Instrumentation.Process
 
+  build-test-processdetector:
+    needs: detect-changes
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'processdetector')
+      || contains(needs.detect-changes.outputs.changes, 'build')
+      || contains(needs.detect-changes.outputs.changes, 'shared')
+    uses: ./.github/workflows/Component.BuildTest.yml
+    with:
+      project-name: OpenTelemetry.ResourceDetectors.Process
+      code-cov-name: ResourceDetectors.Process
+
   build-test-processruntime:
     needs: detect-changes
     if: |
@@ -272,6 +287,7 @@ jobs:
             OpenTelemetry.Instrumentation.Wcf.Tests.csproj,
             OpenTelemetry.PersistentStorage.FileSystem.Tests.csproj,
             OpenTelemetry.ResourceDetectors.Azure.Tests.csproj,
+            OpenTelemetry.ResourceDetectors.Process.Tests.csproj,
             OpenTelemetry.ResourceDetectors.ProcessRuntime.Tests.csproj
 
         $failedProjects = @()
@@ -314,6 +330,7 @@ jobs:
       contains(needs.detect-changes.outputs.changes, 'eventcounters')
       || contains(needs.detect-changes.outputs.changes, 'runtime')
       || contains(needs.detect-changes.outputs.changes, 'azure')
+      || contains(needs.detect-changes.outputs.changes, 'processdetector')
       || contains(needs.detect-changes.outputs.changes, 'processruntime')
       || contains(needs.detect-changes.outputs.changes, 'aottestapp')
       || contains(needs.detect-changes.outputs.changes, 'build')
@@ -336,6 +353,7 @@ jobs:
       build-test-owin,
       build-test-persistentstorage,
       build-test-process,
+      build-test-processdetector,
       build-test-processruntime,
       build-test-redis,
       build-test-redis-integration,

--- a/.github/workflows/package-ResourceDetectors.Process.yml
+++ b/.github/workflows/package-ResourceDetectors.Process.yml
@@ -1,0 +1,21 @@
+name: Pack OpenTelemetry.ResourceDetectors.Process
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+  push:
+    tags:
+      - 'ResourceDetectors.Process-*' # trigger when we create a tag with prefix "ResourceDetectors.Process-"
+
+jobs:
+  call-build-test-pack:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/Component.Package.yml
+    with:
+      project-name: OpenTelemetry.ResourceDetectors.Process
+    secrets: inherit

--- a/build/Projects/OpenTelemetry.ResourceDetectors.Process.proj
+++ b/build/Projects/OpenTelemetry.ResourceDetectors.Process.proj
@@ -1,0 +1,32 @@
+<Project>
+
+  <PropertyGroup>
+    <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.Parent.FullName)</RepoRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.ResourceDetectors.Process\OpenTelemetry.ResourceDetectors.Process.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.ResourceDetectors.Process.Tests\OpenTelemetry.ResourceDetectors.Process.Tests.csproj" />
+
+    <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.ResourceDetectors.Process\OpenTelemetry.ResourceDetectors.Process.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.ResourceDetectors.Process.Tests\OpenTelemetry.ResourceDetectors.Process.Tests.csproj" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <MSBuild Projects="@(SolutionProjects)" Targets="Build" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(SolutionProjects)" Targets="Restore" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="Pack">
+    <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+</Project>

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -67,6 +67,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\package-ResourceDetectors.AWS.yml = .github\workflows\package-ResourceDetectors.AWS.yml
 		.github\workflows\package-ResourceDetectors.Azure.yml = .github\workflows\package-ResourceDetectors.Azure.yml
 		.github\workflows\package-ResourceDetectors.Container.yml = .github\workflows\package-ResourceDetectors.Container.yml
+		.github\workflows\package-ResourceDetectors.Process.yml = .github\workflows\package-ResourceDetectors.Process.yml
 		.github\workflows\package-ResourceDetectors.ProcessRuntime.yml = .github\workflows\package-ResourceDetectors.ProcessRuntime.yml
 		.github\workflows\package-Sampler.AWS.yml = .github\workflows\package-Sampler.AWS.yml
 		.github\workflows\sanitycheck.yml = .github\workflows\sanitycheck.yml
@@ -322,12 +323,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{04
 		build\Projects\OpenTelemetry.Instrumentation.Wcf.proj = build\Projects\OpenTelemetry.Instrumentation.Wcf.proj
 		build\Projects\OpenTelemetry.PersistentStorage.proj = build\Projects\OpenTelemetry.PersistentStorage.proj
 		build\Projects\OpenTelemetry.ResourceDetectors.Azure.proj = build\Projects\OpenTelemetry.ResourceDetectors.Azure.proj
+		build\Projects\OpenTelemetry.ResourceDetectors.Process.proj = build\Projects\OpenTelemetry.ResourceDetectors.Process.proj
 		build\Projects\OpenTelemetry.ResourceDetectors.ProcessRuntime.proj = build\Projects\OpenTelemetry.ResourceDetectors.ProcessRuntime.proj
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetectors.ProcessRuntime", "src\OpenTelemetry.ResourceDetectors.ProcessRuntime\OpenTelemetry.ResourceDetectors.ProcessRuntime.csproj", "{95372E82-CA5B-4C61-BD6C-74E6AB1970D4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetectors.ProcessRuntime.Tests", "test\OpenTelemetry.ResourceDetectors.ProcessRuntime.Tests\OpenTelemetry.ResourceDetectors.ProcessRuntime.Tests.csproj", "{B6157646-8EBA-464C-99B9-C386D474CB12}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetectors.Process", "src\OpenTelemetry.ResourceDetectors.Process\OpenTelemetry.ResourceDetectors.Process.csproj", "{A5FCDD8F-20FF-4657-804E-707EAD4FE31D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetectors.Process.Tests", "test\OpenTelemetry.ResourceDetectors.Process.Tests\OpenTelemetry.ResourceDetectors.Process.Tests.csproj", "{A5EF701C-439E-407F-8BB4-394166000C6D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -655,6 +661,14 @@ Global
 		{B6157646-8EBA-464C-99B9-C386D474CB12}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6157646-8EBA-464C-99B9-C386D474CB12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6157646-8EBA-464C-99B9-C386D474CB12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5FCDD8F-20FF-4657-804E-707EAD4FE31D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5FCDD8F-20FF-4657-804E-707EAD4FE31D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5FCDD8F-20FF-4657-804E-707EAD4FE31D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5FCDD8F-20FF-4657-804E-707EAD4FE31D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5EF701C-439E-407F-8BB4-394166000C6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5EF701C-439E-407F-8BB4-394166000C6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5EF701C-439E-407F-8BB4-394166000C6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5EF701C-439E-407F-8BB4-394166000C6D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -753,6 +767,8 @@ Global
 		{048509D6-FB49-4B84-832A-90E55520B97B} = {824BD1DE-3FA8-4FE0-823A-FD365EAC78AF}
 		{95372E82-CA5B-4C61-BD6C-74E6AB1970D4} = {22DF5DC0-1290-4E83-A9D8-6BB7DE3B3E63}
 		{B6157646-8EBA-464C-99B9-C386D474CB12} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
+		{A5FCDD8F-20FF-4657-804E-707EAD4FE31D} = {22DF5DC0-1290-4E83-A9D8-6BB7DE3B3E63}
+		{A5EF701C-439E-407F-8BB4-394166000C6D} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}

--- a/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+OpenTelemetry.ResourceDetectors.Process.ProcessDetector
+OpenTelemetry.ResourceDetectors.Process.ProcessDetector.Detect() -> OpenTelemetry.Resources.Resource!
+OpenTelemetry.ResourceDetectors.Process.ProcessDetector.ProcessDetector() -> void

--- a/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.ResourceDetectors.Process/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+OpenTelemetry.ResourceDetectors.Process.ProcessDetector
+OpenTelemetry.ResourceDetectors.Process.ProcessDetector.Detect() -> OpenTelemetry.Resources.Resource!
+OpenTelemetry.ResourceDetectors.Process.ProcessDetector.ProcessDetector() -> void

--- a/src/OpenTelemetry.ResourceDetectors.Process/AssemblyInfo.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Process/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED
+[assembly: InternalsVisibleTo("OpenTelemetry.ResourceDetectors.Process.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]
+#else
+[assembly: InternalsVisibleTo("OpenTelemetry.ResourceDetectors.Process.Tests")]
+#endif

--- a/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+* Initial release of `OpenTelemetry.ResourceDetectors.Process` project
+[1506](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1506)

--- a/src/OpenTelemetry.ResourceDetectors.Process/OpenTelemetry.ResourceDetectors.Process.csproj
+++ b/src/OpenTelemetry.ResourceDetectors.Process/OpenTelemetry.ResourceDetectors.Process.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <Description>OpenTelemetry Extensions - Process Resource Detector.</Description>
+    <MinVerTagPrefix>ResourceDetectors.Process-</MinVerTagPrefix>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+  </ItemGroup>
+</Project>

--- a/src/OpenTelemetry.ResourceDetectors.Process/ProcessDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Process/ProcessDetector.cs
@@ -12,7 +12,7 @@ namespace OpenTelemetry.ResourceDetectors.Process;
 /// <summary>
 ///     Process detector.
 /// </summary>
-public class ProcessDetector : IResourceDetector
+public sealed class ProcessDetector : IResourceDetector
 {
     /// <summary>
     ///     Detects the resource attributes for process.

--- a/src/OpenTelemetry.ResourceDetectors.Process/ProcessDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Process/ProcessDetector.cs
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET6_0_OR_GREATER
+using System;
+#endif
+using System.Collections.Generic;
+using OpenTelemetry.Resources;
+
+namespace OpenTelemetry.ResourceDetectors.Process;
+
+/// <summary>
+///     Process detector.
+/// </summary>
+public class ProcessDetector : IResourceDetector
+{
+    /// <summary>
+    ///     Detects the resource attributes for process.
+    /// </summary>
+    /// <returns>Resource with key-value pairs of resource attributes.</returns>
+    public Resource Detect()
+    {
+        return new Resource(new List<KeyValuePair<string, object>>(1)
+        {
+#if NET6_0_OR_GREATER
+            new(ProcessSemanticConventions.AttributeProcessPid, Environment.ProcessId),
+#else
+            new(ProcessSemanticConventions.AttributeProcessPid, System.Diagnostics.Process.GetCurrentProcess().Id),
+#endif
+        });
+    }
+}

--- a/src/OpenTelemetry.ResourceDetectors.Process/ProcessSemanticConventions.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Process/ProcessSemanticConventions.cs
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.ResourceDetectors.Process;
+
+internal static class ProcessSemanticConventions
+{
+    public const string AttributeProcessPid = "process.pid";
+}

--- a/src/OpenTelemetry.ResourceDetectors.Process/README.md
+++ b/src/OpenTelemetry.ResourceDetectors.Process/README.md
@@ -1,4 +1,4 @@
-# Process Runtime Resource Detectors
+# Process Resource Detectors
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.ResourceDetectors.Process)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.Process)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.ResourceDetectors.Process)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.Process)

--- a/src/OpenTelemetry.ResourceDetectors.Process/README.md
+++ b/src/OpenTelemetry.ResourceDetectors.Process/README.md
@@ -1,0 +1,39 @@
+# Process Runtime Resource Detectors
+
+[![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.ResourceDetectors.Process)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.Process)
+[![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.ResourceDetectors.Process)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.Process)
+
+## Getting Started
+
+You need to install the
+`OpenTelemetry.ResourceDetectors.Process` package to be able to use the
+Process Runtime Resource Detectors.
+
+```shell
+dotnet add package OpenTelemetry.ResourceDetectors.Process --prerelease
+```
+
+## Usage
+
+You can configure Process Runtime resource detector to
+the `TracerProvider` with the following example below.
+
+```csharp
+using OpenTelemetry;
+using OpenTelemetry.ResourceDetectors.Process;
+
+var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                        // other configurations
+                        .ConfigureResource(resource => resource
+                            .AddDetector(new ProcessDetector()))
+                        .Build();
+```
+
+The resource detectors will record the following metadata based on where
+your application is running:
+
+- **ProcessDetector**: `process.pid`.
+
+## References
+
+- [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.ResourceDetectors.Process/README.md
+++ b/src/OpenTelemetry.ResourceDetectors.Process/README.md
@@ -3,6 +3,10 @@
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.ResourceDetectors.Process)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.Process)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.ResourceDetectors.Process)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.Process)
 
+> [!IMPORTANT]
+> Resources detected by this packages are defined by [experimental semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/resource/process.md#process).
+> These resources can be changed without prior notification.
+
 ## Getting Started
 
 You need to install the

--- a/src/OpenTelemetry.ResourceDetectors.ProcessRuntime/ProcessRuntimeDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.ProcessRuntime/ProcessRuntimeDetector.cs
@@ -16,7 +16,7 @@ namespace OpenTelemetry.ResourceDetectors.ProcessRuntime;
 /// <summary>
 /// Process runtime detector.
 /// </summary>
-public class ProcessRuntimeDetector : IResourceDetector
+public sealed class ProcessRuntimeDetector : IResourceDetector
 {
     /// <summary>
     /// Detects the resource attributes from .NET runtime.

--- a/src/OpenTelemetry.ResourceDetectors.ProcessRuntime/README.md
+++ b/src/OpenTelemetry.ResourceDetectors.ProcessRuntime/README.md
@@ -3,6 +3,10 @@
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.ResourceDetectors.ProcessRuntime)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.ProcessRuntime)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.ResourceDetectors.ProcessRuntime)](https://www.nuget.org/packages/OpenTelemetry.ResourceDetectors.ProcessRuntime)
 
+> [!IMPORTANT]
+> Resources detected by this packages are defined by [experimental semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/resource/process.md#process-runtimes).
+> These resources can be changed without prior notification.
+
 ## Getting Started
 
 You need to install the

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -17,6 +17,7 @@
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.EventCounters" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.StackExchangeRedis" />
     <TrimmerRootAssembly Include="OpenTelemetry.ResourceDetectors.Azure" />
+    <TrimmerRootAssembly Include="OpenTelemetry.ResourceDetectors.Process" />
     <TrimmerRootAssembly Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" />
 
     <TrimmerRootAssembly Update="@(TrimmerRootAssembly)" Path="$(RepoRoot)\src\%(Identity)\%(Identity).csproj" />

--- a/test/OpenTelemetry.ResourceDetectors.Process.Tests/OpenTelemetry.ResourceDetectors.Process.Tests.csproj
+++ b/test/OpenTelemetry.ResourceDetectors.Process.Tests/OpenTelemetry.ResourceDetectors.Process.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Unit test project for Process Detector for OpenTelemetry</Description>
+    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
+    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.ResourceDetectors.Process\OpenTelemetry.ResourceDetectors.Process.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.ResourceDetectors.Process.Tests/ProcessDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Process.Tests/ProcessDetectorTests.cs
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using OpenTelemetry.Resources;
+using Xunit;
+
+namespace OpenTelemetry.ResourceDetectors.Process.Tests;
+
+public class ProcessDetectorTests
+{
+    [Fact]
+    public void TestProcessAttributes()
+    {
+        var resource = ResourceBuilder.CreateEmpty().AddDetector(new ProcessDetector()).Build();
+
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
+
+        Assert.Single(resourceAttributes);
+
+        Assert.IsType<long>(resourceAttributes[ProcessSemanticConventions.AttributeProcessPid]);
+    }
+}


### PR DESCRIPTION
Fixes N/A.

## Changes

Initial implementation for `process.pid` detector from https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/process.md#process (this attribute is what I need for now).

The plan is to release shortly as alpha with reference to OTel 1.6.0.
Then create follow up `help-wanted` issue to extend it for another attributes and update OTel to 1.7.0.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* [x] Changes in public API reviewed

## Notes

Previous initial implementation of resource detector: #1449
You can expect one more similar, for https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md, espiecially `host.name`.
