### PR TITLE
Disable metric name validation for otlp format

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -42,6 +42,11 @@ public class GenevaMetricExporter : BaseExporter<Metric>
 
         var connectionStringBuilder = new ConnectionStringBuilder(options.ConnectionString);
 
+        if (connectionStringBuilder.DisableMetricNameValidation)
+        {
+            DisableOpenTelemetrySdkMetricNameValidation();
+        }
+
         if (connectionStringBuilder.PrivatePreviewOtlpProtobufMetricExporter != null && connectionStringBuilder.PrivatePreviewOtlpProtobufMetricExporter.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
         {
             var otlpProtobufExporter = new OtlpProtobufMetricExporter(

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
@@ -73,11 +73,6 @@ internal sealed class TlvMetricExporter : IDisposable
         {
             this.fixedPayloadStartIndex = sizeof(BinaryHeader);
         }
-
-        if (connectionStringBuilder.DisableMetricNameValidation)
-        {
-            GenevaMetricExporter.DisableOpenTelemetrySdkMetricNameValidation();
-        }
     }
 
     internal ExportResult Export(in Batch<Metric> batch)

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc.6
+
+Released 2024-Apr-19
+
 * Massive memory leak in OwinInstrumentationMetrics addressed.
   Made both Meter and Histogram singletons.
   ([#1655](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1655))
@@ -17,7 +21,6 @@ Released 2024-Apr-17
   disable this redaction by setting the environment variable
   `OTEL_DOTNET_EXPERIMENTAL_OWIN_DISABLE_URL_QUERY_REDACTION` to `true`.
   ([#1656](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1656))
-
 * `ActivitySource.Version` and `Meter.Version` are set to NuGet package version.
   ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
 * Updated OpenTelemetry SDK to 1.8.0.

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -282,9 +282,11 @@ public class GenevaMetricExporterTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void DisableMetricNameValidationTest(bool disableMetricNameValidation)
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public void DisableMetricNameValidationTest(bool disableMetricNameValidation, bool enableOtlpProtobufexporter)
     {
         var instrumentNameRegexProperty = GenevaMetricExporter.GetOpenTelemetryInstrumentNameRegexProperty();
         var initialInstrumentNameRegexValue = instrumentNameRegexProperty.GetValue(null);
@@ -301,12 +303,12 @@ public class GenevaMetricExporterTests
                 {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        options.ConnectionString = $"Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace;DisableMetricNameValidation={disableMetricNameValidation}";
+                        options.ConnectionString = $"Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace;DisableMetricNameValidation={disableMetricNameValidation};PrivatePreviewOtlpProtobufMetricExporter={enableOtlpProtobufexporter}";
                     }
                     else
                     {
                         var path = GenerateTempFilePath();
-                        options.ConnectionString = $"Endpoint=unix:{path};Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace;DisableMetricNameValidation={disableMetricNameValidation}";
+                        options.ConnectionString = $"Endpoint=unix:{path};Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace;DisableMetricNameValidation={disableMetricNameValidation};PrivatePreviewOtlpProtobufMetricExporter={enableOtlpProtobufexporter}";
 
                         var endpoint = new UnixDomainSocketEndPoint(path);
                         server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);


### PR DESCRIPTION
Towards #1585 

## Changes

Moving the disable logic to common place so that it can be used for both tlv and otlp protobuf format.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
