### PR TITLE
[Instrumentation.GrpcCore] Update minimal supported version of Grpc.Core.Api to 2.46.6

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-* Updated minimal supported version of `Grpc.Core.Api` to `2.43.0`.
-  ([#1936](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1936))
-* Updated minimal supported version of `Grpc.Core.Api` to `2.63.0`.
-  ([#1940](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1940))
+* Updated minimal supported version of `Grpc.Core.Api` to `2.46.6`.
+  ([#1936](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1936),
+   [#1940](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1940))
 
 ## 1.0.0-beta.6
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 * Updated minimal supported version of `Grpc.Core.Api` to `2.43.0`.
   ([#1936](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1936))
+* Updated minimal supported version of `Grpc.Core.Api` to `2.63.0`.
+  ([#1940](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1940))
 
 ## 1.0.0-beta.6
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientStreamWriterProxy.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientStreamWriterProxy.cs
@@ -52,7 +52,7 @@ internal class ClientStreamWriterProxy<T> : IClientStreamWriter<T>
     }
 
     /// <inheritdoc/>
-    public WriteOptions WriteOptions
+    public WriteOptions? WriteOptions
     {
         get => this.writer.WriteOptions;
         set => this.writer.WriteOptions = value;

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="[3.15.0,4.0)" />
-    <PackageReference Include="Grpc.Core.Api" Version="[2.63.0,3.0)" />
+    <PackageReference Include="Grpc.Core.Api" Version="[2.46.6,3.0)" />
     <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="[3.15.0,4.0)" />
-    <PackageReference Include="Grpc.Core.Api" Version="[2.43.0,3.0)" />
+    <PackageReference Include="Grpc.Core.Api" Version="[2.63.0,3.0)" />
     <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerStreamWriterProxy.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerStreamWriterProxy.cs
@@ -38,7 +38,7 @@ internal class ServerStreamWriterProxy<T> : IServerStreamWriter<T>
     }
 
     /// <inheritdoc/>
-    public WriteOptions WriteOptions
+    public WriteOptions? WriteOptions
     {
         get => this.writer.WriteOptions;
         set => this.writer.WriteOptions = value;


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1936#discussion_r1661915696

## Changes

Update minimal supported version of `Grpc.Core.Api` to the latest (from 2.43.0 to 2.46.6).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
~~* [] Unit tests added/updated~~
~~* [] Changes in public API reviewed (if applicable)~~
