### PR TITLE
bugfix: AWS SQS MD5 Hash Mismatch

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* BREAKING: Switched AWSServiceName tag to use ServiceId instead of ServiceName
+  ([#1572](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1572))
+
 ## 1.1.0-beta.3
 
 Released 2024-Jan-26

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSPropagatorPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSPropagatorPipelineHandler.cs
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Extensions.AWS.Trace;
+
+namespace OpenTelemetry.Instrumentation.AWS.Implementation;
+
+/// <summary>
+/// Uses <see cref="AWSXRayPropagator"/> to inject the current Activity Context and
+/// Baggage into the outgoing AWS SDK Request.
+/// <para />
+/// Must execute after the AWS SDK has marshalled (ie serialized)
+/// the outgoing request object so that it can work with the <see cref="IRequest"/>'s
+/// <see cref="IRequest.Headers"/>.
+/// </summary>
+internal class AWSPropagatorPipelineHandler : PipelineHandler
+{
+    private static readonly AWSXRayPropagator AwsPropagator = new();
+
+    private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
+    {
+        carrier[name] = value;
+    };
+
+    /// <summary>
+    /// Rely on the the <see cref="AWSTracingPipelineHandler.Activity"/> for retrieving the current
+    /// context.
+    /// </summary>
+    private readonly AWSTracingPipelineHandler tracingPipelineHandler;
+
+    public AWSPropagatorPipelineHandler(AWSTracingPipelineHandler tracingPipelineHandler)
+    {
+        this.tracingPipelineHandler = tracingPipelineHandler;
+    }
+
+    public override void InvokeSync(IExecutionContext executionContext)
+    {
+        this.ProcessBeginRequest(executionContext);
+
+        base.InvokeSync(executionContext);
+    }
+
+    public override async Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+    {
+        this.ProcessBeginRequest(executionContext);
+
+        return await base.InvokeAsync<T>(executionContext).ConfigureAwait(false);
+    }
+
+    private void ProcessBeginRequest(IExecutionContext executionContext)
+    {
+        if (this.tracingPipelineHandler.Activity == null)
+        {
+            return;
+        }
+
+        AwsPropagator.Inject(
+            new PropagationContext(this.tracingPipelineHandler.Activity.Context, Baggage.Current),
+            executionContext.RequestContext.Request.Headers,
+            Setter);
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
@@ -21,7 +21,7 @@ internal class AWSServiceHelper
     };
 
     internal static string GetAWSServiceName(IRequestContext requestContext)
-        => Utils.RemoveAmazonPrefixFromServiceName(requestContext.Request.ServiceName);
+        => Utils.RemoveAmazonPrefixFromServiceName(requestContext.ServiceMetaData.ServiceId);
 
     internal static string GetAWSOperationName(IRequestContext requestContext)
     {

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
@@ -7,9 +7,9 @@ namespace OpenTelemetry.Instrumentation.AWS.Implementation;
 
 internal class AWSServiceType
 {
-    internal const string DynamoDbService = "DynamoDBv2";
+    internal const string DynamoDbService = "DynamoDB";
     internal const string SQSService = "SQS";
-    internal const string SNSService = "SimpleNotificationService"; // SNS
+    internal const string SNSService = "SNS";
 
     internal static bool IsDynamoDbService(string service)
         => DynamoDbService.Equals(service, StringComparison.OrdinalIgnoreCase);

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
@@ -31,6 +31,6 @@ internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
             return;
         }
 
-        pipeline.AddHandlerBefore<RetryHandler>(new AWSTracingPipelineHandler(this.options));
+        pipeline.AddHandlerBefore<Marshaller>(new AWSTracingPipelineHandler(this.options));
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
@@ -7,6 +7,10 @@ using Amazon.Runtime.Internal;
 
 namespace OpenTelemetry.Instrumentation.AWS.Implementation;
 
+/// <summary>
+/// Wires <see cref="AWSTracingPipelineHandler"/> and <see cref="AWSPropagatorPipelineHandler"/>
+/// into the AWS <see cref="RuntimePipeline"/> so they can inject trace headers and wrap sdk calls in spans.
+/// </summary>
 internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
 {
     private readonly AWSClientInstrumentationOptions options;
@@ -31,6 +35,15 @@ internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
             return;
         }
 
-        pipeline.AddHandlerBefore<Marshaller>(new AWSTracingPipelineHandler(this.options));
+        var tracingPipelineHandler = new AWSTracingPipelineHandler(this.options);
+        var propagatingPipelineHandler = new AWSPropagatorPipelineHandler(tracingPipelineHandler);
+
+        // AWSTracingPipelineHandler must execute early in the AWS SDK pipeline
+        // in order to manipulate outgoing requests objects before they are marshalled (ie serialized).
+        pipeline.AddHandlerBefore<Marshaller>(tracingPipelineHandler);
+
+        // AWSPropagatorPipelineHandler executes after the AWS SDK has marshalled (ie serialized)
+        // the outgoing request object so that it can work with the request's Headers
+        pipeline.AddHandlerBefore<RetryHandler>(propagatingPipelineHandler);
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.Runtime;
-using Amazon.Runtime.Internal;
 using Amazon.SQS.Model;
 
 namespace OpenTelemetry.Instrumentation.AWS.Implementation;
@@ -18,9 +17,8 @@ internal class SqsRequestContextHelper
 
     internal static void AddAttributes(IRequestContext context, IReadOnlyDictionary<string, string> attributes)
     {
-        var parameters = context.Request?.ParameterCollection;
         var originalRequest = context.OriginalRequest as SendMessageRequest;
-        if (originalRequest?.MessageAttributes == null || parameters == null)
+        if (originalRequest?.MessageAttributes == null)
         {
             return;
         }
@@ -38,23 +36,9 @@ internal class SqsRequestContextHelper
             return;
         }
 
-        int nextAttributeIndex = attributesCount + 1;
         foreach (var param in attributes)
         {
-            AddAttribute(parameters, originalRequest, param.Key, param.Value, nextAttributeIndex);
-            nextAttributeIndex++;
+            originalRequest.MessageAttributes[param.Key] = new MessageAttributeValue { DataType = "String", StringValue = param.Value };
         }
-    }
-
-    private static void AddAttribute(ParameterCollection parameters, SendMessageRequest originalRequest, string name, string value, int attributeIndex)
-    {
-        var prefix = "MessageAttribute." + attributeIndex;
-        parameters.Add(prefix + ".Name", name);
-        parameters.Add(prefix + ".Value.DataType", "String");
-        parameters.Add(prefix + ".Value.StringValue", value);
-
-        // Add injected attributes to the original request as well.
-        // This dictionary must be in sync with parameters collection to pass through the MD5 hash matching check.
-        originalRequest.MessageAttributes.Add(name, new MessageAttributeValue { DataType = "String", StringValue = value });
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class TracerProviderBuilderExtensions
         configure?.Invoke(awsClientOptions);
 
         _ = new AWSClientsInstrumentation(awsClientOptions);
-        builder.AddSource("Amazon.AWS.AWSClientInstrumentation");
+        builder.AddSource(AWSTracingPipelineHandler.ActivitySourceName);
         return builder;
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -174,6 +174,7 @@ public class TestAWSClientInstrumentation
             var send_msg_req = new SendMessageRequest();
             send_msg_req.QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue";
             send_msg_req.MessageBody = "Hello from OT";
+            send_msg_req.MessageAttributes.Add("Custom", new MessageAttributeValue { StringValue = "Value", DataType = "String" });
 #if NETFRAMEWORK
             sqs.SendMessage(send_msg_req);
 #else
@@ -198,8 +199,8 @@ public class TestAWSClientInstrumentation
 
     private void ValidateDynamoActivityTags(Activity ddb_activity)
     {
-        Assert.Equal("DynamoDBv2.Scan", ddb_activity.DisplayName);
-        Assert.Equal("DynamoDBv2", Utils.GetTagValue(ddb_activity, "aws.service"));
+        Assert.Equal("DynamoDB.Scan", ddb_activity.DisplayName);
+        Assert.Equal("DynamoDB", Utils.GetTagValue(ddb_activity, "aws.service"));
         Assert.Equal("Scan", Utils.GetTagValue(ddb_activity, "aws.operation"));
         Assert.Equal("us-east-1", Utils.GetTagValue(ddb_activity, "aws.region"));
         Assert.Equal("SampleProduct", Utils.GetTagValue(ddb_activity, "aws.table_name"));

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
@@ -16,6 +16,7 @@ namespace OpenTelemetry.Instrumentation.AWS.Tests;
 internal class TestRequest : IRequest
 {
     private readonly ParameterCollection parameters;
+
     public TestRequest(ParameterCollection? parameters = null)
     {
         this.parameters = parameters ?? new ParameterCollection();

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
@@ -13,9 +13,13 @@ using Amazon.Runtime.Internal.Util;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests;
 
-internal class TestRequest(ParameterCollection parameters) : IRequest
+internal class TestRequest : IRequest
 {
-    private readonly ParameterCollection parameters = parameters;
+    private readonly ParameterCollection parameters;
+    public TestRequest(ParameterCollection? parameters = null)
+    {
+        this.parameters = parameters ?? new ParameterCollection();
+    }
 
     public string RequestName => throw new NotImplementedException();
 


### PR DESCRIPTION
Fixes #1492 

## Changes

A recent change to the AWS SDK implementation of SQS client changes wireline protocol from XML to Json.  This causes the SDK's internal request pipeline to behave differently, causing `AWSTracingPipelineHandler` to no longer be able to manipulate `SendMessageRequest.MessageAttributes` after the Marshalling step has been completed.  

This change moves `AWSTracingPipelineHandler` to run before Marshalling (ie Serialization) so that Open Telemetry headers can be correctly injected.

Injecting propagation context into outgoing requests have been moved to a new handler, `AWSPropagatorPipelineHandler`, which runs later in the SDK request pipeline.

### Service Name Mapping

Moving `AWSTracingPipelineHandler` ahead in the AWS SDK Pipeline made it necessary to also tweak `AWSServiceHelper` to use `requestContext.ServiceMetaData.ServiceId` instead of `requestContext.Request.ServiceName` as the `Request` has not yet been populated at this point.  

ServiceId and ServiceName can differ for some AWS Services, requiring an update to [`AWSServiceType`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1572/files/aaf6fbabedc770a2cc6848ec5bf25851cc98a87b#diff-e1335da399a2c5c58f572a860866987f5235e287da0e3730a0fb6c9c500dbe56).  I have manually verified all 3 Service Names in `AWSServiceType` for correctness.