### PR TITLE
[Instrumentation.Hangfire] Start Activity with expected display name

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
@@ -38,15 +38,12 @@ internal sealed class HangfireInstrumentationJobFilterAttribute : JobFilterAttri
             Baggage.Current = propagationContext.Baggage;
         }
 
-        var activity = HangfireInstrumentation.ActivitySource
-            .StartActivity(HangfireInstrumentationConstants.ActivityName, ActivityKind.Internal, parentContext);
+        var activityName = this.options.DisplayNameFunc(performingContext.BackgroundJob) ?? HangfireInstrumentationConstants.ActivityName;
+
+        var activity = HangfireInstrumentation.ActivitySource.StartActivity(activityName, ActivityKind.Internal, parentContext);
 
         if (activity != null)
         {
-            var displayNameFunc = this.options.DisplayNameFunc;
-
-            activity.DisplayName = displayNameFunc(performingContext.BackgroundJob);
-
             if (activity.IsAllDataRequested)
             {
                 try


### PR DESCRIPTION
Fixes #

Design discussion issue #

## Changes

Calculate the display name before starting the activity. 

### Context

Tools like Elastic APM subscribe for `ActivityStarted` event, but the display name is updated later. Therefore, the job name is always "JOB"

<https://github.com/elastic/apm-agent-dotnet/blob/01708e3fbc09584d8d0a5b908dae63f8bd2bec44/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs#L64>

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
