### PR TITLE
[Instrumentation.AWS] Bump minimal AWS SDKs to 3.7.300

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated dependency on AWS .NET SDK to version 3.7.300.
+  ([#1542](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1542))
+
 ## 1.1.0-beta.2
 
 Released 2023-Dec-01

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.100" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.100" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.300" />
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.100" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -169,8 +169,7 @@ public class TestAWSClientInstrumentation
         {
             var sqs = new AmazonSQSClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             string requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
-            string dummyResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                                   "<ReceiveMessageResponse>SomeDummyResponse</ReceiveMessageResponse>";
+            string dummyResponse = "{}";
             CustomResponses.SetResponse(sqs, dummyResponse, requestId, true);
             var send_msg_req = new SendMessageRequest();
             send_msg_req.QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue";

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.IO;
 using Amazon;
 using Amazon.Runtime;
+using Amazon.Runtime.Endpoints;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal.Util;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests;
 
@@ -80,6 +82,12 @@ internal class TestRequest(ParameterCollection parameters) : IRequest
     public IDictionary<string, string> TrailingHeaders => throw new NotImplementedException();
 
     public bool UseDoubleEncoding { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    public IPropertyBag EndpointAttributes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    public CompressionEncodingAlgorithm CompressionAlgorithm { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    public ChecksumData ChecksumData { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
     public void AddPathResource(string key, string value)
     {

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequestContext.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequestContext.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
@@ -13,10 +14,9 @@ namespace OpenTelemetry.Instrumentation.AWS.Tests;
 
 internal class TestRequestContext(AmazonWebServiceRequest originalRequest, IRequest request) : IRequestContext
 {
-    private readonly AmazonWebServiceRequest originalRequest = originalRequest;
     private IRequest request = request;
 
-    public AmazonWebServiceRequest OriginalRequest => this.originalRequest;
+    public AmazonWebServiceRequest OriginalRequest { get; set; } = originalRequest;
 
     public string RequestName => throw new NotImplementedException();
 
@@ -59,4 +59,6 @@ internal class TestRequestContext(AmazonWebServiceRequest originalRequest, IRequ
     public bool IsLastExceptionRetryable { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
     public Guid InvocationId => throw new NotImplementedException();
+
+    public IDictionary<string, object> ContextAttributes { get; } = new Dictionary<string, object>();
 }


### PR DESCRIPTION
## Changes

Bump AWS SDKs to 3.7.300 for native AoT support.

Without this change, there are two AoT warnings when building the project from the AWS.Core library.

```console
D:\JenkinsWorkspaces\trebuchet-stage-release\AWSDotNetPublic\sdk\src\Core\Amazon.Util\Internal\_netstandard\TypeWrapper.netstandard.cs(184): Trim analysis error IL2080: Amazon.Util.Internal.TypeFactory.TypeInfoWrapper.GetMethod(String,ITypeInfo[]): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String,Type[])'. The field 'Amazon.Util.Internal.TypeFactory.AbstractTypeInfo._type' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [C:\Coding\open-telemetry\opentelemetry-dotnet-contrib\test\OpenTelemetry.AotCompatibility.TestApp\OpenTelemetry.AotCompatibility.TestApp.csproj]
D:\JenkinsWorkspaces\trebuchet-stage-release\AWSDotNetPublic\sdk\src\Core\Amazon.Util\Internal\_netstandard\TypeWrapper.netstandard.cs(68): Trim analysis error IL2080: Amazon.Util.Internal.TypeFactory.TypeInfoWrapper.GetField(String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields' in call to 'System.Type.GetField(String)'. The field 'Amazon.Util.Internal.TypeFactory.AbstractTypeInfo._type' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [C:\Coding\open-telemetry\opentelemetry-dotnet-contrib\test\OpenTelemetry.AotCompatibility.TestApp\OpenTelemetry.AotCompatibility.TestApp.csproj]
```

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
