### PR TITLE
Bump MinVer to 5.0.0

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -29,7 +29,7 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
     -->
-    <MinVerPkgVer>[4.3.0,5.0)</MinVerPkgVer>
+    <MinVerPkgVer>[5.0.0,6.0)</MinVerPkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,5.0)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsOptionsPkgVer>[3.1.0,)</MicrosoftExtensionsOptionsPkgVer>
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.3,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -234,8 +234,8 @@ public class AWSLambdaWrapperTests
         Assert.Equal("testfunction", activity.DisplayName);
         Assert.Equal("OpenTelemetry.Instrumentation.AWSLambda", activity.Source.Name);
 
-        // Version should consist of four decimals separated by dots.
-        Assert.Matches(@"^\d+(\.\d+){3}$", activity.Source.Version);
+        // Version should consist of 3 decimals separated by dots followed by optional pre-release suffix
+        Assert.Matches(@"^\d+(\.\d+){2}(-.+)?$", activity.Source.Version);
     }
 
     private void AssertResourceAttributes(Resource? resource)


### PR DESCRIPTION
Handles major release of https://github.com/adamralph/minver/blob/main/CHANGELOG.md#500

## Changes

Bump MinVer to 5.0.0 - itnernal package.
Breaking changes seems to be no bad impact on OTel packages.~

Upgraded in AutoInstrumentaiton repo some time ago. No issues so far.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~