### PR TITLE
Release native AoT fixes for AWS packages

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog - OpenTelemetry.Instrumentation.AWS
 
-## Unreleased
+## 1.1.0-beta.3
+
+Released 2024-Jan-26
 
 * Updated dependency on AWS .NET SDK to version 3.7.300.
   ([#1542](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1542))

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog - OpenTelemetry.Instrumentation.AWS
 
+## Unreleased
+
 ## 1.1.0-beta.3
 
 Released 2024-Jan-26

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog - OpenTelemetry.Instrumentation.AWSLambda
 
-## Unreleased
+## 1.3.0-beta.1
+
+Released 2024-Jan-26
 
 * BREAKING: `ILambdaContext context` argument of all tracing methods of
   `OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaWrapper` was annotated as non-nullable.

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog - OpenTelemetry.Instrumentation.AWSLambda
 
+## Unreleased
+
 ## 1.3.0-beta.1
 
 Released 2024-Jan-26

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 1.4.0-beta.1
+
+Released 2024-Jan-26
 
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 1.4.0-beta.1
 
 Released 2024-Jan-26


### PR DESCRIPTION
Fixes #1523, #1543.

## Changes

Release native AoT fixes for:

- OpenTelemetry.Instrumentation.AWS - #1542, #1547
- OpenTelemetry.Instrumentation.AWSLambda - #1545, #1544
- OpenTelemetry.ResourceDetectors.AWS - #1541

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes

/cc @open-telemetry/dotnet-contrib-maintainers
