### PR TITLE
[aspnet-examples] Fix security warnings coming from config files

### DIFF
--- a/examples/AspNet/Views/Web.config
+++ b/examples/AspNet/Views/Web.config
@@ -25,6 +25,11 @@
   </appSettings>
 
   <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
     <handlers>
       <remove name="BlockViewHandler"/>
       <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -15,6 +15,11 @@
     <httpRuntime targetFramework="4.8" maxRequestLength="2147483647" executionTimeout="300"/>
   </system.web>
   <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
     <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
       <remove name="OPTIONSVerbHandler"/>

--- a/examples/wcf/server-aspnetframework/Web.config
+++ b/examples/wcf/server-aspnetframework/Web.config
@@ -30,10 +30,14 @@
     </services>
   </system.serviceModel>
   <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+      </customHeaders>
+    </httpProtocol>
     <modules runAllManagedModulesForAllRequests="true">
       <add name="TelemetryHttpModule" type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule,OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" preCondition="integratedMode,managedHandler" />
     </modules>
-    <directoryBrowse enabled="true" />
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
Follow-up to #1581

## Changes

* Fix security warnings from web.configs in aspnet example apps.

## Details

* https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/10
* https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/4
* https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/7
* https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/11