### PR TITLE
[Resources.OperatingSystem] Run tests in macOS

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -33,6 +33,8 @@ jobs:
         exclude:
         - os: ubuntu-latest
           version: net462
+        - os: macos-latest
+          version: net462
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Resources.OperatingSystem]
       code-cov-name: Resources.OperatingSystem
+      os-list: '[ "windows-latest", "ubuntu-latest", "macos-latest" ]'
 
   build-test-resources-process:
     needs: detect-changes


### PR DESCRIPTION
The resource detector does not work properly on macOS.

We should run the OS detector tests on macOS to avoid regression bugs.

An alternative would be to add `macOS` to the default runners list.

CC @ysolomchenko 