### PR TITLE
[Instrumentation.Http] Nullable

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Http/.publicApi/PublicAPI.Shipped.txt
@@ -1,24 +1,25 @@
+#nullable enable
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions
-OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithException.get -> System.Action<System.Diagnostics.Activity, System.Exception>
+OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithException.get -> System.Action<System.Diagnostics.Activity!, System.Exception!>?
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithException.set -> void
-OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpRequestMessage.get -> System.Action<System.Diagnostics.Activity, System.Net.Http.HttpRequestMessage>
+OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpRequestMessage.get -> System.Action<System.Diagnostics.Activity!, System.Net.Http.HttpRequestMessage!>?
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpRequestMessage.set -> void
-OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpResponseMessage.get -> System.Action<System.Diagnostics.Activity, System.Net.Http.HttpResponseMessage>
+OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpResponseMessage.get -> System.Action<System.Diagnostics.Activity!, System.Net.Http.HttpResponseMessage!>?
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpResponseMessage.set -> void
-OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebRequest.get -> System.Action<System.Diagnostics.Activity, System.Net.HttpWebRequest>
+OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebRequest.get -> System.Action<System.Diagnostics.Activity!, System.Net.HttpWebRequest!>?
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebRequest.set -> void
-OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebResponse.get -> System.Action<System.Diagnostics.Activity, System.Net.HttpWebResponse>
+OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebResponse.get -> System.Action<System.Diagnostics.Activity!, System.Net.HttpWebResponse!>?
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebResponse.set -> void
-OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.FilterHttpRequestMessage.get -> System.Func<System.Net.Http.HttpRequestMessage, bool>
+OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.FilterHttpRequestMessage.get -> System.Func<System.Net.Http.HttpRequestMessage!, bool>?
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.FilterHttpRequestMessage.set -> void
-OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.FilterHttpWebRequest.get -> System.Func<System.Net.HttpWebRequest, bool>
+OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.FilterHttpWebRequest.get -> System.Func<System.Net.HttpWebRequest!, bool>?
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.FilterHttpWebRequest.set -> void
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.HttpClientTraceInstrumentationOptions() -> void
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.RecordException.get -> bool
 OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Metrics.HttpClientInstrumentationMeterProviderBuilderExtensions
 OpenTelemetry.Trace.HttpClientInstrumentationTracerProviderBuilderExtensions
-static OpenTelemetry.Metrics.HttpClientInstrumentationMeterProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
-static OpenTelemetry.Trace.HttpClientInstrumentationTracerProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, string name, System.Action<OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions> configureHttpClientTraceInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Trace.HttpClientInstrumentationTracerProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions> configureHttpClientTraceInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Trace.HttpClientInstrumentationTracerProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Metrics.HttpClientInstrumentationMeterProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
+static OpenTelemetry.Trace.HttpClientInstrumentationTracerProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, string? name, System.Action<OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions!>? configureHttpClientTraceInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientInstrumentationTracerProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions!>? configureHttpClientTraceInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientInstrumentationTracerProviderBuilderExtensions.AddHttpClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentation.cs
@@ -25,10 +25,10 @@ internal sealed class HttpClientInstrumentation : IDisposable
 
     private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 
-    private readonly Func<string, object, object, bool> isEnabled = (eventName, _, _)
+    private readonly Func<string, object?, object?, bool> isEnabled = (eventName, _, _)
         => !ExcludedDiagnosticSourceEvents.Contains(eventName);
 
-    private readonly Func<string, object, object, bool> isEnabledNet7OrGreater = (eventName, _, _)
+    private readonly Func<string, object?, object?, bool> isEnabledNet7OrGreater = (eventName, _, _)
         => !ExcludedDiagnosticSourceEventsNet7OrGreater.Contains(eventName);
 
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationTracerProviderBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class HttpClientInstrumentationTracerProviderBuilderExtensions
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddHttpClientInstrumentation(
         this TracerProviderBuilder builder,
-        Action<HttpClientTraceInstrumentationOptions> configureHttpClientTraceInstrumentationOptions)
+        Action<HttpClientTraceInstrumentationOptions>? configureHttpClientTraceInstrumentationOptions)
         => AddHttpClientInstrumentation(builder, name: null, configureHttpClientTraceInstrumentationOptions);
 
     /// <summary>
@@ -42,8 +42,8 @@ public static class HttpClientInstrumentationTracerProviderBuilderExtensions
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
     public static TracerProviderBuilder AddHttpClientInstrumentation(
         this TracerProviderBuilder builder,
-        string name,
-        Action<HttpClientTraceInstrumentationOptions> configureHttpClientTraceInstrumentationOptions)
+        string? name,
+        Action<HttpClientTraceInstrumentationOptions>? configureHttpClientTraceInstrumentationOptions)
     {
         Guard.ThrowIfNull(builder);
 

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientMetrics.cs
@@ -18,7 +18,7 @@ internal sealed class HttpClientMetrics : IDisposable
 
     private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 
-    private readonly Func<string, object, object, bool> isEnabled = (activityName, obj1, obj2)
+    private readonly Func<string, object?, object?, bool> isEnabled = (activityName, _, _)
         => !ExcludedDiagnosticSourceEvents.Contains(activityName);
 
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientTraceInstrumentationOptions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.CompilerServices;
 #if NETFRAMEWORK
@@ -29,7 +30,7 @@ public class HttpClientTraceInstrumentationOptions
     {
         Debug.Assert(configuration != null, "configuration was null");
 
-        if (configuration.TryGetBoolValue(
+        if (configuration!.TryGetBoolValue(
            HttpInstrumentationEventSource.Log,
            "OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION",
            out var disableUrlQueryRedaction))
@@ -58,7 +59,7 @@ public class HttpClientTraceInstrumentationOptions
     /// </list></item>
     /// </list>
     /// </remarks>
-    public Func<HttpRequestMessage, bool> FilterHttpRequestMessage { get; set; }
+    public Func<HttpRequestMessage, bool>? FilterHttpRequestMessage { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpRequestMessage"/>.
@@ -69,7 +70,7 @@ public class HttpClientTraceInstrumentationOptions
     /// cref="HttpWebRequest"/> on .NET and .NET Core are both implemented
     /// using <see cref="HttpRequestMessage"/>.</b></para>
     /// </remarks>
-    public Action<Activity, HttpRequestMessage> EnrichWithHttpRequestMessage { get; set; }
+    public Action<Activity, HttpRequestMessage>? EnrichWithHttpRequestMessage { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpResponseMessage"/>.
@@ -80,7 +81,7 @@ public class HttpClientTraceInstrumentationOptions
     /// cref="HttpWebRequest"/> on .NET and .NET Core are both implemented
     /// using <see cref="HttpRequestMessage"/>.</b></para>
     /// </remarks>
-    public Action<Activity, HttpResponseMessage> EnrichWithHttpResponseMessage { get; set; }
+    public Action<Activity, HttpResponseMessage>? EnrichWithHttpResponseMessage { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="Exception"/>.
@@ -88,7 +89,7 @@ public class HttpClientTraceInstrumentationOptions
     /// <remarks>
     /// <para><b>EnrichWithException is called for all runtimes.</b></para>
     /// </remarks>
-    public Action<Activity, Exception> EnrichWithException { get; set; }
+    public Action<Activity, Exception>? EnrichWithException { get; set; }
 
     /// <summary>
     /// Gets or sets a filter function that determines whether or not to
@@ -110,7 +111,7 @@ public class HttpClientTraceInstrumentationOptions
     /// </list></item>
     /// </list>
     /// </remarks>
-    public Func<HttpWebRequest, bool> FilterHttpWebRequest { get; set; }
+    public Func<HttpWebRequest, bool>? FilterHttpWebRequest { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpWebRequest"/>.
@@ -121,7 +122,7 @@ public class HttpClientTraceInstrumentationOptions
     /// on .NET Framework are both implemented using <see
     /// cref="HttpWebRequest"/>.</b></para>
     /// </remarks>
-    public Action<Activity, HttpWebRequest> EnrichWithHttpWebRequest { get; set; }
+    public Action<Activity, HttpWebRequest>? EnrichWithHttpWebRequest { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpWebResponse"/>.
@@ -132,7 +133,7 @@ public class HttpClientTraceInstrumentationOptions
     /// on .NET Framework are both implemented using <see
     /// cref="HttpWebRequest"/>.</b></para>
     /// </remarks>
-    public Action<Activity, HttpWebResponse> EnrichWithHttpWebResponse { get; set; }
+    public Action<Activity, HttpWebResponse>? EnrichWithHttpWebResponse { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether exception will be recorded
@@ -164,7 +165,7 @@ public class HttpClientTraceInstrumentationOptions
         {
             return
                 this.FilterHttpRequestMessage == null ||
-                !TryParseHttpRequestMessage(activityName, arg1, out HttpRequestMessage requestMessage) ||
+                !TryParseHttpRequestMessage(activityName, arg1, out HttpRequestMessage? requestMessage) ||
                 this.FilterHttpRequestMessage(requestMessage);
         }
         catch (Exception ex)
@@ -188,7 +189,7 @@ public class HttpClientTraceInstrumentationOptions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool TryParseHttpRequestMessage(string activityName, object arg1, out HttpRequestMessage requestMessage)
+    private static bool TryParseHttpRequestMessage(string activityName, object arg1, [NotNullWhen(true)] out HttpRequestMessage? requestMessage)
     {
         return (requestMessage = arg1 as HttpRequestMessage) != null && activityName == "System.Net.Http.HttpRequestOut";
     }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-#if NET
 using System.Diagnostics.CodeAnalysis;
-#endif
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
@@ -26,7 +24,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 
     // https://github.com/dotnet/runtime/blob/7d034ddbbbe1f2f40c264b323b3ed3d6b3d45e9a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L19
     internal static readonly string ActivitySourceName = AssemblyName.Name + ".HttpClient";
-    internal static readonly Version Version = AssemblyName.Version;
+    internal static readonly Version Version = AssemblyName.Version!;
     internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
 
     private const string OnStartEvent = "System.Net.Http.HttpRequestOut.Start";
@@ -45,32 +43,33 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         this.options = options;
     }
 
-    public override void OnEventWritten(string name, object payload)
+    public override void OnEventWritten(string name, object? payload)
     {
+        var activity = Activity.Current!;
         switch (name)
         {
             case OnStartEvent:
                 {
-                    this.OnStartActivity(Activity.Current, payload);
+                    this.OnStartActivity(activity, payload);
                 }
 
                 break;
             case OnStopEvent:
                 {
-                    this.OnStopActivity(Activity.Current, payload);
+                    this.OnStopActivity(activity, payload);
                 }
 
                 break;
             case OnUnhandledExceptionEvent:
                 {
-                    this.OnException(Activity.Current, payload);
+                    this.OnException(activity, payload);
                 }
 
                 break;
         }
     }
 
-    public void OnStartActivity(Activity activity, object payload)
+    public void OnStartActivity(Activity activity, object? payload)
     {
         // The overall flow of what HttpClient library does is as below:
         // Activity.Start()
@@ -82,7 +81,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         // By this time, samplers have already run and
         // activity.IsAllDataRequested populated accordingly.
 
-        if (!TryFetchRequest(payload, out HttpRequestMessage request))
+        if (!TryFetchRequest(payload, out HttpRequestMessage? request))
         {
             HttpInstrumentationEventSource.Log.NullPayload(nameof(HttpHandlerDiagnosticListener), nameof(this.OnStartActivity));
             return;
@@ -137,10 +136,13 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
             // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md
             HttpTagHelper.RequestDataHelper.SetHttpMethodTag(activity, request.Method.Method);
 
-            activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
-            activity.SetTag(SemanticConventions.AttributeServerPort, request.RequestUri.Port);
+            if (request.RequestUri != null)
+            {
+                activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
+                activity.SetTag(SemanticConventions.AttributeServerPort, request.RequestUri.Port);
 
-            activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, this.options.DisableUrlQueryRedaction));
+                activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, this.options.DisableUrlQueryRedaction));
+            }
 
             try
             {
@@ -157,7 +159,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 #if NET
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
-        static bool TryFetchRequest(object payload, out HttpRequestMessage request)
+        static bool TryFetchRequest(object? payload, [NotNullWhen(true)] out HttpRequestMessage? request)
         {
             if (!StartRequestFetcher.TryFetch(payload, out request) || request == null)
             {
@@ -168,7 +170,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         }
     }
 
-    public void OnStopActivity(Activity activity, object payload)
+    public void OnStopActivity(Activity activity, object? payload)
     {
         if (activity.IsAllDataRequested)
         {
@@ -194,7 +196,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 }
             }
 
-            if (TryFetchResponse(payload, out HttpResponseMessage response))
+            if (TryFetchResponse(payload, out HttpResponseMessage? response))
             {
                 if (currentStatusCode == ActivityStatusCode.Unset)
                 {
@@ -223,7 +225,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 #if NET
             [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
-            static TaskStatus GetRequestStatus(object payload)
+            static TaskStatus GetRequestStatus(object? payload)
             {
                 // requestTaskStatus (type is TaskStatus) is a non-nullable enum so we don't need to have a null check here.
                 // See: https://github.com/dotnet/runtime/blob/79c021d65c280020246d1035b0e87ae36f2d36a9/src/libraries/System.Net.Http/src/HttpDiagnosticsGuide.md?plain=1#L69
@@ -238,7 +240,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 #if NET
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
-        static bool TryFetchResponse(object payload, out HttpResponseMessage response)
+        static bool TryFetchResponse(object? payload, [NotNullWhen(true)] out HttpResponseMessage? response)
         {
             if (StopResponseFetcher.TryFetch(payload, out response) && response != null)
             {
@@ -249,17 +251,22 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         }
     }
 
-    public void OnException(Activity activity, object payload)
+    public void OnException(Activity activity, object? payload)
     {
         if (activity.IsAllDataRequested)
         {
-            if (!TryFetchException(payload, out Exception exc))
+            if (!TryFetchException(payload, out Exception? exc))
             {
                 HttpInstrumentationEventSource.Log.NullPayload(nameof(HttpHandlerDiagnosticListener), nameof(this.OnException));
                 return;
             }
 
-            activity.SetTag(SemanticConventions.AttributeErrorType, GetErrorType(exc));
+            var errorType = GetErrorType(exc);
+
+            if (!string.IsNullOrEmpty(errorType))
+            {
+                activity.SetTag(SemanticConventions.AttributeErrorType, errorType);
+            }
 
             if (this.options.RecordException)
             {
@@ -286,7 +293,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 #if NET
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
-        static bool TryFetchException(object payload, out Exception exc)
+        static bool TryFetchException(object? payload, [NotNullWhen(true)] out Exception? exc)
         {
             if (!StopExceptionFetcher.TryFetch(payload, out exc) || exc == null)
             {
@@ -297,7 +304,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         }
     }
 
-    private static string GetErrorType(Exception exc)
+    private static string? GetErrorType(Exception exc)
     {
 #if NET8_0_OR_GREATER
         // For net8.0 and above exception type can be found using HttpRequestError.
@@ -330,7 +337,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
     {
         try
         {
-            return typeof(HttpClient).Assembly.GetName().Version.Major >= 7;
+            return typeof(HttpClient).Assembly.GetName().Version!.Major >= 7;
         }
         catch (Exception)
         {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
+
+#nullable disable
+
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;

--- a/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
+++ b/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
@@ -7,9 +7,6 @@
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
     <MinVerTagPrefix>Instrumentation.Http-</MinVerTagPrefix>
     <PackageValidationBaselineVersion>1.9.0</PackageValidationBaselineVersion>
-
-    <!-- this is temporary. will remove in future PR. -->
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -180,7 +180,7 @@ public partial class GrpcTests
         }
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/5092")]
+    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1727")]
     public void GrpcAndHttpClientInstrumentationWithSuppressInstrumentation()
     {
         var uri = new Uri($"http://localhost:{this.server.Port}");
@@ -233,7 +233,7 @@ public partial class GrpcTests
         Assert.Equal(0, grpcSpan4.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/5092")]
+    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1727")]
     public void GrpcPropagatesContextWithSuppressInstrumentationOptionSetToTrue()
     {
         try
@@ -350,7 +350,7 @@ public partial class GrpcTests
         }
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/5092")]
+    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1727")]
     public void GrpcClientInstrumentationRespectsSdkSuppressInstrumentation()
     {
         try

--- a/test/OpenTelemetry.Instrumentation.Http.Benchmarks/Instrumentation/HttpClientInstrumentationBenchmarks.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Benchmarks/Instrumentation/HttpClientInstrumentationBenchmarks.cs
@@ -30,10 +30,10 @@ public class HttpClientInstrumentationBenchmarks
 {
     private static readonly Uri Url = new("http://localhost:5000");
 
-    private HttpClient httpClient;
-    private WebApplication app;
-    private TracerProvider tracerProvider;
-    private MeterProvider meterProvider;
+    private HttpClient? httpClient;
+    private WebApplication? app;
+    private TracerProvider? tracerProvider;
+    private MeterProvider? meterProvider;
 
     [Flags]
     public enum EnableInstrumentationOption
@@ -114,43 +114,43 @@ public class HttpClientInstrumentationBenchmarks
     {
         if (this.EnableInstrumentation == EnableInstrumentationOption.None)
         {
-            this.httpClient.Dispose();
+            this.httpClient?.Dispose();
 #pragma warning disable CA2012 // Use ValueTasks correctly
-            this.app.DisposeAsync().GetAwaiter().GetResult();
+            this.app?.DisposeAsync().GetAwaiter().GetResult();
 #pragma warning restore CA2012 // Use ValueTasks correctly
         }
         else if (this.EnableInstrumentation == EnableInstrumentationOption.Traces)
         {
-            this.httpClient.Dispose();
+            this.httpClient?.Dispose();
 #pragma warning disable CA2012 // Use ValueTasks correctly
-            this.app.DisposeAsync().GetAwaiter().GetResult();
+            this.app?.DisposeAsync().GetAwaiter().GetResult();
 #pragma warning restore CA2012 // Use ValueTasks correctly
-            this.tracerProvider.Dispose();
+            this.tracerProvider?.Dispose();
         }
         else if (this.EnableInstrumentation == EnableInstrumentationOption.Metrics)
         {
-            this.httpClient.Dispose();
+            this.httpClient?.Dispose();
 #pragma warning disable CA2012 // Use ValueTasks correctly
-            this.app.DisposeAsync().GetAwaiter().GetResult();
+            this.app?.DisposeAsync().GetAwaiter().GetResult();
 #pragma warning restore CA2012 // Use ValueTasks correctly
-            this.meterProvider.Dispose();
+            this.meterProvider?.Dispose();
         }
         else if (this.EnableInstrumentation.HasFlag(EnableInstrumentationOption.Traces) &&
             this.EnableInstrumentation.HasFlag(EnableInstrumentationOption.Metrics))
         {
-            this.httpClient.Dispose();
+            this.httpClient?.Dispose();
 #pragma warning disable CA2012 // Use ValueTasks correctly
-            this.app.DisposeAsync().GetAwaiter().GetResult();
+            this.app?.DisposeAsync().GetAwaiter().GetResult();
 #pragma warning restore CA2012 // Use ValueTasks correctly
-            this.tracerProvider.Dispose();
-            this.meterProvider.Dispose();
+            this.tracerProvider?.Dispose();
+            this.meterProvider?.Dispose();
         }
     }
 
     [Benchmark]
     public async Task HttpClientRequest()
     {
-        var httpResponse = await this.httpClient.GetAsync(Url).ConfigureAwait(false);
+        var httpResponse = await this.httpClient!.GetAsync(Url).ConfigureAwait(false);
         httpResponse.EnsureSuccessStatusCode();
     }
 

--- a/test/OpenTelemetry.Instrumentation.Http.Benchmarks/OpenTelemetry.Instrumentation.Http.Benchmarks.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Benchmarks/OpenTelemetry.Instrumentation.Http.Benchmarks.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
@@ -341,7 +341,7 @@ public partial class HttpClientTests : IDisposable
 
         int maxRetries = 3;
         using var clientHandler = new HttpClientHandler();
-        using var retryHandler = new RetryHandler(clientHandler, maxRetries);
+        using var retryHandler = new RepeatHandler(clientHandler, maxRetries);
         using var httpClient = new HttpClient(retryHandler);
         await httpClient.SendAsync(request);
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
@@ -32,12 +32,14 @@ public partial class HttpClientTests : IDisposable
         this.output = output;
 
         this.serverLifeTime = TestHttpServer.RunServer(
-            (ctx) =>
+            ctx =>
             {
-                string traceparent = ctx.Request.Headers["traceparent"];
-                string custom_traceparent = ctx.Request.Headers["custom_traceparent"];
-                if ((ctx.Request.Headers["contextRequired"] == null
-                    || bool.Parse(ctx.Request.Headers["contextRequired"]))
+                var traceparent = ctx.Request.Headers["traceparent"];
+                var custom_traceparent = ctx.Request.Headers["custom_traceparent"];
+                var contextRequired = ctx.Request.Headers["contextRequired"];
+                var responseCode = ctx.Request.Headers["responseCode"];
+                if ((contextRequired == null
+                     || bool.Parse(contextRequired))
                     &&
                     (string.IsNullOrWhiteSpace(traceparent)
                         && string.IsNullOrWhiteSpace(custom_traceparent)))
@@ -45,18 +47,18 @@ public partial class HttpClientTests : IDisposable
                     ctx.Response.StatusCode = 500;
                     ctx.Response.StatusDescription = "Missing trace context";
                 }
-                else if (ctx.Request.Url.PathAndQuery.Contains("500"))
+                else if (ctx.Request.Url != null && ctx.Request.Url.PathAndQuery.Contains("500"))
                 {
                     ctx.Response.StatusCode = 500;
                 }
-                else if (ctx.Request.Url.PathAndQuery.Contains("redirect"))
+                else if (ctx.Request.Url != null && ctx.Request.Url.PathAndQuery.Contains("redirect"))
                 {
                     ctx.Response.RedirectLocation = "/";
                     ctx.Response.StatusCode = 302;
                 }
-                else if (ctx.Request.Headers["responseCode"] != null)
+                else if (responseCode != null)
                 {
-                    ctx.Response.StatusCode = int.Parse(ctx.Request.Headers["responseCode"]);
+                    ctx.Response.StatusCode = int.Parse(responseCode);
                 }
                 else
                 {
@@ -78,15 +80,15 @@ public partial class HttpClientTests : IDisposable
     [Fact]
     public void AddHttpClientInstrumentation_NamedOptions()
     {
-        int defaultExporterOptionsConfigureOptionsInvocations = 0;
-        int namedExporterOptionsConfigureOptionsInvocations = 0;
+        var defaultExporterOptionsConfigureOptionsInvocations = 0;
+        var namedExporterOptionsConfigureOptionsInvocations = 0;
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .ConfigureServices(services =>
             {
-                services.Configure<HttpClientTraceInstrumentationOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
+                services.Configure<HttpClientTraceInstrumentationOptions>(_ => defaultExporterOptionsConfigureOptionsInvocations++);
 
-                services.Configure<HttpClientTraceInstrumentationOptions>("Instrumentation2", o => namedExporterOptionsConfigureOptionsInvocations++);
+                services.Configure<HttpClientTraceInstrumentationOptions>("Instrumentation2", _ => namedExporterOptionsConfigureOptionsInvocations++);
             })
             .AddHttpClientInstrumentation()
             .AddHttpClientInstrumentation("Instrumentation2", configureHttpClientTraceInstrumentationOptions: null)
@@ -99,8 +101,8 @@ public partial class HttpClientTests : IDisposable
     [Fact]
     public void AddHttpClientInstrumentation_BadArgs()
     {
-        TracerProviderBuilder builder = null;
-        Assert.Throws<ArgumentNullException>(() => builder.AddHttpClientInstrumentation());
+        TracerProviderBuilder? builder = null;
+        Assert.Throws<ArgumentNullException>(() => builder!.AddHttpClientInstrumentation());
     }
 
     [Theory]
@@ -127,22 +129,22 @@ public partial class HttpClientTests : IDisposable
             {
                 if (shouldEnrich)
                 {
-                    o.EnrichWithHttpWebRequest = (activity, httpWebRequest) =>
+                    o.EnrichWithHttpWebRequest = (activity, _) =>
                     {
                         activity.SetTag("enrichedWithHttpWebRequest", "yes");
                     };
 
-                    o.EnrichWithHttpWebResponse = (activity, httpWebResponse) =>
+                    o.EnrichWithHttpWebResponse = (activity, _) =>
                     {
                         activity.SetTag("enrichedWithHttpWebResponse", "yes");
                     };
 
-                    o.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) =>
+                    o.EnrichWithHttpRequestMessage = (activity, _) =>
                     {
                         activity.SetTag("enrichedWithHttpRequestMessage", "yes");
                     };
 
-                    o.EnrichWithHttpResponseMessage = (activity, httpResponseMessage) =>
+                    o.EnrichWithHttpResponseMessage = (activity, _) =>
                     {
                         activity.SetTag("enrichedWithHttpResponseMessage", "yes");
                     };
@@ -214,15 +216,13 @@ public partial class HttpClientTests : IDisposable
     {
         var propagator = new CustomTextMapPropagator();
         propagator.InjectValues.Add("custom_traceParent", context => $"00/{context.ActivityContext.TraceId}/{context.ActivityContext.SpanId}/01");
-        propagator.InjectValues.Add("custom_traceState", context => Activity.Current.TraceStateString);
+        propagator.InjectValues.Add("custom_traceState", context => Activity.Current?.TraceStateString ?? string.Empty);
 
         var exportedItems = new List<Activity>();
 
-        using var request = new HttpRequestMessage
-        {
-            RequestUri = new Uri(this.url),
-            Method = new HttpMethod("GET"),
-        };
+        using var request = new HttpRequestMessage();
+        request.RequestUri = new Uri(this.url);
+        request.Method = new HttpMethod("GET");
 
         using var parent = new Activity("parent")
             .SetIdFormat(ActivityIdFormat.W3C)
@@ -264,29 +264,27 @@ public partial class HttpClientTests : IDisposable
         Assert.Equal("k1=v1,k2=v2", traceStates.Single());
 #endif
 
-        Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
-        {
+        Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(
+        [
             new TraceContextPropagator(),
             new BaggagePropagator(),
-        }));
+        ]));
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/5092")]
+    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1727")]
     public async Task RespectsSuppress()
     {
         try
         {
             var propagator = new CustomTextMapPropagator();
             propagator.InjectValues.Add("custom_traceParent", context => $"00/{context.ActivityContext.TraceId}/{context.ActivityContext.SpanId}/01");
-            propagator.InjectValues.Add("custom_traceState", context => Activity.Current.TraceStateString);
+            propagator.InjectValues.Add("custom_traceState", context => Activity.Current?.TraceStateString ?? string.Empty);
 
             var exportedItems = new List<Activity>();
 
-            using var request = new HttpRequestMessage
-            {
-                RequestUri = new Uri(this.url),
-                Method = new HttpMethod("GET"),
-            };
+            using var request = new HttpRequestMessage();
+            request.RequestUri = new Uri(this.url);
+            request.Method = new HttpMethod("GET");
 
             using var parent = new Activity("parent")
                 .SetIdFormat(ActivityIdFormat.W3C)
@@ -316,11 +314,11 @@ public partial class HttpClientTests : IDisposable
         }
         finally
         {
-            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
-            {
+            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(
+            [
                 new TraceContextPropagator(),
                 new BaggagePropagator(),
-            }));
+            ]));
         }
     }
 
@@ -339,7 +337,7 @@ public partial class HttpClientTests : IDisposable
             .AddInMemoryExporter(exportedItems)
             .Build();
 
-        int maxRetries = 3;
+        var maxRetries = 3;
         using var clientHandler = new HttpClientHandler();
         using var retryHandler = new RepeatHandler(clientHandler, maxRetries);
         using var httpClient = new HttpClient(retryHandler);
@@ -386,7 +384,7 @@ public partial class HttpClientTests : IDisposable
     [InlineData("Patch", "PATCH", "Patch")]
     [InlineData("Trace", "TRACE", "Trace")]
     [InlineData("CUSTOM", "_OTHER", "CUSTOM")]
-    public async Task HttpRequestMethodIsSetOnActivityAsPerSpec(string originalMethod, string expectedMethod, string expectedOriginalMethod)
+    public async Task HttpRequestMethodIsSetOnActivityAsPerSpec(string originalMethod, string expectedMethod, string? expectedOriginalMethod)
     {
         var exportedItems = new List<Activity>();
         using var request = new HttpRequestMessage
@@ -482,13 +480,13 @@ public partial class HttpClientTests : IDisposable
         var mp = metricPoints[0];
 
         // Inspect Metric Attributes
-        var attributes = new Dictionary<string, object>();
+        var attributes = new Dictionary<string, object?>();
         foreach (var tag in mp.Tags)
         {
             attributes[tag.Key] = tag.Value;
         }
 
-        Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpRequestMethod && kvp.Value.ToString() == expectedMethod);
+        Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpRequestMethod && kvp.Value?.ToString() == expectedMethod);
 
         Assert.DoesNotContain(attributes, t => t.Key == SemanticConventions.AttributeHttpRequestMethodOriginal);
     }
@@ -513,11 +511,11 @@ public partial class HttpClientTests : IDisposable
         // found. For now, this is not supported.
 
         Assert.Single(exportedItems);
-        Assert.Contains(exportedItems[0].TagObjects, t => t.Key == "http.response.status_code" && (int)t.Value == 200);
+        Assert.Contains(exportedItems[0].TagObjects, t => t.Key == "http.response.status_code" && (int?)t.Value == 200);
 #else
         Assert.Equal(2, exportedItems.Count);
-        Assert.Contains(exportedItems[0].TagObjects, t => t.Key == "http.response.status_code" && (int)t.Value == 302);
-        Assert.Contains(exportedItems[1].TagObjects, t => t.Key == "http.response.status_code" && (int)t.Value == 200);
+        Assert.Contains(exportedItems[0].TagObjects, t => t.Key == "http.response.status_code" && (int?)t.Value == 302);
+        Assert.Contains(exportedItems[1].TagObjects, t => t.Key == "http.response.status_code" && (int?)t.Value == 200);
 #endif
     }
 
@@ -526,22 +524,22 @@ public partial class HttpClientTests : IDisposable
     {
         var exportedItems = new List<Activity>();
 
-        bool httpWebRequestFilterApplied = false;
-        bool httpRequestMessageFilterApplied = false;
+        var httpWebRequestFilterApplied = false;
+        var httpRequestMessageFilterApplied = false;
 
         using (Sdk.CreateTracerProviderBuilder()
             .AddHttpClientInstrumentation(
                 opt =>
                 {
-                    opt.FilterHttpWebRequest = (req) =>
+                    opt.FilterHttpWebRequest = req =>
                     {
                         httpWebRequestFilterApplied = true;
                         return !req.RequestUri.OriginalString.Contains(this.url);
                     };
-                    opt.FilterHttpRequestMessage = (req) =>
+                    opt.FilterHttpRequestMessage = req =>
                     {
                         httpRequestMessageFilterApplied = true;
-                        return !req.RequestUri.OriginalString.Contains(this.url);
+                        return req.RequestUri != null && !req.RequestUri.OriginalString.Contains(this.url);
                     };
                 })
             .AddInMemoryExporter(exportedItems)
@@ -569,10 +567,10 @@ public partial class HttpClientTests : IDisposable
 
         using (Sdk.CreateTracerProviderBuilder()
             .AddHttpClientInstrumentation(
-                (opt) =>
+                opt =>
                 {
-                    opt.FilterHttpWebRequest = (req) => throw new Exception("From InstrumentationFilter");
-                    opt.FilterHttpRequestMessage = (req) => throw new Exception("From InstrumentationFilter");
+                    opt.FilterHttpWebRequest = _ => throw new Exception("From InstrumentationFilter");
+                    opt.FilterHttpRequestMessage = _ => throw new Exception("From InstrumentationFilter");
                 })
             .AddInMemoryExporter(exportedItems)
             .Build())
@@ -580,7 +578,7 @@ public partial class HttpClientTests : IDisposable
             using var c = new HttpClient();
             using var inMemoryEventListener = new InMemoryEventListener(HttpInstrumentationEventSource.Log);
             await c.GetAsync(new Uri(this.url));
-            Assert.Single(inMemoryEventListener.Events.Where((e) => e.EventId == 4));
+            Assert.Single(inMemoryEventListener.Events.Where(e => e.EventId == 4));
         }
 
         Assert.Empty(exportedItems);
@@ -590,7 +588,7 @@ public partial class HttpClientTests : IDisposable
     public async Task ReportsExceptionEventForNetworkFailuresWithGetAsync()
     {
         var exportedItems = new List<Activity>();
-        bool exceptionThrown = false;
+        var exceptionThrown = false;
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddHttpClientInstrumentation(o => o.RecordException = true)
@@ -616,7 +614,7 @@ public partial class HttpClientTests : IDisposable
     public async Task DoesNotReportExceptionEventOnErrorResponseWithGetAsync()
     {
         var exportedItems = new List<Activity>();
-        bool exceptionThrown = false;
+        var exceptionThrown = false;
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddHttpClientInstrumentation(o => o.RecordException = true)
@@ -642,7 +640,7 @@ public partial class HttpClientTests : IDisposable
     public async Task DoesNotReportExceptionEventOnErrorResponseWithGetStringAsync()
     {
         var exportedItems = new List<Activity>();
-        bool exceptionThrown = false;
+        var exceptionThrown = false;
         using var request = new HttpRequestMessage
         {
             RequestUri = new Uri($"{this.url}500"),
@@ -704,7 +702,7 @@ public partial class HttpClientTests : IDisposable
         var exportedItems = new List<Activity>();
 
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string> { ["OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION"] = disableQueryRedaction.ToString() })
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION"] = disableQueryRedaction.ToString() })
             .Build();
 
         // Arrange
@@ -737,15 +735,17 @@ public partial class HttpClientTests : IDisposable
     [InlineData(false, false)]
     public async Task CustomPropagatorCalled(bool sample, bool createParentActivity)
     {
+#if NETFRAMEWORK
         ActivityContext parentContext = default;
+#endif
         ActivityContext contextFromPropagator = default;
 
         var propagator = new CustomTextMapPropagator
         {
-            Injected = (context) => contextFromPropagator = context.ActivityContext,
+            Injected = context => contextFromPropagator = context.ActivityContext,
         };
         propagator.InjectValues.Add("custom_traceParent", context => $"00/{context.ActivityContext.TraceId}/{context.ActivityContext.SpanId}/01");
-        propagator.InjectValues.Add("custom_traceState", context => Activity.Current.TraceStateString);
+        propagator.InjectValues.Add("custom_traceState", context => Activity.Current?.TraceStateString ?? string.Empty);
 
         var exportedItems = new List<Activity>();
 
@@ -758,7 +758,7 @@ public partial class HttpClientTests : IDisposable
             var previousDefaultTextMapPropagator = Propagators.DefaultTextMapPropagator;
             Sdk.SetDefaultTextMapPropagator(propagator);
 
-            Activity parent = null;
+            Activity? parent = null;
             if (createParentActivity)
             {
                 parent = new Activity("parent")
@@ -768,14 +768,14 @@ public partial class HttpClientTests : IDisposable
                 parent.TraceStateString = "k1=v1,k2=v2";
                 parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
+#if NETFRAMEWORK
                 parentContext = parent.Context;
+#endif
             }
 
-            using var request = new HttpRequestMessage
-            {
-                RequestUri = new Uri(this.url),
-                Method = new HttpMethod("GET"),
-            };
+            using var request = new HttpRequestMessage();
+            request.RequestUri = new Uri(this.url);
+            request.Method = new HttpMethod("GET");
 
             using var c = new HttpClient();
             await c.SendAsync(request);

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -103,7 +103,7 @@ public partial class HttpClientTests
                 ",
             JsonSerializerOptions);
 
-        var t = (Task)this.GetType().InvokeMember(nameof(this.HttpOutCallsAreCollectedSuccessfullyTracesAndMetricsSemanticConventionsAsync), BindingFlags.InvokeMethod, null, this, HttpTestData.GetArgumentsFromTestCaseObject(input).First(), CultureInfo.InvariantCulture);
+        var t = (Task)this.GetType().InvokeMember(nameof(this.HttpOutCallsAreCollectedSuccessfullyTracesAndMetricsSemanticConventionsAsync), BindingFlags.InvokeMethod, null, this, HttpTestData.GetArgumentsFromTestCaseObject(input).First(), CultureInfo.InvariantCulture)!;
         await t;
     }
 #endif
@@ -200,13 +200,13 @@ public partial class HttpClientTests
         if (enableTracing)
         {
             tracerProviderBuilder
-                .AddHttpClientInstrumentation((opt) =>
+                .AddHttpClientInstrumentation(opt =>
                 {
-                    opt.EnrichWithHttpWebRequest = (activity, httpRequestMessage) => { enrichWithHttpWebRequestCalled = true; };
-                    opt.EnrichWithHttpWebResponse = (activity, httpResponseMessage) => { enrichWithHttpWebResponseCalled = true; };
-                    opt.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) => { enrichWithHttpRequestMessageCalled = true; };
-                    opt.EnrichWithHttpResponseMessage = (activity, httpResponseMessage) => { enrichWithHttpResponseMessageCalled = true; };
-                    opt.EnrichWithException = (activity, exception) => { enrichWithExceptionCalled = true; };
+                    opt.EnrichWithHttpWebRequest = (_, _) => { enrichWithHttpWebRequestCalled = true; };
+                    opt.EnrichWithHttpWebResponse = (_, _) => { enrichWithHttpWebResponseCalled = true; };
+                    opt.EnrichWithHttpRequestMessage = (_, _) => { enrichWithHttpRequestMessageCalled = true; };
+                    opt.EnrichWithHttpResponseMessage = (_, _) => { enrichWithHttpResponseMessageCalled = true; };
+                    opt.EnrichWithException = (_, _) => { enrichWithExceptionCalled = true; };
                     opt.RecordException = tc.RecordException ?? false;
                 });
         }
@@ -293,7 +293,7 @@ public partial class HttpClientTests
             Assert.Equal(tc.SpanStatus, activity.Status.ToString());
             Assert.Null(activity.StatusDescription);
 
-            var normalizedAttributes = activity.TagObjects.Where(kv => !kv.Key.StartsWith("otel.", StringComparison.Ordinal)).ToDictionary(x => x.Key, x => x.Value.ToString());
+            var normalizedAttributes = activity.TagObjects.Where(kv => !kv.Key.StartsWith("otel.", StringComparison.Ordinal)).ToDictionary(x => x.Key, x => x.Value?.ToString());
 
             int numberOfTags = activity.Status == ActivityStatusCode.Error ? 5 : 4;
 
@@ -301,18 +301,18 @@ public partial class HttpClientTests
 
             Assert.Equal(expectedAttributeCount, normalizedAttributes.Count);
 
-            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeHttpRequestMethod && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpRequestMethod]);
-            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeServerAddress && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerAddress]);
-            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeServerPort && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerPort]);
-            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeUrlFull && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeUrlFull]);
+            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeHttpRequestMethod && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpRequestMethod]);
+            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeServerAddress && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerAddress]);
+            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeServerPort && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerPort]);
+            Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeUrlFull && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeUrlFull]);
             if (tc.ResponseExpected)
             {
-                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetworkProtocolVersion]);
-                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
+                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetworkProtocolVersion]);
+                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
 
                 if (tc.ResponseCode >= 400)
                 {
-                    Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
+                    Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
                 }
             }
             else
@@ -323,11 +323,11 @@ public partial class HttpClientTests
 #if NET8_0_OR_GREATER
                 // we are using fake address so it will be "name_resolution_error"
                 // TODO: test other error types.
-                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "name_resolution_error");
+                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "name_resolution_error");
 #elif NETFRAMEWORK
-                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "name_resolution_failure");
+                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "name_resolution_failure");
 #else
-                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "System.Net.Http.HttpRequestException");
+                Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "System.Net.Http.HttpRequestException");
 #endif
             }
 
@@ -378,7 +378,7 @@ public partial class HttpClientTests
             }
 
             // Inspect Metric Attributes
-            var attributes = new Dictionary<string, object>();
+            var attributes = new Dictionary<string, object?>();
             foreach (var tag in metricPoint.Tags)
             {
                 attributes[tag.Key] = tag.Value;
@@ -399,19 +399,19 @@ public partial class HttpClientTests
 
             Assert.Equal(expectedAttributeCount, attributes.Count);
 
-            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpRequestMethod && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpRequestMethod]);
-            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerAddress && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerAddress]);
-            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerPort && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerPort]);
-            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeUrlScheme && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeUrlScheme]);
+            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpRequestMethod && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpRequestMethod]);
+            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerAddress && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerAddress]);
+            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerPort && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeServerPort]);
+            Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeUrlScheme && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeUrlScheme]);
 
             if (tc.ResponseExpected)
             {
-                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetworkProtocolVersion]);
-                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
+                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetworkProtocolVersion]);
+                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
 
                 if (tc.ResponseCode >= 400)
                 {
-                    Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
+                    Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpResponseStatusCode]);
                 }
             }
             else
@@ -422,12 +422,12 @@ public partial class HttpClientTests
 #if NET8_0_OR_GREATER
                 // we are using fake address so it will be "name_resolution_error"
                 // TODO: test other error types.
-                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "name_resolution_error");
+                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "name_resolution_error");
 #elif NETFRAMEWORK
-                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "name_resolution_failure");
+                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "name_resolution_failure");
 
 #else
-                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "System.Net.Http.HttpRequestException");
+                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "System.Net.Http.HttpRequestException");
 #endif
             }
 
@@ -463,11 +463,11 @@ public partial class HttpClientTests
             .SetSampler(sampler)
             .AddHttpClientInstrumentation(options =>
             {
-                options.EnrichWithHttpWebRequest = (activity, httpRequestMessage) => { enrichWithHttpWebRequestCalled = true; };
-                options.EnrichWithHttpWebResponse = (activity, httpResponseMessage) => { enrichWithHttpWebResponseCalled = true; };
+                options.EnrichWithHttpWebRequest = (_, _) => { enrichWithHttpWebRequestCalled = true; };
+                options.EnrichWithHttpWebResponse = (_, _) => { enrichWithHttpWebResponseCalled = true; };
 
-                options.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) => { enrichWithHttpRequestMessageCalled = true; };
-                options.EnrichWithHttpResponseMessage = (activity, httpResponseMessage) => { enrichWithHttpResponseMessageCalled = true; };
+                options.EnrichWithHttpRequestMessage = (_, _) => { enrichWithHttpRequestMessageCalled = true; };
+                options.EnrichWithHttpResponseMessage = (_, _) => { enrichWithHttpResponseMessageCalled = true; };
             })
             .Build())
         {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpOutTestCase.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpOutTestCase.cs
@@ -5,6 +5,20 @@ namespace OpenTelemetry.Instrumentation.Http.Tests;
 
 public class HttpOutTestCase
 {
+    public HttpOutTestCase(string name, string method, string url, Dictionary<string, string>? headers, int responseCode, string spanName, bool responseExpected, bool? recordException, string spanStatus, Dictionary<string, string> spanAttributes)
+    {
+        this.Name = name;
+        this.Method = method;
+        this.Url = url;
+        this.Headers = headers;
+        this.ResponseCode = responseCode;
+        this.SpanName = spanName;
+        this.ResponseExpected = responseExpected;
+        this.RecordException = recordException;
+        this.SpanStatus = spanStatus;
+        this.SpanAttributes = spanAttributes;
+    }
+
     public string Name { get; set; }
 
     public string Method { get; set; }
@@ -14,7 +28,7 @@ public class HttpOutTestCase
 #pragma warning restore CA1056
 
 #pragma warning disable CA2227
-    public Dictionary<string, string> Headers { get; set; }
+    public Dictionary<string, string>? Headers { get; set; }
 #pragma warning restore CA2227
 
     public int ResponseCode { get; set; }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
@@ -14,21 +14,25 @@ public static class HttpTestData
     {
         var assembly = Assembly.GetExecutingAssembly();
         var input = JsonSerializer.Deserialize<HttpOutTestCase[]>(
-            assembly.GetManifestResourceStream("OpenTelemetry.Instrumentation.Http.Tests.http-out-test-cases.json"),
+            assembly.GetManifestResourceStream("OpenTelemetry.Instrumentation.Http.Tests.http-out-test-cases.json")!,
             JsonSerializerOptions);
         return GetArgumentsFromTestCaseObject(input);
     }
 
-    public static IEnumerable<object[]> GetArgumentsFromTestCaseObject(IEnumerable<HttpOutTestCase> input)
+    public static IEnumerable<object[]> GetArgumentsFromTestCaseObject(IEnumerable<HttpOutTestCase>? input)
     {
         var result = new List<object[]>();
 
+        if (input == null)
+        {
+            return result;
+        }
+
         foreach (var testCase in input)
         {
-            result.Add(new object[]
-            {
-                testCase,
-            });
+            result.Add([
+                testCase
+            ]);
         }
 
         return result;

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 #if NETFRAMEWORK
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -27,7 +29,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
     {
         HttpClientTraceInstrumentationOptions options = new()
         {
-            EnrichWithHttpWebRequest = (activity, httpWebRequest) =>
+            EnrichWithHttpWebRequest = (_, httpWebRequest) =>
             {
                 VerifyHeaders(httpWebRequest);
 
@@ -714,7 +716,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         }
 
         // wait up to 10 sec for all requests and suppress exceptions
-        await Task.WhenAll(tasks.Select(t => t.Value).ToArray()).ContinueWith(async tt =>
+        await Task.WhenAll(tasks.Select(t => t.Value).ToArray()).ContinueWith(async _ =>
         {
             foreach (var task in tasks)
             {
@@ -817,10 +819,10 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         {
             this.activityListener = new ActivityListener
             {
-                ShouldListenTo = (activitySource) => activitySource.Name == HttpWebRequestActivitySource.ActivitySourceName,
+                ShouldListenTo = activitySource => activitySource.Name == HttpWebRequestActivitySource.ActivitySourceName,
                 ActivityStarted = this.ActivityStarted,
                 ActivityStopped = this.ActivityStopped,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => activitySamplingResult,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => activitySamplingResult,
             };
 
             ActivitySource.AddActivityListener(this.activityListener);

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -3,9 +3,6 @@
     <Description>Unit test project for OpenTelemetry HTTP instrumentations</Description>
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
-
-    <!-- this is temporary. will remove in future PR. -->
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/RepeatHandler.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/RepeatHandler.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/RepeatHandler.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/RepeatHandler.cs
@@ -1,17 +1,19 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
 
 namespace OpenTelemetry.Tests;
 
-public class RetryHandler : DelegatingHandler
+public class RepeatHandler : DelegatingHandler
 {
     private readonly int maxRetries;
 
-    public RetryHandler(HttpMessageHandler innerHandler, int maxRetries)
+    public RepeatHandler(HttpMessageHandler innerHandler, int maxRetries)
         : base(innerHandler)
     {
         this.maxRetries = maxRetries;
@@ -21,7 +23,7 @@ public class RetryHandler : DelegatingHandler
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
-        HttpResponseMessage response = null;
+        HttpResponseMessage? response = null;
         for (int i = 0; i < this.maxRetries; i++)
         {
             response?.Dispose();
@@ -35,6 +37,6 @@ public class RetryHandler : DelegatingHandler
             }
         }
 
-        return response;
+        return response!;
     }
 }


### PR DESCRIPTION
Towards #894

## Changes

[Instrumentation.Http] Nullable except `HttpWebRequestActivitySource` and corresponding tests.
I think that this class deserves separate PR.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [x] Changes in public API reviewed (if applicable)
