### PR TITLE
[Instrumentation.AspNet] Rename options class to AspNetTraceInstrumentationOptions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,19 +1,19 @@
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.AspNetInstrumentationOptions() -> void
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity!, string!, object!>?
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Enrich.set -> void
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.get -> System.Func<System.Web.HttpContext!, bool>?
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.set -> void
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.get -> bool
-OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions
 OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.AspNetMetricsInstrumentationOptions() -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Enrich.get -> OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichFunc?
 OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Enrich.set -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichFunc
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.AspNetTraceInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity!, string!, object!>?
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.Enrich.set -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.Filter.get -> System.Func<System.Web.HttpContext!, bool>?
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.Filter.set -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Metrics.MeterProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
@@ -17,7 +17,7 @@ internal sealed class AspNetInstrumentation : IDisposable
     /// Initializes a new instance of the <see cref="AspNetInstrumentation"/> class.
     /// </summary>
     /// <param name="options">Configuration options for ASP.NET instrumentation.</param>
-    public AspNetInstrumentation(AspNetInstrumentationOptions options)
+    public AspNetInstrumentation(AspNetTraceInstrumentationOptions options)
     {
         this.httpInListener = new HttpInListener(options);
     }

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetTraceInstrumentationOptions.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Instrumentation.AspNet;
 /// <summary>
 /// Options for ASP.NET instrumentation.
 /// </summary>
-public class AspNetInstrumentationOptions
+public class AspNetTraceInstrumentationOptions
 {
     /// <summary>
     /// Gets or sets a filter callback function that determines on a per

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* **Breaking Change**: Renamed `AspNetInstrumentationOptions` to
+  `AspNetTraceInstrumentationOptions`.
+  ([#1604](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1604))
+
 ## 1.7.0-beta.2
 
 Released 2024-Feb-07

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -13,9 +13,9 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation;
 internal sealed class HttpInListener : IDisposable
 {
     private readonly HttpRequestRouteHelper routeHelper = new();
-    private readonly AspNetInstrumentationOptions options;
+    private readonly AspNetTraceInstrumentationOptions options;
 
-    public HttpInListener(AspNetInstrumentationOptions options)
+    public HttpInListener(AspNetTraceInstrumentationOptions options)
     {
         Guard.ThrowIfNull(options);
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -131,14 +131,14 @@ Currently, the instrumentation supports the following metric.
 ## Advanced trace configuration
 
 This instrumentation can be configured to change the default behavior by using
-`AspNetInstrumentationOptions`, which allows configuring `Filter` as explained
+`AspNetTraceInstrumentationOptions`, which allows configuring `Filter` as explained
 below.
 
 ### Trace Filter
 
 This instrumentation by default collects all the incoming http requests. It
 allows filtering of requests by using the `Filter` function in
-`AspNetInstrumentationOptions`. This defines the condition for allowable
+`AspNetTraceInstrumentationOptions`. This defines the condition for allowable
 requests. The Filter receives the `HttpContext` of the incoming request, and
 does not collect telemetry about the request if the Filter returns false or
 throws exception.

--- a/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
@@ -28,11 +28,11 @@ public static class TracerProviderBuilderExtensions
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddAspNetInstrumentation(
         this TracerProviderBuilder builder,
-        Action<AspNetInstrumentationOptions>? configure)
+        Action<AspNetTraceInstrumentationOptions>? configure)
     {
         Guard.ThrowIfNull(builder);
 
-        var aspnetOptions = new AspNetInstrumentationOptions();
+        var aspnetOptions = new AspNetTraceInstrumentationOptions();
         configure?.Invoke(aspnetOptions);
 
         builder.AddInstrumentation(() => new AspNetInstrumentation(aspnetOptions));


### PR DESCRIPTION
Propagate changes from https://github.com/open-telemetry/opentelemetry-dotnet/pull/5285

## Changes

[Instrumentation.AspNet] Rename options class to AspNetTraceInstrumentationOptions

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [x] Changes in public API reviewed
