### PR TITLE
Fix native AoT test scripts

### DIFF
--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         version: [ net8.0 ]
 
     runs-on: ${{ matrix.os }}
@@ -19,4 +19,3 @@ jobs:
     - name: publish AOT testApp, assert static analysis warning count, and run the app
       shell: pwsh
       run: .\build\test-aot-compatibility.ps1 ${{ matrix.version }}
-

--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -10,7 +10,7 @@ $actualWarningCount = 0
 
 foreach ($line in $($publishOutput -split "`r`n"))
 {
-    if ($line -like "*analysis warning IL*") 
+    if (($line -like "*analysis warning IL*") -or ($line -like "*analysis error IL*"))
     {
         Write-Host $line
         $actualWarningCount += 1
@@ -19,6 +19,11 @@ foreach ($line in $($publishOutput -split "`r`n"))
 
 Write-Host "Actual warning count is:", $actualWarningCount
 $expectedWarningCount = 0
+
+if ($LastExitCode -ne 0)
+{
+    Write-Host "There was an error while publishing AotCompatibility Test App. LastExitCode is:", $LastExitCode
+}
 
 pushd $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/$runtime
 

--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -23,6 +23,7 @@ $expectedWarningCount = 0
 if ($LastExitCode -ne 0)
 {
     Write-Host "There was an error while publishing AotCompatibility Test App. LastExitCode is:", $LastExitCode
+    Write-Host $publishOutput
 }
 
 pushd $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/$runtime

--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -26,7 +26,7 @@ if ($LastExitCode -ne 0)
     Write-Host $publishOutput
 }
 
-pushd $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/$runtime
+Push-Location $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/$runtime
 
 Write-Host "Executing test App..."
 $app
@@ -37,7 +37,7 @@ if ($LastExitCode -ne 0)
   Write-Host "There was an error while executing AotCompatibility Test App. LastExitCode is:", $LastExitCode
 }
 
-popd
+Pop-Location
 
 $testPassed = 0
 if ($actualWarningCount -ne $expectedWarningCount)

--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -1,7 +1,10 @@
 param([string]$targetNetFramework)
 
+$runtime = $IsWindows ? "win-x64" : "linux-x64"
+$app = $IsWindows ? "./OpenTelemetry.AotCompatibility.TestApp.exe" : "./OpenTelemetry.AotCompatibility.TestApp"
+
 $rootDirectory = Split-Path $PSScriptRoot -Parent
-$publishOutput = dotnet publish $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj -nodeReuse:false /p:UseSharedCompilation=false
+$publishOutput = dotnet publish $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj --runtime $runtime -nodeReuse:false /p:UseSharedCompilation=false
 
 $actualWarningCount = 0
 
@@ -17,10 +20,10 @@ foreach ($line in $($publishOutput -split "`r`n"))
 Write-Host "Actual warning count is:", $actualWarningCount
 $expectedWarningCount = 0
 
-pushd $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/linux-x64
+pushd $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/$runtime
 
 Write-Host "Executing test App..."
-./OpenTelemetry.AotCompatibility.TestApp
+$app
 Write-Host "Finished executing test App"
 
 if ($LastExitCode -ne 0)

--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -1,10 +1,7 @@
 param([string]$targetNetFramework)
 
-$runtime = $IsWindows ? "win-x64" : "linux-x64"
-$app = $IsWindows ? "./OpenTelemetry.AotCompatibility.TestApp.exe" : "./OpenTelemetry.AotCompatibility.TestApp"
-
 $rootDirectory = Split-Path $PSScriptRoot -Parent
-$publishOutput = dotnet publish $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj --runtime $runtime -nodeReuse:false /p:UseSharedCompilation=false
+$publishOutput = dotnet publish $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj -nodeReuse:false /p:UseSharedCompilation=false
 
 $actualWarningCount = 0
 
@@ -25,6 +22,9 @@ if ($LastExitCode -ne 0)
     Write-Host "There was an error while publishing AotCompatibility Test App. LastExitCode is:", $LastExitCode
     Write-Host $publishOutput
 }
+
+$runtime = $IsWindows ? "win-x64" : ($IsMacOS ? "macos-x64" : "linux-x64")
+$app = $IsWindows ? "./OpenTelemetry.AotCompatibility.TestApp.exe" : "./OpenTelemetry.AotCompatibility.TestApp"
 
 Push-Location $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/$runtime
 

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <PublishAot Condition="!$([MSBuild]::IsOSPlatform('OSX'))">true</PublishAot>
+    <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!--
       When adding projects here please also update the verify-aot-compat job in
-      .github\workflows\ci.yml so that it runs for the project being added.
+      .github\workflows\ci.yml so that it runs for the project(s) being added.
     -->
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions.Enrichment" />


### PR DESCRIPTION
## Changes

- Support the AoT compatibility script being run locally on Windows.
- Fix AoT test script not failing for IL compiler errors, only warnings.
- Fix AoT test script not failing if `dotnet publish` fails.
- .NET 8 supports native AoT publishing on macOS, so remove condition.

Found while looking into an app of mine is getting trim warnings from OpenTelemetry.Instrumentation.AWS to see if they were easy to fix.