### PR TITLE
[Sampler.AWS]  Use DateTimeOffset to beter handle timezones.

### DIFF
--- a/src/OpenTelemetry.Sampler.AWS/AWSXRayRemoteSampler.cs
+++ b/src/OpenTelemetry.Sampler.AWS/AWSXRayRemoteSampler.cs
@@ -156,7 +156,7 @@ public sealed class AWSXRayRemoteSampler : Trace.Sampler, IDisposable
 
             if (response.LastRuleModification > 0)
             {
-                DateTime lastRuleModificationTime = this.Clock.ToDateTime(response.LastRuleModification);
+                var lastRuleModificationTime = this.Clock.ToDateTime(response.LastRuleModification);
 
                 if (lastRuleModificationTime > this.RulesCache.GetUpdatedAt())
                 {
@@ -167,7 +167,7 @@ public sealed class AWSXRayRemoteSampler : Trace.Sampler, IDisposable
         }
 
         // schedule next target poll
-        DateTime nextTargetFetchTime = this.RulesCache.NextTargetFetchTime();
+        var nextTargetFetchTime = this.RulesCache.NextTargetFetchTime();
         TimeSpan nextTargetFetchInterval = nextTargetFetchTime.Subtract(this.Clock.Now());
         if (nextTargetFetchInterval < TimeSpan.Zero)
         {

--- a/src/OpenTelemetry.Sampler.AWS/Clock.cs
+++ b/src/OpenTelemetry.Sampler.AWS/Clock.cs
@@ -13,11 +13,11 @@ internal abstract class Clock
         return SystemClock.GetInstance();
     }
 
-    public abstract DateTime Now();
+    public abstract DateTimeOffset Now();
 
     public abstract long NowInMilliSeconds();
 
-    public abstract DateTime ToDateTime(double seconds);
+    public abstract DateTimeOffset ToDateTime(double seconds);
 
-    public abstract double ToDouble(DateTime dateTime);
+    public abstract double ToDouble(DateTimeOffset dateTime);
 }

--- a/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
+++ b/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
@@ -37,7 +37,7 @@ internal class RulesCache : IDisposable
 
     internal List<SamplingRuleApplier> RuleAppliers { get; set; }
 
-    internal DateTime UpdatedAt { get; set; }
+    internal DateTimeOffset UpdatedAt { get; set; }
 
     public bool Expired()
     {
@@ -96,7 +96,7 @@ internal class RulesCache : IDisposable
         return this.FallbackSampler.ShouldSample(in samplingParameters);
     }
 
-    public List<SamplingStatisticsDocument> Snapshot(DateTime now)
+    public List<SamplingStatisticsDocument> Snapshot(DateTimeOffset now)
     {
         List<SamplingStatisticsDocument> snapshots = new List<SamplingStatisticsDocument>();
         foreach (var ruleApplier in this.RuleAppliers)
@@ -135,7 +135,7 @@ internal class RulesCache : IDisposable
         }
     }
 
-    public DateTime NextTargetFetchTime()
+    public DateTimeOffset NextTargetFetchTime()
     {
         var defaultPollingTime = this.Clock.Now().AddSeconds(AWSXRayRemoteSampler.DefaultTargetInterval.TotalSeconds);
 
@@ -162,7 +162,7 @@ internal class RulesCache : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    internal DateTime GetUpdatedAt()
+    internal DateTimeOffset GetUpdatedAt()
     {
         this.rwLock.EnterReadLock();
         try

--- a/src/OpenTelemetry.Sampler.AWS/SamplingRuleApplier.cs
+++ b/src/OpenTelemetry.Sampler.AWS/SamplingRuleApplier.cs
@@ -50,8 +50,8 @@ internal class SamplingRuleApplier
         Trace.Sampler fixedRateSampler,
         bool borrowing,
         Statistics statistics,
-        DateTime reservoirEndTime,
-        DateTime nextSnapshotTime)
+        DateTimeOffset reservoirEndTime,
+        DateTimeOffset nextSnapshotTime)
     {
         this.ClientId = clientId;
         this.Rule = rule;
@@ -81,9 +81,9 @@ internal class SamplingRuleApplier
 
     internal bool Borrowing { get; set; }
 
-    internal DateTime ReservoirEndTime { get; set; }
+    internal DateTimeOffset ReservoirEndTime { get; set; }
 
-    internal DateTime NextSnapshotTime { get; set; }
+    internal DateTimeOffset NextSnapshotTime { get; set; }
 
     // check if this rule applier matches the request
     public bool Matches(SamplingParameters samplingParameters, Resource resource)
@@ -179,7 +179,7 @@ internal class SamplingRuleApplier
     }
 
     // take the snapshot and reset the statistics.
-    public SamplingStatisticsDocument Snapshot(DateTime now)
+    public SamplingStatisticsDocument Snapshot(DateTimeOffset now)
     {
         double timestamp = this.Clock.ToDouble(now);
 
@@ -198,14 +198,14 @@ internal class SamplingRuleApplier
         return statiscticsDocument;
     }
 
-    public SamplingRuleApplier WithTarget(SamplingTargetDocument target, DateTime now)
+    public SamplingRuleApplier WithTarget(SamplingTargetDocument target, DateTimeOffset now)
     {
         Trace.Sampler newFixedRateSampler = target.FixedRate != null
             ? new ParentBasedSampler(new TraceIdRatioBasedSampler(target.FixedRate.Value))
             : this.FixedRateSampler;
 
         Trace.Sampler newReservoirSampler = new AlwaysOffSampler();
-        DateTime newReservoirEndTime = DateTime.MaxValue;
+        DateTimeOffset newReservoirEndTime = DateTimeOffset.MaxValue;
         if (target.ReservoirQuota != null && target.ReservoirQuotaTTL != null)
         {
             if (target.ReservoirQuota > 0)
@@ -220,7 +220,7 @@ internal class SamplingRuleApplier
             newReservoirEndTime = this.Clock.ToDateTime(target.ReservoirQuotaTTL.Value);
         }
 
-        DateTime newNextSnapshotTime = target.Interval != null
+        DateTimeOffset newNextSnapshotTime = target.Interval != null
             ? now.AddSeconds(target.Interval.Value)
             : now.Add(AWSXRayRemoteSampler.DefaultTargetInterval);
 

--- a/src/OpenTelemetry.Sampler.AWS/SystemClock.cs
+++ b/src/OpenTelemetry.Sampler.AWS/SystemClock.cs
@@ -10,7 +10,7 @@ internal class SystemClock : Clock
 {
     private static readonly SystemClock Instance = new SystemClock();
 
-    private static readonly DateTime EpochStart = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset EpochStart = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     private SystemClock()
     {
@@ -21,9 +21,9 @@ internal class SystemClock : Clock
         return Instance;
     }
 
-    public override DateTime Now()
+    public override DateTimeOffset Now()
     {
-        return DateTime.UtcNow;
+        return DateTimeOffset.UtcNow;
     }
 
     public override long NowInMilliSeconds()
@@ -31,12 +31,12 @@ internal class SystemClock : Clock
         return (long)this.Now().ToUniversalTime().Subtract(EpochStart).TotalMilliseconds;
     }
 
-    public override DateTime ToDateTime(double seconds)
+    public override DateTimeOffset ToDateTime(double seconds)
     {
         return EpochStart.AddSeconds(seconds);
     }
 
-    public override double ToDouble(DateTime dateTime)
+    public override double ToDouble(DateTimeOffset dateTime)
     {
         var current = new TimeSpan(dateTime.ToUniversalTime().Ticks - EpochStart.Ticks);
         double timestamp = Math.Round(current.TotalMilliseconds, 0) / 1000.0;

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestClock.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestClock.cs
@@ -20,7 +20,7 @@ internal class TestClock : Clock
         this.nowTime = time;
     }
 
-    public override DateTime Now()
+    public override DateTimeOffset Now()
     {
         return this.nowTime;
     }
@@ -30,12 +30,12 @@ internal class TestClock : Clock
         return (long)this.nowTime.ToUniversalTime().Subtract(EpochStart).TotalMilliseconds;
     }
 
-    public override DateTime ToDateTime(double seconds)
+    public override DateTimeOffset ToDateTime(double seconds)
     {
         return EpochStart.AddSeconds(seconds);
     }
 
-    public override double ToDouble(DateTime dateTime)
+    public override double ToDouble(DateTimeOffset dateTime)
     {
         TimeSpan current = new TimeSpan(dateTime.ToUniversalTime().Ticks - EpochStart.Ticks);
         double timestamp = Math.Round(current.TotalMilliseconds, 0) / 1000.0;


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1219

## Changes

Changes Sampler.AWS to use `DateTimeOffset` instead of `DateTime` as it has better time zone support.

## Note

Do a second pass on change set to evaluate any breaking changes.