### PR TITLE
[Exporter.Stackdriver] Fixes the case when Activity/ActivityLink has several Tags with the same key

### DIFF
--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Update OpenTelemetry SDK version to `1.8.0`.
   ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
+* Fixes an issue when Activity/ActivityLink tags contain duplicate tag keys
+  that lead to ArgumentException.
+  ([#1660](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1660))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/ActivityExtensions.cs
@@ -67,15 +67,12 @@ internal static class ActivityExtensions
         // Span Attributes
         if (activity.Tags != null)
         {
-            span.Attributes = new Span.Types.Attributes
+            span.Attributes = new Span.Types.Attributes();
+            var attrMap = span.Attributes.AttributeMap;
+            foreach (var att in activity.Tags)
             {
-                AttributeMap =
-                {
-                    activity.Tags.ToDictionary(
-                        s => s.Key,
-                        s => s.Value.ToAttributeValue()),
-                },
-            };
+                attrMap[att.Key] = att.Value.ToAttributeValue();
+            }
         }
 
         // StackDriver uses different labels that are used to categorize spans
@@ -102,15 +99,12 @@ internal static class ActivityExtensions
 
         if (link.Tags != null)
         {
-            ret.Attributes = new Span.Types.Attributes
+            ret.Attributes = new Span.Types.Attributes();
+            var attrMap = ret.Attributes.AttributeMap;
+            foreach (var att in link.Tags)
             {
-                AttributeMap =
-                {
-                    link.Tags.ToDictionary(
-                        att => att.Key,
-                        att => att.Value?.ToAttributeValue()),
-                },
-            };
+                attrMap[att.Key] = att.Value.ToAttributeValue();
+            }
         }
 
         return ret;

--- a/test/OpenTelemetry.Exporter.Stackdriver.Tests/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.Stackdriver.Tests/ActivityExtensionsTest.cs
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Exporter.Stackdriver.Implementation;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Stackdriver.Tests;
+
+public class ActivityExtensionsTest
+{
+    static ActivityExtensionsTest()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+    }
+
+    [Fact]
+    public void ActivityExtensions_Export_Duplicate_Activity_Tag_Key()
+    {
+        var activity = new Activity("Test");
+        activity.SetStartTime(activity.StartTimeUtc.ToUniversalTime());
+
+        activity.AddTag("key", "value");
+        activity.AddTag("key2", "value2");
+        activity.AddTag("key2", "value3");
+
+        var span = activity.ToSpan("project1");
+        Assert.True(span.Attributes.AttributeMap.Count == 2);
+        Assert.True(span.Attributes.AttributeMap["key2"].StringValue.Value == "value3");
+    }
+
+    [Fact]
+    public void ActivityExtensions_Export_Duplicate_ActivityLink_Tag_Key()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId1 = ActivitySpanId.CreateRandom();
+        var spanId2 = ActivitySpanId.CreateRandom();
+
+        ActivityContext context1 = new ActivityContext(traceId, spanId1, ActivityTraceFlags.Recorded, isRemote: true);
+        ActivityContext context2 = new ActivityContext(traceId, spanId2, ActivityTraceFlags.Recorded, isRemote: true);
+
+        KeyValuePair<string, object?>[] dupTags = new[]
+        {
+            new KeyValuePair<string, object?>("key1", "value1"),
+            new KeyValuePair<string, object?>("key2", "value2"),
+            new KeyValuePair<string, object?>("key1", "value3"),
+        };
+        ActivityLink link1 = new ActivityLink(context1, tags: new ActivityTagsCollection(dupTags));
+        ActivityLink link2 = new ActivityLink(context2);
+
+        var links = new List<ActivityLink> { link1, link2 };
+
+        using var source = new ActivitySource("TestActivitySource");
+        using var activity = source.StartActivity("NewActivityWithLinks", ActivityKind.Internal, parentContext: default, links: links);
+
+        var span = activity?.ToSpan("project1");
+        Assert.True((span?.Links.Link.Count ?? 0) == 2);
+        Assert.True(span?.Links.Link.First().Attributes.AttributeMap["key1"].StringValue.Value == "value3");
+    }
+}


### PR DESCRIPTION

Fixes #1622.

The fix also slightly minimizes allocations: avoids allocating a dictionary class instance.