### PR TITLE
[repo] Switch core-version-update workflow to use a dedicated bot account

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,0 +1,34 @@
+name: Resolve automation settings
+
+on:
+  workflow_call:
+    outputs:
+      enabled:
+        value: ${{ jobs.resolve-automation.outputs.enabled == 'true' }}
+      token-secret-name:
+        value: ${{ jobs.resolve-automation.outputs.token-secret-name }}
+      username:
+        value: ${{ vars.AUTOMATION_USERNAME }}
+      email:
+        value: ${{ vars.AUTOMATION_EMAIL }}
+    secrets:
+      OPENTELEMETRYBOT_GITHUB_TOKEN:
+        required: true
+
+jobs:
+  resolve-automation:
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      enabled: ${{ steps.evaluate.outputs.enabled }}
+      token-secret-name: ${{ steps.evaluate.outputs.token-secret-name }}
+
+    env:
+      OPENTELEMETRYBOT_GITHUB_TOKEN_EXISTS: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN != '' }}
+
+    steps:
+    - id: evaluate
+      run: |
+        echo "enabled=${{ env.OPENTELEMETRYBOT_GITHUB_TOKEN_EXISTS == 'true' }}" >> "$GITHUB_OUTPUT"
+        echo "token-secret-name=OPENTELEMETRYBOT_GITHUB_TOKEN" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -8,23 +8,26 @@ on:
         description: 'Release tag'
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  core-version-update:
+  automation:
+    uses: ./.github/workflows/automation.yml
+    secrets: inherit
 
-    runs-on: windows-latest
+  core-version-update:
+    runs-on: ubuntu-latest
+
+    needs: automation
+
+    if: needs.automation.outputs.enabled
+
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     steps:
     - uses: actions/checkout@v4
       with:
-        # Note: By default GitHub only fetches 1 commit. MinVer needs to find
-        # the version tag which is typically NOT on the first commit so we
-        # retrieve them all.
-        fetch-depth: 0
-
+        ref: ${{ github.event.repository.default_branch }}
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
 
@@ -34,6 +37,8 @@ jobs:
         Import-Module .\build\scripts\post-release.psm1
 
         CreateOpenTelemetryCoreLatestVersionUpdatePullRequest `
-          -tag '${{ inputs.tag }}'
-      env:
-        GH_TOKEN: ${{ github.token }}
+          -gitRepository '${{ github.repository }}' `
+          -tag '${{ inputs.tag }}' `
+          -targetBranch '${{ github.event.repository.default_branch }}' `
+          -gitUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserEmail '${{ needs.automation.outputs.email }}'

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -201,10 +201,11 @@ Export-ModuleMember -Function CreatePackageValidationBaselineVersionUpdatePullRe
 
 function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
   param(
+    [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$tag,
-    [Parameter()][string]$gitUserName=$gitHubBotUserName,
-    [Parameter()][string]$gitUserEmail=$gitHubBotEmail,
-    [Parameter()][string]$targetBranch="main"
+    [Parameter()][string]$targetBranch="main",
+    [Parameter()][string]$gitUserName,
+    [Parameter()][string]$gitUserEmail
   )
 
   $match = [regex]::Match($tag, '^(.*?-)(.*)$')
@@ -257,8 +258,14 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
     }
   }
 
-  git config user.name $gitUserName
-  git config user.email $gitUserEmail
+  if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
+  {
+    git config user.name $gitUserName
+  }
+  if ([string]::IsNullOrEmpty($gitUserEmail) -eq $false)
+  {
+    git config user.email $gitUserEmail
+  }
 
   git switch --create $branch origin/$targetBranch --no-track 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -29,6 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\add-labels.yml = .github\workflows\add-labels.yml
 		.github\workflows\assign-reviewers.yml = .github\workflows\assign-reviewers.yml
+		.github\workflows\automation.yml = .github\workflows\automation.yml
 		.github\workflows\ci-Exporter.OneCollector-Integration.yml = .github\workflows\ci-Exporter.OneCollector-Integration.yml
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml


### PR DESCRIPTION
## Changes

* Use a dedicated bot account for the `core-version-update.yml` workflow

## Details

Relates to https://github.com/open-telemetry/opentelemetry-dotnet/pull/5657

Previously we were using the `github-actions` bot with workflow permissions. However things done in that context (push, create pr, publish release, etc.) don't trigger other workflows. So the PRs which are opened won't have CI run for example. The recommendation (see: https://github.com/open-telemetry/community/issues/2127#issue-2308782705) was to use `OpenTelemetryBot` instead which is more or less a normal account.

Demo PR: https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/3

Note: That demo shows `CodeBlanchBot` because it is my test org but when run here it will be `OpenTelemetryBot`.
