### PR TITLE
Releases with OTel 1.7.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.9
+
+Released 2024-Jan-03
+
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.5.0-beta.4
+
+Released 2024-Jan-03
+
 * Update `OpenTelemetry.Api` to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.1
+
+Released 2024-Jan-03
+
 * Fix issue of multiple instances of OpenTelemetry-Instrumentation EventSource
   being created
   ([#1362](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1362))

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.0
+
+Released 2024-Jan-03
+
 * Update `OpenTelemetry.Api` to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc9.13
+
+Released 2024-Jan-03
+
 * Update `OpenTelemetry.Api.ProviderBuilderExtensions` version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc.14
+
+Released 2024-Jan-03
+
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 

--- a/src/OpenTelemetry.ResourceDetectors.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Azure/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.4
+
+Released 2024-Jan-03
+
 * Added NET6 target framework to support Trimming.
   ([#1405](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1405))
 * Update OpenTelemetry SDK version to `1.7.0`.

--- a/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.5
+
+Released 2024-Jan-03
+
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 

--- a/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.2
+
+Released 2024-Jan-03
+
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1518](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1518))
 

--- a/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.2
+
+Released 2023-Jan-03
+
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1518](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1518))
 

--- a/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Process/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.1.0-alpha.2
 
-Released 2023-Jan-03
+Released 2024-Jan-03
 
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1518](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1518))

--- a/src/OpenTelemetry.ResourceDetectors.ProcessRuntime/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.ProcessRuntime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.1.0-alpha.2
+
+Released 2024-Jan-03
+
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/3204

## Changes

Request releases with 1.7.0 for packages used by OTel Auto.

New versions based on the latest versioning. Only exception is for Quartz changed from alpha to beta.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
