### PR TITLE
[infra] Allow to release -rc9. versions

### DIFF
--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -9,7 +9,7 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
     [Parameter()][string]$gitUserEmail
   )
 
-  $match = [regex]::Match($version, '^(\d+\.\d+\.\d+)(?:-((?:alpha)|(?:beta)|(?:rc))\.(\d+))?$')
+  $match = [regex]::Match($version, '^(\d+\.\d+\.\d+)(?:-((?:alpha)|(?:beta)|(?:rc)|(?:rc9))\.(\d+))?$')
   if ($match.Success -eq $false)
   {
       throw 'Input version did not match expected format'


### PR DESCRIPTION
## Changes

Fixes possibility to release `-rc9.version`  packages. See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/10038153233/job/27739471486

It can be removed in the future, when all packages will be released in the standard way.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
