### PR TITLE
[Instrumentation.AWSLambda] Fix AoT warnings

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -11,6 +11,10 @@
   ([#1295](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1295))
 * BREAKING: Target `net6.0` instead of `netstandard2.0`
   ([#1545](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1545))
+* Add support for native AoT.
+  `Amazon.Lambda.*` NuGet package dependencies have been upgraded, see package
+  dependencies for details.
+  ([#1544](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1544))
 
 ## 1.2.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSMessagingUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSMessagingUtils.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.Json;
 using Amazon.Lambda.SNSEvents;
 using Amazon.Lambda.SQSEvents;
-using Newtonsoft.Json;
 using OpenTelemetry.Context.Propagation;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Implementation;
@@ -132,7 +132,7 @@ internal class AWSMessagingUtils
         {
             try
             {
-                snsMessage = JsonConvert.DeserializeObject<SNSEvent.SNSMessage>(body);
+                snsMessage = JsonSerializer.Deserialize(body, SourceGenerationContext.Default.SNSMessage);
             }
             catch (Exception)
             {

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -8,12 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.1" />
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/SourceGenerationContext.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/SourceGenerationContext.cs
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json.Serialization;
+using Amazon.Lambda.SNSEvents;
+
+namespace OpenTelemetry.Instrumentation.AWSLambda;
+
+/// <summary>
+/// "Source Generation" is feature added to System.Text.Json in .NET 6.0.
+/// This is a performance optimization that avoids runtime reflection when performing serialization.
+/// Serialization metadata will be computed at compile-time and included in the assembly.
+/// <see href="https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation-modes" />.
+/// <see href="https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation" />.
+/// <see href="https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-source-generator/" />.
+/// </summary>
+[JsonSerializable(typeof(SNSEvent.SNSMessage))]
+internal sealed partial class SourceGenerationContext : JsonSerializerContext
+{
+}

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -14,7 +14,6 @@
       .github\workflows\ci.yml so that it runs for the project being added.
     -->
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions" />
-    <TrimmerRootAssembly Include="OpenTelemetry.Extensions.AWS" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions.Enrichment" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.AWSLambda" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.EventCounters" />

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -16,8 +16,9 @@
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions.AWS" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions.Enrichment" />
-    <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.Runtime" />
+    <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.AWSLambda" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.EventCounters" />
+    <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.Runtime" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.StackExchangeRedis" />
     <TrimmerRootAssembly Include="OpenTelemetry.ResourceDetectors.AWS" />
     <TrimmerRootAssembly Include="OpenTelemetry.ResourceDetectors.Azure" />


### PR DESCRIPTION
- Fixes #1523.
- Depends on #1545.

## Changes

Make OpenTelemetry.Instrumentation.AWSLambda AoT compatible by:
- Using System.Text.Json to deserialize SNS messages
- Updating to Amazon.Lambda packages that support native AoT.

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
