### PR TITLE
[ResourceDetectors.AWS] Implement support for some cloud.* attributes in AWS ECS detector

### DIFF
--- a/src/OpenTelemetry.ResourceDetectors.AWS/AWSEC2ResourceDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/AWSEC2ResourceDetector.cs
@@ -59,7 +59,7 @@ public sealed class AWSEC2ResourceDetector : IResourceDetector
 
             if (identity.AvailabilityZone != null)
             {
-                resourceAttributes.Add(new KeyValuePair<string, object>(AWSSemanticConventions.AttributeCloudAvailableZone, identity.AvailabilityZone));
+                resourceAttributes.Add(new KeyValuePair<string, object>(AWSSemanticConventions.AttributeCloudAvailabilityZone, identity.AvailabilityZone));
             }
 
             if (identity.InstanceId != null)

--- a/src/OpenTelemetry.ResourceDetectors.AWS/AWSSemanticConventions.cs
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/AWSSemanticConventions.cs
@@ -6,7 +6,7 @@ namespace OpenTelemetry.ResourceDetectors.AWS;
 internal static class AWSSemanticConventions
 {
     public const string AttributeCloudAccountID = "cloud.account.id";
-    public const string AttributeCloudAvailableZone = "cloud.availability_zone";
+    public const string AttributeCloudAvailabilityZone = "cloud.availability_zone";
     public const string AttributeCloudPlatform = "cloud.platform";
     public const string AttributeCloudProvider = "cloud.provider";
     public const string AttributeCloudRegion = "cloud.region";

--- a/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Implement support for cloud.{account.id,availability_zone,region} attributes in
+  AWS ECS detector.
+  ([#1552](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1552))
+
 ## 1.4.0-beta.1
 
 Released 2024-Jan-26

--- a/src/OpenTelemetry.ResourceDetectors.AWS/README.md
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/README.md
@@ -37,10 +37,13 @@ The resource detectors will record the following metadata based on where
 your application is running:
 
 - **AWSEC2ResourceDetector**: cloud provider, cloud platform, account id,
-cloud available zone, host id, host type, aws region, host name.
+cloud availability zone, host id, host type, aws region, host name.
 - **AWSEBSResourceDetector**: cloud provider, cloud platform, service name,
 service namespace, instance id, service version.
-- **AWSECSResourceDetector**: cloud provider, cloud platform, container id.
+- **AWSECSResourceDetector**: cloud provider, cloud platform, account id,
+cloud availability zone, cloud region, container id, cluster arn, task arn,
+task family, task revision, launch type, container arn, log group names,
+log group ids, log stream names, log stream ids.
 - **AWSEKSResourceDetector**: cloud provider, cloud platform, cluster name,
 container id.
 

--- a/test/OpenTelemetry.ResourceDetectors.AWS.Tests/AWSEC2ResourceDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.AWS.Tests/AWSEC2ResourceDetectorTests.cs
@@ -24,7 +24,7 @@ public class AWSEC2ResourceDetectorTests
         Assert.Equal("aws", resourceAttributes[AWSSemanticConventions.AttributeCloudProvider]);
         Assert.Equal("aws_ec2", resourceAttributes[AWSSemanticConventions.AttributeCloudPlatform]);
         Assert.Equal("Test account id", resourceAttributes[AWSSemanticConventions.AttributeCloudAccountID]);
-        Assert.Equal("Test availability zone", resourceAttributes[AWSSemanticConventions.AttributeCloudAvailableZone]);
+        Assert.Equal("Test availability zone", resourceAttributes[AWSSemanticConventions.AttributeCloudAvailabilityZone]);
         Assert.Equal("Test instance id", resourceAttributes[AWSSemanticConventions.AttributeHostID]);
         Assert.Equal("Test instance type", resourceAttributes[AWSSemanticConventions.AttributeHostType]);
         Assert.Equal("Test aws region", resourceAttributes[AWSSemanticConventions.AttributeCloudRegion]);

--- a/test/OpenTelemetry.ResourceDetectors.AWS.Tests/AWSECSResourceDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.AWS.Tests/AWSECSResourceDetectorTests.cs
@@ -73,6 +73,9 @@ public class AWSECSResourceDetectorTests : IDisposable
 
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudProvider], "aws");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudPlatform], "aws_ecs");
+            Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudAccountID], "111122223333");
+            Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudAvailabilityZone], "us-west-2d");
+            Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudRegion], "us-west-2");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsContainerArn], "arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsLaunchtype], "ec2");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskArn], "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c");
@@ -101,6 +104,9 @@ public class AWSECSResourceDetectorTests : IDisposable
 
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudProvider], "aws");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudPlatform], "aws_ecs");
+            Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudAccountID], "111122223333");
+            Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudAvailabilityZone], "us-west-2a");
+            Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeCloudRegion], "us-west-2");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsContainerArn], "arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsLaunchtype], "fargate");
             Assert.Equal(resourceAttributes[AWSSemanticConventions.AttributeEcsTaskArn], "arn:aws:ecs:us-west-2:111122223333:task/default/e9028f8d5d8e4f258373e7b93ce9a3c3");


### PR DESCRIPTION
## Changes

Implement support for the following resource attributes in the AWS ECS detector when using the metadata endpoint v4:

* cloud.account.id
* cloud.availability_zone
* cloud.region

Also, fix mispelling of the AWSSemanticConventions.AttributeCloudAvailableZone to AWSSemanticConventions.AttributeCloudAvailabilityZone

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
