### PR TITLE
Release v1.0.0-beta.5 of OpenTelemetry.Extensions package

### DIFF
--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.5
+
+Released 2024-May-08
+
 * Add LogToActivityEventConversionOptions.Filter callback
   ([#1059](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1059))
 


### PR DESCRIPTION
## Changes

Updates the Changelog for OpenTelemtry.Extensions so the next version of the package can be published.

cc @open-telemetry/dotnet-contrib-maintainers 
