### PR TITLE
[Tests] Simplify usage of SamplingResult constructor

### DIFF
--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -1220,12 +1220,7 @@ public sealed class BasicTests
 
         public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
         {
-            if (this.attributes != null)
-            {
-                return new SamplingResult(this.samplingDecision, this.attributes);
-            }
-
-            return new SamplingResult(this.samplingDecision);
+            return new SamplingResult(this.samplingDecision, this.attributes);
         }
     }
 

--- a/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/ElasticsearchClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/ElasticsearchClientTests.cs
@@ -190,7 +190,7 @@ public class ElasticsearchClientTests
         var sampler = new TestSampler
         {
             SamplingAction =
-                (samplingParameters) =>
+                _ =>
                 {
                     samplerCalled = true;
                     return new SamplingResult(SamplingDecision.RecordAndSample);
@@ -207,7 +207,7 @@ public class ElasticsearchClientTests
             {
                 Assert.True(samplerCalled);
                 Assert.False(Sdk.SuppressInstrumentation);
-                Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
+                Assert.True(a.IsAllDataRequested); // If Processor.OnStart is called, activity's IsAllDataRequested is set to true
                 startCalled++;
             };
 
@@ -250,7 +250,7 @@ public class ElasticsearchClientTests
         var sampler = new TestSampler
         {
             SamplingAction =
-                (samplingParameters) =>
+                _ =>
                 {
                     samplerCalled = true;
                     return new SamplingResult(SamplingDecision.RecordAndSample);
@@ -267,7 +267,7 @@ public class ElasticsearchClientTests
             {
                 Assert.True(samplerCalled);
                 Assert.False(Sdk.SuppressInstrumentation);
-                Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
+                Assert.True(a.IsAllDataRequested); // If Processor.OnStart is called, activity's IsAllDataRequested is set to true
                 startCalled++;
             };
 
@@ -310,7 +310,7 @@ public class ElasticsearchClientTests
         var sampler = new TestSampler
         {
             SamplingAction =
-                (samplingParameters) =>
+                _ =>
                 {
                     samplerCalled = true;
                     return new SamplingResult(SamplingDecision.Drop);
@@ -327,7 +327,7 @@ public class ElasticsearchClientTests
             {
                 Assert.True(samplerCalled);
                 Assert.False(Sdk.SuppressInstrumentation);
-                Assert.False(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
+                Assert.False(a.IsAllDataRequested); // If Processor.OnStart is called, activity's IsAllDataRequested is set to true
                 startCalled++;
             };
 
@@ -740,7 +740,7 @@ public class ElasticsearchClientTests
         var client = new ElasticClient(new ConnectionSettings(new InMemoryConnection()).DefaultIndex("customer"));
 
         using (Sdk.CreateTracerProviderBuilder()
-                   .SetSampler(new TestSampler() { SamplingAction = (samplingParameters) => new SamplingResult(samplingDecision) })
+                   .SetSampler(new TestSampler() { SamplingAction = _ => new SamplingResult(samplingDecision) })
                    .AddElasticsearchClientInstrumentation()
                    .SetResourceBuilder(expectedResource)
                    .AddProcessor(processor)


### PR DESCRIPTION
## Changes

Cleanup code after 1.9.0 release. Ref: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5614
Minor other cleanups while checking all usages of the constructor.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
