### PR TITLE
[ResourceDetector.Host] Log exception when cannot detect host.name

### DIFF
--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -25,9 +25,9 @@ public sealed class HostDetector : IResourceDetector
                 new(HostSemanticConventions.AttributeHostName, Environment.MachineName),
             });
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
-            // TODO replace comment by logging mechanism. Tracked under https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1514
+            HostResourceEventSource.Log.ResourceAttributesExtractException(nameof(HostDetector), ex);
         }
 
         return Resource.Empty;

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -27,6 +27,7 @@ public sealed class HostDetector : IResourceDetector
         }
         catch (InvalidOperationException ex)
         {
+            // Handling InvalidOperationException due to https://learn.microsoft.com/en-us/dotnet/api/system.environment.machinename#exceptions
             HostResourceEventSource.Log.ResourceAttributesExtractException(nameof(HostDetector), ex);
         }
 

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostResourceEventSource.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostResourceEventSource.cs
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Diagnostics.Tracing;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.ResourceDetectors.Host;
+
+[EventSource(Name = "OpenTelemetry-ResourceDetectors-Host")]
+internal class HostResourceEventSource : EventSource
+{
+    public static HostResourceEventSource Log = new();
+
+    [NonEvent]
+    public void ResourceAttributesExtractException(string format, Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.FailedToExtractResourceAttributes(format, ex.ToInvariantString());
+        }
+    }
+
+    [Event(1, Message = "Failed to extract resource attributes in '{0}'.", Level = EventLevel.Warning)]
+    public void FailedToExtractResourceAttributes(string format, string exception)
+    {
+        this.WriteEvent(3, format, exception);
+    }
+}

--- a/src/OpenTelemetry.ResourceDetectors.Host/OpenTelemetry.ResourceDetectors.Host.csproj
+++ b/src/OpenTelemetry.ResourceDetectors.Host/OpenTelemetry.ResourceDetectors.Host.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry Extensions - Host Resource Detector.</Description>
     <MinVerTagPrefix>ResourceDetectors.Host-</MinVerTagPrefix>
+    <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />


### PR DESCRIPTION
Fixes #1514.

## Changes

[ResourceDetector.Host] Log exception when cannot detect host.name

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~ I would skip this in changelog.
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
