### PR TITLE
[Extensions.AWS] Remove NuGet reference to System.Net.Http

### DIFF
--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Update OpenTelemetry SDK version to `1.8.1`.
   ([#1668](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1668))
+* Remove NuGet reference to `System.Net.Http`
+  ([#1713](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1713))
 
 ## 1.3.0-beta.1
 

--- a/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
+++ b/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'">


### PR DESCRIPTION
## Changes

Remove the reference to System.Net.Http to reduce noise in the NuGet dependency graph.

Including this reference requires restoring all these packages during builds. Most of them are stubs that don't contain binaries. They are not required on any of the supported .NET runtimes. (In fact, this project doesn't reference anything from the System.Net.Http namespace.)

```json
"System.Net.Http": {
  "type": "Transitive",
  "resolved": "4.3.4",
  "contentHash": "aOa2d51SEbmM+H+Csw7yJOuNZoHkrP2XnAurye5HWYgGVVU54YZDvsLUYRv6h18X3sPnjNCANmN7ZhIPiqMcjA==",
  "dependencies": {
    "Microsoft.NETCore.Platforms": "1.1.1",
    "System.Collections": "4.3.0",
    "System.Diagnostics.Debug": "4.3.0",
    "System.Diagnostics.DiagnosticSource": "4.3.0",
    "System.Diagnostics.Tracing": "4.3.0",
    "System.Globalization": "4.3.0",
    "System.Globalization.Extensions": "4.3.0",
    "System.IO": "4.3.0",
    "System.IO.FileSystem": "4.3.0",
    "System.Net.Primitives": "4.3.0",
    "System.Resources.ResourceManager": "4.3.0",
    "System.Runtime": "4.3.0",
    "System.Runtime.Extensions": "4.3.0",
    "System.Runtime.Handles": "4.3.0",
    "System.Runtime.InteropServices": "4.3.0",
    "System.Security.Cryptography.Algorithms": "4.3.0",
    "System.Security.Cryptography.Encoding": "4.3.0",
    "System.Security.Cryptography.OpenSsl": "4.3.0",
    "System.Security.Cryptography.Primitives": "4.3.0",
    "System.Security.Cryptography.X509Certificates": "4.3.0",
    "System.Text.Encoding": "4.3.0",
    "System.Threading": "4.3.0",
    "System.Threading.Tasks": "4.3.0",
    "runtime.native.System": "4.3.0",
    "runtime.native.System.Net.Http": "4.3.0",
    "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
  }
}
```