### PR TITLE
[ResourceDetector.Host] Add host.id for non-containerized systems

### DIFF
--- a/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Adds support for `host.id` resource attribute on non-containerized systems.
-`host.id` will be set per [semantic convention rules](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md)
+`host.id` will be set per [semantic convention rules](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/resource/host.md)
   ([#1631](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1631))
 
 ## 0.1.0-alpha.3

--- a/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Host/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Adds support for `host.id` resource attribute on non-containerized systems.
+`host.id` will be set per [semantic convention rules](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md)
+  ([#1631](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1631))
+
 ## 0.1.0-alpha.3
 
 Released 2024-Apr-05

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -39,6 +39,7 @@ public sealed class HostDetector : IResourceDetector
     /// Initializes a new instance of the <see cref="HostDetector"/> class for testing.
     /// </summary>
     /// <param name="platformId">Target platform ID.</param>
+    /// <param name="getFilePaths">Function to get Linux file paths to probe.</param>
     /// <param name="getMacOsMachineId">Function to get MacOS machine ID.</param>
     /// <param name="getWindowsMachineId">Function to get Windows machine ID.</param>
     internal HostDetector(PlatformID platformId, Func<IEnumerable<string>> getFilePaths, Func<string> getMacOsMachineId, Func<string> getWindowsMachineId)

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -20,8 +20,8 @@ public sealed class HostDetector : IResourceDetector
     private const string ETCVARDBUSMACHINEID = "/var/lib/dbus/machine-id";
     private readonly PlatformID platformId;
     private readonly Func<IEnumerable<string>> getFilePaths;
-    private readonly Func<string> getMacOsMachineId;
-    private readonly Func<string> getWindowsMachineId;
+    private readonly Func<string?> getMacOsMachineId;
+    private readonly Func<string?> getWindowsMachineId;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HostDetector"/> class.
@@ -42,7 +42,7 @@ public sealed class HostDetector : IResourceDetector
     /// <param name="getFilePaths">Function to get Linux file paths to probe.</param>
     /// <param name="getMacOsMachineId">Function to get MacOS machine ID.</param>
     /// <param name="getWindowsMachineId">Function to get Windows machine ID.</param>
-    internal HostDetector(PlatformID platformId, Func<IEnumerable<string>> getFilePaths, Func<string> getMacOsMachineId, Func<string> getWindowsMachineId)
+    internal HostDetector(PlatformID platformId, Func<IEnumerable<string>> getFilePaths, Func<string?> getMacOsMachineId, Func<string?> getWindowsMachineId)
     {
         this.platformId = platformId;
         this.getFilePaths = getFilePaths ?? throw new ArgumentNullException(nameof(getFilePaths));
@@ -64,7 +64,7 @@ public sealed class HostDetector : IResourceDetector
             };
             var machineId = this.GetMachineId();
 
-            if (!string.IsNullOrEmpty(machineId))
+            if (machineId != null && !string.IsNullOrEmpty(machineId))
             {
                 attributes.Add(new(HostSemanticConventions.AttributeHostId, machineId));
             }
@@ -142,7 +142,7 @@ public sealed class HostDetector : IResourceDetector
         };
     }
 
-    private string GetMachineIdLinux()
+    private string? GetMachineIdLinux()
     {
         var paths = this.getFilePaths();
 

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -16,8 +16,8 @@ namespace OpenTelemetry.ResourceDetectors.Host;
 /// </summary>
 public sealed class HostDetector : IResourceDetector
 {
-    private const string ETC_MACHINEID = "/etc/machine-id";
-    private const string ETC_VAR_DBUS_MACHINEID = "/var/lib/dbus/machine-id";
+    private const string ETCMACHINEID = "/etc/machine-id";
+    private const string ETCVARDBUSMACHINEID = "/var/lib/dbus/machine-id";
     private readonly PlatformID platformId;
     private readonly Func<IEnumerable<string>> getFilePaths;
     private readonly Func<string> getMacOsMachineId;
@@ -81,8 +81,8 @@ public sealed class HostDetector : IResourceDetector
 
     private static IEnumerable<string> GetFilePaths()
     {
-        yield return ETC_MACHINEID;
-        yield return ETC_VAR_DBUS_MACHINEID;
+        yield return ETCMACHINEID;
+        yield return ETCVARDBUSMACHINEID;
     }
 
     private static string? GetMachineIdMacOs()

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -57,11 +57,18 @@ public sealed class HostDetector : IResourceDetector
     {
         try
         {
-            return new Resource(new List<KeyValuePair<string, object>>(2)
+            var attributes = new List<KeyValuePair<string, object>>(2)
             {
                 new(HostSemanticConventions.AttributeHostName, Environment.MachineName),
-                new(HostSemanticConventions.AttributeHostId, this.GetMachineId()),
-            });
+            };
+            var machineId = this.GetMachineId();
+
+            if (!string.IsNullOrEmpty(machineId))
+            {
+                attributes.Add(new(HostSemanticConventions.AttributeHostId, machineId));
+            }
+
+            return new Resource(attributes);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -3,6 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Microsoft.Win32;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.ResourceDetectors.Host;
@@ -23,6 +27,7 @@ public sealed class HostDetector : IResourceDetector
             return new Resource(new List<KeyValuePair<string, object>>(1)
             {
                 new(HostSemanticConventions.AttributeHostName, Environment.MachineName),
+                new(HostSemanticConventions.AttributeHostId, GetMachineId()),
             });
         }
         catch (InvalidOperationException ex)
@@ -33,4 +38,64 @@ public sealed class HostDetector : IResourceDetector
 
         return Resource.Empty;
     }
+
+    private static string GetMachineId()
+    {
+        return Environment.OSVersion.Platform switch
+        {
+            PlatformID.Unix => GetMachineIdLinux(),
+            PlatformID.MacOSX => GetMachineIdMacOs(),
+            PlatformID.Win32NT => GetMachineIdWindows(),
+            _ => string.Empty,
+        };
+    }
+
+    private static string GetMachineIdLinux()
+    {
+        var paths = new[] { "/etc/machine-id", "/var/lib/dbus/machine-id" };
+
+        foreach (var path in paths)
+        {
+            if (File.Exists(path))
+            {
+                try
+                {
+                    return File.ReadAllText(path).Trim();
+                }
+                catch (Exception ex)
+                {
+                    HostResourceEventSource.Log.ResourceAttributesExtractException(nameof(HostDetector), ex);
+                }
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static string GetMachineIdMacOs()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "sh",
+            Arguments = "ioreg -rd1 -c IOPlatformExpertDevice | awk '/IOPlatformUUID/ { split($0, line, \"\\\"\"); printf(\"%s\\n\", line[4]); }'",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+        };
+
+        var sb = new StringBuilder();
+        using var process = Process.Start(startInfo);
+        process?.WaitForExit();
+        sb.Append(process?.StandardOutput.ReadToEnd());
+        return sb.ToString();
+    }
+
+#pragma warning disable CA1416
+    // stylecop wants this protected by System.OperatingSystem.IsWindows
+    // this type only exists in .NET 5+
+    private static string GetMachineIdWindows()
+    {
+        return Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false)?.GetValue("MachineGuid") as string ?? string.Empty;
+    }
+#pragma warning restore CA1416
 }

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -78,7 +78,7 @@ public sealed class HostDetector : IResourceDetector
         yield return ETC_VAR_DBUS_MACHINEID;
     }
 
-    private static string GetMachineIdMacOs()
+    private static string? GetMachineIdMacOs()
     {
         var startInfo = new ProcessStartInfo
         {
@@ -99,20 +99,20 @@ public sealed class HostDetector : IResourceDetector
 #pragma warning disable CA1416
     // stylecop wants this protected by System.OperatingSystem.IsWindows
     // this type only exists in .NET 5+
-    private static string GetMachineIdWindows()
+    private static string? GetMachineIdWindows()
     {
-        return Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false)?.GetValue("MachineGuid") as string ?? string.Empty;
+        return Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false)?.GetValue("MachineGuid") as string ?? null;
     }
 #pragma warning restore CA1416
 
-    private string GetMachineId()
+    private string? GetMachineId()
     {
         return this.platformId switch
         {
             PlatformID.Unix => this.GetMachineIdLinux(),
             PlatformID.MacOSX => this.getMacOsMachineId(),
             PlatformID.Win32NT => this.getWindowsMachineId(),
-            _ => string.Empty,
+            _ => null,
         };
     }
 
@@ -135,6 +135,6 @@ public sealed class HostDetector : IResourceDetector
             }
         }
 
-        return string.Empty;
+        return null;
     }
 }

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -57,7 +57,7 @@ public sealed class HostDetector : IResourceDetector
     {
         try
         {
-            return new Resource(new List<KeyValuePair<string, object>>(1)
+            return new Resource(new List<KeyValuePair<string, object>>(2)
             {
                 new(HostSemanticConventions.AttributeHostName, Environment.MachineName),
                 new(HostSemanticConventions.AttributeHostId, this.GetMachineId()),

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostDetector.cs
@@ -120,7 +120,8 @@ public sealed class HostDetector : IResourceDetector
     {
         try
         {
-            return Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false)?.GetValue("MachineGuid") as string ?? null;
+            using var subKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false);
+            return subKey?.GetValue("MachineGuid") as string ?? null;
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.ResourceDetectors.Host/HostSemanticConventions.cs
+++ b/src/OpenTelemetry.ResourceDetectors.Host/HostSemanticConventions.cs
@@ -6,4 +6,5 @@ namespace OpenTelemetry.ResourceDetectors.Host;
 internal static class HostSemanticConventions
 {
     public const string AttributeHostName = "host.name";
+    public const string AttributeHostId = "host.id";
 }

--- a/src/OpenTelemetry.ResourceDetectors.Host/README.md
+++ b/src/OpenTelemetry.ResourceDetectors.Host/README.md
@@ -36,8 +36,7 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
 The resource detectors will record the following metadata based on where
 your application is running:
 
-- **HostDetector**: `host.name`.
-- **HostDetector**: `host.id` when running on non-containerized systems.
+- **HostDetector**: `host.id` (when running on non-containerized systems), `host.name`.
 
 ## References
 

--- a/src/OpenTelemetry.ResourceDetectors.Host/README.md
+++ b/src/OpenTelemetry.ResourceDetectors.Host/README.md
@@ -37,6 +37,7 @@ The resource detectors will record the following metadata based on where
 your application is running:
 
 - **HostDetector**: `host.name`.
+- **HostDetector**: `host.id` when running on non-containerized systems.
 
 ## References
 

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using OpenTelemetry.Resources;
 using Xunit;
 

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -13,8 +13,8 @@ namespace OpenTelemetry.ResourceDetectors.Host.Tests;
 
 public class HostDetectorTests
 {
-    private static readonly IEnumerable<string> ETC_MACHINEID = new[] { "Samples/etc_machineid" };
-    private static readonly IEnumerable<string> ETC_VAR_DBUS_MACHINEID = new[] { "Samples/etc_var_dbus_machineid" };
+    private static readonly IEnumerable<string> ETCMACHINEID = new[] { "Samples/etc_machineid" };
+    private static readonly IEnumerable<string> ETCVARDBUSMACHINEID = new[] { "Samples/etc_var_dbus_machineid" };
 
     [Fact]
     public void TestHostAttributes()
@@ -35,9 +35,9 @@ public class HostDetectorTests
         var combos = new[]
         {
             (Enumerable.Empty<string>(), string.Empty),
-            (ETC_MACHINEID, "etc_machineid"),
-            (ETC_VAR_DBUS_MACHINEID, "etc_var_dbus_machineid"),
-            (Enumerable.Concat(ETC_MACHINEID, ETC_VAR_DBUS_MACHINEID), "etc_machineid"),
+            (ETCMACHINEID, "etc_machineid"),
+            (ETCVARDBUSMACHINEID, "etc_var_dbus_machineid"),
+            (Enumerable.Concat(ETCMACHINEID, ETCVARDBUSMACHINEID), "etc_machineid"),
         };
 
         foreach (var (path, expected) in combos)

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -52,7 +52,8 @@ public class HostDetectorTests
             if (string.IsNullOrEmpty(expected))
             {
                 Assert.Empty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
-            } else
+            }
+            else
             {
                 Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
                 Assert.Equal(expected, resourceAttributes[HostSemanticConventions.AttributeHostId]);

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -32,7 +32,7 @@ public class HostDetectorTests
     {
         var combos = new[]
         {
-            (Enumerable.Empty<string>(), string.Empty),
+            (Enumerable.Empty<string>(), null),
             (ETCMACHINEID, "etc_machineid"),
             (ETCVARDBUSMACHINEID, "etc_var_dbus_machineid"),
             (Enumerable.Concat(ETCMACHINEID, ETCVARDBUSMACHINEID), "etc_machineid"),
@@ -50,7 +50,7 @@ public class HostDetectorTests
 
             if (string.IsNullOrEmpty(expected))
             {
-                Assert.Empty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+                Assert.False(resourceAttributes.ContainsKey(HostSemanticConventions.AttributeHostId));
             }
             else
             {

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenTelemetry.Resources;

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -1,7 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 using OpenTelemetry.Resources;
 using Xunit;
 
@@ -20,5 +23,43 @@ public class HostDetectorTests
 
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostName]);
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+    }
+
+    [Fact]
+    public void TestHostMachineId()
+    {
+        var etcMachineIdStream = (string path) =>
+        {
+            return path == "/etc/machine-id"
+                ? new MemoryStream(Encoding.UTF8.GetBytes("etc-machine-id"))
+                : null;
+        };
+        var varLibDbusMachineIdStream = new MemoryStream(Encoding.UTF8.GetBytes("var-lib-dbus-machine-id"));
+    }
+
+    [Fact]
+    public void TestHostMachineIdMacOs()
+    {
+        var detector = new HostDetector(
+            PlatformID.MacOSX,
+            () => "macos-machine-id",
+            () => throw new Exception("should not be called"));
+        var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
+        Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.Equal("macos-machine-id", resourceAttributes[HostSemanticConventions.AttributeHostId]);
+    }
+
+    [Fact]
+    public void TestHostMachineIdWindows()
+    {
+        var detector = new HostDetector(
+            PlatformID.Win32NT,
+            () => throw new Exception("should not be called"),
+            () => "windows-machine-id");
+        var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
+        Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.Equal("windows-machine-id", resourceAttributes[HostSemanticConventions.AttributeHostId]);
     }
 }

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -11,6 +11,35 @@ namespace OpenTelemetry.ResourceDetectors.Host.Tests;
 
 public class HostDetectorTests
 {
+    private const string MacOSMachineIdOutput = @"+-o J293AP  <class IOPlatformExpertDevice, id 0x100000227, registered, matched,$
+        {
+          ""IOPolledInterface"" = ""AppleARMWatchdogTimerHibernateHandler is not seria$
+          ""#address-cells"" = <02000000>
+          ""AAPL,phandle"" = <01000000>
+          ""serial-number"" = <432123465233514651303544000000000000000000000000000000$
+          ""IOBusyInterest"" = ""IOCommand is not serializable""
+          ""target-type"" = <""J293"">
+          ""platform-name"" = <743831303300000000000000000000000000000000000000000000$
+          ""secure-root-prefix"" = <""md"">
+          ""name"" = <""device-tree"">
+          ""region-info"" = <4c4c2f41000000000000000000000000000000000000000000000000$
+          ""manufacturer"" = <""Apple Inc."">
+          ""compatible"" = <""J293AP"",""MacBookPro17,1"",""AppleARM"">
+          ""config-number"" = <000000000000000000000000000000000000000000000000000000$
+          ""IOPlatformSerialNumber"" = ""A01BC3QFQ05D""
+          ""regulatory-model-number"" = <41323333380000000000000000000000000000000000$
+          ""time-stamp"" = <""Mon Jun 27 20:12:10 PDT 2022"">
+          ""clock-frequency"" = <00366e01>
+          ""model"" = <""MacBookPro17,1"">
+          ""mlb-serial-number"" = <432123413230363030455151384c4c314a0000000000000000$
+          ""model-number"" = <4d59443832000000000000000000000000000000000000000000000$
+          ""IONWInterrupts"" = ""IONWInterrupts""
+          ""model-config"" = <""SUNWAY;MoPED=0x803914B08BE6C5AF0E6C990D7D8240DA4CAC2FF$
+          ""device_type"" = <""bootrom"">
+          ""#size-cells"" = <02000000>
+          ""IOPlatformUUID"" = ""1AB2345C-03E4-57D4-A375-1234D48DE123""
+        }";
+
     private static readonly IEnumerable<string> ETCMACHINEID = new[] { "Samples/etc_machineid" };
     private static readonly IEnumerable<string> ETCVARDBUSMACHINEID = new[] { "Samples/etc_var_dbus_machineid" };
 
@@ -66,12 +95,19 @@ public class HostDetectorTests
         var detector = new HostDetector(
             PlatformID.MacOSX,
             () => Enumerable.Empty<string>(),
-            () => "macos-machine-id",
+            () => MacOSMachineIdOutput,
             () => throw new Exception("should not be called"));
         var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
-        Assert.Equal("macos-machine-id", resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.Equal("1AB2345C-03E4-57D4-A375-1234D48DE123", resourceAttributes[HostSemanticConventions.AttributeHostId]);
+    }
+
+    [Fact]
+    public void TestParseMacOsOutput()
+    {
+        var id = HostDetector.ParseMacOsOutput(MacOSMachineIdOutput);
+        Assert.Equal("1AB2345C-03E4-57D4-A375-1234D48DE123", id);
     }
 
     [Fact]

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -16,8 +16,9 @@ public class HostDetectorTests
 
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 
-        Assert.Single(resourceAttributes);
+        Assert.Equal(2, resourceAttributes.Count);
 
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostName]);
+        Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
     }
 }

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/HostDetectorTests.cs
@@ -15,7 +15,7 @@ public class HostDetectorTests
 {
     private static readonly IEnumerable<string> ETC_MACHINEID = new[] { "Samples/etc_machineid" };
     private static readonly IEnumerable<string> ETC_VAR_DBUS_MACHINEID = new[] { "Samples/etc_var_dbus_machineid" };
- 
+
     [Fact]
     public void TestHostAttributes()
     {

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/OpenTelemetry.ResourceDetectors.Host.Tests.csproj
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/OpenTelemetry.ResourceDetectors.Host.Tests.csproj
@@ -11,4 +11,13 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.ResourceDetectors.Host\OpenTelemetry.ResourceDetectors.Host.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Samples\etc_machineid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Samples\etc_var_dbus_machineid">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/Samples/etc_machineid
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/Samples/etc_machineid
@@ -1,0 +1,1 @@
+etc_machineid

--- a/test/OpenTelemetry.ResourceDetectors.Host.Tests/Samples/etc_var_dbus_machineid
+++ b/test/OpenTelemetry.ResourceDetectors.Host.Tests/Samples/etc_var_dbus_machineid
@@ -1,0 +1,1 @@
+etc_var_dbus_machineid


### PR DESCRIPTION
Fixes #1630 

## Changes

Adds support for setting `host.id` on Linux, MacOS, and Windows when running outside a container.

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
