### PR TITLE
Add instrumentation for Bedrock and BedrockRuntime services

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSSemanticConventions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSSemanticConventions.cs
@@ -13,6 +13,11 @@ internal static class AWSSemanticConventions
     public const string AttributeAWSDynamoTableName = "aws.table_name";
     public const string AttributeAWSSQSQueueUrl = "aws.queue_url";
 
+    public const string AttributeAWSBedrockDataSourceId = "aws.bedrock.data_source.id";
+    public const string AttributeAWSBedrockKnowledgeBaseId = "aws.bedrock.knowledge_base.id";
+    public const string AttributeAWSBedrockAgentId = "aws.bedrock.agent.id";
+    public const string AttributeAWSBedrockGuardrailId = "aws.bedrock.guardrail.id";
+
     public const string AttributeHttpStatusCode = "http.status_code";
     public const string AttributeHttpResponseContentLength = "http.response_content_length";
 

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSSemanticConventions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSSemanticConventions.cs
@@ -18,6 +18,10 @@ internal static class AWSSemanticConventions
     public const string AttributeAWSBedrockAgentId = "aws.bedrock.agent.id";
     public const string AttributeAWSBedrockGuardrailId = "aws.bedrock.guardrail.id";
 
+    // should be global convention for Gen AI attributes
+    public const string AttributeGenAiModelId = "gen_ai.request.model";
+    public const string AttributeGenAiSystem = "gen_ai.system";
+
     public const string AttributeHttpStatusCode = "http.status_code";
     public const string AttributeHttpResponseContentLength = "http.response_content_length";
 

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
@@ -10,8 +10,8 @@ internal class AWSServiceHelper
     internal static IReadOnlyDictionary<string, List<string>> ServiceParameterMap = new Dictionary<string, List<string>>()
     {
         { AWSServiceType.DynamoDbService, new List<string> { "TableName" } },
-        { AWSServiceType.SQSService, new List<string> { "QueueUrl" } }, 
-        { AWSServiceType.BedrockRuntimeService, new List<string> { "ModelId" } }
+        { AWSServiceType.SQSService, new List<string> { "QueueUrl" } },
+        { AWSServiceType.BedrockRuntimeService, new List<string> { "ModelId" } },
     };
 
     internal static IReadOnlyDictionary<string, string> ParameterAttributeMap = new Dictionary<string, string>()

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
@@ -7,16 +7,18 @@ namespace OpenTelemetry.Instrumentation.AWS.Implementation;
 
 internal class AWSServiceHelper
 {
-    internal static IReadOnlyDictionary<string, string> ServiceParameterMap = new Dictionary<string, string>()
+    internal static IReadOnlyDictionary<string, List<string>> ServiceParameterMap = new Dictionary<string, List<string>>()
     {
-        { AWSServiceType.DynamoDbService, "TableName" },
-        { AWSServiceType.SQSService, "QueueUrl" },
+        { AWSServiceType.DynamoDbService, new List<string> { "TableName" } },
+        { AWSServiceType.SQSService, new List<string> { "QueueUrl" } }, 
+        { AWSServiceType.BedrockRuntimeService, new List<string> { "ModelId" } }
     };
 
     internal static IReadOnlyDictionary<string, string> ParameterAttributeMap = new Dictionary<string, string>()
     {
         { "TableName", AWSSemanticConventions.AttributeAWSDynamoTableName },
         { "QueueUrl", AWSSemanticConventions.AttributeAWSSQSQueueUrl },
+        { "ModelId", AWSSemanticConventions.AttributeGenAiModelId },
     };
 
     internal static string GetAWSServiceName(IRequestContext requestContext)

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
@@ -9,9 +9,9 @@ internal class AWSServiceType
     internal const string SQSService = "SQS";
     internal const string SNSService = "SNS";
     internal const string BedrockService = "Bedrock";
-    internal const string BedrockAgentService = "BedrockAgent";
-    internal const string BedrockAgentRuntimeService = "BedrockAgentRuntime";
-    internal const string BedrockRuntimeService = "BedrockRuntime";
+    internal const string BedrockAgentService = "Bedrock Agent";
+    internal const string BedrockAgentRuntimeService = "Bedrock Agent Runtime";
+    internal const string BedrockRuntimeService = "Bedrock Runtime";
 
     internal static bool IsDynamoDbService(string service)
         => DynamoDbService.Equals(service, StringComparison.OrdinalIgnoreCase);

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
@@ -8,6 +8,10 @@ internal class AWSServiceType
     internal const string DynamoDbService = "DynamoDB";
     internal const string SQSService = "SQS";
     internal const string SNSService = "SNS";
+    internal const string BedrockService = "Bedrock";
+    internal const string BedrockAgentService = "BedrockAgent";
+    internal const string BedrockAgentRuntimeService = "BedrockAgentRuntime";
+    internal const string BedrockRuntimeService = "BedrockRuntime";
 
     internal static bool IsDynamoDbService(string service)
         => DynamoDbService.Equals(service, StringComparison.OrdinalIgnoreCase);
@@ -17,4 +21,16 @@ internal class AWSServiceType
 
     internal static bool IsSnsService(string service)
         => SNSService.Equals(service, StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsBedrockService(string service)
+        => BedrockService.Equals(service, StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsBedrockAgentService(string service)
+        => BedrockAgentService.Equals(service, StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsBedrockAgentRuntimeService(string service)
+        => BedrockAgentRuntimeService.Equals(service, StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsBedrockRuntimeService(string service)
+        => BedrockRuntimeService.Equals(service, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -136,25 +136,28 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
 #endif
     private static void AddRequestSpecificInformation(Activity activity, IRequestContext requestContext, string service)
     {
-        if (AWSServiceHelper.ServiceParameterMap.TryGetValue(service, out var parameter))
+        if (AWSServiceHelper.ServiceParameterMap.TryGetValue(service, out var parameters))
         {
             AmazonWebServiceRequest request = requestContext.OriginalRequest;
 
-            try
+            foreach (var parameter in parameters)
             {
-                var property = request.GetType().GetProperty(parameter);
-                if (property != null)
+                try
                 {
-                    if (AWSServiceHelper.ParameterAttributeMap.TryGetValue(parameter, out var attribute))
+                    var property = request.GetType().GetProperty(parameter);
+                    if (property != null)
                     {
-                        activity.SetTag(attribute, property.GetValue(request));
+                        if (AWSServiceHelper.ParameterAttributeMap.TryGetValue(parameter, out var attribute))
+                        {
+                            activity.SetTag(attribute, property.GetValue(request));
+                        }
                     }
                 }
-            }
-            catch (Exception)
-            {
-                // Guard against any reflection-related exceptions when running in AoT.
-                // See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1543#issuecomment-1907667722.
+                catch (Exception)
+                {
+                    // Guard against any reflection-related exceptions when running in AoT.
+                    // See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1543#issuecomment-1907667722.
+                }
             }
         }
 
@@ -171,6 +174,10 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
         {
             SnsRequestContextHelper.AddAttributes(
                 requestContext, AWSMessagingUtils.InjectIntoDictionary(new PropagationContext(activity.Context, Baggage.Current)));
+        }
+        else if (AWSServiceType.IsBedrockRuntimeService(service))
+        {
+            activity.SetTag(AWSSemanticConventions.AttributeGenAiSystem, "aws_bedrock");
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
@@ -30,8 +30,6 @@ public static class TracerProviderBuilderExtensions
         this TracerProviderBuilder builder,
         Action<AWSClientInstrumentationOptions>? configure)
     {
-        // log something to console
-        Console.WriteLine("Adding AWS Instrumentation from local repo");
         Guard.ThrowIfNull(builder);
 
         var awsClientOptions = new AWSClientInstrumentationOptions();

--- a/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
@@ -30,6 +30,8 @@ public static class TracerProviderBuilderExtensions
         this TracerProviderBuilder builder,
         Action<AWSClientInstrumentationOptions>? configure)
     {
+        // log something to console
+        Console.WriteLine("Adding AWS Instrumentation from local repo");
         Guard.ThrowIfNull(builder);
 
         var awsClientOptions = new AWSClientInstrumentationOptions();

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <Description>Unit test project for AWS client instrumentation for OpenTelemetry.</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.Bedrock" Version="3.7.303.3" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.303.3" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -3,6 +3,10 @@
 
 using System.Diagnostics;
 using Amazon;
+using Amazon.Bedrock;
+using Amazon.Bedrock.Model;
+using Amazon.BedrockRuntime;
+using Amazon.BedrockRuntime.Model;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Runtime;
@@ -198,6 +202,86 @@ public class TestAWSClientInstrumentation
         }
     }
 
+    [Fact]
+#if NETFRAMEWORK
+    public void TestBedrockGetGuardrailSuccessful()
+#else
+    public async Task TestBedrockGetGuardrailSuccessful()
+#endif
+    {
+        var exportedItems = new List<Activity>();
+
+        var parent = new Activity("parent").Start();
+
+        using (Sdk.CreateTracerProviderBuilder()
+                   .AddXRayTraceId()
+                   .SetSampler(new AlwaysOnSampler())
+                   .AddAWSInstrumentation()
+                   .AddInMemoryExporter(exportedItems)
+                   .Build())
+        {
+            var bedrock = new AmazonBedrockClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
+            string requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+            string dummyResponse = "{\"GuardrailId\":\"123456789\"}";
+            CustomResponses.SetResponse(bedrock, dummyResponse, requestId, true);
+            var get_guardrail_req = new GetGuardrailRequest();
+            get_guardrail_req.GuardrailIdentifier = "123456789";
+#if NETFRAMEWORK
+            var response = bedrock.GetGuardrail(get_guardrail_req);
+#else
+            var response = await bedrock.GetGuardrailAsync(get_guardrail_req);
+#endif
+            Assert.Single(exportedItems);
+            Activity awssdk_activity = exportedItems[0];
+
+            this.ValidateAWSActivity(awssdk_activity, parent);
+            this.ValidateBedrockActivityTags(awssdk_activity);
+
+            Assert.Equal(Status.Unset, awssdk_activity.GetStatus());
+            Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.requestId"));
+        }
+    }
+
+    [Fact]
+#if NETFRAMEWORK
+    public void TestBedrockRuntimeInvokeModelSuccessful()
+#else
+    public async Task TestBedrockRuntimeInvokeModelSuccessful()
+#endif
+    {
+        var exportedItems = new List<Activity>();
+
+        var parent = new Activity("parent").Start();
+
+        using (Sdk.CreateTracerProviderBuilder()
+                   .AddXRayTraceId()
+                   .SetSampler(new AlwaysOnSampler())
+                   .AddAWSInstrumentation()
+                   .AddInMemoryExporter(exportedItems)
+                   .Build())
+        {
+            var bedrockruntime = new AmazonBedrockRuntimeClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
+            string requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+            string dummyResponse = "{}";
+            CustomResponses.SetResponse(bedrockruntime, dummyResponse, requestId, true);
+            var invoke_model_req = new InvokeModelRequest();
+            invoke_model_req.ModelId = "amazon.titan-text-express-v1";
+#if NETFRAMEWORK
+            var response = bedrockruntime.InvokeModel(invoke_model_req);
+#else
+            var response = await bedrockruntime.InvokeModelAsync(invoke_model_req);
+#endif
+            Assert.Single(exportedItems);
+            Activity awssdk_activity = exportedItems[0];
+
+            this.ValidateAWSActivity(awssdk_activity, parent);
+            this.ValidateBedrockRuntimeActivityTags(awssdk_activity);
+
+            Assert.Equal(Status.Unset, awssdk_activity.GetStatus());
+            Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.requestId"));
+        }
+    }
+
     private void ValidateAWSActivity(Activity aws_activity, Activity parent)
     {
         Assert.Equal(parent.SpanId, aws_activity.ParentSpanId);
@@ -227,5 +311,30 @@ public class TestAWSClientInstrumentation
         Assert.Equal("aws-api", Utils.GetTagValue(sqs_activity, "rpc.system"));
         Assert.Equal("SQS", Utils.GetTagValue(sqs_activity, "rpc.service"));
         Assert.Equal("SendMessage", Utils.GetTagValue(sqs_activity, "rpc.method"));
+    }
+
+    private void ValidateBedrockActivityTags(Activity bedrock_activity)
+    {
+        Assert.Equal("Bedrock.GetGuardrail", bedrock_activity.DisplayName);
+        Assert.Equal("Bedrock", Utils.GetTagValue(bedrock_activity, "aws.service"));
+        Assert.Equal("GetGuardrail", Utils.GetTagValue(bedrock_activity, "aws.operation"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "aws.region"));
+        Assert.Equal("123456789", Utils.GetTagValue(bedrock_activity, "aws.bedrock.guardrail.id"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("Bedrock", Utils.GetTagValue(bedrock_activity, "rpc.service"));
+        Assert.Equal("GetGuardrail", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+    }
+
+    private void ValidateBedrockRuntimeActivityTags(Activity bedrock_activity)
+    {
+        Assert.Equal("Bedrock Runtime.InvokeModel", bedrock_activity.DisplayName);
+        Assert.Equal("Bedrock Runtime", Utils.GetTagValue(bedrock_activity, "aws.service"));
+        Assert.Equal("InvokeModel", Utils.GetTagValue(bedrock_activity, "aws.operation"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "aws.region"));
+        Assert.Equal("amazon.titan-text-express-v1", Utils.GetTagValue(bedrock_activity, "gen_ai.request.model"));
+        Assert.Equal("aws_bedrock", Utils.GetTagValue(bedrock_activity, "gen_ai.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("Bedrock Runtime", Utils.GetTagValue(bedrock_activity, "rpc.service"));
+        Assert.Equal("InvokeModel", Utils.GetTagValue(bedrock_activity, "rpc.method"));
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Tools/HttpResponseMessageBody.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Tools/HttpResponseMessageBody.cs
@@ -27,20 +27,14 @@ internal class HttpResponseMessageBody : IHttpResponseBody
 
     Stream IHttpResponseBody.OpenResponse()
     {
-        if (this.disposed)
-        {
-            throw new ObjectDisposedException("HttpWebResponseBody");
-        }
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(HttpResponseMessageBody));
 
         return this.response.Content.ReadAsStreamAsync().Result;
     }
 
     Task<Stream> IHttpResponseBody.OpenResponseAsync()
     {
-        if (this.disposed)
-        {
-            throw new ObjectDisposedException("HttpWebResponseBody");
-        }
+        ObjectDisposedException.ThrowIf(this.disposed, nameof(HttpResponseMessageBody));
 
         if (this.response.Content != null)
         {


### PR DESCRIPTION
## Changes

Add AWS Bedrock and BedrockRuntime support with the following changes:
* For Bedrock, extract Guardrail Id attribute if it exists in the API response and add to span as `aws.bedrock.guardrail.id`.
* for BedrockRuntime, extract the attributes `gen_ai.request.model` and `gen_ai.system` as per [Gen AI semantic-conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/gen-ai.md) and add to span.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
