### PR TITLE
Bump codecov/codecov-action from 3.1.5 to 4.0.1

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -57,13 +57,15 @@ jobs:
       run: dotnet-coverage merge -r -f cobertura -o ./TestResults/Cobertura.xml ./TestResults/*.coverage
 
     - name: Upload code coverage ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
-      uses: codecov/codecov-action@v3.1.6
+      uses: codecov/codecov-action@v4
       continue-on-error: true # Note: Don't fail for upload failures
       env:
         OS: ${{ matrix.os }}
         TFM: ${{ matrix.version }}
+        token: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: TestResults/Cobertura.xml
         env_vars: OS,TFM
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Code Coverage for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
+        codecov_yml_path: .github/codecov.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,16 +334,18 @@ jobs:
     - name: Merging test results
       run: dotnet-coverage merge -r -f cobertura -o ./TestResults/Cobertura.xml ./TestResults/*.coverage
 
-    - uses: codecov/codecov-action@v3.1.6
+    - uses: codecov/codecov-action@v4
       continue-on-error: true # Note: Don't fail for upload failures
       env:
         OS: ${{ matrix.os }}
         TFM: ${{ matrix.version }}
+        token: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: TestResults/Cobertura.xml
         env_vars: OS,TFM
         flags: unittests-Solution
         name: Code Coverage for solution on [${{ matrix.os }}.${{ matrix.version }}]
+        codecov_yml_path: .github/codecov.yml
 
   verify-aot-compat:
     needs: detect-changes


### PR DESCRIPTION
Applying what was done [in the main repo](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5294) to contrib.
