### PR TITLE
[onecollector] Expose SetHttpClientFactory to allow users to configure the HttpClient used to transmit telemetry

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback) -> System.IDisposable?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
@@ -10,6 +11,7 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallba
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.CopyPayloadToStream(System.IO.Stream! destination) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.OneCollectorExporterPayloadTransmittedCallbackArguments() -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.PayloadSizeInBytes.get -> long
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.TransportEndpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType.Ignore = 0 -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
+OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetHttpClientFactory(System.Func<System.Net.Http.HttpClient!>! httpClientFactory) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback) -> System.IDisposable?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
@@ -10,6 +11,7 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallba
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.CopyPayloadToStream(System.IO.Stream! destination) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.OneCollectorExporterPayloadTransmittedCallbackArguments() -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.PayloadSizeInBytes.get -> long
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.TransportEndpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType.Ignore = 0 -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
+OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetHttpClientFactory(System.Func<System.Net.Http.HttpClient!>! httpClientFactory) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback) -> System.IDisposable?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
@@ -10,6 +11,7 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallba
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.CopyPayloadToStream(System.IO.Stream! destination) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.OneCollectorExporterPayloadTransmittedCallbackArguments() -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.PayloadSizeInBytes.get -> long
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.TransportEndpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType.Ignore = 0 -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/net7.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
+OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetHttpClientFactory(System.Func<System.Net.Http.HttpClient!>! httpClientFactory) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback) -> System.IDisposable?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
@@ -10,6 +11,7 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallba
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.CopyPayloadToStream(System.IO.Stream! destination) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.OneCollectorExporterPayloadTransmittedCallbackArguments() -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.PayloadSizeInBytes.get -> long
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.TransportEndpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType.Ignore = 0 -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
+OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetHttpClientFactory(System.Func<System.Net.Http.HttpClient!>! httpClientFactory) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback) -> System.IDisposable?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
@@ -10,6 +11,7 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallba
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.CopyPayloadToStream(System.IO.Stream! destination) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.OneCollectorExporterPayloadTransmittedCallbackArguments() -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.PayloadSizeInBytes.get -> long
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.TransportEndpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType.Ignore = 0 -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
+OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetHttpClientFactory(System.Func<System.Net.Http.HttpClient!>! httpClientFactory) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * Exposed `OneCollectorLogExportProcessorBuilder.SetHttpClientFactory` so users
   can configure the `HttpClient` used to send telemetry over HTTP transports.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1619](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1619))
 
 ## 1.6.0
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Update OpenTelemetry SDK version to `1.7.0`.
   ([#1486](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1486))
 
+* Exposed `OneCollectorLogExportProcessorBuilder.SetHttpClientFactory` so users
+  can configure the `HttpClient` used to send telemetry over HTTP transports.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.6.0
 
 Released 2023-Oct-25

--- a/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExportProcessorBuilder.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Logs/OneCollectorLogExportProcessorBuilder.cs
@@ -168,7 +168,7 @@ public sealed class OneCollectorLogExportProcessorBuilder
     /// <returns>The supplied <see
     /// cref="OneCollectorLogExportProcessorBuilder"/> for call
     /// chaining.</returns>
-    internal OneCollectorLogExportProcessorBuilder SetHttpClientFactory(
+    public OneCollectorLogExportProcessorBuilder SetHttpClientFactory(
         Func<HttpClient> httpClientFactory)
     {
         Guard.ThrowIfNull(httpClientFactory);

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
@@ -79,4 +79,38 @@ public class OneCollectorOpenTelemetryLoggerOptionsExtensionsTests
                 }));
         });
     }
+
+    [Fact]
+    public void SetHttpClientFactoryTest()
+    {
+        var testExecuted = false;
+
+        using var loggerFactory1 = LoggerFactory.Create(builder => builder
+            .AddOpenTelemetry(builder =>
+            {
+                builder.AddOneCollectorExporter(
+                    "InstrumentationKey=token-extrainformation",
+                    configure => configure.SetHttpClientFactory(() =>
+                    {
+                        testExecuted = true;
+                        return new();
+                    }));
+            }));
+
+        Assert.True(testExecuted);
+
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            using var loggerFactory2 = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(builder =>
+                {
+                    builder.AddOneCollectorExporter(
+                        "InstrumentationKey=token-extrainformation",
+                        configure => configure.SetHttpClientFactory(() =>
+                        {
+                            return null!;
+                        }));
+                }));
+        });
+    }
 }


### PR DESCRIPTION
## Changes

* Expose `SetHttpClientFactory` to allow users to configure the `HttpClient` used to transmit telemetry

## TODOs:

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [X] Unit tests updated
* [ ] Changes in public API reviewed
