### PR TITLE
[repo-ci] Sync-up with changes made in the main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     outputs:
       changes: ${{ steps.changes.outputs.changes }}
     steps:
-    - uses: AurorNZ/paths-filter@v3
+    - uses: AurorNZ/paths-filter@v4
       id: changes
       with:
         filters: |
           md: [ '**.md' ]
-          build: ['build/**', '.github/**/*.yml', '!.github/workflows/package-*']
+          build: ['build/**', '.github/**/*.yml', '!.github/workflows/package-*', '**/*.targets', '**/*.props']
           shared: ['src/Shared/**']
-          code: ['**.cs', '.editorconfig']
+          code: ['**.cs', '**.csproj', '.editorconfig']
           aot: ['src/OpenTelemetry.Extensions.Enrichment/**']
           aottestapp: ['test/OpenTelemetry.AotCompatibility.TestApp/**']
           aspnet: ['*/OpenTelemetry.Instrumentation.AspNet*/**', 'examples/AspNet/**', '!**/*.md']
@@ -75,12 +75,16 @@ jobs:
 
   lint-md:
     needs: detect-changes
-    if: contains(needs.detect-changes.outputs.changes, 'md')
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'md')
+      || contains(needs.detect-changes.outputs.changes, 'build')
     uses: ./.github/workflows/markdownlint.yml
 
   lint-dotnet-format:
     needs: detect-changes
-    if: contains(needs.detect-changes.outputs.changes, 'code')
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'code')
+      || contains(needs.detect-changes.outputs.changes, 'build')
     uses: ./.github/workflows/dotnet-format.yml
 
   build-test-aspnet:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -11,8 +11,9 @@ jobs:
     - name: check out code
       uses: actions/checkout@v4
 
-    - name: install markdownlint-cli
-      run: sudo npm install -g markdownlint-cli
-
     - name: run markdownlint
-      run: markdownlint .
+      uses: DavidAnson/markdownlint-cli2-action@v14.0.0
+      with:
+        globs: |
+          **/*.md
+          !.github/**/*.md


### PR DESCRIPTION
## Changes

* Bump AurorNZ/paths-filter (https://github.com/open-telemetry/opentelemetry-dotnet/pull/5288)
* markdownlint tweaks (https://github.com/open-telemetry/opentelemetry-dotnet/pull/5281)
* Include .targets & .props files in "build" filter and include .csproj files in "code" filter (don't recall exactly when those changes were made)
