### PR TITLE
Bump OTel to 1.7.0 for ResourceDetectors Host and Process

### DIFF
--- a/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+* Update OpenTelemetry SDK version to `1.7.0`.
+  ([#1518](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1518))
+
 ## 0.1.0-alpha.1
 
 Released 2023-Dec-21
 
 * Initial release of `OpenTelemetry.ResourceDetectors.Host` project
-[1507](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1507)
+  [1507](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1507)

--- a/src/OpenTelemetry.ResourceDetectors.Host/OpenTelemetry.ResourceDetectors.Host.csproj
+++ b/src/OpenTelemetry.ResourceDetectors.Host/OpenTelemetry.ResourceDetectors.Host.csproj
@@ -7,6 +7,6 @@
     <MinVerTagPrefix>ResourceDetectors.Host-</MinVerTagPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+* Update OpenTelemetry SDK version to `1.7.0`.
+  ([#1518](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1518))
+
 ## 0.1.0-alpha.1
 
 Released 2023-Dec-21
 
 * Initial release of `OpenTelemetry.ResourceDetectors.Process` project
-[1506](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1506)
+  [1506](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1506)

--- a/src/OpenTelemetry.ResourceDetectors.Process/OpenTelemetry.ResourceDetectors.Process.csproj
+++ b/src/OpenTelemetry.ResourceDetectors.Process/OpenTelemetry.ResourceDetectors.Process.csproj
@@ -7,6 +7,6 @@
     <MinVerTagPrefix>ResourceDetectors.Process-</MinVerTagPrefix>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1507#discussion_r1433243308 and https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1506#discussion_r1433245459

## Changes

Bump OTel to 1.7.0 for ResourceDetectors Host and Process

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
