### PR TITLE
[Exporter.Geneva][Otlp protobuf] Rename private preview option

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -77,7 +77,7 @@ internal sealed class ConnectionStringBuilder
 
     public string PrivatePreviewEnableOtlpProtobufEncoding
     {
-        get => this._parts.TryGetValue(nameof(this.PrivatePreviewEnableOtlpProtobufEncoding ), out var value) ? value : null;
+        get => this._parts.TryGetValue(nameof(this.PrivatePreviewEnableOtlpProtobufEncoding), out var value) ? value : null;
         set => this._parts[nameof(this.PrivatePreviewEnableOtlpProtobufEncoding)] = value;
     }
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -75,10 +75,10 @@ internal sealed class ConnectionStringBuilder
         set => this._parts[nameof(this.PrivatePreviewEnableTraceLoggingDynamic)] = value;
     }
 
-    public string PrivatePreviewEnableOtlpProtobufEncoding 
+    public string PrivatePreviewEnableOtlpProtobufEncoding
     {
         get => this._parts.TryGetValue(nameof(this.PrivatePreviewEnableOtlpProtobufEncoding ), out var value) ? value : null;
-        set => this._parts[nameof(this.PrivatePreviewEnableOtlpProtobufEncoding )] = value;
+        set => this._parts[nameof(this.PrivatePreviewEnableOtlpProtobufEncoding)] = value;
     }
 
     public string Endpoint

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -75,10 +75,10 @@ internal sealed class ConnectionStringBuilder
         set => this._parts[nameof(this.PrivatePreviewEnableTraceLoggingDynamic)] = value;
     }
 
-    public string PrivatePreviewOtlpProtobufMetricExporter
+    public string PrivatePreviewEnableOtlpProtobufEncoding 
     {
-        get => this._parts.TryGetValue(nameof(this.PrivatePreviewOtlpProtobufMetricExporter), out var value) ? value : null;
-        set => this._parts[nameof(this.PrivatePreviewOtlpProtobufMetricExporter)] = value;
+        get => this._parts.TryGetValue(nameof(this.PrivatePreviewEnableOtlpProtobufEncoding ), out var value) ? value : null;
+        set => this._parts[nameof(this.PrivatePreviewEnableOtlpProtobufEncoding )] = value;
     }
 
     public string Endpoint

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -42,7 +42,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
 
         var connectionStringBuilder = new ConnectionStringBuilder(options.ConnectionString);
 
-        if (connectionStringBuilder.PrivatePreviewOtlpProtobufMetricExporter != null && connectionStringBuilder.PrivatePreviewOtlpProtobufMetricExporter.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        if (connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding  != null && connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding .Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
         {
             var otlpProtobufExporter = new OtlpProtobufMetricExporter(
                 () => { return this.Resource; },

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -42,7 +42,7 @@ public class GenevaMetricExporter : BaseExporter<Metric>
 
         var connectionStringBuilder = new ConnectionStringBuilder(options.ConnectionString);
 
-        if (connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding  != null && connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding .Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        if (connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding != null && connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
         {
             var otlpProtobufExporter = new OtlpProtobufMetricExporter(
                 () => { return this.Resource; },


### PR DESCRIPTION
Towards #1585 

## Changes

Renaming `PrivatePreviewOtlpProtobufMetricExporter` to `PrivatePreviewEnableOtlpProtobufEncoding`

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
