### PR TITLE
[Instrumentation.StackExchangeRedis] Updates `StackExchange.Redis` to `2.6.80`

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -42,7 +42,7 @@
     <OpenTelemetryCoreUnstableLatestVersion>[1.9.0-beta.2]</OpenTelemetryCoreUnstableLatestVersion>
     <OpenTelemetryCoreLatestVersion>[1.9.0,2.0)</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.9.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
-    <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
+    <StackExchangeRedisPkgVer>[2.6.80,3.0)</StackExchangeRedisPkgVer>
     <ConfluentKafkaPkgVer>[2.3.0,3.0)</ConfluentKafkaPkgVer>
     <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.507,2.0)</StyleCopAnalyzersPkgVer>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add support for instrumenting `IConnectionMultiplexer`
   which is added with service key.
   ([#1885](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1885))
+* Update `StackExchange.Redis` to `2.6.80`, resolving warnings about [CVE-2021-24112](https://github.com/advisories/GHSA-rxg9-xrhp-64gj).
+  ([#1959](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1959))
 
 ## 1.0.0-rc9.15
 


### PR DESCRIPTION
Fixes #1951

## Changes

Updates `StackExchange.Redis` to `2.6.80` to resolve CVE warnings in a transistive dependency. See #1951 for additional details.

[Version 2.6.80 of `StackExchange.Redis`](https://github.com/StackExchange/StackExchange.Redis/issues/2283#issuecomment-1292028155) dropped the dependency causing the warning.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
