### PR TITLE
[Instrumentation.Process] Adjust metrics and attributes to Sem. Conv. 1.25.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -6,7 +6,7 @@
   * `process.cpu.time` metric attribute renamed from `state` to `process.cpu.state`,
   * Metric descriptions fixed for `process.memory.usage` and `process.memory.virtual`,
   * Metric `process.threads` renamed to `process.thread.count`
-    (its unit changed from `{threads}` to `{thread}`.
+    (its unit changed from `{threads}` to `{thread}`).
   ([#1643](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1643))
 
 ## 0.5.0-beta.5

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Following changes related to [Semantic Convention v1.25.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.25.0/docs/system/process-metrics.md)
+  * `process.cpu.time` metric attribute renamed from `state` to `process.cpu.state`,
+  * Metric descriptions fixed for `process.memory.usage` and `process.memory.virtual`,
+  * Metric `process.threads` renamed to `process.thread.count`
+    (its unit changed from `{threads}` to `{thread}`.
+  ([#1643](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1643))
+
 ## 0.5.0-beta.5
 
 Released 2024-Apr-05

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -67,7 +67,7 @@ internal sealed class ProcessMetrics
             {
                 return Diagnostics.Process.GetCurrentProcess().Threads.Count;
             },
-            unit: "{threads}",
+            unit: "{thread}",
             description: "Process threads count.");
     }
 

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -62,7 +62,7 @@ internal sealed class ProcessMetrics
             description: "The number of processors (CPU cores) available to the current process.");
 
         MeterInstance.CreateObservableUpDownCounter(
-            "process.threads",
+            "process.thread.count",
             () =>
             {
                 return Diagnostics.Process.GetCurrentProcess().Threads.Count;

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -45,8 +45,8 @@ internal sealed class ProcessMetrics
                 var process = Diagnostics.Process.GetCurrentProcess();
                 return new[]
                 {
-                    new Measurement<double>(process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("state", "user")),
-                    new Measurement<double>(process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("state", "system")),
+                    new Measurement<double>(process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "user")),
+                    new Measurement<double>(process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "system")),
                 };
             },
             unit: "s",

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -27,7 +27,7 @@ internal sealed class ProcessMetrics
                 return Diagnostics.Process.GetCurrentProcess().WorkingSet64;
             },
             unit: "By",
-            description: "The amount of physical memory allocated for this process.");
+            description: "The amount of physical memory in use.");
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.memory.virtual",
@@ -36,7 +36,7 @@ internal sealed class ProcessMetrics
                 return Diagnostics.Process.GetCurrentProcess().VirtualMemorySize64;
             },
             unit: "By",
-            description: "The amount of committed virtual memory for this process.");
+            description: "The amount of committed virtual memory.");
 
         MeterInstance.CreateObservableCounter(
             "process.cpu.time",

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -136,7 +136,7 @@ Process threads count.
 
 | Units      | Instrument Type         | Value Type |
 |------------|-------------------------|------------|
-| `{threads}`| ObservableUpDownCounter | `Int32`    |
+| `{thread}` | ObservableUpDownCounter | `Int32`    |
 
 The API used to retrieve the value is:
 

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -130,7 +130,7 @@ and not part of the [Process Metrics
 Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md)
 at this time.
 
-### process.threads
+### process.thread.count
 
 Process threads count.
 

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -100,9 +100,9 @@ process.
 
 Total CPU seconds broken down by states.
 
-| Units | Instrument Type   | Value Type | Attribute Key(s) | Attribute Values |
-|-------|-------------------|------------|------------------|------------------|
-|  `s`  | ObservableCounter | `Double`   | state            | user, system     |
+| Units | Instrument Type   | Value Type | Attribute Key(s)  | Attribute Values |
+|-------|-------------------|------------|-------------------|------------------|
+|  `s`  | ObservableCounter | `Double`   | process.cpu.state | user, system     |
 
 The APIs used to retrieve the values are:
 

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -142,7 +142,7 @@ public class ProcessMetricsTests
         Assert.NotNull(cpuTimeMetricA);
         var processorCountMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.cpu.count");
         Assert.NotNull(processorCountMetricA);
-        var threadMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.threads");
+        var threadMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.thread.count");
         Assert.NotNull(threadMetricA);
 
         Assert.True(exportedItemsB.Count == 5);
@@ -154,7 +154,7 @@ public class ProcessMetricsTests
         Assert.NotNull(cpuTimeMetricB);
         var processorCountMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.cpu.count");
         Assert.NotNull(processorCountMetricB);
-        var threadMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.threads");
+        var threadMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.thread.count");
         Assert.NotNull(threadMetricB);
     }
 

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -133,7 +133,7 @@ public class ProcessMetricsTests
 
         Task.WaitAll(tasks.ToArray());
 
-        Assert.True(exportedItemsA.Count == 5);
+        Assert.Equal(5, exportedItemsA.Count);
         var physicalMemoryMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetricA);
         var virtualMemoryMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.memory.virtual");
@@ -145,7 +145,7 @@ public class ProcessMetricsTests
         var threadMetricA = exportedItemsA.FirstOrDefault(i => i.Name == "process.thread.count");
         Assert.NotNull(threadMetricA);
 
-        Assert.True(exportedItemsB.Count == 5);
+        Assert.Equal(5, exportedItemsB.Count);
         var physicalMemoryMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.memory.usage");
         Assert.NotNull(physicalMemoryMetricB);
         var virtualMemoryMetricB = exportedItemsB.FirstOrDefault(i => i.Name == "process.memory.virtual");

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -83,11 +83,11 @@ public class ProcessMetricsTests
             {
                 Assert.NotNull(tag.Value);
 
-                if (tag.Key == "state" && tag.Value!.ToString() == "user")
+                if (tag.Key == "process.cpu.state" && tag.Value!.ToString() == "user")
                 {
                     userTimeCaptured = true;
                 }
-                else if (tag.Key == "state" && tag.Value!.ToString() == "system")
+                else if (tag.Key == "process.cpu.state" && tag.Value!.ToString() == "system")
                 {
                     systemTimeCaptured = true;
                 }


### PR DESCRIPTION
Fixes #1638.

## Changes

* Following changes related to [Semantic Convention v1.25.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.25.0/docs/system/process-metrics.md)
  * `process.cpu.time` metric attribute renamed from `state` to `process.cpu.state`,
  * Metric descriptions fixed for `process.memory.usage` and `process.memory.virtual`,
  * Metric `process.threads` renamed to `process.thread.count`
    (its unit changed from `{threads}` to `{thread}`.

`process.cpu.count` is not part of the semantic convention (and it never was). It is still produced.
Also not all metrics defined by sem.conv. are covered.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
