### PR TITLE
[Instrumentation.Redis] Fix and modernize example

### DIFF
--- a/examples/redis/Examples.StackExchangeRedis/Examples.StackExchangeRedis.csproj
+++ b/examples/redis/Examples.StackExchangeRedis/Examples.StackExchangeRedis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/examples/redis/Examples.StackExchangeRedis/Examples.StackExchangeRedis.csproj
+++ b/examples/redis/Examples.StackExchangeRedis/Examples.StackExchangeRedis.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/redis/Examples.StackExchangeRedis/Examples.StackExchangeRedis.csproj
+++ b/examples/redis/Examples.StackExchangeRedis/Examples.StackExchangeRedis.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/redis/Examples.StackExchangeRedis/Program.cs
+++ b/examples/redis/Examples.StackExchangeRedis/Program.cs
@@ -5,35 +5,29 @@ using OpenTelemetry;
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
 
-public class Program
-{
-    public static void Main()
+// Prerequisite:
+/*
+ * Setup redis service inside local docker.
+ * docker run --name opentelemetry-redis-test -d -p 6379:6379 redis
+ */
+
+// connect to the redis server. The default port 6379 will be used.
+var connection = ConnectionMultiplexer.Connect("localhost");
+
+// Configure exporter to export traces to Zipkin
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddConsoleExporter()
+    .AddRedisInstrumentation(connection, options =>
     {
-        // Prerequisite:
-        /*
-         * Setup redis service inside local docker.
-         * docker run --name opentelemetry-redis-test -d -p 6379:6379 redis
-         */
+        // changing flush interval from 10s to 5s
+        options.FlushInterval = TimeSpan.FromSeconds(5);
+    })
+    .Build();
 
-        // connect to the redis server. The default port 6379 will be used.
-        var connection = ConnectionMultiplexer.Connect("localhost");
+// select a database (by default, DB = 0)
+var db = connection.GetDatabase();
+db.StringSet("key", "value " + DateTime.Now.ToLongDateString());
+Thread.Sleep(1000);
 
-        // Configure exporter to export traces to Zipkin
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddConsoleExporter()
-                .AddRedisInstrumentation(connection, options =>
-                {
-                    // changing flush interval from 10s to 5s
-                    options.FlushInterval = TimeSpan.FromSeconds(5);
-                })
-                .Build();
-
-        // select a database (by default, DB = 0)
-        var db = connection.GetDatabase();
-        db.StringSet("key", "value " + DateTime.Now.ToLongDateString());
-        Thread.Sleep(1000);
-
-        // run a command, in this case a GET
-        var myVal = db.StringGet("key");
-    }
-}
+// run a command, in this case a GET
+var myVal = db.StringGet("key");

--- a/examples/redis/Examples.StackExchangeRedis/README.md
+++ b/examples/redis/Examples.StackExchangeRedis/README.md
@@ -7,14 +7,14 @@ this application (please look at the prerequisite for running the application in
 [Program.cs](./Program.cs):
 
 ```text
-Activity.TraceId:          f1a47baec558ebb97e57a6fb7d029a29
-Activity.SpanId:           d0abf2503ad3d1b6
-Activity.TraceFlags:           Recorded
+Activity.TraceId:            ebf13ff051d73072f87d07ebf08d5f26
+Activity.SpanId:             326c619dbda12231
+Activity.TraceFlags:         Recorded
 Activity.ActivitySourceName: OpenTelemetry.Instrumentation.StackExchangeRedis
-Activity.DisplayName: SET
-Activity.Kind:        Client
-Activity.StartTime:   2022-06-06T22:17:40.8927802Z
-Activity.Duration:    00:00:00.0237767
+Activity.DisplayName:        SET
+Activity.Kind:               Client
+Activity.StartTime:          2024-03-14T09:35:28.1473251Z
+Activity.Duration:           00:00:00.0050600
 Activity.Tags:
     db.system: redis
     db.redis.flags: DemandMaster
@@ -22,22 +22,24 @@ Activity.Tags:
     net.peer.name: localhost
     net.peer.port: 6379
     db.redis.database_index: 0
-   StatusCode : UNSET
 Activity.Events:
-    Enqueued [6/6/2022 10:17:40 PM +00:00]
-    Sent [6/6/2022 10:17:40 PM +00:00]
-    ResponseReceived [6/6/2022 10:17:40 PM +00:00]
+    Enqueued [3/14/2024 9:35:28 AM +00:00]
+    Sent [3/14/2024 9:35:28 AM +00:00]
+    ResponseReceived [3/14/2024 9:35:28 AM +00:00]
 Resource associated with Activity:
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: dotnet
+    telemetry.sdk.version: 1.7.0
     service.name: unknown_service:Examples.StackExchangeRedis
 
-Activity.TraceId:          0db37d796826693e23b17e3b082356a4
-Activity.SpanId:           cd01d518b8b5cfa2
-Activity.TraceFlags:           Recorded
+Activity.TraceId:            1824275fc972c4f0f3180a175ba38acc
+Activity.SpanId:             734196993db5b8dd
+Activity.TraceFlags:         Recorded
 Activity.ActivitySourceName: OpenTelemetry.Instrumentation.StackExchangeRedis
-Activity.DisplayName: GET
-Activity.Kind:        Client
-Activity.StartTime:   2022-06-06T22:17:41.9223474Z
-Activity.Duration:    00:00:00.0067062
+Activity.DisplayName:        GET
+Activity.Kind:               Client
+Activity.StartTime:          2024-03-14T09:35:29.1575041Z
+Activity.Duration:           00:00:00.0031683
 Activity.Tags:
     db.system: redis
     db.redis.flags: None
@@ -45,11 +47,13 @@ Activity.Tags:
     net.peer.name: localhost
     net.peer.port: 6379
     db.redis.database_index: 0
-   StatusCode : UNSET
 Activity.Events:
-    Enqueued [6/6/2022 10:17:41 PM +00:00]
-    Sent [6/6/2022 10:17:41 PM +00:00]
-    ResponseReceived [6/6/2022 10:17:41 PM +00:00]
+    Enqueued [3/14/2024 9:35:29 AM +00:00]
+    Sent [3/14/2024 9:35:29 AM +00:00]
+    ResponseReceived [3/14/2024 9:35:29 AM +00:00]
 Resource associated with Activity:
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: dotnet
+    telemetry.sdk.version: 1.7.0
     service.name: unknown_service:Examples.StackExchangeRedis
 ```


### PR DESCRIPTION
Fixes #1530.

## Changes

* Bugfix - d460d0c1c8e7532a119e0d0eee993cd81ac4509c - update Console exporter. There were a conflict with newer OTel referenced by Redis instrumentation package.
* Update .NET from 6 to 8
* Use top-level statement to reduce code [consider to review without white characters]
* Update output based on local execution
* EDIT: Console pinned to `$(OpenTelemetryCoreLatestVersion)` to avoid such issues in the future.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
