### PR TITLE
[Instrumentation.AspNet] Spans - semantic convention v1.24.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -9,7 +9,19 @@
   for `http.server.request.duration` metric.
   ([#1606](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1606))
 * **Breaking change** Spans names and attributes
-  based on [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md).
+  based on [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md):
+  * span names follows: `{HTTP method} [route name if available]` pattern
+  * `error.type` added when exception occurred while processing request,
+  * `http.request.method` replaces `http.method`,
+  * `http.request.method_original` added when `http.request.method` is not in
+    canonical form,
+  * `http.response.status_code` replaces `http.status_code`,
+  * `network.protocol.version` added with HTTP version value,
+  * `server.address` and `server.port` replace `http.host`,
+  * `url.path` replaces `http.target`,
+  * `url.query` added when query url part is not empty,
+  * `url.scheme` added with `http` or `https` value,
+  * `user_agent.original` replaces `http.user_agent`.
   ([#1607](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1607))
 
 ## 1.7.0-beta.2
@@ -99,7 +111,7 @@ Released 2022-Nov-28
 
 Released 2022-Sep-28
 
-* Migrate to native Activity `Status` and `StatusDesciption`.
+* Migrate to native Activity `Status` and `StatusDescription`.
   ([#651](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/651))
 
 ## 1.0.0-rc9.5 (source code moved to contrib repo)

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -5,6 +5,8 @@
 * **Breaking Change**: Renamed `AspNetInstrumentationOptions` to
   `AspNetTraceInstrumentationOptions`.
   ([#1604](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1604))
+* **Breaking change** Spans attributes based on [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md).
+  ([#1607](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1607))
 
 ## 1.7.0-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -9,7 +9,7 @@
   for `http.server.request.duration` metric.
   ([#1606](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1606))
 * **Breaking change** Spans names and attributes
-  based on [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md):
+ will be set as per [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md):
   * span names follows: `{HTTP method} [route name if available]` pattern
   * `error.type` added when exception occurred while processing request,
   * `http.request.method` replaces `http.method`,

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -8,7 +8,8 @@
 * **Breaking Change**: `server.address` and `server.port` no longer added
   for `http.server.request.duration` metric.
   ([#1606](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1606))
-* **Breaking change** Spans attributes based on [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md).
+* **Breaking change** Spans names and attributes
+  based on [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md).
   ([#1607](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1607))
 
 ## 1.7.0-beta.2

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -93,6 +93,7 @@ internal sealed class HttpInListener : IDisposable
 
             activity.SetTag(SemanticConventions.AttributeUrlPath, path);
 
+            // TODO url.query should be sanitized
             var query = url.Query;
             if (!string.IsNullOrEmpty(query))
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -76,7 +76,7 @@ internal sealed class HttpInListener : IDisposable
             var request = context.Request;
             var requestValues = request.Unvalidated;
 
-            // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
+            // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md
             var path = requestValues.Path;
             activity.DisplayName = path;
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -14,7 +14,7 @@ internal sealed class HttpInListener : IDisposable
 {
     private readonly HttpRequestRouteHelper routeHelper = new();
     private readonly AspNetTraceInstrumentationOptions options;
-    private readonly RequestMethodHelper requestMethodHelper = new();
+    private readonly RequestDataHelper requestDataHelper = new();
 
     public HttpInListener(AspNetTraceInstrumentationOptions options)
     {
@@ -87,12 +87,18 @@ internal sealed class HttpInListener : IDisposable
             activity.SetTag(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
             var originalHttpMethod = request.HttpMethod;
-            var normalizedHttpMethod = this.requestMethodHelper.GetNormalizedHttpMethod(originalHttpMethod);
+            var normalizedHttpMethod = this.requestDataHelper.GetNormalizedHttpMethod(originalHttpMethod);
             activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, normalizedHttpMethod);
 
             if (originalHttpMethod != normalizedHttpMethod)
             {
                 activity.SetTag(SemanticConventions.AttributeHttpRequestMethodOriginal, originalHttpMethod);
+            }
+
+            var protocolVersion = RequestDataHelper.GetHttpProtocolVersion(request);
+            if (!string.IsNullOrEmpty(protocolVersion))
+            {
+                activity.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, protocolVersion);
             }
 
             activity.SetTag(SemanticConventions.AttributeUrlPath, path);

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -103,7 +103,6 @@ internal sealed class HttpInListener : IDisposable
 
             activity.SetTag(SemanticConventions.AttributeUrlPath, path);
             activity.SetTag(SemanticConventions.AttributeUserAgentOriginal, request.UserAgent);
-            activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUriTagValueFromRequestUri(request.Url));
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -95,7 +95,7 @@ internal sealed class HttpInListener : IDisposable
             }
 
             activity.SetTag(SemanticConventions.AttributeHttpTarget, path);
-            activity.SetTag(SemanticConventions.AttributeHttpUserAgent, request.UserAgent);
+            activity.SetTag(SemanticConventions.AttributeUserAgentOriginal, request.UserAgent);
             activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUriTagValueFromRequestUri(request.Url));
 
             try

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -94,7 +94,7 @@ internal sealed class HttpInListener : IDisposable
                 activity.SetTag(SemanticConventions.AttributeHttpRequestMethodOriginal, originalHttpMethod);
             }
 
-            activity.SetTag(SemanticConventions.AttributeHttpTarget, path);
+            activity.SetTag(SemanticConventions.AttributeUrlPath, path);
             activity.SetTag(SemanticConventions.AttributeUserAgentOriginal, request.UserAgent);
             activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUriTagValueFromRequestUri(request.Url));
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -115,7 +115,7 @@ internal sealed class HttpInListener : IDisposable
         {
             var response = context.Response;
 
-            activity.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
+            activity.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, response.StatusCode);
 
             if (activity.Status == ActivityStatusCode.Unset)
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -77,13 +77,7 @@ internal sealed class HttpInListener : IDisposable
             activity.SetTag(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
             var originalHttpMethod = request.HttpMethod;
-            var normalizedHttpMethod = this.requestDataHelper.GetNormalizedHttpMethod(originalHttpMethod);
-            activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, normalizedHttpMethod);
-
-            if (originalHttpMethod != normalizedHttpMethod)
-            {
-                activity.SetTag(SemanticConventions.AttributeHttpRequestMethodOriginal, originalHttpMethod);
-            }
+            this.requestDataHelper.SetHttpMethodTag(activity, originalHttpMethod);
 
             var protocolVersion = RequestDataHelper.GetHttpProtocolVersion(request);
             if (!string.IsNullOrEmpty(protocolVersion))

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -80,14 +80,9 @@ internal sealed class HttpInListener : IDisposable
             var path = requestValues.Path;
             activity.DisplayName = path;
 
-            if (request.Url.Port == 80 || request.Url.Port == 443)
-            {
-                activity.SetTag(SemanticConventions.AttributeHttpHost, request.Url.Host);
-            }
-            else
-            {
-                activity.SetTag(SemanticConventions.AttributeHttpHost, request.Url.Host + ":" + request.Url.Port);
-            }
+            var url = request.Url;
+            activity.SetTag(SemanticConventions.AttributeServerAddress, url.Host);
+            activity.SetTag(SemanticConventions.AttributeServerPort, url.Port);
 
             activity.SetTag(SemanticConventions.AttributeHttpMethod, request.HttpMethod);
             activity.SetTag(SemanticConventions.AttributeHttpTarget, path);

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -162,6 +162,7 @@ internal sealed class HttpInListener : IDisposable
             }
 
             activity.SetStatus(ActivityStatusCode.Error, exception.Message);
+            activity.SetTag(SemanticConventions.AttributeErrorType, exception.GetType().FullName);
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -36,16 +36,6 @@ internal sealed class HttpInListener : IDisposable
         TelemetryHttpModule.Options.OnExceptionCallback -= this.OnException;
     }
 
-    /// <summary>
-    /// Gets the OpenTelemetry standard uri tag value for a span based on its request <see cref="Uri"/>.
-    /// </summary>
-    /// <param name="uri"><see cref="Uri"/>.</param>
-    /// <returns>Span uri value.</returns>
-    private static string GetUriTagValueFromRequestUri(Uri uri)
-    {
-        return string.IsNullOrEmpty(uri.UserInfo) ? uri.ToString() : string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
-    }
-
     private void OnStartActivity(Activity activity, HttpContext context)
     {
         if (activity.IsAllDataRequested)
@@ -102,6 +92,20 @@ internal sealed class HttpInListener : IDisposable
             }
 
             activity.SetTag(SemanticConventions.AttributeUrlPath, path);
+
+            var query = url.Query;
+            if (!string.IsNullOrEmpty(query))
+            {
+                if (query.StartsWith("?", StringComparison.InvariantCulture))
+                {
+                    activity.SetTag(SemanticConventions.AttributeUrlQuery, query.Substring(1));
+                }
+                else
+                {
+                    activity.SetTag(SemanticConventions.AttributeUrlQuery, query);
+                }
+            }
+
             activity.SetTag(SemanticConventions.AttributeUserAgentOriginal, request.UserAgent);
 
             try

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -84,6 +84,7 @@ internal sealed class HttpInListener : IDisposable
             var url = request.Url;
             activity.SetTag(SemanticConventions.AttributeServerAddress, url.Host);
             activity.SetTag(SemanticConventions.AttributeServerPort, url.Port);
+            activity.SetTag(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
             var originalHttpMethod = request.HttpMethod;
             var normalizedHttpMethod = this.requestMethodHelper.GetNormalizedHttpMethod(originalHttpMethod);

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -101,7 +101,11 @@ internal sealed class HttpInListener : IDisposable
                 }
             }
 
-            activity.SetTag(SemanticConventions.AttributeUserAgentOriginal, request.UserAgent);
+            var userAgent = request.UserAgent;
+            if (!string.IsNullOrEmpty(userAgent))
+            {
+                activity.SetTag(SemanticConventions.AttributeUserAgentOriginal, userAgent);
+            }
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
@@ -12,7 +12,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation;
 internal sealed class HttpInMetricsListener : IDisposable
 {
     private readonly HttpRequestRouteHelper routeHelper = new();
-    private readonly RequestMethodHelper requestMethodHelper = new();
+    private readonly RequestDataHelper requestDataHelper = new();
     private readonly Histogram<double> httpServerDuration;
     private readonly AspNetMetricsInstrumentationOptions options;
 
@@ -31,18 +31,6 @@ internal sealed class HttpInMetricsListener : IDisposable
         TelemetryHttpModule.Options.OnRequestStoppedCallback -= this.OnStopActivity;
     }
 
-    private static string GetHttpProtocolVersion(HttpRequest request)
-    {
-        var protocol = request.ServerVariables["SERVER_PROTOCOL"];
-        return protocol switch
-        {
-            "HTTP/1.1" => "1.1",
-            "HTTP/2" => "2",
-            "HTTP/3" => "3",
-            _ => protocol,
-        };
-    }
-
     private void OnStopActivity(Activity activity, HttpContext context)
     {
         var request = context.Request;
@@ -55,10 +43,10 @@ internal sealed class HttpInMetricsListener : IDisposable
             { SemanticConventions.AttributeHttpResponseStatusCode, context.Response.StatusCode },
         };
 
-        var normalizedMethod = this.requestMethodHelper.GetNormalizedHttpMethod(request.HttpMethod);
+        var normalizedMethod = this.requestDataHelper.GetNormalizedHttpMethod(request.HttpMethod);
         tags.Add(SemanticConventions.AttributeHttpRequestMethod, normalizedMethod);
 
-        var protocolVersion = GetHttpProtocolVersion(request);
+        var protocolVersion = RequestDataHelper.GetHttpProtocolVersion(request);
         if (!string.IsNullOrEmpty(protocolVersion))
         {
             tags.Add(SemanticConventions.AttributeNetworkProtocolVersion, protocolVersion);

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/RequestDataHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/RequestDataHelper.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Implementation;
 
-internal sealed class RequestMethodHelper
+internal sealed class RequestDataHelper
 {
     private const string KnownHttpMethodsEnvironmentVariable = "OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS";
 
@@ -20,7 +21,7 @@ internal sealed class RequestMethodHelper
     // List of known HTTP methods as per spec.
     private readonly Dictionary<string, string> knownHttpMethods;
 
-    public RequestMethodHelper()
+    public RequestDataHelper()
     {
         var suppliedKnownMethods = Environment.GetEnvironmentVariable(KnownHttpMethodsEnvironmentVariable)
             ?.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries);
@@ -40,10 +41,26 @@ internal sealed class RequestMethodHelper
             };
     }
 
+    public static string GetHttpProtocolVersion(HttpRequest request)
+    {
+        return GetHttpProtocolVersion(request.ServerVariables["SERVER_PROTOCOL"]);
+    }
+
     public string GetNormalizedHttpMethod(string method)
     {
         return this.knownHttpMethods.TryGetValue(method, out var normalizedMethod)
             ? normalizedMethod
             : OtherHttpMethod;
+    }
+
+    internal static string GetHttpProtocolVersion(string protocol)
+    {
+        return protocol switch
+        {
+            "HTTP/1.1" => "1.1",
+            "HTTP/2" => "2",
+            "HTTP/3" => "3",
+            _ => protocol,
+        };
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/RequestDataHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/RequestDataHelper.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Web;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Implementation;
 
@@ -44,6 +46,17 @@ internal sealed class RequestDataHelper
     public static string GetHttpProtocolVersion(HttpRequest request)
     {
         return GetHttpProtocolVersion(request.ServerVariables["SERVER_PROTOCOL"]);
+    }
+
+    public void SetHttpMethodTag(Activity activity, string originalHttpMethod)
+    {
+        var normalizedHttpMethod = this.GetNormalizedHttpMethod(originalHttpMethod);
+        activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, normalizedHttpMethod);
+
+        if (originalHttpMethod != normalizedHttpMethod)
+        {
+            activity.SetTag(SemanticConventions.AttributeHttpRequestMethodOriginal, originalHttpMethod);
+        }
     }
 
     public string GetNormalizedHttpMethod(string method)

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -108,5 +108,6 @@ internal static class SemanticConventions
     public const string AttributeNetworkProtocolVersion = "network.protocol.version"; // replaces: "http.flavor" (AttributeHttpFlavor)
     public const string AttributeServerAddress = "server.address"; // replaces: "net.host.name" (AttributeNetHostName)
     public const string AttributeServerPort = "server.port"; // replaces: "net.host.port" (AttributeNetHostPort)
+    public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: http.user_agent (AttributeHttpUserAgent)
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -99,6 +99,7 @@ internal static class SemanticConventions
     // v1.21.0
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-metrics.md#http-server
     public const string AttributeHttpRequestMethod = "http.request.method"; // replaces: "http.method" (AttributeHttpMethod)
+    public const string AttributeHttpRequestMethodOriginal = "http.request.method_original";
     public const string AttributeHttpResponseStatusCode = "http.response.status_code"; // replaces: "http.status_code" (AttributeHttpStatusCode)
     public const string AttributeUrlScheme = "url.scheme"; // replaces: "http.scheme" (AttributeHttpScheme)
 

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -102,6 +102,8 @@ internal static class SemanticConventions
     public const string AttributeHttpRequestMethodOriginal = "http.request.method_original";
     public const string AttributeHttpResponseStatusCode = "http.response.status_code"; // replaces: "http.status_code" (AttributeHttpStatusCode)
     public const string AttributeUrlScheme = "url.scheme"; // replaces: "http.scheme" (AttributeHttpScheme)
+    public const string AttributeUrlPath = "url.path"; // replaces: "http.target" (AttributeHttpTarget)
+    public const string AttributeUrlQuery = "url.query"; // replaces: "http.target" (AttributeHttpTarget)
 
     // v1.23.0
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-metrics.md#http-server

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -95,6 +95,7 @@ internal static class SemanticConventions
     public const string AttributeExceptionType = "exception.type";
     public const string AttributeExceptionMessage = "exception.message";
     public const string AttributeExceptionStacktrace = "exception.stacktrace";
+    public const string AttributeErrorType = "error.type";
 
     // v1.21.0
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-metrics.md#http-server

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -20,24 +20,26 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 public class HttpInListenerTests
 {
     [Theory]
-    [InlineData("http://localhost/", "http://localhost/", 0, null)]
-    [InlineData("http://localhost/", "http://localhost/", 0, null, true)]
-    [InlineData("https://localhost/", "https://localhost/", 0, null)]
-    [InlineData("https://localhost/", "https://user:pass@localhost/", 0, null)] // Test URL sanitization
-    [InlineData("http://localhost:443/", "http://localhost:443/", 0, null)] // Test http over 443
-    [InlineData("https://localhost:80/", "https://localhost:80/", 0, null)] // Test https over 80
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", 0, null)] // Test complex URL
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", 0, null)] // Test complex URL sanitization
-    [InlineData("http://localhost:80/Index", "http://localhost:80/Index", 1, "{controller}/{action}/{id}")]
-    [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", 2, "about_attr_route/{customerId}")]
-    [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", 3, "api/{controller}/{id}")]
-    [InlineData("https://localhost:1843/subroute/10", "https://localhost:1843/subroute/10", 4, "subroute/{customerId}")]
-    [InlineData("http://localhost/api/value", "http://localhost/api/value", 0, null, false, "/api/value")] // Request will be filtered
-    [InlineData("http://localhost/api/value", "http://localhost/api/value", 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
-    [InlineData("http://localhost/", "http://localhost/", 0, null, false, null, true)] // Test RecordException option
+    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, 0, null)]
+    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, 0, null, true)]
+    [InlineData("https://localhost/", "https://localhost/", "localhost", 443, 0, null)]
+    [InlineData("https://localhost/", "https://user:pass@localhost/", "localhost", 443, 0, null)] // Test URL sanitization
+    [InlineData("http://localhost:443/", "http://localhost:443/", "localhost", 443, 0, null)] // Test http over 443
+    [InlineData("https://localhost:80/", "https://localhost:80/", "localhost", 80, 0, null)] // Test https over 80
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, 0, null)] // Test complex URL
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, 0, null)] // Test complex URL sanitization
+    [InlineData("http://localhost:80/Index", "http://localhost:80/Index", "localhost", 80, 1, "{controller}/{action}/{id}")]
+    [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", "localhost", 443, 2, "about_attr_route/{customerId}")]
+    [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", "localhost", 1880, 3, "api/{controller}/{id}")]
+    [InlineData("https://localhost:1843/subroute/10", "https://localhost:1843/subroute/10", "localhost", 1843, 4, "subroute/{customerId}")]
+    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, 0, null, false, "/api/value")] // Request will be filtered
+    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
+    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, 0, null, false, null, true)] // Test RecordException option
     public void AspNetRequestsAreCollectedSuccessfully(
         string expectedUrl,
         string url,
+        string expectedHost,
+        int expectedPort,
         int routeType,
         string routeTemplate,
         bool setStatusToErrorInEnrich = false,
@@ -130,19 +132,8 @@ public class HttpInListenerTests
             Assert.Contains($":{expectedUri.Port}", actualUrl as string);
         }
 
-        // Host includes port if it isn't 80 or 443.
-        if (expectedUri.Port is 80 or 443)
-        {
-            Assert.Equal(
-                expectedUri.Host,
-                span.GetTagValue(SemanticConventions.AttributeHttpHost) as string);
-        }
-        else
-        {
-            Assert.Equal(
-                $"{expectedUri.Host}:{expectedUri.Port}",
-                span.GetTagValue(SemanticConventions.AttributeHttpHost) as string);
-        }
+        Assert.Equal(expectedHost, span.GetTagValue("server.address"));
+        Assert.Equal(expectedPort, span.GetTagValue("server.port"));
 
         Assert.Equal(HttpContext.Current.Request.HttpMethod, span.GetTagValue(SemanticConventions.AttributeHttpMethod) as string);
         Assert.Equal(HttpContext.Current.Request.Path, span.GetTagValue(SemanticConventions.AttributeHttpTarget) as string);

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -142,6 +142,7 @@ public class HttpInListenerTests
 
         Assert.Equal(expectedRequestMethod, span.GetTagValue("http.request.method"));
         Assert.Equal(expectedOriginalRequestMethod, span.GetTagValue("http.request.method_original"));
+        Assert.Equal("FakeHTTP/123", span.GetTagValue("network.protocol.version"));
 
         Assert.Equal(expectedUrlPath, span.GetTagValue("url.path"));
         Assert.Equal(expectedUrlScheme, span.GetTagValue("url.scheme"));

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -118,7 +118,7 @@ public class HttpInListenerTests
         Assert.Equal(ActivityKind.Server, span.Kind);
         Assert.True(span.Duration != TimeSpan.Zero);
 
-        Assert.Equal(200, span.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
+        Assert.Equal(200, span.GetTagValue("http.response.status_code"));
 
         var expectedUri = new Uri(expectedUrl);
         var actualUrl = span.GetTagValue(SemanticConventions.AttributeHttpUrl);

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -21,15 +21,15 @@ public class HttpInListenerTests
 {
     [Theory]
     [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null)]
-    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/",  "foo=bar&baz=test", "localhost", 80, "POST", "POST", null, 0, null, true)]
-    [InlineData("https://localhost/", "https", "/",  null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
-    [InlineData("https://user:pass@localhost/", "https", "/", null,  "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
+    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", "localhost", 80, "POST", "POST", null, 0, null, true)]
+    [InlineData("https://localhost/", "https", "/", null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
+    [InlineData("https://user:pass@localhost/", "https", "/", null, "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
     [InlineData("http://localhost:443/", "http", "/", null, "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
     [InlineData("https://localhost:80/", "https", "/", null, "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
     [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL
-    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2",  "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
+    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
     [InlineData("http://localhost:80/Index", "http", "/Index", null, "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}")]
-    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null,  "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
+    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null, "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
     [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}")]
     [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}")]
     [InlineData("http://localhost/api/value", "http", "/api/value", null, "localhost", 80, "GET", "GET", null, 0, null, false, "/api/value")] // Request will be filtered

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -142,7 +142,7 @@ public class HttpInListenerTests
         Assert.Equal(expectedOriginalRequestMethod, span.GetTagValue("http.request.method_original"));
 
         Assert.Equal(HttpContext.Current.Request.Path, span.GetTagValue(SemanticConventions.AttributeHttpTarget) as string);
-        Assert.Equal(HttpContext.Current.Request.UserAgent, span.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
+        Assert.Equal("Custom User Agent v1.2.3", span.GetTagValue("user_agent.original"));
 
         if (recordException)
         {

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -23,7 +23,7 @@ public class HttpInListenerTests
     [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null)]
     [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", "localhost", 80, "POST", "POST", null, 0, null, true)]
     [InlineData("https://localhost/", "https", "/", null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
-    [InlineData("https://user:pass@localhost/", "https", "/", null, "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
+    [InlineData("https://user:pass@localhost/", "https", "/", null, "localhost", 443, "GeT", "GET", "GeT", 0, null)] // Test URL sanitization
     [InlineData("http://localhost:443/", "http", "/", null, "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
     [InlineData("https://localhost:80/", "https", "/", null, "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
     [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -20,33 +20,36 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 public class HttpInListenerTests
 {
     [Theory]
-    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, 0, null)]
-    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, 0, null, true)]
-    [InlineData("https://localhost/", "https://localhost/", "localhost", 443, 0, null)]
-    [InlineData("https://localhost/", "https://user:pass@localhost/", "localhost", 443, 0, null)] // Test URL sanitization
-    [InlineData("http://localhost:443/", "http://localhost:443/", "localhost", 443, 0, null)] // Test http over 443
-    [InlineData("https://localhost:80/", "https://localhost:80/", "localhost", 80, 0, null)] // Test https over 80
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, 0, null)] // Test complex URL
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, 0, null)] // Test complex URL sanitization
-    [InlineData("http://localhost:80/Index", "http://localhost:80/Index", "localhost", 80, 1, "{controller}/{action}/{id}")]
-    [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", "localhost", 443, 2, "about_attr_route/{customerId}")]
-    [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", "localhost", 1880, 3, "api/{controller}/{id}")]
-    [InlineData("https://localhost:1843/subroute/10", "https://localhost:1843/subroute/10", "localhost", 1843, 4, "subroute/{customerId}")]
-    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, 0, null, false, "/api/value")] // Request will be filtered
-    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
-    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, 0, null, false, null, true)] // Test RecordException option
+    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, "GET", "GET", null, 0, null)]
+    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, "POST", "POST", null, 0, null, true)]
+    [InlineData("https://localhost/", "https://localhost/", "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
+    [InlineData("https://localhost/", "https://user:pass@localhost/", "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
+    [InlineData("http://localhost:443/", "http://localhost:443/", "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
+    [InlineData("https://localhost:80/", "https://localhost:80/", "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
+    [InlineData("http://localhost:80/Index", "http://localhost:80/Index", "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}")]
+    [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
+    [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}")]
+    [InlineData("https://localhost:1843/subroute/10", "https://localhost:1843/subroute/10", "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}")]
+    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "/api/value")] // Request will be filtered
+    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
+    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, "GET", "GET", null, 0, null, false, null, true)] // Test RecordException option
     public void AspNetRequestsAreCollectedSuccessfully(
         string expectedUrl,
         string url,
         string expectedHost,
         int expectedPort,
+        string requestMethod,
+        string expectedRequestMethod,
+        string? expectedOriginalRequestMethod,
         int routeType,
         string routeTemplate,
         bool setStatusToErrorInEnrich = false,
         string? filter = null,
         bool recordException = false)
     {
-        HttpContext.Current = RouteTestHelper.BuildHttpContext(url, routeType, routeTemplate);
+        HttpContext.Current = RouteTestHelper.BuildHttpContext(url, routeType, routeTemplate, requestMethod);
 
         typeof(HttpRequest).GetField("_wr", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(HttpContext.Current.Request, new TestHttpWorkerRequest());
 
@@ -135,7 +138,9 @@ public class HttpInListenerTests
         Assert.Equal(expectedHost, span.GetTagValue("server.address"));
         Assert.Equal(expectedPort, span.GetTagValue("server.port"));
 
-        Assert.Equal(HttpContext.Current.Request.HttpMethod, span.GetTagValue(SemanticConventions.AttributeHttpMethod) as string);
+        Assert.Equal(expectedRequestMethod, span.GetTagValue("http.request.method"));
+        Assert.Equal(expectedOriginalRequestMethod, span.GetTagValue("http.request.method_original"));
+
         Assert.Equal(HttpContext.Current.Request.Path, span.GetTagValue(SemanticConventions.AttributeHttpTarget) as string);
         Assert.Equal(HttpContext.Current.Request.UserAgent, span.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -20,25 +20,26 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 public class HttpInListenerTests
 {
     [Theory]
-    [InlineData("http://localhost/", "http", "/", "localhost", 80, "GET", "GET", null, 0, null)]
-    [InlineData("http://localhost/", "http", "/", "localhost", 80, "POST", "POST", null, 0, null, true)]
-    [InlineData("https://localhost/", "https", "/", "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
-    [InlineData("https://user:pass@localhost/", "https", "/", "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
-    [InlineData("http://localhost:443/", "http", "/", "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
-    [InlineData("https://localhost:80/", "https", "/", "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL
-    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm",  "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
-    [InlineData("http://localhost:80/Index", "http", "/Index", "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}")]
-    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10",  "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
-    [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}")]
-    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}")]
-    [InlineData("http://localhost/api/value", "http", "/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "/api/value")] // Request will be filtered
-    [InlineData("http://localhost/api/value", "http", "/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
-    [InlineData("http://localhost/", "http", "/", "localhost", 80, "GET", "GET", null, 0, null, false, null, true)] // Test RecordException option
+    [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null)]
+    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/",  "foo=bar&baz=test", "localhost", 80, "POST", "POST", null, 0, null, true)]
+    [InlineData("https://localhost/", "https", "/",  null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
+    [InlineData("https://user:pass@localhost/", "https", "/", null,  "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
+    [InlineData("http://localhost:443/", "http", "/", null, "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
+    [InlineData("https://localhost:80/", "https", "/", null, "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL
+    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2",  "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
+    [InlineData("http://localhost:80/Index", "http", "/Index", null, "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}")]
+    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null,  "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
+    [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}")]
+    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}")]
+    [InlineData("http://localhost/api/value", "http", "/api/value", null, "localhost", 80, "GET", "GET", null, 0, null, false, "/api/value")] // Request will be filtered
+    [InlineData("http://localhost/api/value", "http", "/api/value", null, "localhost", 80, "GET", "GET", null, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
+    [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null, false, null, true)] // Test RecordException option
     public void AspNetRequestsAreCollectedSuccessfully(
         string url,
         string expectedUrlScheme,
         string expectedUrlPath,
+        string expectedUrlQuery,
         string expectedHost,
         int expectedPort,
         string requestMethod,
@@ -129,6 +130,7 @@ public class HttpInListenerTests
         Assert.Equal("FakeHTTP/123", span.GetTagValue("network.protocol.version"));
 
         Assert.Equal(expectedUrlPath, span.GetTagValue("url.path"));
+        Assert.Equal(expectedUrlQuery, span.GetTagValue("url.query"));
         Assert.Equal(expectedUrlScheme, span.GetTagValue("url.scheme"));
         Assert.Equal("Custom User Agent v1.2.3", span.GetTagValue("user_agent.original"));
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -20,21 +20,21 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 public class HttpInListenerTests
 {
     [Theory]
-    [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null)]
-    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", "localhost", 80, "POST", "POST", null, 0, null, true)]
-    [InlineData("https://localhost/", "https", "/", null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
-    [InlineData("https://user:pass@localhost/", "https", "/", null, "localhost", 443, "GeT", "GET", "GeT", 0, null)] // Test URL sanitization
-    [InlineData("http://localhost:443/", "http", "/", null, "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
-    [InlineData("https://localhost:80/", "https", "/", null, "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL
-    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
-    [InlineData("http://localhost:80/Index", "http", "/Index", null, "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}")]
-    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null, "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
-    [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}")]
-    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}")]
-    [InlineData("http://localhost/api/value", "http", "/api/value", null, "localhost", 80, "GET", "GET", null, 0, null, false, "/api/value")] // Request will be filtered
-    [InlineData("http://localhost/api/value", "http", "/api/value", null, "localhost", 80, "GET", "GET", null, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
-    [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null, false, null, true, "System.InvalidOperationException")] // Test RecordException option
+    [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null, "GET")]
+    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", "localhost", 80, "POST", "POST", null, 0, null, "POST", true)]
+    [InlineData("https://localhost/", "https", "/", null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null, "HTTP")]
+    [InlineData("https://user:pass@localhost/", "https", "/", null, "localhost", 443, "GeT", "GET", "GeT", 0, null, "GET")] // Test URL sanitization
+    [InlineData("http://localhost:443/", "http", "/", null, "localhost", 443, "GET", "GET", null, 0, null, "GET")] // Test http over 443
+    [InlineData("https://localhost:80/", "https", "/", null, "localhost", 80, "GET", "GET", null, 0, null, "GET")] // Test https over 80
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null, "GET")] // Test complex URL
+    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", "localhost", 80, "GET", "GET", null, 0, null, "GET")] // Test complex URL sanitization
+    [InlineData("http://localhost:80/Index", "http", "/Index", null, "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}", "GET {controller}/{action}/{id}")]
+    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null, "localhost", 443, "HEAD", "HEAD", null, 2, "about_attr_route/{customerId}", "HEAD about_attr_route/{customerId}")]
+    [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}", "GET api/{controller}/{id}")]
+    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}", "GET subroute/{customerId}")]
+    [InlineData("http://localhost/api/value", "http", "/api/value", null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, "/api/value")] // Request will be filtered
+    [InlineData("http://localhost/api/value", "http", "/api/value", null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, "{ThrowException}")] // Filter user code will throw an exception
+    [InlineData("http://localhost/", "http", "/", null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, null, true, "System.InvalidOperationException")] // Test RecordException option
     public void AspNetRequestsAreCollectedSuccessfully(
         string url,
         string expectedUrlScheme,
@@ -46,7 +46,8 @@ public class HttpInListenerTests
         string expectedRequestMethod,
         string? expectedOriginalRequestMethod,
         int routeType,
-        string routeTemplate,
+        string? routeTemplate,
+        string expectedName,
         bool setStatusToErrorInEnrich = false,
         string? filter = null,
         bool recordException = false,
@@ -117,7 +118,7 @@ public class HttpInListenerTests
         Assert.Equal(TelemetryHttpModule.AspNetActivityName, span.OperationName);
         Assert.NotEqual(TimeSpan.Zero, span.Duration);
 
-        Assert.Equal(routeTemplate ?? HttpContext.Current.Request.Path, span.DisplayName);
+        Assert.Equal(expectedName, span.DisplayName);
         Assert.Equal(ActivityKind.Server, span.Kind);
         Assert.True(span.Duration != TimeSpan.Zero);
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -20,24 +20,25 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 public class HttpInListenerTests
 {
     [Theory]
-    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, "GET", "GET", null, 0, null)]
-    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, "POST", "POST", null, 0, null, true)]
-    [InlineData("https://localhost/", "https://localhost/", "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
-    [InlineData("https://localhost/", "https://user:pass@localhost/", "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
-    [InlineData("http://localhost:443/", "http://localhost:443/", "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
-    [InlineData("https://localhost:80/", "https://localhost:80/", "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
-    [InlineData("http://localhost:80/Index", "http://localhost:80/Index", "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}")]
-    [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
-    [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}")]
-    [InlineData("https://localhost:1843/subroute/10", "https://localhost:1843/subroute/10", "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}")]
-    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "/api/value")] // Request will be filtered
-    [InlineData("http://localhost/api/value", "http://localhost/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
-    [InlineData("http://localhost/", "http://localhost/", "localhost", 80, "GET", "GET", null, 0, null, false, null, true)] // Test RecordException option
+    [InlineData("http://localhost/", "http://localhost/", "/", "localhost", 80, "GET", "GET", null, 0, null)]
+    [InlineData("http://localhost/", "http://localhost/", "/", "localhost", 80, "POST", "POST", null, 0, null, true)]
+    [InlineData("https://localhost/", "https://localhost/", "/", "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null)]
+    [InlineData("https://localhost/", "https://user:pass@localhost/", "/", "localhost", 443, "GET", "GET", null, 0, null)] // Test URL sanitization
+    [InlineData("http://localhost:443/", "http://localhost:443/", "/", "localhost", 443, "GET", "GET", null, 0, null)] // Test http over 443
+    [InlineData("https://localhost:80/", "https://localhost:80/", "/", "localhost", 80, "GET", "GET", null, 0, null)] // Test https over 80
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "/Home/Index.htm", "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "/Home/Index.htm",  "localhost", 80, "GET", "GET", null, 0, null)] // Test complex URL sanitization
+    [InlineData("http://localhost:80/Index", "http://localhost:80/Index", "/Index", "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}")]
+    [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", "/about_attr_route/10",  "localhost", 443, "GET", "GET", null, 2, "about_attr_route/{customerId}")]
+    [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", "/api/weatherforecast", "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}")]
+    [InlineData("https://localhost:1843/subroute/10", "https://localhost:1843/subroute/10", "/subroute/10", "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}")]
+    [InlineData("http://localhost/api/value", "http://localhost/api/value", "/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "/api/value")] // Request will be filtered
+    [InlineData("http://localhost/api/value", "http://localhost/api/value", "/api/value", "localhost", 80, "GET", "GET", null, 0, null, false, "{ThrowException}")] // Filter user code will throw an exception
+    [InlineData("http://localhost/", "http://localhost/", "/", "localhost", 80, "GET", "GET", null, 0, null, false, null, true)] // Test RecordException option
     public void AspNetRequestsAreCollectedSuccessfully(
         string expectedUrl,
         string url,
+        string expectedUrlPath,
         string expectedHost,
         int expectedPort,
         string requestMethod,
@@ -141,7 +142,7 @@ public class HttpInListenerTests
         Assert.Equal(expectedRequestMethod, span.GetTagValue("http.request.method"));
         Assert.Equal(expectedOriginalRequestMethod, span.GetTagValue("http.request.method_original"));
 
-        Assert.Equal(HttpContext.Current.Request.Path, span.GetTagValue(SemanticConventions.AttributeHttpTarget) as string);
+        Assert.Equal(expectedUrlPath, span.GetTagValue("url.path"));
         Assert.Equal("Custom User Agent v1.2.3", span.GetTagValue("user_agent.original"));
 
         if (recordException)

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -41,7 +41,7 @@ public class HttpInMetricsListenerTests
         int expectedStatus)
     {
         double duration = 0;
-        HttpContext.Current = RouteTestHelper.BuildHttpContext(url, routeType, routeTemplate);
+        HttpContext.Current = RouteTestHelper.BuildHttpContext(url, routeType, routeTemplate, "GET");
         HttpContext.Current.Response.StatusCode = expectedStatus;
 
         // This is to enable activity creation

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperTests.cs
@@ -41,11 +41,11 @@ public class RequestDataHelperTests : IDisposable
     [InlineData("get", "GET")]
     [InlineData("post", "POST")]
     [InlineData("invalid", "_OTHER")]
-    public void MethodMappingWorksForEnvironmentVariables(string protocolVersion, string expected)
+    public void MethodMappingWorksForEnvironmentVariables(string method, string expected)
     {
         Environment.SetEnvironmentVariable("OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS", "GET,POST");
         var requestHelper = new RequestDataHelper();
-        var actual = requestHelper.GetNormalizedHttpMethod(protocolVersion);
+        var actual = requestHelper.GetNormalizedHttpMethod(method);
         Assert.Equal(expected, actual);
     }
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 
-public class RequestMethodHelperTests : IDisposable
+public class RequestDataHelperTests : IDisposable
 {
     [Theory]
     [InlineData("GET", "GET")]
@@ -23,7 +23,7 @@ public class RequestMethodHelperTests : IDisposable
     [InlineData("invalid", "_OTHER")]
     public void MethodMappingWorksForKnownMethods(string method, string expected)
     {
-        var requestHelper = new RequestMethodHelper();
+        var requestHelper = new RequestDataHelper();
         var actual = requestHelper.GetNormalizedHttpMethod(method);
         Assert.Equal(expected, actual);
     }
@@ -41,11 +41,22 @@ public class RequestMethodHelperTests : IDisposable
     [InlineData("get", "GET")]
     [InlineData("post", "POST")]
     [InlineData("invalid", "_OTHER")]
-    public void MethodMappingWorksForEnvironmentVariables(string method, string expected)
+    public void MethodMappingWorksForEnvironmentVariables(string protocolVersion, string expected)
     {
         Environment.SetEnvironmentVariable("OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS", "GET,POST");
-        var requestHelper = new RequestMethodHelper();
-        var actual = requestHelper.GetNormalizedHttpMethod(method);
+        var requestHelper = new RequestDataHelper();
+        var actual = requestHelper.GetNormalizedHttpMethod(protocolVersion);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("HTTP/1.1", "1.1")]
+    [InlineData("HTTP/2", "2")]
+    [InlineData("HTTP/3", "3")]
+    [InlineData("Unknown", "Unknown")]
+    public void MappingProtocolToVersion(string protocolVersion, string expected)
+    {
+        var actual = RequestDataHelper.GetHttpProtocolVersion(protocolVersion);
         Assert.Equal(expected, actual);
     }
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 
 internal static class RouteTestHelper
 {
-    public static HttpContext BuildHttpContext(string url, int routeType, string routeTemplate, string requestMethod)
+    public static HttpContext BuildHttpContext(string url, int routeType, string? routeTemplate, string requestMethod)
     {
         RouteData routeData;
         switch (routeType)
@@ -21,7 +21,7 @@ internal static class RouteTestHelper
             case 1: // Traditional MVC.
             case 2: // Attribute routing MVC.
             case 3: // Traditional WebAPI.
-                routeData = new RouteData()
+                routeData = new RouteData
                 {
                     Route = new Route(routeTemplate, null),
                 };

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 
 internal static class RouteTestHelper
 {
-    public static HttpContext BuildHttpContext(string url, int routeType, string routeTemplate)
+    public static HttpContext BuildHttpContext(string url, int routeType, string routeTemplate, string requestMethod)
     {
         RouteData routeData;
         switch (routeType)
@@ -48,11 +48,13 @@ internal static class RouteTestHelper
 
         var request = new HttpRequest(string.Empty, url, string.Empty)
         {
-            RequestContext = new RequestContext()
+            RequestContext = new RequestContext
             {
                 RouteData = routeData,
             },
         };
+
+        typeof(HttpRequest).GetField("_httpMethod", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).SetValue(request, requestMethod);
 
         return new HttpContext(request, new HttpResponse(new StringWriter()));
     }

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/TestHttpWorkerRequest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/TestHttpWorkerRequest.cs
@@ -35,17 +35,17 @@ internal class TestHttpWorkerRequest : HttpWorkerRequest
 
     public override string GetHttpVersion()
     {
-        throw new NotImplementedException();
+        return "FakeHTTP/123";
     }
 
     public override string GetLocalAddress()
     {
-        throw new NotImplementedException();
+        return "fake-local-address"; // avoid throwing exception
     }
 
     public override int GetLocalPort()
     {
-        throw new NotImplementedException();
+        return 1234; // avoid throwing exception
     }
 
     public override string GetQueryString()
@@ -60,7 +60,7 @@ internal class TestHttpWorkerRequest : HttpWorkerRequest
 
     public override string GetRemoteAddress()
     {
-        throw new NotImplementedException();
+        return "fake-remote-address"; // avoid throwing exception
     }
 
     public override int GetRemotePort()

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/TestHttpWorkerRequest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/TestHttpWorkerRequest.cs
@@ -8,6 +8,16 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 
 internal class TestHttpWorkerRequest : HttpWorkerRequest
 {
+    public override string GetKnownRequestHeader(int index)
+    {
+        if (index == 39)
+        {
+            return "Custom User Agent v1.2.3";
+        }
+
+        return base.GetKnownRequestHeader(index);
+    }
+
     public override void EndOfRequest()
     {
         throw new NotImplementedException();


### PR DESCRIPTION
Fixes N/A

## Changes

Span attributes based on [HTTP semantic convention v1.24.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md) - Common and Server part sections.

Span names:
* [x] Span names: 87bf97bf081b20b4433554840278844b37af8931

Common part

* [x] `error.type` -  ccb1d4f44a4e285419065393d48303d40d694d6a
* [x] `http.request.method` and `http.request.method_original` - e31b6875bba6e2b9fe2c5c7fa9d8f19e66629554
* [ ] `http.response.header.<key>` - Opn-In - skipping for now
* [x] `http.response.status_code` - 5677f4ffbd4c1dd6bd7a009783cae42e91265e4e
* [ ] `network.peer.address` and `network.peer.port` - Recommended - skipping for now
* [x] `network.protocol.name` - empty, means HTTP by default
* [x] `network.protocol.version` - a79495128f842f015af5541c266b0cfbb78eae40
* [ ] `network.transport` -  Opn-In - skipping for now

Server part:

* [ ] `client.address` - Recommended - skipping for now
* [ ] `client.port` - Opt-In skipping for now
* [ ] `http.request.header.<key>` - Opt-In skipping for now
* [x] `http.route` - already handled, no changes
* [ ] `network.local.address` and `network.local.port` - Opt-In skipping for now
* [x] `server.address` and `server.port` - 3d3ce2ec172e0f2ae9eec411003ea0e73e6278f1
* [x] `url.path` - 86fdf5a6449c3430aa664ae2cf722b30ed4b9e87
* [x] `url.query` - e92046869895544cd03888caadf9ea3932c689b0
* [x] `url.scheme` - 445a6849be46deffad7d6888950958111423d005
* [x] `user_agent.original` - 78e266a31331faea9e8b93b67dbbe3ae95bf59a0

Consider to review commits separately.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
