### PR TITLE
[Instrumentation.StackExchangeRedis] @matt-hensley as component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -53,6 +53,8 @@ components:
     - Yun-Ting
   src/OpenTelemetry.Instrumentation.Quartz/:
     - maldago
+  src/OpenTelemetry.Instrumentation.StackExchangeRedis/:
+    - matt-hensley
   src/OpenTelemetry.Instrumentation.Runtime/:
     - twenzel
     - xiang17
@@ -151,6 +153,8 @@ components:
     - codeblanch
   test/OpenTelemetry.Instrumentation.Quartz.Tests/:
     - maldago
+  test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/:
+    - matt-hensley
   test/OpenTelemetry.Instrumentation.Runtime.Tests/:
     - twenzel
     - xiang17


### PR DESCRIPTION
## Changes

Volunteering myself as component owner for Redis instrumentation.

Adds @matt-hensley as owner of instrumentation and relevant tests.

## Merge requirement checklist

* [ ] ~[CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)~
* [ ] ~Unit tests added/updated~
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~
