### PR TITLE
[Instrumentation.AWS] Update AWS SDK Activity Tags (#1857)

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog - OpenTelemetry.Instrumentation.AWS
 
 ## Unreleased
-* Updates AWS SDK Activity Tags based on https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/cloud-providers/aws-sdk.md#common-attributes.
+* Added `rpc.system`, `rpc.service`, and `rpc.method` to activity tags based on
+  [semantic convention v1.26.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/cloud-providers/aws-sdk.md#common-attributes).
+  ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1865))
   ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1865))
 
 ## 1.1.0-beta.4

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -4,7 +4,6 @@
 * Added `rpc.system`, `rpc.service`, and `rpc.method` to activity tags based on
   [semantic convention v1.26.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/cloud-providers/aws-sdk.md#common-attributes).
   ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1865))
-  ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1865))
 
 ## 1.1.0-beta.4
 

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog - OpenTelemetry.Instrumentation.AWS
 
 ## Unreleased
+* Updates AWS SDK Activity Tags based on https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/cloud-providers/aws-sdk.md#common-attributes.
+  ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1865))
 
 ## 1.1.0-beta.4
 

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog - OpenTelemetry.Instrumentation.AWS
 
 ## Unreleased
+
 * Added `rpc.system`, `rpc.service`, and `rpc.method` to activity tags based on
   [semantic convention v1.26.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/cloud-providers/aws-sdk.md#common-attributes).
   ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1865))

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSSemanticConventions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSSemanticConventions.cs
@@ -17,4 +17,8 @@ internal static class AWSSemanticConventions
     public const string AttributeHttpResponseContentLength = "http.response_content_length";
 
     public const string AttributeValueDynamoDb = "dynamodb";
+
+    public const string AttributeValueRPCSystem = "rpc.system";
+    public const string AttributeValueRPCService = "rpc.service";
+    public const string AttributeValueRPCMethod = "rpc.method";
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -233,6 +233,11 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
         {
             activity.SetTag(AWSSemanticConventions.AttributeAWSServiceName, service);
             activity.SetTag(AWSSemanticConventions.AttributeAWSOperationName, operation);
+
+            // Follow: https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/aws-sdk/#common-attributes
+            activity.SetTag(AWSSemanticConventions.AttributeValueRPCSystem, "aws-api");
+            activity.SetTag(AWSSemanticConventions.AttributeValueRPCService, service);
+            activity.SetTag(AWSSemanticConventions.AttributeValueRPCMethod, operation);
             var client = executionContext.RequestContext.ClientConfig;
             if (client != null)
             {

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -234,7 +234,7 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
             activity.SetTag(AWSSemanticConventions.AttributeAWSServiceName, service);
             activity.SetTag(AWSSemanticConventions.AttributeAWSOperationName, operation);
 
-            // Follow: https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/aws-sdk/#common-attributes
+            // Follow: https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/cloud-providers/aws-sdk.md#common-attributes
             activity.SetTag(AWSSemanticConventions.AttributeValueRPCSystem, "aws-api");
             activity.SetTag(AWSSemanticConventions.AttributeValueRPCService, service);
             activity.SetTag(AWSSemanticConventions.AttributeValueRPCMethod, operation);

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -205,6 +205,9 @@ public class TestAWSClientInstrumentation
         Assert.Equal("us-east-1", Utils.GetTagValue(ddb_activity, "aws.region"));
         Assert.Equal("SampleProduct", Utils.GetTagValue(ddb_activity, "aws.table_name"));
         Assert.Equal("dynamodb", Utils.GetTagValue(ddb_activity, "db.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(ddb_activity, "rpc.system"));
+        Assert.Equal("DynamoDB", Utils.GetTagValue(ddb_activity, "rpc.service"));
+        Assert.Equal("Scan", Utils.GetTagValue(ddb_activity, "rpc.method"));
     }
 
     private void ValidateSqsActivityTags(Activity sqs_activity)
@@ -214,5 +217,8 @@ public class TestAWSClientInstrumentation
         Assert.Equal("SendMessage", Utils.GetTagValue(sqs_activity, "aws.operation"));
         Assert.Equal("us-east-1", Utils.GetTagValue(sqs_activity, "aws.region"));
         Assert.Equal("https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue", Utils.GetTagValue(sqs_activity, "aws.queue_url"));
+        Assert.Equal("aws-api", Utils.GetTagValue(sqs_activity, "rpc.system"));
+        Assert.Equal("SQS", Utils.GetTagValue(sqs_activity, "rpc.service"));
+        Assert.Equal("SendMessage", Utils.GetTagValue(sqs_activity, "rpc.method"));
     }
 }


### PR DESCRIPTION
Based on Opentelemetry Semantic Conventions for AWS SDK: https://opentelemetry.io/docs/specs/semconv/cloud-providers/aws-sdk, update Activity Tags for `rpc.service, rpc.system, rpc.method`.

Fixes #1857 

## Changes

Currently AWS SDK instrumentation did not set RPC Activity Tags as mentioned in https://opentelemetry.io/docs/specs/semconv/cloud-providers/aws-sdk/, this change will add missing tags. Changes have been tested with OpenTelemetry.Instrumentation.AWS.Tests
