### PR TITLE
[Instrumentation.EntityFrameworkCore] Stop emitting db.statement_type attribute

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Stop emitting `db.statement_type` attribute.
+* **Breaking Change**: Stop emitting `db.statement_type` attribute.
   ([#1559](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1559))
 
 ## 1.0.0-beta.9

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Stop emitting `db.statement_type` attribute.
+  ([#1559](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1559))
+
 ## 1.0.0-beta.9
 
 Released 2024-Jan-03

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
@@ -194,7 +194,6 @@ internal sealed class EntityFrameworkDiagnosticListener : ListenerHandler
                             switch (commandType)
                             {
                                 case CommandType.StoredProcedure:
-                                    activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
                                     if (this.options.SetDbStatementForStoredProcedure)
                                     {
                                         activity.AddTag(AttributeDbStatement, commandText);
@@ -203,7 +202,6 @@ internal sealed class EntityFrameworkDiagnosticListener : ListenerHandler
                                     break;
 
                                 case CommandType.Text:
-                                    activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.Text));
                                     if (this.options.SetDbStatementForText)
                                     {
                                         activity.AddTag(AttributeDbStatement, commandText);
@@ -212,7 +210,6 @@ internal sealed class EntityFrameworkDiagnosticListener : ListenerHandler
                                     break;
 
                                 case CommandType.TableDirect:
-                                    activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.TableDirect));
                                     break;
                             }
                         }

--- a/src/Shared/SpanAttributeConstants.cs
+++ b/src/Shared/SpanAttributeConstants.cs
@@ -11,7 +11,6 @@ internal static class SpanAttributeConstants
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public const string StatusCodeKey = "otel.status_code";
     public const string StatusDescriptionKey = "otel.status_description";
-    public const string DatabaseStatementTypeKey = "db.statement_type";
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -241,7 +241,6 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         Assert.DoesNotContain(activity.Tags, t => t.Key == EntityFrameworkDiagnosticListener.AttributePeerService);
 
         Assert.Equal(altDisplayName ?? "main", activity.Tags.FirstOrDefault(t => t.Key == EntityFrameworkDiagnosticListener.AttributeDbName).Value);
-        Assert.Equal(CommandType.Text.ToString(), activity.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.DatabaseStatementTypeKey).Value);
 
         if (!isError)
         {


### PR DESCRIPTION
## Changes

Similar changes to https://github.com/open-telemetry/opentelemetry-dotnet/pull/5301
[Instrumentation.EntityFrameworkCore] Stop emitting `db.statement_type` attribute

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
