### PR TITLE
[Instrumentation.Owin] Remove SDK dependency

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -9,6 +9,11 @@
   `IConfiguration`.
   ([#1973](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1973))
 
+* **Breaking change** Updated to depend on the
+  `OpenTelemetry.Api.ProviderBuilderExtensions` (API) package instead of the
+  `OpenTelemetry` (SDK) package.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-rc.6
 
 Released 2024-Apr-19

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -12,7 +12,7 @@
 * **Breaking change** Updated to depend on the
   `OpenTelemetry.Api.ProviderBuilderExtensions` (API) package instead of the
   `OpenTelemetry` (SDK) package.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1977](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1977))
 
 ## 1.0.0-rc.6
 

--- a/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
+++ b/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
@@ -25,7 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPkgVer)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPkgVer)" />
     <PackageReference Include="Microsoft.Owin" Version="$(MicrosoftOwinPkgVer)" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes

* Switches Owin to depend on API instead of SDK

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
