### PR TITLE
Removing use of response.EnsureSuccessStatusCode in HttpJsonPostTransport 

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/HttpJsonPostTransport.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/HttpJsonPostTransport.cs
@@ -107,10 +107,8 @@ internal sealed class HttpJsonPostTransport : ITransport, IDisposable
 
             using var response = this.httpClient.Send(request, CancellationToken.None);
 
-            try
+            if (response.IsSuccessStatusCode)
             {
-                response.EnsureSuccessStatusCode();
-
                 OneCollectorExporterEventSource.Log.WriteTransportDataSentEventIfEnabled(sendRequest.ItemType, sendRequest.NumberOfItems, this.Description);
 
                 var root = this.payloadTransmittedSuccessCallbacks.Root;
@@ -125,7 +123,7 @@ internal sealed class HttpJsonPostTransport : ITransport, IDisposable
 
                 return true;
             }
-            catch
+            else
             {
                 response.Headers.TryGetValues("Collector-Error", out var collectorErrors);
 


### PR DESCRIPTION
Fixes # 
Design discussion issue #

## Changes

Updating **HttpJsonPostTransport** to use `IsSuccessStatusCode` instead of `EnsureSuccessStatusCode` to ensure that the response is not disposed when the call fails.

Per https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpresponsemessage.ensuresuccessstatuscode?view=net-8.0

"The [EnsureSuccessStatusCode](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpresponsemessage.ensuresuccessstatuscode?view=net-8.0) method throws an exception if the HTTP response was unsuccessful. In .NET Framework and .NET Core 2.2 and earlier versions, if the [Content](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpresponsemessage.content?view=net-8.0) is not null, this method will also call [Dispose](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpresponsemessage.dispose?view=net-8.0) to free managed and unmanaged resources. Starting with .NET Core 3.0, the content will not be disposed."

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [n/a] Unit tests added/updated
* [n/a] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [n/a] Changes in public API reviewed (if applicable)
