### PR TITLE
[OneCollector] Update public api files for things released stable in 1.6.0

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback) -> System.IDisposable?
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterOptions.ConnectionString.set -> void
@@ -10,6 +11,7 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallba
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.CopyPayloadToStream(System.IO.Stream! destination) -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.OneCollectorExporterPayloadTransmittedCallbackArguments() -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.PayloadSizeInBytes.get -> long
+OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.TransportEndpoint.get -> System.Uri!
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType
 OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType.Ignore = 0 -> OpenTelemetry.Exporter.OneCollector.OneCollectorExporterSerializationExceptionStackTraceHandlingType
@@ -44,3 +46,4 @@ static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOn
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, string! connectionString, System.Action<OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 static OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions.AddOneCollectorExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions! options, System.Action<OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
+virtual OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction.Invoke(in OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments args) -> void

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Unshipped.txt
@@ -1,3 +1,0 @@
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.RegisterPayloadTransmittedCallback(OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction! callback, bool includeFailures) -> System.IDisposable?
-OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments.Succeeded.get -> bool
-virtual OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackAction.Invoke(in OpenTelemetry.Exporter.OneCollector.OneCollectorExporterPayloadTransmittedCallbackArguments args) -> void


### PR DESCRIPTION
Relates to #1412

## Changes

* Moves things shipped stable in `OneCollectorExporter` `1.6.0` release to shipped public api file
