### PR TITLE
[Instrumentation.AWS] Support .NET 6 and resolve AoT warning

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWS/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/OpenTelemetry.Instrumentation.AWS/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWS/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,8 @@
+#nullable enable
+OpenTelemetry.Instrumentation.AWS.AWSClientInstrumentationOptions
+OpenTelemetry.Instrumentation.AWS.AWSClientInstrumentationOptions.AWSClientInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.AWS.AWSClientInstrumentationOptions.SuppressDownstreamInstrumentation.get -> bool
+OpenTelemetry.Instrumentation.AWS.AWSClientInstrumentationOptions.SuppressDownstreamInstrumentation.set -> void
+OpenTelemetry.Trace.TracerProviderBuilderExtensions
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAWSInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAWSInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AWS.AWSClientInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Updated dependency on AWS .NET SDK to version 3.7.300.
   ([#1542](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1542))
+* Add target for `net6.0`.
+  ([#1547](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1547))
+* Add support for native AoT.
+  ([#1547](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1547))
 
 ## 1.1.0-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -14,7 +14,7 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AWS.Implementation;
 
-internal class AWSTracingPipelineHandler : PipelineHandler
+internal sealed class AWSTracingPipelineHandler : PipelineHandler
 {
     internal const string ActivitySourceName = "Amazon.AWS.AWSClientInstrumentation";
 

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -130,14 +130,14 @@ internal class AWSTracingPipelineHandler : PipelineHandler
 
     private static void AddRequestSpecificInformation(Activity activity, IRequestContext requestContext, string service)
     {
-        if (AWSServiceHelper.ServiceParameterMap.TryGetValue(service, out string parameter))
+        if (AWSServiceHelper.ServiceParameterMap.TryGetValue(service, out var parameter))
         {
             AmazonWebServiceRequest request = requestContext.OriginalRequest;
 
             var property = request.GetType().GetProperty(parameter);
             if (property != null)
             {
-                if (AWSServiceHelper.ParameterAttributeMap.TryGetValue(parameter, out string attribute))
+                if (AWSServiceHelper.ParameterAttributeMap.TryGetValue(parameter, out var attribute))
                 {
                     activity.SetTag(attribute, property.GetValue(request));
                 }
@@ -176,7 +176,7 @@ internal class AWSTracingPipelineHandler : PipelineHandler
         else
         {
             var request_headers = requestContext.Request.Headers;
-            if (string.IsNullOrEmpty(request_id) && request_headers.TryGetValue("x-amzn-RequestId", out string req_id))
+            if (string.IsNullOrEmpty(request_id) && request_headers.TryGetValue("x-amzn-RequestId", out var req_id))
             {
                 request_id = req_id;
             }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -18,13 +18,13 @@ internal class AWSTracingPipelineHandler : PipelineHandler
 {
     internal const string ActivitySourceName = "Amazon.AWS.AWSClientInstrumentation";
 
-    private static readonly AWSXRayPropagator AwsPropagator = new AWSXRayPropagator();
+    private static readonly AWSXRayPropagator AwsPropagator = new();
     private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
     {
         carrier[name] = value;
     };
 
-    private static readonly ActivitySource AWSSDKActivitySource = new ActivitySource(ActivitySourceName);
+    private static readonly ActivitySource AWSSDKActivitySource = new(ActivitySourceName);
 
     private readonly AWSClientInstrumentationOptions options;
 

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>AWS client instrumentation for OpenTelemetry .NET</Description>
 	  <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -15,6 +15,7 @@
     -->
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions.Enrichment" />
+    <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.AWS" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.AWSLambda" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.EventCounters" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.Runtime" />


### PR DESCRIPTION
Fixes #1543.

## Changes

- Add `net6.0` TFM and fix nullability warnings.
- Resolve native AoT warning.
- Mark `AWSTracingPipelineHandler` as `sealed` (e.g. #1510).
- Fix `IDE0090` suggestions.

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
