### PR TITLE
[Instrumentation.StackExchangeRedis] Updates `StackExchange.Redis` to `2.6.122`

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -42,7 +42,7 @@
     <OpenTelemetryCoreUnstableLatestVersion>[1.9.0-beta.2]</OpenTelemetryCoreUnstableLatestVersion>
     <OpenTelemetryCoreLatestVersion>[1.9.0,2.0)</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.9.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
-    <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
+    <StackExchangeRedisPkgVer>[2.6.122,3.0)</StackExchangeRedisPkgVer>
     <ConfluentKafkaPkgVer>[2.3.0,3.0)</ConfluentKafkaPkgVer>
     <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.507,2.0)</StyleCopAnalyzersPkgVer>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add support for instrumenting `IConnectionMultiplexer`
   which is added with service key.
   ([#1885](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1885))
+* Update `StackExchange.Redis` version to `2.6.122`, resolving warnings about
+  [CVE-2021-24112](https://github.com/advisories/GHSA-rxg9-xrhp-64gj).
+  ([#1961](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1961))
 
 ## 1.0.0-rc9.15
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -36,7 +36,7 @@ public class StackExchangeRedisCallsInstrumentationTests
         {
             AbortOnConnectFail = true,
         };
-        connectionOptions.EndPoints.Add(RedisEndPoint);
+        connectionOptions.EndPoints.Add(RedisEndPoint!);
 
         using var connection = ConnectionMultiplexer.Connect(connectionOptions);
         var db = connection.GetDatabase();
@@ -90,7 +90,7 @@ public class StackExchangeRedisCallsInstrumentationTests
         {
             AbortOnConnectFail = true,
         };
-        connectionOptions.EndPoints.Add(RedisEndPoint);
+        connectionOptions.EndPoints.Add(RedisEndPoint!);
 
         ConnectionMultiplexer? connection = null;
         var exportedItems = new List<Activity>();
@@ -173,7 +173,7 @@ public class StackExchangeRedisCallsInstrumentationTests
         {
             AbortOnConnectFail = true,
         };
-        connectionOptions.EndPoints.Add(RedisEndPoint);
+        connectionOptions.EndPoints.Add(RedisEndPoint!);
         using var connection = ConnectionMultiplexer.Connect(connectionOptions);
 
         var exportedItems = new List<Activity>();


### PR DESCRIPTION
Fixes #1951

## Changes

Updates `StackExchange.Redis` to `2.6.122` to resolve CVE warnings in a transitive dependency. See #1951 for additional details.

Starting with [version 2.6.80 of `StackExchange.Redis`](https://github.com/StackExchange/StackExchange.Redis/issues/2283#issuecomment-1292028155) the dependency causing the warning was dropped.

Upgrading to `2.6.122` as this is the earliest version with the dependency fix and [a correction to the type signature for `IConnectionMultiplexer.RegisterProfiler`](https://github.com/StackExchange/StackExchange.Redis/releases/tag/2.6.122).

Some tests have had the null-forgiving operator applied to variables. The test attributes look to cause those cases to be skipped if the variable wouldn't have been populated.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
