### PR TITLE
Fix variable usage in test-aot-compatibility script

### DIFF
--- a/build/scripts/test-aot-compatibility.ps1
+++ b/build/scripts/test-aot-compatibility.ps1
@@ -44,7 +44,7 @@ $testPassed = 0
 if ($actualWarningCount -ne $expectedWarningCount)
 {
     $testPassed = 1
-    Write-Host "Actual warning count:", actualWarningCount, "is not as expected. Expected warning count is:", $expectedWarningCount
+    Write-Host "Actual warning count:", $actualWarningCount, "is not as expected. Expected warning count is:", $expectedWarningCount
 }
 
 Exit $testPassed


### PR DESCRIPTION
Minor fix up of the powershell script.

Porting change from https://github.com/open-telemetry/opentelemetry-dotnet/pull/5645.