### PR TITLE
[OneCollector] Fix events not firing for failed responses on .NET Framework

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -27,8 +27,8 @@
     <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryCoreLatestVersion)</OpenTelemetryExporterInMemoryPkgVer>
     <OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>$(OpenTelemetryCoreLatestPrereleaseVersion)</OpenTelemetryExporterInMemoryLatestPreReleasePkgVer>
     <SupportedNetTargets>net8.0;net7.0;net6.0</SupportedNetTargets>
-    <XUnitRunnerVisualStudioPkgVer>[2.8.1,3.0)</XUnitRunnerVisualStudioPkgVer>
-    <XUnitPkgVer>[2.8.1,3.0)</XUnitPkgVer>
+    <XUnitRunnerVisualStudioPkgVer>[2.8.2,3.0)</XUnitRunnerVisualStudioPkgVer>
+    <XUnitPkgVer>[2.9.0,3.0)</XUnitPkgVer>
     <WiremockNetPkgVer>[1.5.58,2.0)</WiremockNetPkgVer>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed a bug preventing `HttpTransportErrorResponseReceived` events from firing
+  on .NET Framework.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.9.0
 
 Released 2024-Jun-17

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed a bug preventing `HttpTransportErrorResponseReceived` events from firing
   on .NET Framework.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1987](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1987))
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
@@ -28,15 +28,6 @@ internal sealed class OneCollectorExporterEventSource : EventSource
     }
 
     [NonEvent]
-    public void WriteTransportDataSentEventIfEnabled(string itemType, int? numberOfRecords, string transportDescription)
-    {
-        if (this.IsInformationalLoggingEnabled())
-        {
-            this.TransportDataSent(itemType, numberOfRecords ?? -1, transportDescription);
-        }
-    }
-
-    [NonEvent]
     public void WriteSinkDataWrittenEventIfEnabled(string itemType, int numberOfRecords, string sinkDescription)
     {
         if (this.IsInformationalLoggingEnabled())

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -746,7 +746,7 @@ public class GenevaMetricExporterTests
             Assert.Equal(7, exportedItems.Count);
 
             // observableLongCounter and observableDoubleGauge are dropped
-            Assert.Empty(exportedItems.Where(item => item.Name == "observableLongCounter" || item.Name == "observableDoubleGauge"));
+            Assert.DoesNotContain(exportedItems, item => item.Name == "observableLongCounter" || item.Name == "observableDoubleGauge");
 
             // check serialization for longCounter
             CheckSerializationWithTLVForSingleMetricPoint(exportedItems[0], exporter, exporterOptions);

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OpenTelemetry.Exporter.OneCollector.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OpenTelemetry.Exporter.OneCollector.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\SkipUnlessEnvVarFoundFactAttribute.cs" Link="Includes\SkipUnlessEnvVarFoundFactAttribute.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\SkipUnlessEnvVarFoundTheoryAttribute.cs" Link="Includes\SkipUnlessEnvVarFoundTheoryAttribute.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -175,8 +175,8 @@ public partial class GrpcTests
         }
         else
         {
-            Assert.Empty(grpcSpan.Tags.Where(tag => tag.Key == "enrichedWithHttpRequestMessage"));
-            Assert.Empty(grpcSpan.Tags.Where(tag => tag.Key == "enrichedWithHttpResponseMessage"));
+            Assert.DoesNotContain(grpcSpan.Tags, tag => tag.Key == "enrichedWithHttpRequestMessage");
+            Assert.DoesNotContain(grpcSpan.Tags, tag => tag.Key == "enrichedWithHttpResponseMessage");
         }
     }
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -338,7 +338,7 @@ public class SqlClientTests : IDisposable
         }
         else
         {
-            Assert.Empty(activity.Tags.Where(tag => tag.Key == "enriched"));
+            Assert.DoesNotContain(activity.Tags, tag => tag.Key == "enriched");
         }
 
         Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));

--- a/test/Shared/InMemoryEventListener.cs
+++ b/test/Shared/InMemoryEventListener.cs
@@ -10,11 +10,22 @@ namespace OpenTelemetry.Tests;
 
 internal class InMemoryEventListener : EventListener
 {
-    public ConcurrentQueue<EventWrittenEventArgs> Events = new();
+    private readonly EventSource eventSource;
 
     public InMemoryEventListener(EventSource eventSource, EventLevel minLevel = EventLevel.Verbose)
     {
+        this.eventSource = eventSource;
+
         this.EnableEvents(eventSource, minLevel);
+    }
+
+    public ConcurrentQueue<EventWrittenEventArgs> Events { get; } = new();
+
+    public override void Dispose()
+    {
+        this.DisableEvents(this.eventSource);
+
+        base.Dispose();
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)


### PR DESCRIPTION
Relates to #1984

## Changes

* Switch to using `IsSuccessStatusCode` instead of calling `EnsureSuccessStatusCode` to ensure that the response is not disposed on older runtimes.

## Details

Per https://learn.microsoft.com/dotnet/api/system.net.http.httpresponsemessage.ensuresuccessstatuscode

> The `EnsureSuccessStatusCode` method throws an exception if the HTTP response was unsuccessful. In .NET Framework and .NET Core 2.2 and earlier versions, if the `Content` is not null, this method will also call `Dispose` to free managed and unmanaged resources. Starting with .NET Core 3.0, the content will not be disposed."

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
