### PR TITLE
[Exporter.Geneva] 1.9.0-alpha.1 release prep

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.9.0-alpha.1
+
+Released 2024-May-22
+
+* Update OpenTelemetry SDK version to `1.9.0-alpha.1`.
+  ([#1798](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1798))
+
 ## 1.8.0
 
 Released 2024-May-15

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -7,7 +7,7 @@
 Released 2024-May-22
 
 * Update OpenTelemetry SDK version to `1.9.0-alpha.1`.
-  ([#1798](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1798))
+  ([#1834](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1834))
 
 ## 1.8.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
+++ b/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <OTelSdkVersion>$(OpenTelemetryCoreLatestVersion)</OTelSdkVersion>
+    <OTelSdkVersion>$(OpenTelemetryCoreLatestPrereleaseVersion)</OTelSdkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(OTelSdkVersion.Contains('alpha')) OR $(OTelSdkVersion.Contains('beta')) OR $(OTelSdkVersion.Contains('rc'))">

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
@@ -394,7 +394,6 @@ internal sealed class OtlpProtobufSerializer
                                 }
                             }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
                             if (metricPoint.TryGetExemplars(out var exemplars))
                             {
                                 foreach (ref readonly var exemplar in exemplars)
@@ -402,7 +401,6 @@ internal sealed class OtlpProtobufSerializer
                                     this.SerializeExemplar(buffer, ref cursor, in exemplar, exemplar.DoubleValue, FieldNumberConstants.HistogramDataPoint_exemplars);
                                 }
                             }
-#endif
 
                             var metricPointStartPosition = this.metricPointTagAndLengthIndex;
 
@@ -489,7 +487,6 @@ internal sealed class OtlpProtobufSerializer
                             // write Bucket
                             ProtobufSerializerHelper.WriteTagAndLengthPrefix(buffer, ref positiveBucketIndex, cursor - positiveBucketValueIndex, FieldNumberConstants.ExponentialHistogramDataPoint_positive, WireType.LEN);
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
                             if (metricPoint.TryGetExemplars(out var exemplars))
                             {
                                 foreach (ref readonly var exemplar in exemplars)
@@ -497,7 +494,6 @@ internal sealed class OtlpProtobufSerializer
                                     this.SerializeExemplar(buffer, ref cursor, in exemplar, exemplar.DoubleValue, FieldNumberConstants.ExponentialHistogramDataPoint_exemplars);
                                 }
                             }
-#endif
 
                             var metricPointStartPosition = this.metricPointTagAndLengthIndex;
 
@@ -549,7 +545,6 @@ internal sealed class OtlpProtobufSerializer
             cursor += this.prepopulatedNumberDataPointAttributesLength;
         }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         if (metricPoint.TryGetExemplars(out var exemplars))
         {
             foreach (ref readonly var exemplar in exemplars)
@@ -564,7 +559,6 @@ internal sealed class OtlpProtobufSerializer
                 }
             }
         }
-#endif
 
         var metricPointStartPosition = this.metricPointTagAndLengthIndex;
 
@@ -572,7 +566,6 @@ internal sealed class OtlpProtobufSerializer
         ProtobufSerializerHelper.WriteTagAndLengthPrefix(buffer, ref metricPointStartPosition, cursor - this.metricPointValueIndex, fieldNumber, WireType.LEN);
     }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
     private void SerializeExemplar<T>(byte[] buffer, ref int cursor, in Exemplar exemplar, T value, int fieldNumber)
     {
         int exemplarTagAndLengthIndex = cursor;
@@ -617,7 +610,6 @@ internal sealed class OtlpProtobufSerializer
             SerializeTag(buffer, ref cursor, tag.Key, tag.Value, FieldNumberConstants.Exemplar_attributes);
         }
     }
-#endif
 
     private void WriteIndividualMessageTagsAndLength(byte[] buffer, ref int cursor, MetricType metricType)
     {

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
@@ -87,9 +87,8 @@ internal sealed class TlvMetricExporter : IDisposable
             {
                 try
                 {
-#if EXPOSE_EXPERIMENTAL_FEATURES
                     metricPoint.TryGetExemplars(out var exemplars);
-#endif
+
                     var metricType = metric.MetricType;
                     switch (metricType)
                     {
@@ -103,10 +102,8 @@ internal sealed class TlvMetricExporter : IDisposable
                                     metricPoint.EndTime.ToFileTime(), // Using the endTime here as the timestamp as Geneva Metrics only allows for one field for timestamp
                                     metricPoint.Tags,
                                     metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                                     metricType,
                                     exemplars,
-#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -126,10 +123,8 @@ internal sealed class TlvMetricExporter : IDisposable
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                                     metricType,
                                     exemplars,
-#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -149,10 +144,8 @@ internal sealed class TlvMetricExporter : IDisposable
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                                     metricType,
                                     exemplars,
-#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -170,10 +163,8 @@ internal sealed class TlvMetricExporter : IDisposable
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                                     metricType,
                                     exemplars,
-#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -190,10 +181,8 @@ internal sealed class TlvMetricExporter : IDisposable
                                     metricPoint.EndTime.ToFileTime(),
                                     metricPoint.Tags,
                                     metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                                     metricType,
                                     exemplars,
-#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -219,10 +208,8 @@ internal sealed class TlvMetricExporter : IDisposable
                                     count,
                                     min,
                                     max,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                                     metricType,
                                     exemplars,
-#endif
                                     out monitoringAccount,
                                     out metricNamespace);
                                 this.metricDataTransport.Send(MetricEventType.TLV, this.buffer, bodyLength);
@@ -271,10 +258,8 @@ internal sealed class TlvMetricExporter : IDisposable
         long timestamp,
         in ReadOnlyTagCollection tags,
         MetricData value,
-#if EXPOSE_EXPERIMENTAL_FEATURES
         MetricType metricType,
         ReadOnlyExemplarCollection exemplars,
-#endif
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -301,9 +286,7 @@ internal sealed class TlvMetricExporter : IDisposable
                 out monitoringAccount,
                 out metricNamespace);
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
             SerializeExemplars(exemplars, metricType, this.buffer, ref bufferIndex);
-#endif
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -336,10 +319,8 @@ internal sealed class TlvMetricExporter : IDisposable
         uint count,
         double min,
         double max,
-#if EXPOSE_EXPERIMENTAL_FEATURES
         MetricType metricType,
         ReadOnlyExemplarCollection exemplars,
-#endif
         out string monitoringAccount,
         out string metricNamespace)
     {
@@ -366,9 +347,7 @@ internal sealed class TlvMetricExporter : IDisposable
                 out monitoringAccount,
                 out metricNamespace);
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
             SerializeExemplars(exemplars, metricType, this.buffer, ref bufferIndex);
-#endif
 
             SerializeMonitoringAccount(monitoringAccount, this.buffer, ref bufferIndex);
 
@@ -413,7 +392,6 @@ internal sealed class TlvMetricExporter : IDisposable
         MetricSerializer.SerializeString(buffer, ref bufferIndex, monitoringAccount);
     }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeExemplars(in ReadOnlyExemplarCollection exemplars, MetricType metricType, byte[] buffer, ref int bufferIndex)
     {
@@ -516,7 +494,6 @@ internal sealed class TlvMetricExporter : IDisposable
         var exemplarLength = bufferIndex - bufferIndexForLength + 1;
         MetricSerializer.SerializeByte(buffer, ref bufferIndexForLength, (byte)exemplarLength);
     }
-#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void SerializeNonHistogramMetricData(MetricEventType eventType, MetricData value, long timestamp, byte[] buffer, ref int bufferIndex)

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
@@ -574,19 +574,16 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void SerializeCounterMetricItemWith3Dimensions()
     {
-#if EXPOSE_EXPERIMENTAL_FEATURES
         this.counterMetricPointWith3Dimensions.TryGetExemplars(out var exemplars);
-#endif
+
         this.tlvMetricsExporter.SerializeMetricWithTLV(
             MetricEventType.ULongMetric,
             this.counterMetricWith3Dimensions.Name,
             this.counterMetricPointWith3Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith3Dimensions.Tags,
             this.counterMetricDataWith3Dimensions,
-#if EXPOSE_EXPERIMENTAL_FEATURES
             MetricType.LongSum,
             exemplars,
-#endif
             out _,
             out _);
     }
@@ -594,19 +591,15 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void SerializeCounterMetricItemWith4Dimensions()
     {
-#if EXPOSE_EXPERIMENTAL_FEATURES
         this.counterMetricPointWith4Dimensions.TryGetExemplars(out var exemplars);
-#endif
         this.tlvMetricsExporter.SerializeMetricWithTLV(
             MetricEventType.ULongMetric,
             this.counterMetricWith4Dimensions.Name,
             this.counterMetricPointWith4Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith4Dimensions.Tags,
             this.counterMetricDataWith4Dimensions,
-#if EXPOSE_EXPERIMENTAL_FEATURES
             MetricType.LongSum,
             exemplars,
-#endif
             out _,
             out _);
     }
@@ -626,9 +619,7 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void SerializeHistogramMetricItemWith3Dimensions()
     {
-#if EXPOSE_EXPERIMENTAL_FEATURES
         this.histogramMetricPointWith3Dimensions.TryGetExemplars(out var exemplars);
-#endif
         this.tlvMetricsExporter.SerializeHistogramMetricWithTLV(
             this.histogramMetricWith3Dimensions.Name,
             this.histogramMetricPointWith3Dimensions.EndTime.ToFileTime(),
@@ -638,10 +629,8 @@ public class MetricExporterBenchmarks
             this.histogramCountWith3Dimensions,
             this.histogramMinWith3Dimensions,
             this.histogramMaxWith3Dimensions,
-#if EXPOSE_EXPERIMENTAL_FEATURES
             MetricType.Histogram,
             exemplars,
-#endif
             out _,
             out _);
     }
@@ -649,9 +638,7 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void SerializeHistogramMetricItemWith4Dimensions()
     {
-#if EXPOSE_EXPERIMENTAL_FEATURES
         this.histogramMetricPointWith4Dimensions.TryGetExemplars(out var exemplars);
-#endif
         this.tlvMetricsExporter.SerializeHistogramMetricWithTLV(
             this.histogramMetricWith4Dimensions.Name,
             this.histogramMetricPointWith4Dimensions.EndTime.ToFileTime(),
@@ -661,10 +648,8 @@ public class MetricExporterBenchmarks
             this.histogramCountWith4Dimensions,
             this.histogramMinWith4Dimensions,
             this.histogramMaxWith4Dimensions,
-#if EXPOSE_EXPERIMENTAL_FEATURES
             MetricType.Histogram,
             exemplars,
-#endif
             out _,
             out _);
     }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -185,19 +185,15 @@ public class GenevaMetricExporterTests
                 var metricDataValue = Convert.ToUInt64(metricPoint.GetSumLong());
                 var metricData = new MetricData { UInt64Value = metricDataValue };
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricPoint.TryGetExemplars(out var exemplars);
-#endif
                 var bodyLength = exporter.SerializeMetricWithTLV(
                     MetricEventType.ULongMetric,
                     metric.Name,
                     metricPoint.EndTime.ToFileTime(),
                     metricPoint.Tags,
                     metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                     MetricType.LongSum,
                     exemplars,
-#endif
                     out _,
                     out _);
 
@@ -385,9 +381,7 @@ public class GenevaMetricExporterTests
 
         if (hasExemplars)
         {
-#if EXPOSE_EXPERIMENTAL_FEATURES
             meterProviderBuilder.SetExemplarFilter(ExemplarFilterType.AlwaysOn);
-#endif
         }
 
         if (hasFilteredTagsForExemplars)
@@ -983,9 +977,7 @@ public class GenevaMetricExporterTests
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         metricPoint.TryGetExemplars(out var exemplars);
-#endif
 
         List<TlvField> fields = null;
 
@@ -1000,10 +992,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1029,10 +1019,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1060,10 +1048,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1091,10 +1077,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1129,10 +1113,8 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1171,7 +1153,6 @@ public class GenevaMetricExporterTests
             Assert.Equal(bodyLength, data.LenBody);
         }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         List<Exemplar> validExemplars = new List<Exemplar>();
 
         foreach (var exemplar in exemplars)
@@ -1198,7 +1179,6 @@ public class GenevaMetricExporterTests
                 AssertExemplarFilteredTagSerialization(expectedExemplar, serializedExemplar);
             }
         }
-#endif
 
         // Check metric name, account, and namespace
         var connectionStringBuilder = new ConnectionStringBuilder(exporterOptions.ConnectionString);
@@ -1271,7 +1251,6 @@ public class GenevaMetricExporterTests
         Assert.Equal(dimensionsCount, dimensions.NumDimensions);
     }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
     private static void AssertExemplarFilteredTagSerialization(Exemplar expectedExemplar, SingleExemplar serializedExemplar)
     {
         var serializedExemplarBody = serializedExemplar.Body;
@@ -1328,7 +1307,6 @@ public class GenevaMetricExporterTests
 
         Assert.Equal(filteredTagsExpectedCount, filteredTagsActualCount);
     }
-#endif
 
     private static UserdataV2 GetSerializedData(Metric metric, TlvMetricExporter exporter)
     {
@@ -1337,9 +1315,7 @@ public class GenevaMetricExporterTests
         metricPointsEnumerator.MoveNext();
         var metricPoint = metricPointsEnumerator.Current;
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         metricPoint.TryGetExemplars(out var exemplars);
-#endif
 
         UserdataV2 result = null;
 
@@ -1353,10 +1329,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1375,10 +1349,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1399,10 +1371,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1423,10 +1393,8 @@ public class GenevaMetricExporterTests
                 metricPoint.EndTime.ToFileTime(),
                 metricPoint.Tags,
                 metricData,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 
@@ -1454,10 +1422,8 @@ public class GenevaMetricExporterTests
                 count,
                 min,
                 max,
-#if EXPOSE_EXPERIMENTAL_FEATURES
                 metricType,
                 exemplars,
-#endif
                 out _,
                 out _);
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -30,7 +30,6 @@ public class OtlpProtobufMetricExporterTests
         { "Dim3", 3 },
     };
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
     private static readonly string[] TagKeys = new[]
     {
         "boolKey",
@@ -51,7 +50,6 @@ public class OtlpProtobufMetricExporterTests
         "ulongKey",
         "ushortKey",
     };
-#endif
 
     private TagList exemplarTagList;
 
@@ -206,10 +204,8 @@ public class OtlpProtobufMetricExporterTests
             .AddReader(inMemoryReader);
         if (isExemplarsEnabled)
         {
-#if EXPOSE_EXPERIMENTAL_FEATURES
             meterProviderBuilder.SetExemplarFilter(ExemplarFilterType.AlwaysOn);
             meterProviderBuilder.AddView("*", new MetricStreamConfiguration { TagKeys = TagKeys });
-#endif
         }
 
         var meterProvider = meterProviderBuilder.Build();
@@ -217,7 +213,6 @@ public class OtlpProtobufMetricExporterTests
         if (longValue != null)
         {
             var counter = meter.CreateCounter<long>(instrumentName);
-#if EXPOSE_EXPERIMENTAL_FEATURES
             if (isExemplarsEnabled)
             {
                 counter.Add(longValue.Value, this.exemplarTagList);
@@ -226,14 +221,10 @@ public class OtlpProtobufMetricExporterTests
             {
                 counter.Add(longValue.Value, this.TagList);
             }
-#else
-            counter.Add(longValue.Value, this.TagList);
-#endif
         }
         else
         {
             var counter = meter.CreateCounter<double>(instrumentName);
-#if EXPOSE_EXPERIMENTAL_FEATURES
             if (isExemplarsEnabled)
             {
                 counter.Add(doubleValue.Value, this.exemplarTagList);
@@ -242,9 +233,6 @@ public class OtlpProtobufMetricExporterTests
             {
                 counter.Add(doubleValue.Value, this.TagList);
             }
-#else
-            counter.Add(doubleValue.Value, this.TagList);
-#endif
         }
 
         meterProvider.ForceFlush();
@@ -311,7 +299,6 @@ public class OtlpProtobufMetricExporterTests
 
         Assert.Equal((ulong)metricPoint.EndTime.ToUnixTimeNanoseconds(), dataPoint.TimeUnixNano);
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         if (isExemplarsEnabled)
         {
             Assert.Single(dataPoint.Exemplars);
@@ -361,7 +348,6 @@ public class OtlpProtobufMetricExporterTests
         {
             Assert.Empty(dataPoint.Exemplars);
         }
-#endif
 
         if (addPrepopulatedDimensions)
         {
@@ -806,16 +792,14 @@ public class OtlpProtobufMetricExporterTests
            .AddReader(inMemoryReader);
         if (isExemplarsEnabled)
         {
-#if EXPOSE_EXPERIMENTAL_FEATURES
             meterProviderBuilder.SetExemplarFilter(ExemplarFilterType.AlwaysOn);
             meterProviderBuilder.AddView("*", new MetricStreamConfiguration { TagKeys = TagKeys });
-#endif
         }
 
         var meterProvider = meterProviderBuilder.Build();
 
         var histogram = meter.CreateHistogram<double>("TestHistogram");
-#if EXPOSE_EXPERIMENTAL_FEATURES
+
         if (isExemplarsEnabled)
         {
             histogram.Record(doubleValue, this.exemplarTagList);
@@ -824,9 +808,6 @@ public class OtlpProtobufMetricExporterTests
         {
             histogram.Record(doubleValue, this.TagList);
         }
-#else
-        histogram.Record(doubleValue, this.TagList);
-#endif
 
         meterProvider.ForceFlush();
 
@@ -916,7 +897,6 @@ public class OtlpProtobufMetricExporterTests
             AssertOtlpAttributes(this.TagList, dataPoint.Attributes);
         }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         if (isExemplarsEnabled)
         {
             Assert.Single(dataPoint.Exemplars);
@@ -959,7 +939,6 @@ public class OtlpProtobufMetricExporterTests
         {
             Assert.Empty(dataPoint.Exemplars);
         }
-#endif
     }
 
     [Theory]
@@ -1418,18 +1397,12 @@ public class OtlpProtobufMetricExporterTests
 
         if (isExemplarsEnabled)
         {
-#if EXPOSE_EXPERIMENTAL_FEATURES
             meterProviderBuilder.SetExemplarFilter(ExemplarFilterType.AlwaysOn);
-#endif
         }
 
         meterProviderBuilder.AddView(instrument =>
         {
-#if EXPOSE_EXPERIMENTAL_FEATURES
             return new Base2ExponentialBucketHistogramConfiguration() { TagKeys = TagKeys };
-#else
-            return new Base2ExponentialBucketHistogramConfiguration();
-#endif
         });
 
         var meterProvider = meterProviderBuilder.Build();
@@ -1437,7 +1410,6 @@ public class OtlpProtobufMetricExporterTests
         var instrumentName = "doubleExponentialHistogram";
         var histogram = meter.CreateHistogram<double>(instrumentName);
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         if (isExemplarsEnabled)
         {
             histogram.Record(doubleValue.Value, this.exemplarTagList);
@@ -1448,10 +1420,6 @@ public class OtlpProtobufMetricExporterTests
             histogram.Record(doubleValue.Value, this.TagList);
             histogram.Record(0, this.TagList);
         }
-#else
-        histogram.Record(doubleValue.Value, this.TagList);
-        histogram.Record(0, this.TagList);
-#endif
 
         meterProvider.ForceFlush();
 
@@ -1542,7 +1510,6 @@ public class OtlpProtobufMetricExporterTests
             AssertOtlpAttributes(this.TagList, dataPoint.Attributes);
         }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
         if (isExemplarsEnabled)
         {
             // Exemplars are only emitted for positive/0 values.
@@ -1600,7 +1567,6 @@ public class OtlpProtobufMetricExporterTests
         {
             Assert.Empty(dataPoint.Exemplars);
         }
-#endif
     }
 
     internal static void AssertOtlpAttributes(


### PR DESCRIPTION
Fixes #.

## Changes

Updates SDK version to `1.9.0-alpha.1` and removes `EXPOSE_EXPERIMENTAL_FEATURES` directives

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
