### PR TITLE
[OpenTelemetry.Exporter.Stackdriver] Release 1.0.0-beta.5 (#1579)

### DIFF
--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.0-beta.5
 
-Released 2024-Feb-13
+Released 2024-Feb-15
 
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.5
+
+Released 2024-Feb-13
+
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 * Add support of a native "gRPC for .NET" for apps targeting .NET 6.0 or later.


### PR DESCRIPTION
Fixes #1579.

## Changes

Releases `OpenTelemetry.Exporter.Stackdriver` 1.0.0-beta.5