### PR TITLE
[aspnet] Add url.path to sampler tags

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -60,7 +60,13 @@ internal static class ActivityHelper
     {
         PropagationContext propagationContext = textMapPropagator.Extract(default, context.Request, HttpRequestHeaderValuesGetter);
 
-        Activity? activity = AspNetSource.StartActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext);
+        IEnumerable<KeyValuePair<string, object?>>? enumerable = null;
+        if (context.Request?.Unvalidated?.Path is string path)
+        {
+            enumerable = [new KeyValuePair<string, object?>("url.path", path)];
+        }
+
+        Activity? activity = AspNetSource.StartActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext, enumerable);
 
         if (activity != null)
         {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -63,17 +63,16 @@ internal static class ActivityHelper
     {
         PropagationContext propagationContext = textMapPropagator.Extract(default, context.Request, HttpRequestHeaderValuesGetter);
 
-        KeyValuePair<string, object?>[]? tags = null;
+        KeyValuePair<string, object?>[]? tags;
         if (context.Request?.Unvalidated?.Path is string path)
         {
-            tags = cachedTagsStorage;
-            if (tags is null)
-            {
-                tags = new KeyValuePair<string, object?>[1];
-                cachedTagsStorage = tags;
-            }
+            tags = cachedTagsStorage ??= new KeyValuePair<string, object?>[1];
 
             tags[0] = new KeyValuePair<string, object?>("url.path", path);
+        }
+        else
+        {
+            tags = null;
         }
 
         Activity? activity = AspNetSource.StartActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext, tags);

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -5,8 +5,9 @@
 * `TelemetryHttpModule` will now pass the `url.path` tag (set to
   [Request.Unvalidated.Path](https://learn.microsoft.com/dotnet/api/system.web.unvalidatedrequestvalues.path))
   when starting `Activity` instances for incoming requests so that it is
-  available to custom samplers and may be used to influence the sampling
-  decision.
+  available to samplers and may be used to influence the sampling decision made
+  by [custom
+  implementations](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/trace/extending-the-sdk#sampler).
   ([#1871](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1871))
 
 ## 1.9.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed HttpInListener so that `url.path` is set to the Unvalidated.Path of the request
+  when the activity is started so that it can be used in sampling decisions.
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
-* Changed HttpInListener so that `url.path` is set to the Unvalidated.Path of the request
-  when the activity is started so that it can be used in sampling decisions.
+* `TelemetryHttpModule` will now pass the `url.path` tag (set to
+  [Request.Unvalidated.Path](https://learn.microsoft.com/dotnet/api/system.web.unvalidatedrequestvalues.path))
+  when starting `Activity` instances for incoming requests so that it is
+  available to custom samplers and may be used to influence the sampling
+  decision.
+  ([#1871](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1871))
 
 ## 1.9.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -64,7 +64,6 @@ internal sealed class HttpInListener : IDisposable
             }
 
             var request = context.Request;
-            var requestValues = request.Unvalidated;
 
             // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md
             var originalHttpMethod = request.HttpMethod;
@@ -82,8 +81,6 @@ internal sealed class HttpInListener : IDisposable
             {
                 activity.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, protocolVersion);
             }
-
-            activity.SetTag(SemanticConventions.AttributeUrlPath, requestValues.Path);
 
             // TODO url.query should be sanitized
             var query = url.Query;

--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -137,6 +137,18 @@ below.
 
 ### Trace Filter
 
+> [!NOTE]
+> OpenTelemetry has the concept of a
+[Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling).
+When using `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule` the
+`url.path` tag is supplied automatically to samplers when telemetry is started
+for incoming requests. It is recommended to use a sampler which inspects
+`url.path` (as opposed to the `Filter` option described below) in order to
+perform filtering as it will prevent child spans from being created and bypass
+data collection for anything NOT recorded by the sampler. The sampler approach
+will reduce the impact on the process being instrumented for all filtered
+requests.
+
 This instrumentation by default collects all the incoming http requests. It
 allows filtering of requests by using the `Filter` function in
 `AspNetTraceInstrumentationOptions`. This defines the condition for allowable
@@ -157,11 +169,6 @@ this.tracerProvider = Sdk.CreateTracerProviderBuilder()
             })
     .Build();
 ```
-
-It is important to note that this `Filter` option is specific to this
-instrumentation. OpenTelemetry has a concept of a
-[Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling),
-and the `Filter` option does the filtering *before* the Sampler is invoked.
 
 ### Trace Enrich
 


### PR DESCRIPTION
Added the "url.path" tag to the tags for newly created activities in StartAspNetActivity.

To ignore a path like a healthcheck it is best to use a sampler to ensure that the activity and all child activities are dropped in a sampler. To do this the sampler needs to be able to provide enough information for the sampler author to detect the path. This is only currently possible by using HttpContext.Current or other method of injecting the request into the sampler. This is unsatisfying because the caller of the sampler has information about the current request it just doesn't have a way to pass that information to the sampler. 

This PR changes the way StartAspNetActivity works by adding the request.Unvalidated.Path of the request to the tags that are used to construct the activity. The tags are one of the few things that are passed to samplers when an activity is started. With this change it is now possible to write a sampler which uses only provided context information in the sampler to decide whether a particular request root activity should be dropped.

There are no public api changes.
