### PR TITLE
Minor docs improvement for Geneva Exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -22,13 +22,6 @@ Therefore, each type of telemetry **must be** enabled separately.
 
 ### Enable Logs
 
-Install the latest stable version of
-[`Microsoft.Extensions.Logging`](https://www.nuget.org/packages/Microsoft.Extensions.Logging/)
-
-```shell
-dotnet add package Microsoft.Extensions.Logging
-```
-
 This snippet shows how to configure the Geneva Exporter for Logs
 
 ```csharp


### PR DESCRIPTION
There is no need to explicitly install the latest version of Microsoft.Extensions.Logging since it is covered by the OpenTelemetry SDK https://github.com/open-telemetry/opentelemetry-dotnet/pull/4920.