### PR TITLE
[OneCollectorExporter] Resolve AOT warnings in OpenTelemetry.Exporter.OneCollector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,7 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'aot')
       || contains(needs.detect-changes.outputs.changes, 'aottestapp')
       || contains(needs.detect-changes.outputs.changes, 'build')
+      || contains(needs.detect-changes.outputs.changes, 'onecollector')
       || contains(needs.detect-changes.outputs.changes, 'redis')
       || contains(needs.detect-changes.outputs.changes, 'shared')
     uses: ./.github/workflows/verifyaotcompat.yml

--- a/build/Common.props
+++ b/build/Common.props
@@ -31,6 +31,7 @@
     -->
     <MinVerPkgVer>[5.0.0,6.0)</MinVerPkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,5.0)</MicrosoftExtensionsHostingAbstractionsPkgVer>
+    <MicrosoftExtensionsConfigurationBinderPkgVer>[8.0.1,)</MicrosoftExtensionsConfigurationBinderPkgVer>
     <MicrosoftExtensionsOptionsPkgVer>[3.1.0,)</MicrosoftExtensionsOptionsPkgVer>
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.3,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
     <MicrosoftOwinPkgVer>[4.2.2,5.0)</MicrosoftOwinPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -30,8 +30,8 @@
       Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
     -->
     <MinVerPkgVer>[5.0.0,6.0)</MinVerPkgVer>
-    <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,5.0)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsConfigurationBinderPkgVer>[8.0.1,)</MicrosoftExtensionsConfigurationBinderPkgVer>
+    <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,5.0)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsOptionsPkgVer>[3.1.0,)</MicrosoftExtensionsOptionsPkgVer>
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.3,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
     <MicrosoftOwinPkgVer>[4.2.2,5.0)</MicrosoftOwinPkgVer>

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Native AOT compatibility.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 * Update OpenTelemetry SDK version to `1.8.0`.
   ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Native AOT compatibility.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#1670](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1670))
 
 * Update OpenTelemetry SDK version to `1.8.0`.
   ([#1635](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1635))

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
@@ -76,12 +79,18 @@ internal sealed class OneCollectorExporterEventSource : EventSource
     }
 
     [Event(2, Message = "Sent '{0}' batch of {1} item(s) to '{2}' transport.", Level = EventLevel.Informational)]
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primitive values.")]
+#endif
     public void TransportDataSent(string itemType, int numberOfRecords, string transportDescription)
     {
         this.WriteEvent(2, itemType, numberOfRecords, transportDescription);
     }
 
     [Event(3, Message = "Wrote '{0}' batch of {1} item(s) to '{2}' sink.", Level = EventLevel.Informational)]
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primitive values.")]
+#endif
     public void SinkDataWritten(string itemType, int numberOfRecords, string sinkDescription)
     {
         this.WriteEvent(3, itemType, numberOfRecords, sinkDescription);
@@ -100,6 +109,9 @@ internal sealed class OneCollectorExporterEventSource : EventSource
     }
 
     [Event(6, Message = "Error response received by '{0}' transport. StatusCode: {1}, ErrorMessage: '{2}', ErrorDetails: '{3}'", Level = EventLevel.Error)]
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primitive values.")]
+#endif
     public void HttpTransportErrorResponseReceived(string transportType, int statusCode, string errorMessage, string errorDetails)
     {
         this.WriteEvent(6, transportType, statusCode, errorMessage, errorDetails);

--- a/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
+++ b/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
@@ -8,11 +8,19 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <MinVerTagPrefix>Exporter.OneCollector-</MinVerTagPrefix>
     <ImplicitUsings>true</ImplicitUsings>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <!-- Note: SYSLIB1100;SYSLIB1101 - Configuration.Binder: Can't create
+    instance and unsupported type are being emitted by config source generator
+    processing OneCollectorExporterTransportOptions. It would be preferable to suppress
+    this at the call site but there is a bug. This could possibly be cleaned up
+    in the future (hopefully .NET 9) see https://github.com/dotnet/runtime/issues/92509 -->
+    <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPkgVer)" Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net6.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPkgVer)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -13,6 +13,7 @@
       When adding projects here please also update the verify-aot-compat job in
       .github\workflows\ci.yml so that it runs for the project(s) being added.
     -->
+    <TrimmerRootAssembly Include="OpenTelemetry.Exporter.OneCollector" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions.Enrichment" />
     <TrimmerRootAssembly Include="OpenTelemetry.Instrumentation.AWS" />


### PR DESCRIPTION
## Changes

Make OpenTelemetry.Exporter.OneCollector compatible with native AOT.

- Need to use the Microsoft.Extensions.Configuration.Binder source generator to solve 2 warnings. Need to reference the 8.0.1 version to get the latest updated to the source generator.

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
