### PR TITLE
Add extension on ILoggerBuilder that allows attaching TraceIds to logs

### DIFF
--- a/src/OpenTelemetry.Extensions/Internal/AddTraceIdLogger.cs
+++ b/src/OpenTelemetry.Extensions/Internal/AddTraceIdLogger.cs
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Extensions.Logging;
+
+internal sealed class AddTraceIdLogger : ILogger
+{
+    private readonly ILogger innerLogger;
+
+    public AddTraceIdLogger(ILogger baseLogger)
+    {
+        this.innerLogger = baseLogger;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => this.innerLogger.BeginScope(state);
+
+    public bool IsEnabled(LogLevel logLevel) => this.innerLogger.IsEnabled(logLevel);
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (Activity.Current is { TraceId: { } traceId })
+        {
+            this.innerLogger.Log(logLevel, eventId, new FormattedLogValues<TState>(state, traceId), exception, (state, ex) => formatter(state.Inner, ex));
+        }
+        else
+        {
+            this.innerLogger.Log(logLevel, eventId, state, exception, formatter);
+        }
+    }
+}

--- a/src/OpenTelemetry.Extensions/Internal/AddTraceIdLoggerProvider.cs
+++ b/src/OpenTelemetry.Extensions/Internal/AddTraceIdLoggerProvider.cs
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Microsoft.Extensions.Logging;
+
+internal sealed class AddTraceIdLoggerProvider : ILoggerProvider
+{
+    private readonly ILoggerProvider innerLoggerProvider;
+
+    public AddTraceIdLoggerProvider(ILoggerProvider baseProvider)
+    {
+        this.innerLoggerProvider = baseProvider;
+    }
+
+    public ILogger CreateLogger(string categoryName) => new AddTraceIdLogger(this.innerLoggerProvider.CreateLogger(categoryName));
+
+    public void Dispose() => this.innerLoggerProvider.Dispose();
+}

--- a/src/OpenTelemetry.Extensions/Internal/FormattedLogValues.cs
+++ b/src/OpenTelemetry.Extensions/Internal/FormattedLogValues.cs
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Extensions.Logging;
+
+internal readonly struct FormattedLogValues<TInnerState> : IReadOnlyList<KeyValuePair<string, object?>>
+{
+    private readonly ActivityTraceId traceId;
+    private readonly IReadOnlyList<KeyValuePair<string, object?>>? properties;
+
+    public FormattedLogValues(TInnerState inner, ActivityTraceId traceId)
+    {
+        this.Inner = inner;
+        this.traceId = traceId;
+        this.properties = inner as IReadOnlyList<KeyValuePair<string, object?>>;
+    }
+
+    public TInnerState Inner { get; }
+
+    public int Count => (this.properties?.Count).GetValueOrDefault() + 1;
+
+    public KeyValuePair<string, object?> this[int index] => index == 0
+        ? new KeyValuePair<string, object?>("TraceId", this.traceId)
+        : this.properties is { } properties
+            ? properties[index - 1]
+            : throw new ArgumentOutOfRangeException(nameof(index));
+
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+    {
+        for (var i = 0; i < this.Count; i++)
+        {
+            yield return this[i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+    public override string? ToString() => this.Inner?.ToString();
+
+}


### PR DESCRIPTION
## Changes

In cases where logs and traces are still treated separately (i.e. where logs aren't treated as some kind of span event), it is often still possible to correlate logs to traces. For example AWS Cloudwatch allows to correlate logs from log groups to X-Ray traces.

However, I the trace ids don't automatically make it into the logs unless they are attached to the log message or something else.

This PR exploits the fact that the built in Json-Logger of ASP.NET leverages the `IReadOnlyList<KeyValuePair<string, object?>>` interface if implemented by the log state, which is usually of type `FormattedLogValues`. The `AddTraceIds` extension decorates registrations of `ILoggerProvider` to wrap existing instances of `ILoggerProvider`. This in turn will wrap instances of `ILogger` which will wrap the state parameter of calls to `Log` with instances of a generic `FormattedLogValues` struct. This also implements `IReadOnlyList<KeyValuePair<string, object?>>` and will recreate all the entries from the wrapped state, but also add a `TraceId` entry. The trace id will then end up being logged (if the log formatter picks it up), Cloudwatch will correlate the logs to the trace and everybody's happy.

Open to review/suggestions.