### PR TITLE
[Instrumentation.OWIN] Bugfix - make Meter and Histogram as a singletons

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Massive memory leak in OwinInstrumentationMetrics addressed.
+  Made both Meter and Histogram singletons.
+  ([#1655](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1655))
+
 ## 1.0.0-rc.5
 
 Released 2024-Apr-17

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/OwinInstrumentationMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/OwinInstrumentationMetrics.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using OpenTelemetry.Internal;
@@ -11,10 +12,7 @@ internal static class OwinInstrumentationMetrics
 {
     internal static readonly Assembly Assembly = typeof(OwinInstrumentationMetrics).Assembly;
     internal static readonly AssemblyName AssemblyName = Assembly.GetName();
-
-    public static string MeterName => AssemblyName.Name;
-
-    public static Meter Instance => new(MeterName, Assembly.GetPackageVersion());
-
-    public static Histogram<double> HttpServerDuration => Instance.CreateHistogram<double>("http.server.request.duration", "s", "Duration of HTTP server requests.");
+    internal static readonly string MeterName = AssemblyName.Name;
+    internal static readonly Meter Instance = new(MeterName, Assembly.GetPackageVersion());
+    internal static readonly Histogram<double> HttpServerDuration = Instance.CreateHistogram<double>("http.server.request.duration", "s", "Duration of HTTP server requests.");
 }

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/OwinInstrumentationMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/OwinInstrumentationMetrics.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using OpenTelemetry.Internal;


### PR DESCRIPTION
Fixes #1654.

## Changes

Made both the Meter and Histogram singletons

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue #
* [ ] Changes in public API reviewed
