### PR TITLE
[Instrumentation.AWS] Add AWS metrics instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWS/.publicApi/PublicAPI.Unshipped.txt
@@ -6,3 +6,5 @@ OpenTelemetry.Instrumentation.AWS.AWSClientInstrumentationOptions.SuppressDownst
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAWSInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAWSInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AWS.AWSClientInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+OpenTelemetry.Metrics.MeterProviderBuilderExtensions
+static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAWSInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add AWS metrics instrumentation.
+  ([#1980](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1980))
 * Added `rpc.system`, `rpc.service`, and `rpc.method` to activity tags based on
   [semantic convention v1.26.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/cloud-providers/aws-sdk.md#common-attributes).
   ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1865))

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSHistogram.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSHistogram.cs
@@ -20,6 +20,7 @@ internal class AWSHistogram<T> : Histogram<T>
     {
         if (attributes != null)
         {
+            // TODO: remove ToArray call and use when AttributesAsSpan expected to be added at AWS SDK v4.
             this.histogram.Record(value, attributes.AllAttributes.ToArray());
         }
         else

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSHistogram.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSHistogram.cs
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
+
+namespace OpenTelemetry.Instrumentation.AWS.Implementation.Metrics;
+
+internal class AWSHistogram<T> : Histogram<T>
+    where T : struct
+{
+    private readonly System.Diagnostics.Metrics.Histogram<T> histogram;
+
+    public AWSHistogram(System.Diagnostics.Metrics.Histogram<T> histogram)
+    {
+        this.histogram = histogram;
+    }
+
+    public override void Record(T value, Attributes? attributes = null)
+    {
+        if (attributes != null)
+        {
+            this.histogram.Record(value, attributes.AllAttributes.ToArray());
+        }
+        else
+        {
+            this.histogram.Record(value);
+        }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMeter.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMeter.cs
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.Telemetry.Metrics;
+
+namespace OpenTelemetry.Instrumentation.AWS.Implementation.Metrics;
+
+internal class AWSMeter : Meter
+{
+    private readonly System.Diagnostics.Metrics.Meter meter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AWSMeter"/> class.
+    /// </summary>
+    /// <param name="meter">The Meter used for creating and tracking the Instruments.</param>
+    public AWSMeter(System.Diagnostics.Metrics.Meter meter)
+    {
+        this.meter = meter ?? throw new ArgumentNullException(nameof(meter));
+    }
+
+    public override UpDownCounter<T> CreateUpDownCounter<T>(
+        string name,
+        string? units = null,
+        string? description = null)
+        where T : struct
+    {
+        var upDownCounter = this.meter.CreateUpDownCounter<T>(name, units, description);
+        return new AWSUpDownCounter<T>(upDownCounter);
+    }
+
+    public override MonotonicCounter<T> CreateMonotonicCounter<T>(
+        string name,
+        string? units = null,
+        string? description = null)
+        where T : struct
+    {
+        var counter = this.meter.CreateCounter<T>(name, units, description);
+        return new AWSMonotonicCounter<T>(counter);
+    }
+
+    public override Histogram<T> CreateHistogram<T>(
+        string name,
+        string? units = null,
+        string? description = null)
+        where T : struct
+    {
+        var histogram = this.meter.CreateHistogram<T>(name, units, description);
+        return new AWSHistogram<T>(histogram);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.meter?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMeterProvider.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMeterProvider.cs
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
+
+namespace OpenTelemetry.Instrumentation.AWS.Implementation.Metrics;
+
+internal class AWSMeterProvider : MeterProvider
+{
+    public override Meter GetMeter(string scope, Attributes? attributes = null)
+    {
+        // Passing attributes to the Meter is currently not possible due to version limitations
+        // in the dependencies. Since none of the SDK operations utilize attributes at this level,
+        // so we will omit the attributes for now.
+        // This will be revisited after the release of OpenTelemetry.Extensions.AWS which will
+        // update OpenTelemetry core component version(s) to `1.9.0` and allow passing tags to
+        // the meter constructor.
+
+        var meter = new System.Diagnostics.Metrics.Meter(scope);
+        return new AWSMeter(meter);
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMonotonicCounter.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMonotonicCounter.cs
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
+
+namespace OpenTelemetry.Instrumentation.AWS.Implementation.Metrics;
+
+internal class AWSMonotonicCounter<T> : MonotonicCounter<T>
+    where T : struct
+{
+    private readonly System.Diagnostics.Metrics.Counter<T> counter;
+
+    public AWSMonotonicCounter(System.Diagnostics.Metrics.Counter<T> counter)
+    {
+        this.counter = counter;
+    }
+
+    public override void Add(T value, Attributes? attributes = null)
+    {
+        if (attributes != null)
+        {
+            this.counter.Add(value, attributes.AllAttributes.ToArray());
+        }
+        else
+        {
+            this.counter.Add(value);
+        }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMonotonicCounter.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMonotonicCounter.cs
@@ -20,6 +20,7 @@ internal class AWSMonotonicCounter<T> : MonotonicCounter<T>
     {
         if (attributes != null)
         {
+            // TODO: remove ToArray call and use when AttributesAsSpan expected to be added at AWS SDK v4.
             this.counter.Add(value, attributes.AllAttributes.ToArray());
         }
         else

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSUpDownCounter.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSUpDownCounter.cs
@@ -20,6 +20,7 @@ internal class AWSUpDownCounter<T> : UpDownCounter<T>
     {
         if (attributes != null)
         {
+            // TODO: remove ToArray call and use when AttributesAsSpan expected to be added at AWS SDK v4.
             this.upDownCounter.Add(value, attributes.AllAttributes.ToArray());
         }
         else

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSUpDownCounter.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSUpDownCounter.cs
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime.Telemetry;
+using Amazon.Runtime.Telemetry.Metrics;
+
+namespace OpenTelemetry.Instrumentation.AWS.Implementation.Metrics;
+
+internal class AWSUpDownCounter<T> : UpDownCounter<T>
+    where T : struct
+{
+    private readonly System.Diagnostics.Metrics.UpDownCounter<T> upDownCounter;
+
+    public AWSUpDownCounter(System.Diagnostics.Metrics.UpDownCounter<T> upDownCounter)
+    {
+        this.upDownCounter = upDownCounter;
+    }
+
+    public override void Add(T value, Attributes? attributes = null)
+    {
+        if (attributes != null)
+        {
+            this.upDownCounter.Add(value, attributes.AllAttributes.ToArray());
+        }
+        else
+        {
+            this.upDownCounter.Add(value);
+        }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/MeterProviderBuilderExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon;
+using Amazon.Runtime.Telemetry;
+using OpenTelemetry.Instrumentation.AWS.Implementation.Metrics;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Extension methods to simplify registering of dependency instrumentation.
+/// </summary>
+public static class MeterProviderBuilderExtensions
+{
+    /// <summary>
+    /// Enables AWS instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddAWSInstrumentation(
+        this MeterProviderBuilder builder)
+    {
+        Guard.ThrowIfNull(builder);
+
+        AWSConfigs.TelemetryProvider.RegisterMeterProvider(new AWSMeterProvider());
+        builder.AddMeter($"{TelemetryConstants.TelemetryScopePrefix}.*");
+
+        return builder;
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.300" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.300" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400" />
     <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.400" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -90,9 +90,10 @@ public class TestAWSClientInstrumentation
 #else
             await ddb.ScanAsync(scan_request);
 #endif
-            Assert.Single(exportedItems);
+            Assert.NotEmpty(exportedItems);
 
-            Activity awssdk_activity = exportedItems[0];
+            Activity? awssdk_activity = exportedItems.FirstOrDefault(e => e.DisplayName == "DynamoDB.Scan");
+            Assert.NotNull(awssdk_activity);
 
             this.ValidateAWSActivity(awssdk_activity, parent);
             this.ValidateDynamoActivityTags(awssdk_activity);
@@ -142,9 +143,10 @@ public class TestAWSClientInstrumentation
             }
             catch (AmazonServiceException)
             {
-                Assert.Single(exportedItems);
+                Assert.NotEmpty(exportedItems);
 
-                Activity awssdk_activity = exportedItems[0];
+                Activity? awssdk_activity = exportedItems.FirstOrDefault(e => e.DisplayName == "DynamoDB.Scan");
+                Assert.NotNull(awssdk_activity);
 
                 this.ValidateAWSActivity(awssdk_activity, parent);
                 this.ValidateDynamoActivityTags(awssdk_activity);
@@ -187,8 +189,9 @@ public class TestAWSClientInstrumentation
 #else
             await sqs.SendMessageAsync(send_msg_req);
 #endif
-            Assert.Single(exportedItems);
-            Activity awssdk_activity = exportedItems[0];
+            Assert.NotEmpty(exportedItems);
+            Activity? awssdk_activity = exportedItems.FirstOrDefault(e => e.DisplayName == "SQS.SendMessage");
+            Assert.NotNull(awssdk_activity);
 
             this.ValidateAWSActivity(awssdk_activity, parent);
             this.ValidateSqsActivityTags(awssdk_activity);

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -47,9 +47,10 @@ public class TestAWSClientInstrumentation
 #else
             await ddb.ScanAsync(scan_request);
 #endif
-            Assert.Single(exportedItems);
+            Assert.NotEmpty(exportedItems);
 
-            Activity awssdk_activity = exportedItems[0];
+            Activity? awssdk_activity = exportedItems.FirstOrDefault(e => e.DisplayName == "DynamoDB.Scan");
+            Assert.NotNull(awssdk_activity);
 
             this.ValidateAWSActivity(awssdk_activity, parent);
             this.ValidateDynamoActivityTags(awssdk_activity);

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientMetricsInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientMetricsInstrumentation.cs
@@ -1,0 +1,199 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using OpenTelemetry.Instrumentation.AWS.Tests.Tools;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.AWS.Tests;
+
+public class TestAWSClientMetricsInstrumentation
+{
+    [Fact]
+#if NETFRAMEWORK
+    public void TestS3PutObjectSuccessful()
+#else
+    public async Task TestS3PutObjectSuccessful()
+#endif
+    {
+        var exportedItems = new List<Metrics.Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddAWSInstrumentation()
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var s3 = new AmazonS3Client(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
+        CustomResponses.SetResponse(s3, null, "test_request_id", true);
+        var putObjectRequest = new PutObjectRequest
+        {
+            BucketName = "TestBucket",
+            Key = "TestKey",
+            ContentBody = "Test Content",
+        };
+#if NETFRAMEWORK
+        s3.PutObject(putObjectRequest);
+#else
+        await s3.PutObjectAsync(putObjectRequest);
+#endif
+        meterProvider.ForceFlush();
+
+        this.ValidateCommonMetrics(exportedItems);
+        this.ValidateHTTPBytesMetric(exportedItems, "client.http.bytes_sent");
+    }
+
+    [Fact]
+#if NETFRAMEWORK
+    public void TestSNSCreateTopicUnsuccessful()
+#else
+    public async Task TestSNSCreateTopicUnsuccessful()
+#endif
+    {
+        var exportedItems = new List<Metrics.Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddAWSInstrumentation()
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var sns = new AmazonSimpleNotificationServiceClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
+        AmazonServiceException amazonServiceException = new AmazonServiceException();
+        amazonServiceException.StatusCode = System.Net.HttpStatusCode.NotFound;
+        amazonServiceException.RequestId = "requestId";
+        CustomResponses.SetResponse(sns, (request) => { throw amazonServiceException; });
+        var createTopicRequest = new CreateTopicRequest
+        {
+            Name = "NewTopic",
+        };
+
+        try
+        {
+#if NETFRAMEWORK
+            sns.CreateTopic(createTopicRequest);
+#else
+            await sns.CreateTopicAsync(createTopicRequest);
+#endif
+        }
+        catch (AmazonServiceException)
+        {
+            meterProvider.ForceFlush();
+
+            this.ValidateCommonMetrics(exportedItems, false);
+
+            var callErrorsMetric = exportedItems.FirstOrDefault(i => i.Name == "client.call.errors");
+            Assert.NotNull(callErrorsMetric);
+
+            var metricPoints = new List<MetricPoint>();
+            foreach (var p in callErrorsMetric.GetMetricPoints())
+            {
+                metricPoints.Add(p);
+            }
+
+            var metricPoint = metricPoints[0];
+            var sum = metricPoint.GetSumLong();
+
+            Assert.Equal(MetricType.LongSum, callErrorsMetric.MetricType);
+            Assert.Equal("{error}", callErrorsMetric.Unit);
+            Assert.True(sum > 0);
+        }
+    }
+
+    [Fact]
+#if NETFRAMEWORK
+    public void TestSQSCreateQueueSuccessful()
+#else
+    public async Task TestSQSCreateQueueSuccessful()
+#endif
+    {
+        var exportedItems = new List<Metrics.Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddAWSInstrumentation()
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var sqs = new AmazonSQSClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
+        string dummyResponse = "{}";
+        CustomResponses.SetResponse(sqs, dummyResponse, "requestId", true);
+        var send_msg_req = new CreateQueueRequest()
+        {
+            QueueName = "MyTestQueue",
+        };
+
+#if NETFRAMEWORK
+        sqs.CreateQueue(send_msg_req);
+#else
+        await sqs.CreateQueueAsync(send_msg_req);
+#endif
+        meterProvider.ForceFlush();
+
+        this.ValidateCommonMetrics(exportedItems);
+        this.ValidateHTTPBytesMetric(exportedItems, "client.http.bytes_sent");
+        this.ValidateHTTPBytesMetric(exportedItems, "client.http.bytes_received");
+    }
+
+    private void ValidateHTTPBytesMetric(List<Metrics.Metric> exportedMetrics, string metricName)
+    {
+        var httpBytesSent = exportedMetrics.FirstOrDefault(i => i.Name == metricName);
+        Assert.NotNull(httpBytesSent);
+
+        var metricPoints = new List<MetricPoint>();
+        foreach (var p in httpBytesSent.GetMetricPoints())
+        {
+            metricPoints.Add(p);
+        }
+
+        var metricPoint = metricPoints[0];
+        var sum = metricPoint.GetSumLong();
+
+        Assert.Equal(MetricType.LongSum, httpBytesSent.MetricType);
+        Assert.Equal("By", httpBytesSent.Unit);
+        Assert.True(sum > 0);
+    }
+
+    private void ValidateCommonMetrics(List<Metrics.Metric> exportedMetrics, bool successful = true)
+    {
+        var callDuration = exportedMetrics.FirstOrDefault(i => i.Name == "client.call.duration");
+        this.ValidateDurationMetric(callDuration);
+
+        var callSerializationDuration = exportedMetrics.FirstOrDefault(i => i.Name == "client.call.serialization_duration");
+        this.ValidateDurationMetric(callSerializationDuration);
+
+        var callResolveEndpointDuration = exportedMetrics.FirstOrDefault(i => i.Name == "client.call.resolve_endpoint_duration");
+        this.ValidateDurationMetric(callResolveEndpointDuration);
+
+        var callAttemptDuration = exportedMetrics.FirstOrDefault(i => i.Name == "client.call.attempt_duration");
+        this.ValidateDurationMetric(callAttemptDuration);
+
+        // Unsuccessful calls wont reach the deserialization stage.
+        if (successful)
+        {
+            var callDeserializationDuration = exportedMetrics.FirstOrDefault(i => i.Name == "client.call.deserialization_duration");
+            this.ValidateDurationMetric(callDeserializationDuration);
+        }
+    }
+
+    private void ValidateDurationMetric(Metrics.Metric? durationMetric)
+    {
+        Assert.NotNull(durationMetric);
+
+        var metricPoints = new List<MetricPoint>();
+        foreach (var p in durationMetric.GetMetricPoints())
+        {
+            metricPoints.Add(p);
+        }
+
+        var metricPoint = metricPoints[0];
+        var count = metricPoint.GetHistogramCount();
+
+        Assert.Equal(MetricType.Histogram, durationMetric.MetricType);
+        Assert.Equal("s", durationMetric.Unit);
+        Assert.True(count > 0);
+    }
+}


### PR DESCRIPTION
## Changes

* Integration of New Metrics APIs:
Implemented the new AWS SDK tracing APIs, starting with `AWSMeterProvider`.

* Added Instrumentation Method:
Introduced `MeterProviderBuilderExtensions.AddAWSInstrumentation` to enable metrics instrumentation.

* SDK Version Update:
Updated the SDK version to `3.7.400` to incorporate the new tracing APIs.
This update conflicts with the changes in PR [#1974](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1974). The last merged PR will rebase accordingly.



## Merge requirement checklist

* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
