### PR TITLE
[repo] Auto-label PR workflow improvements

### DIFF
--- a/build/scripts/add-labels.psm1
+++ b/build/scripts/add-labels.psm1
@@ -24,7 +24,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
   # Note: This function is intended to work on main repo and on contrib. Please
   # keep them in sync.
 
-  $repoLabels = gh label list --json name,id | ConvertFrom-Json
+  $repoLabels = gh label list --json name,id -L 200 | ConvertFrom-Json
 
   $filesChangedOnPullRequest = gh pr diff $pullRequestNumber --name-only
 


### PR DESCRIPTION
## Changes

* Retrieve up to 200 labels from the repo to use for tagging PRs based on the files changed. The default is 30.
