### PR TITLE
[infra] Automation sync-up with main repo

### DIFF
--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         ref: ${{ github.event.repository.default_branch }}
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -92,6 +92,7 @@ jobs:
           -gitRepository '${{ github.repository }}' `
           -component '${{ inputs.component }}' `
           -version '${{ inputs.version }}' `
+          -requestedByUserName '${{ github.event.sender.login }}' `
           -targetBranch '${{ github.ref_name }}' `
           -gitUserName '${{ needs.automation.outputs.username }}' `
           -gitUserEmail '${{ needs.automation.outputs.email }}'
@@ -164,5 +165,45 @@ jobs:
           -gitRepository '${{ github.repository }}' `
           -pullRequestNumber '${{ github.event.issue.number }}' `
           -botUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserEmail '${{ needs.automation.outputs.email }}'
+
+  update-changelog-release-dates-on-prepare-pr-post-notice:
+    runs-on: ubuntu-latest
+
+    needs: automation
+
+    if: |
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && github.event.issue.state == 'open'
+      && github.event.comment.user.login != needs.automation.outputs.username
+      && contains(github.event.comment.body, '/UpdateReleaseDates')
+      && startsWith(github.event.issue.title, '[release] Prepare release ')
+      && github.event.issue.pull_request.merged_at == null
+      && needs.automation.outputs.enabled
+
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
+    steps:
+    - name: check out code
+      uses: actions/checkout@v4
+      with:
+        # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
+        fetch-depth: 0
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
+    - name: Update release date
+      id: create-tag
+      shell: pwsh
+      run: |
+        Import-Module .\build\scripts\prepare-release.psm1
+
+        UpdateChangelogReleaseDatesAndPostNoticeOnPullRequest `
+          -gitRepository '${{ github.repository }}' `
+          -pullRequestNumber '${{ github.event.issue.number }}' `
+          -botUserName '${{ needs.automation.outputs.username }}' `
+          -commentUserName '${{ github.event.comment.user.login }}' `
           -gitUserName '${{ needs.automation.outputs.username }}' `
           -gitUserEmail '${{ needs.automation.outputs.email }}'

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -301,11 +301,26 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
     Return
   }
 
-  $projectsAndDependenciesBefore = GetCoreDependenciesForProjects
-
   $branch="release/post-core-${version}-update"
 
-  (Get-Content build/Common.props) `
+  if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
+  {
+    git config user.name $gitUserName
+  }
+  if ([string]::IsNullOrEmpty($gitUserEmail) -eq $false)
+  {
+    git config user.email $gitUserEmail
+  }
+
+  git switch --create $branch origin/$targetBranch --no-track 2>&1 | % ToString
+  if ($LASTEXITCODE -gt 0)
+  {
+      throw 'git switch failure'
+  }
+
+  $projectsAndDependenciesBefore = GetCoreDependenciesForProjects
+
+    (Get-Content build/Common.props) `
       -replace "<$propertyName>.*<\/$propertyName>", "<$propertyName>$propertyVersion</$propertyName>" |
     Set-Content build/Common.props
 
@@ -326,21 +341,6 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
           $changedProjects[$projectDir] = $true
       }
     }
-  }
-
-  if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
-  {
-    git config user.name $gitUserName
-  }
-  if ([string]::IsNullOrEmpty($gitUserEmail) -eq $false)
-  {
-    git config user.email $gitUserEmail
-  }
-
-  git switch --create $branch origin/$targetBranch --no-track 2>&1 | % ToString
-  if ($LASTEXITCODE -gt 0)
-  {
-      throw 'git switch failure'
   }
 
   git add build/Common.props 2>&1 | % ToString

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -320,7 +320,7 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
 
   $projectsAndDependenciesBefore = GetCoreDependenciesForProjects
 
-    (Get-Content build/Common.props) `
+  (Get-Content build/Common.props) `
       -replace "<$propertyName>.*<\/$propertyName>", "<$propertyName>$propertyVersion</$propertyName>" |
     Set-Content build/Common.props
 

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -3,10 +3,17 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
     [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$component,
     [Parameter(Mandatory=$true)][string]$version,
+    [Parameter(Mandatory=$true)][string]$requestedByUserName,
     [Parameter()][string]$targetBranch="main",
     [Parameter()][string]$gitUserName,
     [Parameter()][string]$gitUserEmail
   )
+
+  $match = [regex]::Match($version, '^(\d+\.\d+\.\d+)(?:-((?:alpha)|(?:beta)|(?:rc))\.(\d+))?$')
+  if ($match.Success -eq $false)
+  {
+      throw 'Input version did not match expected format'
+  }
 
   $projectContent = Get-Content -Path src/$component/$component.csproj
 
@@ -39,6 +46,8 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
 @"
 Note: This PR was opened automatically by the [prepare release workflow](https://github.com/$gitRepository/actions/workflows/prepare-release.yml).
 
+Requested by: @$requestedByUserName
+
 ## Changes
 
 * CHANGELOG files updated for projects being released.
@@ -54,6 +63,15 @@ Note: This PR was opened automatically by the [prepare release workflow](https:/
 
     $body += "`r`n* Public API files updated for projects being released (only performed for stable releases)."
   }
+
+  $body +=
+@"
+
+## Commands
+
+``/UpdateReleaseDates``: Use to update release dates in CHANGELOGs before merging [``approvers``, ``maintainers``]
+``/CreateReleaseTag``: Use after merging to push the release tag and trigger the job to create packages and push to NuGet [``approvers``, ``maintainers``]
+"@
 
   git commit -a -m "Prepare repo to release $tag." 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
@@ -183,3 +201,106 @@ The [package workflow](https://github.com/$gitRepository/actions/workflows/publi
 }
 
 Export-ModuleMember -Function CreateReleaseTagAndPostNoticeOnPullRequest
+
+function UpdateChangelogReleaseDatesAndPostNoticeOnPullRequest {
+  param(
+    [Parameter(Mandatory=$true)][string]$gitRepository,
+    [Parameter(Mandatory=$true)][string]$pullRequestNumber,
+    [Parameter(Mandatory=$true)][string]$botUserName,
+    [Parameter(Mandatory=$true)][string]$commentUserName,
+    [Parameter()][string]$gitUserName,
+    [Parameter()][string]$gitUserEmail
+  )
+
+  $prViewResponse = gh pr view $pullRequestNumber --json headRefName,author,title | ConvertFrom-Json
+
+  if ($prViewResponse.author.login -ne $botUserName)
+  {
+      throw 'PR author was unexpected'
+  }
+
+  $match = [regex]::Match($prViewResponse.title, '^\[release\] Prepare release (.*)$')
+  if ($match.Success -eq $false)
+  {
+      throw 'Could not parse tag from PR title'
+  }
+
+  $tag = $match.Groups[1].Value
+
+  $match = [regex]::Match($tag, '^(.*?-)(.*)$')
+  if ($match.Success -eq $false)
+  {
+      throw 'Could not parse prefix or version from tag'
+  }
+
+  $tagPrefix = $match.Groups[1].Value
+  $version = $match.Groups[2].Value
+
+  $commentUserPermission = gh api "repos/$gitRepository/collaborators/$commentUserName/permission" | ConvertFrom-Json
+  if ($commentUserPermission.permission -ne 'admin' -and $commentUserPermission.permission -ne 'write')
+  {
+    gh pr comment $pullRequestNumber `
+      --body "I'm sorry @$commentUserName but you don't have permission to update this PR. Only maintainers and approvers can update this PR."
+    return
+  }
+
+  if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
+  {
+    git config user.name $gitUserName
+  }
+  if ([string]::IsNullOrEmpty($gitUserEmail) -eq $false)
+  {
+    git config user.email $gitUserEmail
+  }
+
+  git switch $prViewResponse.headRefName 2>&1 | % ToString
+  if ($LASTEXITCODE -gt 0)
+  {
+      throw 'git switch failure'
+  }
+
+  $updatedFiles = 0
+  $newHeader =
+@"
+## $version
+
+Released $(Get-Date -UFormat '%Y-%b-%d')
+"@
+
+  $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+
+  foreach ($projectDir in $projectDirs)
+  {
+    $content = (Get-Content "$projectDir/CHANGELOG.md" -Raw)
+
+    $newContent = $content -replace "## $version\s*Released .*", $newHeader
+
+    if ($content -ne $newContent)
+    {
+      $updatedFiles++
+      Set-Content -Path "$projectDir/CHANGELOG.md" $newContent.Trim()
+    }
+  }
+
+  if ($updatedFiles -eq 0)
+  {
+    gh pr comment $pullRequestNumber --body "All of the CHANGELOG files have valid release dates."
+    return
+  }
+
+  git commit -a -m "Update CHANGELOG release dates for $tag." 2>&1 | % ToString
+  if ($LASTEXITCODE -gt 0)
+  {
+      throw 'git commit failure'
+  }
+
+  git push -u origin $prViewResponse.headRefName 2>&1 | % ToString
+  if ($LASTEXITCODE -gt 0)
+  {
+      throw 'git push failure'
+  }
+
+  gh pr comment $pullRequestNumber --body "I updated the CHANGELOG release dates."
+}
+
+Export-ModuleMember -Function UpdateChangelogReleaseDatesAndPostNoticeOnPullRequest


### PR DESCRIPTION
## Changes

* Version validation (https://github.com/open-telemetry/opentelemetry-dotnet/pull/5723)
* From https://github.com/open-telemetry/opentelemetry-dotnet/pull/5714:
  * Show who requested the release on the PR description
  * Add a command `/UpdateReleaseDates` which can be used pre-merge to bump CHANGELOG dates to whenever the command is issued
  * Show the possible commands in the PR description
* Some misc clean up from https://github.com/open-telemetry/opentelemetry-dotnet/pull/5698 which was to perform `git switch` before capturing dependencies

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
