### PR TITLE
[repo] Release automation improvements

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -35,16 +35,6 @@ jobs:
         ref: ${{ github.event.repository.default_branch }}
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
-    - name: Post notice when release is published
-      shell: pwsh
-      run: |
-        Import-Module .\build\scripts\post-release.psm1
-
-        TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
-          -gitRepository '${{ github.repository }}' `
-          -botUserName '${{ needs.automation.outputs.username }}' `
-          -tag '${{ inputs.tag || github.ref_name }}'
-
     - name: Create GitHub Pull Request to update PackageValidationBaselineVersion in projects
       if: |
         (github.ref_type == 'tag' && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc'))

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,61 @@
+name: Complete release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        description: 'Release tag'
+        type: string
+  release:
+    types: [published]
+
+jobs:
+  automation:
+    uses: ./.github/workflows/automation.yml
+    secrets: inherit
+
+  post-release:
+    runs-on: ubuntu-latest
+
+    needs:
+    - automation
+
+    if: needs.automation.outputs.enabled
+
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # Note: By default GitHub only fetches 1 commit. We need all the tags
+        # for this work.
+        fetch-depth: 0
+        ref: ${{ github.event.repository.default_branch }}
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
+    - name: Post notice when release is published
+      shell: pwsh
+      run: |
+        Import-Module .\build\scripts\post-release.psm1
+
+        TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
+          -gitRepository '${{ github.repository }}' `
+          -botUserName '${{ needs.automation.outputs.username }}' `
+          -tag '${{ inputs.tag || github.ref_name }}'
+
+    - name: Create GitHub Pull Request to update PackageValidationBaselineVersion in projects
+      if: |
+        (github.ref_type == 'tag' && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc'))
+        || (inputs.tag && !contains(inputs.tag, '-alpha') && !contains(inputs.tag, '-beta') && !contains(inputs.tag, '-rc'))
+      shell: pwsh
+      run: |
+        Import-Module .\build\scripts\post-release.psm1
+
+        CreatePackageValidationBaselineVersionUpdatePullRequest `
+          -gitRepository '${{ github.repository }}' `
+          -tag '${{ inputs.tag || github.ref_name }}' `
+          -targetBranch '${{ github.event.repository.default_branch }}' `
+          -gitUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserEmail '${{ needs.automation.outputs.email }}'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -62,19 +62,26 @@ on:
     types:
     - created
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  prepare-release-pr:
-    if: github.event_name == 'workflow_dispatch'
+  automation:
+    uses: ./.github/workflows/automation.yml
+    secrets: inherit
 
-    runs-on: windows-latest
+  prepare-release-pr:
+    runs-on: ubuntu-latest
+
+    needs: automation
+
+    if: github.event_name == 'workflow_dispatch' && needs.automation.outputs.enabled
+
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     steps:
     - name: check out code
       uses: actions/checkout@v4
+      with:
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     - name: Create GitHub Pull Request to prepare release
       shell: pwsh
@@ -82,25 +89,34 @@ jobs:
         Import-Module .\build\scripts\prepare-release.psm1
 
         CreatePullRequestToUpdateChangelogsAndPublicApis `
+          -gitRepository '${{ github.repository }}' `
           -component '${{ inputs.component }}' `
           -version '${{ inputs.version }}' `
-          -targetBranch '${{ github.ref_name }}'
-      env:
-        GH_TOKEN: ${{ github.token }}
+          -targetBranch '${{ github.ref_name }}' `
+          -gitUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserEmail '${{ needs.automation.outputs.email }}'
 
   lock-pr-and-post-notice-to-create-release-tag:
+    runs-on: ubuntu-latest
+
+    needs: automation
+
     if: |
       github.event_name == 'pull_request'
       && github.event.action == 'closed'
-      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.user.login == needs.automation.outputs.username
       && github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.title, '[repo] Prepare release ')
+      && needs.automation.outputs.enabled
 
-    runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     steps:
     - name: check out code
       uses: actions/checkout@v4
+      with:
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     - name: Lock GitHub Pull Request to prepare release
       shell: pwsh
@@ -108,23 +124,27 @@ jobs:
         Import-Module .\build\scripts\prepare-release.psm1
 
         LockPullRequestAndPostNoticeToCreateReleaseTag `
-          -pullRequestNumber '${{ github.event.pull_request.number }}'
-      env:
-        GH_TOKEN: ${{ github.token }}
+          -gitRepository '${{ github.repository }}' `
+          -pullRequestNumber '${{ github.event.pull_request.number }}' `
+          -botUserName '${{ needs.automation.outputs.username }}'
 
   create-release-tag-unlock-pr-post-notice:
+    runs-on: ubuntu-latest
+
+    needs: automation
+
     if: |
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request
       && github.event.issue.locked == true
+      && github.event.comment.user.login != needs.automation.outputs.username
       && contains(github.event.comment.body, '/CreateReleaseTag')
       && startsWith(github.event.issue.title, '[repo] Prepare release ')
       && github.event.issue.pull_request.merged_at
+      && needs.automation.outputs.enabled
 
-    runs-on: windows-latest
-
-    outputs:
-      tag: ${{ steps.create-tag.outputs.tag }}
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     steps:
     - name: check out code
@@ -132,6 +152,7 @@ jobs:
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     - name: Create release tag
       id: create-tag
@@ -139,41 +160,9 @@ jobs:
       run: |
         Import-Module .\build\scripts\prepare-release.psm1
 
-        $tag = ''
-
-        CreateReleaseTag `
+        CreateReleaseTagAndPostNoticeOnPullRequest `
+          -gitRepository '${{ github.repository }}' `
           -pullRequestNumber '${{ github.event.issue.number }}' `
-          -actionRunId '${{ github.run_id }}' `
-          -tag ([ref]$tag)
-
-        echo "tag=$tag" >> $env:GITHUB_OUTPUT
-      env:
-        GH_TOKEN: ${{ github.token }}
-
-  invoke-package-workflow:
-    needs: create-release-tag-unlock-pr-post-notice
-    uses: ./.github/workflows/publish-packages.yml
-    with:
-      tag: ${{ needs.create-release-tag-unlock-pr-post-notice.outputs.tag }}
-    secrets: inherit
-
-  post-packages-ready-notice:
-    needs:
-    - create-release-tag-unlock-pr-post-notice
-    - invoke-package-workflow
-    runs-on: windows-latest
-    steps:
-    - name: check out code
-      uses: actions/checkout@v4
-
-    - name: Post notice when packages are ready
-      shell: pwsh
-      run: |
-        Import-Module .\build\scripts\prepare-release.psm1
-
-        PostPackagesReadyNotice `
-          -pullRequestNumber '${{ github.event.issue.number }}' `
-          -tag '${{ needs.create-release-tag-unlock-pr-post-notice.outputs.tag }}' `
-          -packagesUrl '${{ needs.invoke-package-workflow.outputs.artifact-url }}'
-      env:
-        GH_TOKEN: ${{ github.token }}
+          -botUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserEmail '${{ needs.automation.outputs.email }}'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -12,30 +12,19 @@ on:
       - 'Resources.*-*'
       - 'Sampler.*-*'
       - 'SemanticConventions-*'
-  workflow_call:
-    inputs:
-      tag:
-        required: true
-        type: string
-    outputs:
-      artifact-id:
-        value: ${{ jobs.build-pack-publish.outputs.artifact-id }}
-      artifact-url:
-        value: ${{ jobs.build-pack-publish.outputs.artifact-url }}
   schedule:
     - cron: '0 0 * * *' # once in a day at 00:00
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
+  automation:
+    uses: ./.github/workflows/automation.yml
+    secrets: inherit
+
   build-pack-publish:
 
     runs-on: windows-latest
 
     outputs:
-      artifact-id: ${{ steps.upload-artifacts.outputs.artifact-id }}
       artifact-url: ${{ steps.upload-artifacts.outputs.artifact-url }}
 
     steps:
@@ -45,7 +34,6 @@ jobs:
         # the version tag which is typically NOT on the first commit so we
         # retrieve them all.
         fetch-depth: 0
-        ref: ${{ inputs.tag || github.ref || 'main' }}
 
     - name: Resolve project
       id: resolve-project
@@ -65,7 +53,7 @@ jobs:
         $component = '' # Used to tell Component.proj what to build
 
         ResolveProjectForTag `
-          -tag '${{ github.ref_type == 'tag' && github.ref_name || inputs.tag || '' }}' `
+          -tag '${{ github.ref_type == 'tag' && github.ref_name || '' }}' `
           -title ([ref]$title) `
           -project ([ref]$project) `
           -component ([ref]$component)
@@ -90,13 +78,13 @@ jobs:
       run: dotnet test ${{ steps.resolve-project.outputs.project }} --configuration Release --no-restore --no-build
 
     - name: dotnet pack ${{ steps.resolve-project.outputs.title }}
-      run: dotnet pack ${{ steps.resolve-project.outputs.project }} --configuration Release --no-restore --no-build  -p:PackTag=${{ github.ref_type == 'tag' && github.ref_name || inputs.tag || '' }}
+      run: dotnet pack ${{ steps.resolve-project.outputs.project }} --configuration Release --no-restore --no-build  -p:PackTag=${{ github.ref_type == 'tag' && github.ref_name || '' }}
 
     - name: Publish Artifacts
       id: upload-artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.tag || github.ref_name }}-packages
+        name: ${{ github.ref_name }}-packages
         path: 'src\**\*.*nupkg'
 
     - name: Publish MyGet
@@ -110,30 +98,46 @@ jobs:
     - name: Publish NuGets
       env:
         NUGET_TOKEN_EXISTS: ${{ secrets.NUGET_TOKEN != '' }}
-      if: (github.ref_type == 'tag' || inputs.tag) && env.NUGET_TOKEN_EXISTS == 'true' # Skip NuGet publish for scheduled nightly builds or if run on a fork without the secret
+      if: github.ref_type == 'tag' && env.NUGET_TOKEN_EXISTS == 'true' # Skip NuGet publish for scheduled nightly builds or if run on a fork without the secret
       run: |
         nuget push src\**\*.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_TOKEN }} -SymbolApiKey ${{ secrets.NUGET_TOKEN }}
 
+  post-build:
+    runs-on: ubuntu-latest
+
+    needs:
+    - automation
+    - build-pack-publish
+
+    if: needs.automation.outputs.enabled && github.event_name == 'push'
+
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
+    steps:
+    - name: check out code
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
     - name: Create GitHub Release
-      if: github.ref_type == 'tag' || inputs.tag
+      if: github.ref_type == 'tag'
       shell: pwsh
       run: |
         Import-Module .\build\scripts\post-release.psm1
 
         CreateRelease `
-          -tag '${{ inputs.tag || github.ref_name }}'
-      env:
-        GH_TOKEN: ${{ github.token }}
+          -gitRepository '${{ github.repository }}' `
+          -tag '${{ github.ref_name }}'
 
-    - name: Create GitHub Pull Request to update PackageValidationBaselineVersion in projects
-      if: |
-        (github.ref_type == 'tag' && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc'))
-        || (inputs.tag && !contains(inputs.tag, '-alpha') && !contains(inputs.tag, '-beta') && !contains(inputs.tag, '-rc'))
+    - name: Post notice when packages are ready
       shell: pwsh
       run: |
         Import-Module .\build\scripts\post-release.psm1
 
-        CreatePackageValidationBaselineVersionUpdatePullRequest `
-          -tag '${{ inputs.tag || github.ref_name }}'
-      env:
-        GH_TOKEN: ${{ github.token }}
+        TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
+          -gitRepository '${{ github.repository }}' `
+          -tag '${{ github.ref_name }}' `
+          -tagSha '${{ github.sha }}' `
+          -packagesUrl '${{ needs.build-pack-publish.outputs.artifact-url }}' `
+          -botUserName '${{ needs.automation.outputs.username }}'

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -148,7 +148,7 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
   param(
     [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$tag,
-    [Parameter()][string]$targetBranch="main"
+    [Parameter()][string]$targetBranch="main",
     [Parameter()][string]$gitUserName,
     [Parameter()][string]$gitUserEmail
   )

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -128,7 +128,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
 
   $body =
 @"
-The [packages]($packagesUrl) for [$tag](https://github.com/$gitRepository/releases/tag/$tag) should be available on NuGet shortly.
+The [packages]($packagesUrl) for [$tag](https://github.com/$gitRepository/releases/tag/$tag) should be available on NuGet momentarily.
 
 Have a nice day!
 "@

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -67,7 +67,7 @@ $content
 "@
   }
 
-  if ($firstPackageVersion -match '-alpha' -or $firstPackageVersion -match '-beta' -or $firstPackageVersion -match '-rc')
+  if ($version -match '-alpha' -or $version -match '-beta' -or $version -match '-rc')
   {
     gh release create $tag `
       --title $tag `

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -1,17 +1,11 @@
-$gitHubBotUserName="github-actions[bot]"
-$gitHubBotEmail="41898282+github-actions[bot]@users.noreply.github.com"
-
-$repoViewResponse = gh repo view --json nameWithOwner | ConvertFrom-Json
-
-$gitRepository = $repoViewResponse.nameWithOwner
-
 function CreatePullRequestToUpdateChangelogsAndPublicApis {
   param(
+    [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$component,
     [Parameter(Mandatory=$true)][string]$version,
-    [Parameter()][string]$gitUserName=$gitHubBotUserName,
-    [Parameter()][string]$gitUserEmail=$gitHubBotEmail,
-    [Parameter()][string]$targetBranch="main"
+    [Parameter()][string]$targetBranch="main",
+    [Parameter()][string]$gitUserName,
+    [Parameter()][string]$gitUserEmail
   )
 
   $projectContent = Get-Content -Path src/$component/$component.csproj
@@ -26,8 +20,14 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
   $tag="${minVerTagPrefix}${version}"
   $branch="release/prepare-${tag}-release"
 
-  git config user.name $gitUserName
-  git config user.email $gitUserEmail
+  if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
+  {
+    git config user.name $gitUserName
+  }
+  if ([string]::IsNullOrEmpty($gitUserEmail) -eq $false)
+  {
+    git config user.email $gitUserEmail
+  }
 
   git switch --create $branch 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
@@ -79,17 +79,14 @@ Export-ModuleMember -Function CreatePullRequestToUpdateChangelogsAndPublicApis
 
 function LockPullRequestAndPostNoticeToCreateReleaseTag {
   param(
+    [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$pullRequestNumber,
-    [Parameter()][string]$gitUserName=$gitHubBotUserName,
-    [Parameter()][string]$gitUserEmail=$gitHubBotEmail
+    [Parameter(Mandatory=$true)][string]$botUserName
   )
-
-  git config user.name $gitUserName
-  git config user.email $gitUserEmail
 
   $prViewResponse = gh pr view $pullRequestNumber --json mergeCommit,author,title | ConvertFrom-Json
 
-  if ($prViewResponse.author.is_bot -eq $false -or $prViewResponse.author.login -ne 'app/github-actions')
+  if ($prViewResponse.author.login -ne $botUserName)
   {
       throw 'PR author was unexpected'
   }
@@ -122,21 +119,18 @@ Post a comment with "/CreateReleaseTag" in the body if you would like me to crea
 
 Export-ModuleMember -Function LockPullRequestAndPostNoticeToCreateReleaseTag
 
-function CreateReleaseTag {
+function CreateReleaseTagAndPostNoticeOnPullRequest {
   param(
+    [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$pullRequestNumber,
-    [Parameter(Mandatory=$true)][string]$actionRunId,
-    [Parameter()][string]$gitUserName=$gitHubBotUserName,
-    [Parameter()][string]$gitUserEmail=$gitHubBotEmail,
-    [Parameter()][ref]$tag
+    [Parameter(Mandatory=$true)][string]$botUserName,
+    [Parameter()][string]$gitUserName,
+    [Parameter()][string]$gitUserEmail
   )
-
-  git config user.name $gitUserName
-  git config user.email $gitUserEmail
 
   $prViewResponse = gh pr view $pullRequestNumber --json mergeCommit,author,title | ConvertFrom-Json
 
-  if ($prViewResponse.author.is_bot -eq $false -or $prViewResponse.author.login -ne 'app/github-actions')
+  if ($prViewResponse.author.login -ne $botUserName)
   {
       throw 'PR author was unexpected'
   }
@@ -147,7 +141,7 @@ function CreateReleaseTag {
       throw 'Could not parse tag from PR title'
   }
 
-  $tagValue = $match.Groups[1].Value
+  $tag = $match.Groups[1].Value
 
   $commit = $prViewResponse.mergeCommit.oid
   if ([string]::IsNullOrEmpty($commit) -eq $true)
@@ -155,13 +149,22 @@ function CreateReleaseTag {
       throw 'Could not find merge commit'
   }
 
-  git tag -a $tagValue -m "$tagValue" $commit 2>&1 | % ToString
+  if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
+  {
+    git config user.name $gitUserName
+  }
+  if ([string]::IsNullOrEmpty($gitUserEmail) -eq $false)
+  {
+    git config user.email $gitUserEmail
+  }
+
+  git tag -a $tagValue -m "$tag" $commit 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git tag failure'
   }
 
-  git push origin $tagValue 2>&1 | % ToString
+  git push origin $tag 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git push failure'
@@ -171,33 +174,12 @@ function CreateReleaseTag {
 
   $body =
 @"
-I just pushed the [$tagValue](https://github.com/$gitRepository/releases/tag/$tagValue) tag.
+I just pushed the [$tag](https://github.com/$gitRepository/releases/tag/$tag) tag.
 
-The [package workflow](https://github.com/$gitRepository/actions/runs/$actionRunId) should begin momentarily.
-"@
-
-  gh pr comment $pullRequestNumber --body $body
-
-  $tag.value = $tagValue
-}
-
-Export-ModuleMember -Function CreateReleaseTag
-
-function PostPackagesReadyNotice {
-  param(
-    [Parameter(Mandatory=$true)][string]$pullRequestNumber,
-    [Parameter(Mandatory=$true)][string]$tag,
-    [Parameter(Mandatory=$true)][string]$packagesUrl
-  )
-
-  $body =
-@"
-The [packages]($packagesUrl) for [$tag](https://github.com/$gitRepository/releases/tag/$tag) should be available on NuGet shortly.
-
-Have a nice day!
+The [package workflow](https://github.com/$gitRepository/actions/workflows/publish-packages.yml) should begin momentarily.
 "@
 
   gh pr comment $pullRequestNumber --body $body
 }
 
-Export-ModuleMember -Function PostPackagesReadyNotice
+Export-ModuleMember -Function CreateReleaseTagAndPostNoticeOnPullRequest

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -158,7 +158,7 @@ function CreateReleaseTagAndPostNoticeOnPullRequest {
     git config user.email $gitUserEmail
   }
 
-  git tag -a $tagValue -m "$tag" $commit 2>&1 | % ToString
+  git tag -a $tag -m "$tag" $commit 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git tag failure'

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -38,6 +38,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\dotnet-format.yml = .github\workflows\dotnet-format.yml
 		.github\workflows\integration.yml = .github\workflows\integration.yml
 		.github\workflows\markdownlint.yml = .github\workflows\markdownlint.yml
+		.github\workflows\post-release.yml = .github\workflows\post-release.yml
 		.github\workflows\prepare-release.yml = .github\workflows\prepare-release.yml
 		.github\workflows\publish-packages.yml = .github\workflows\publish-packages.yml
 		.github\workflows\sanitycheck.yml = .github\workflows\sanitycheck.yml


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-dotnet/pull/5657

## Changes

* Sets up the release automation to use `OpenTelemetryBot`
* Refactors post-release PackageValidationBaselineVersion PR update job from package workflow into a new workflow triggered by the release publish

## Details

This PR syncs up contrib with the main repo such that the release automation uses `OpenTelemetryBot`.

Test runs:

* https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/8
* https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/9