### PR TITLE
[PersistantStorage] fix event source throws `System.FormatException`

### DIFF
--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -341,6 +341,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.ResourceDetectors.Host.Tests", "test\OpenTelemetry.ResourceDetectors.Host.Tests\OpenTelemetry.ResourceDetectors.Host.Tests.csproj", "{36271347-2055-438E-9659-B71542A17A73}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.PersistentStorage.Abstractions.Tests", "test\OpenTelemetry.PersistentStorage.Abstractions.Tests\OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj", "{7AD707F9-DC6D-430A-8834-D5DCD517BF6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -683,6 +685,10 @@ Global
 		{36271347-2055-438E-9659-B71542A17A73}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36271347-2055-438E-9659-B71542A17A73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36271347-2055-438E-9659-B71542A17A73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AD707F9-DC6D-430A-8834-D5DCD517BF6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AD707F9-DC6D-430A-8834-D5DCD517BF6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AD707F9-DC6D-430A-8834-D5DCD517BF6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AD707F9-DC6D-430A-8834-D5DCD517BF6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -785,6 +791,7 @@ Global
 		{A5EF701C-439E-407F-8BB4-394166000C6D} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 		{033CA8D4-1529-413A-B244-07958D5F9A48} = {22DF5DC0-1290-4E83-A9D8-6BB7DE3B3E63}
 		{36271347-2055-438E-9659-B71542A17A73} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
+		{7AD707F9-DC6D-430A-8834-D5DCD517BF6E} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}

--- a/src/OpenTelemetry.PersistentStorage.Abstractions/AssemblyInfo.cs
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/AssemblyInfo.cs
@@ -2,5 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
+
+[assembly: InternalsVisibleTo("OpenTelemetry.PersistentStorage.Abstractions.Tests" + AssemblyInfo.PublicKey)]
+
+#if SIGNED
+internal static class AssemblyInfo
+{
+    public const string PublicKey = ", PublicKey=002400000480000094000000060200000024000052534131000400000100010051C1562A090FB0C9F391012A32198B5E5D9A60E9B80FA2D7B434C9E5CCB7259BD606E66F9660676AFC6692B8CDC6793D190904551D2103B7B22FA636DCBB8208839785BA402EA08FC00C8F1500CCEF28BBF599AA64FFB1E1D5DC1BF3420A3777BADFE697856E9D52070A50C3EA5821C80BEF17CA3ACFFA28F89DD413F096F898";
+}
+#else
+internal static class AssemblyInfo
+{
+    public const string PublicKey = "";
+}
+#endif

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - OpenTelemetry.PersistentStorage.FileSystem
 
+## Unrealeased
+
+* Fix `System.FormatException` thrown by `PersistentStorageEventSource`.
+  [#1613](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1613)
+
 ## 1.0.0
 
 Released 2023-Aug-28

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/PersistentStorageEventSource.cs
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/PersistentStorageEventSource.cs
@@ -146,7 +146,7 @@ internal sealed class PersistentStorageEventSource : EventSource
         this.WriteEvent(8, srcFilePath, destFilePath, ex);
     }
 
-    [Event(9, Message = "{0}: Error Message: {1}. Exception: {3}", Level = EventLevel.Error)]
+    [Event(9, Message = "{0}: Error Message: {1}. Exception: {2}", Level = EventLevel.Error)]
     public void PersistentStorageException(string className, string message, string ex)
     {
         this.WriteEvent(9, className, message, ex);

--- a/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/EventSourceTests.cs
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Tests;
+using Xunit;
+
+namespace OpenTelemetry.PersistentStorage.Abstractions.Tests;
+
+public class EventSourceTests
+{
+    [Fact]
+    public void EventSourceTest_PersistentStorageEventSource()
+    {
+        EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(PersistentStorageAbstractionsEventSource.Log);
+    }
+}

--- a/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj
+++ b/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.FileSystem\OpenTelemetry.PersistentStorage.FileSystem.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.Abstractions\OpenTelemetry.PersistentStorage.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/EventSourceTests.cs
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Tests;
+using Xunit;
+
+namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
+
+public class EventSourceTests
+{
+
+    [Fact]
+    public void EventSourceTest_PersistentStorageEventSource()
+    {
+        EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(PersistentStorageEventSource.Log);
+    }
+}

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/EventSourceTests.cs
@@ -8,7 +8,6 @@ namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
 
 public class EventSourceTests
 {
-
     [Fact]
     public void EventSourceTest_PersistentStorageEventSource()
     {


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-dotnet/pull/5451

This PR fixes a bug in the `PersistentStorageEventSource` class. 

```
System.FormatException
  HResult=0x80131537
  Message=Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
  Source=System.Private.CoreLib
  StackTrace:
   at System.ThrowHelper.ThrowFormatIndexOutOfRange()
   at System.Text.ValueStringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at System.String.Format(IFormatProvider provider, String format, Object[] args)
   at Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.OpenTelemetryEventListener.OnEventWritten(EventWrittenEventArgs eventData) in C:\Users\Rohit Ranjan\source\repos\azure-functions-host\src\WebJobs.Script.WebHost\Diagnostics\OpenTelemetryEventListener.cs:line 54
   at System.Diagnostics.Tracing.EventSource.DispatchToAllListeners(EventWrittenEventArgs eventCallbackArgs)
```




### Changes
- PersistantStorage.FileSystem
  - `PersistentStorageEventSource`: fix index in Event attribute.
  -  Add unit test to verify event source class.
- PersistantStorage.Abstractions
  - Add test project 
  - Add unit test to verify event source class.
