### PR TITLE
[tests - resource packages] Use extension method instead of constructor in Tests

### DIFF
--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -32,7 +32,7 @@ public class AzureResourceDetectorTests : IDisposable
         {
         }
 
-        var resource = ResourceBuilder.CreateEmpty().AddDetector(new AppServiceResourceDetector()).Build();
+        var resource = ResourceBuilder.CreateEmpty().AddAzureAppServiceDetector().Build();
         Assert.NotNull(resource);
 
         var expectedResourceUri = "/subscriptions/testtestSubscriptionId/resourceGroups/testResourceGroup/providers/Microsoft.Web/sites/sitename";
@@ -65,7 +65,7 @@ public class AzureResourceDetectorTests : IDisposable
             };
         };
 
-        var resource = ResourceBuilder.CreateEmpty().AddDetector(new AzureVMResourceDetector()).Build();
+        var resource = ResourceBuilder.CreateEmpty().AddAzureVMDetector().Build();
         Assert.NotNull(resource);
 
         foreach (var field in AzureVMResourceDetector.ExpectedAzureAmsFields)
@@ -108,7 +108,7 @@ public class AzureResourceDetectorTests : IDisposable
         {
         }
 
-        var resource = ResourceBuilder.CreateEmpty().AddDetector(new AzureContainerAppsResourceDetector()).Build();
+        var resource = ResourceBuilder.CreateEmpty().AddAzureContainerAppsDetector().Build();
         Assert.NotNull(resource);
 
         Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, "containerAppName"), resource.Attributes);

--- a/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
@@ -42,7 +42,7 @@ public class HostDetectorTests
     [Fact]
     public void TestHostAttributes()
     {
-        var resource = ResourceBuilder.CreateEmpty().AddDetector(new HostDetector()).Build();
+        var resource = ResourceBuilder.CreateEmpty().AddHostDetector().Build();
 
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 

--- a/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
@@ -10,7 +10,7 @@ public class ProcessDetectorTests
     [Fact]
     public void TestProcessAttributes()
     {
-        var resource = ResourceBuilder.CreateEmpty().AddDetector(new ProcessDetector()).Build();
+        var resource = ResourceBuilder.CreateEmpty().AddProcessDetector().Build();
 
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 

--- a/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
@@ -10,7 +10,7 @@ public class ProcessRuntimeDetectorTests
     [Fact]
     public void TestProcessRuntimeAttributes()
     {
-        var resource = ResourceBuilder.CreateEmpty().AddDetector(new ProcessRuntimeDetector()).Build();
+        var resource = ResourceBuilder.CreateEmpty().AddProcessRuntimeDetector().Build();
 
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 


### PR DESCRIPTION
Design discussion issue #
[discussion](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1943#discussion_r1671348344)

## Changes
Instead of instantiating objects via constructors, a static extension method is now used in tests to enhance code readability and maintainability

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
