### PR TITLE
[repo] CodeQL workflow tweaks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,8 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        config: |
+          command: 'dotnet build -p:Configuration=Release'
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -49,8 +51,6 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3
-      env:
-        CONFIGURATION: Release
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ name: "CodeQL"
 
 on:
   schedule:
-    - cron: '0 0 * * *' # once in a day at 00:00  
+    - cron: '0 0 * * *' # once in a day at 00:00
   workflow_dispatch:
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
@@ -49,6 +49,8 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3
+      env:
+        CONFIGURATION: Release
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
 
-    - name: dotnet build opentelemetry-dotnet-contrib.sln
-      run: dotnet build opentelemetry-dotnet-contrib.sln --configuration Release
+    - name: dotnet pack opentelemetry-dotnet-contrib.proj
+      run: dotnet pack opentelemetry-dotnet-contrib.proj --configuration Release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,11 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language: ['csharp']
-        # Learn more...
-        # https://docs.github.com/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
     - name: configure Pagefile
@@ -35,33 +31,16 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        config: |
-          command: 'dotnet build -p:Configuration=Release'
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: dotnet build opentelemetry-dotnet-contrib.sln
+      run: dotnet build opentelemetry-dotnet-contrib.sln --configuration Release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/examples/wcf/server-aspnetframework/Web.Release.config
+++ b/examples/wcf/server-aspnetframework/Web.Release.config
@@ -15,7 +15,7 @@
     </connectionStrings>
   -->
   <system.web>
-    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--<compilation xdt:Transform="RemoveAttributes(debug)" />-->
     <!--
       In the example below, the "Replace" transform will replace the entire
       <customErrors> section of your web.config file.

--- a/examples/wcf/server-aspnetframework/Web.Release.config
+++ b/examples/wcf/server-aspnetframework/Web.Release.config
@@ -15,7 +15,7 @@
     </connectionStrings>
   -->
   <system.web>
-    <!--<compilation xdt:Transform="RemoveAttributes(debug)" />-->
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
     <!--
       In the example below, the "Replace" transform will replace the entire
       <customErrors> section of your web.config file.

--- a/opentelemetry-dotnet-contrib.proj
+++ b/opentelemetry-dotnet-contrib.proj
@@ -2,16 +2,24 @@
 
   <ItemGroup>
     <SolutionProjects Include="**\*.csproj" />
-
+    <TestProjects Include="test\**\*.csproj" />
     <PackProjects Include="src\**\*.csproj" />
   </ItemGroup>
 
   <Target Name="Build">
-    <MSBuild Projects="@(SolutionProjects)" Targets="Restore;Build" ContinueOnError="ErrorAndStop" />
+    <MSBuild Projects="@(SolutionProjects)" Targets="Build" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(SolutionProjects)" Targets="Restore" ContinueOnError="ErrorAndStop" />
   </Target>
 
   <Target Name="Pack">
     <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Changes

* Switches CodeQL workflow to build only the pack projects and in `Release` configuration.

## Details

This should clear these security issues:

* https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/8
* https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/9
* https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/12
