### PR TITLE
[Exporter.Geneva] Add exponential histogram support

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/FieldNumberConstants.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/FieldNumberConstants.cs
@@ -76,6 +76,26 @@ internal static class FieldNumberConstants
     internal const int HistogramDataPoint_min = 11;
     internal const int HistogramDataPoint_max = 12;
 
+    // ExponentialHistogramDataPoint
+    internal const int ExponentialHistogramDataPoint_attributes = 1;
+    internal const int ExponentialHistogramDataPoint_start_time_unix_nano = 2;
+    internal const int ExponentialHistogramDataPoint_time_unix_nano = 3;
+    internal const int ExponentialHistogramDataPoint_count = 4;
+    internal const int ExponentialHistogramDataPoint_sum = 5;
+    internal const int ExponentialHistogramDataPoint_scale = 6;
+    internal const int ExponentialHistogramDataPoint_zero_count = 7;
+    internal const int ExponentialHistogramDataPoint_positive = 8;
+    internal const int ExponentialHistogramDataPoint_negative = 9;
+    internal const int ExponentialHistogramDataPoint_flags = 10;
+    internal const int ExponentialHistogramDataPoint_exemplars = 11;
+    internal const int ExponentialHistogramDataPoint_min = 12;
+    internal const int ExponentialHistogramDataPoint_max = 13;
+    internal const int ExponentialHistogramDataPoint_zero_threshold = 14;
+
+    // Buckets
+    internal const int Bucket_offset = 1;
+    internal const int Bucket_bucket_counts = 2;
+
     // AnyValue
     internal const int AnyValue_string_value = 1;
     internal const int AnyValue_bool_value = 2;

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/ProtobufSerializerHelper.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/ProtobufSerializerHelper.cs
@@ -63,6 +63,15 @@ internal static class ProtobufSerializerHelper
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteSInt32WithTag(byte[] buffer, ref int cursor, int fieldNumber, int value)
+    {
+        WriteTag(buffer, ref cursor, fieldNumber, WireType.VARINT);
+
+        // https://protobuf.dev/programming-guides/encoding/#signed-ints
+        WriteVarint32(buffer, ref cursor, (uint)((value << 1) ^ (value >> 31)));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void WriteDoubleWithTag(byte[] buffer, ref int cursor, int fieldNumber, double value)
     {
         WriteTag(buffer, ref cursor, fieldNumber, WireType.I64);


### PR DESCRIPTION
Fixes #1378 

## Changes

Adds support for exporting exponential histograms when OTLP protobuf encoding is enable for metric exporter.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
