### PR TITLE
[Instrumentation.SqlClient] Database metrics `db.client.operation.duration` prototype

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientMetricDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientMetricDiagnosticListener.cs
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+#if NET6_0_OR_GREATER
+internal class SqlClientMetricDiagnosticListener : ListenerHandler
+{
+    internal static readonly Assembly Assembly = typeof(SqlClientMetricDiagnosticListener).Assembly;
+    internal static readonly AssemblyName AssemblyName = Assembly.GetName();
+    internal static readonly string MeterName = AssemblyName.Name!;
+    internal static readonly string MeterVersion = AssemblyName.Version!.ToString();
+    internal static readonly Meter Meter = new(MeterName, MeterVersion);
+    private static readonly Histogram<double> DbClientOperationDuration = Meter.CreateHistogram<double>(
+        "db.client.operation.duration",
+        "s",
+        "Duration of database client operations.");
+
+    private readonly AsyncLocal<long> beginTimestamp = new AsyncLocal<long>();
+
+    public SqlClientMetricDiagnosticListener(string sourceName)
+        : base(sourceName)
+    {
+    }
+
+    public override void OnEventWritten(string name, object? payload)
+    {
+        var activity = Activity.Current;
+        switch (name)
+        {
+            case SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand:
+            case SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand:
+                {
+                    // only record the duration if tracing is disabled or sampling has occured
+
+                    if (activity == null)
+                    {
+                        this.beginTimestamp.Value = Stopwatch.GetTimestamp();
+                    }
+
+                    break;
+                }
+
+            case SqlClientDiagnosticListener.SqlDataAfterExecuteCommand:
+            case SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand:
+                {
+                    if (activity == null)
+                    {
+                        if (this.beginTimestamp.Value != 0)
+                        {
+                            var endTimestamp = Stopwatch.GetTimestamp();
+                            var duration = TimeSpan.FromTicks(endTimestamp - this.beginTimestamp.Value);
+                            DbClientOperationDuration.Record(duration.TotalSeconds);
+                        }
+                    }
+                    else
+                    {
+                        activity.Stop();
+                        DbClientOperationDuration.Record(activity.Duration.TotalSeconds);
+                    }
+
+                    break;
+                }
+        }
+    }
+}
+#endif

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientMeterProviderBuilderExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Instrumentation.SqlClient.Implementation;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Metrics;
+
+namespace OpenTelemetry.Instrumentation.SqlClient;
+
+public static class SqlClientMeterProviderBuilderExtensions
+{
+    /// <summary>
+    /// Adds SqlClient instrumentation to the meter provider.
+    /// </summary>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddSqlClientInstrumentation(
+        this MeterProviderBuilder builder)
+    {
+        Guard.ThrowIfNull(builder);
+
+#if NET6_0_OR_GREATER
+        builder.AddInstrumentation(sp =>
+        {
+            return new SqlClientMetricInstrumentation();
+        });
+
+        builder.AddMeter(SqlClientMetricDiagnosticListener.MeterName);
+#endif
+
+        return builder;
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientMetricInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientMetricInstrumentation.cs
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+namespace OpenTelemetry.Instrumentation.SqlClient;
+
+#if NET6_0_OR_GREATER
+/// <summary>
+/// SqlClient metric instrumentation.
+/// </summary>
+internal sealed class SqlClientMetricInstrumentation : IDisposable
+{
+    internal const string SqlClientDiagnosticListenerName = "SqlClientDiagnosticListener";
+    internal const string SqlClientTrimmingUnsupportedMessage = "Trimming is not yet supported with SqlClient instrumentation.";
+
+    private static readonly HashSet<string> DiagnosticSourceEvents = new()
+    {
+        "System.Data.SqlClient.WriteCommandBefore",
+        "Microsoft.Data.SqlClient.WriteCommandBefore",
+        "System.Data.SqlClient.WriteCommandAfter",
+        "Microsoft.Data.SqlClient.WriteCommandAfter",
+        "System.Data.SqlClient.WriteCommandError",
+        "Microsoft.Data.SqlClient.WriteCommandError",
+    };
+
+    private readonly Func<string, object?, object?, bool> isEnabled = (eventName, _, _)
+        => DiagnosticSourceEvents.Contains(eventName);
+
+    private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlClientMetricInstrumentation"/> class.
+    /// </summary>
+    [RequiresUnreferencedCode(SqlClientTrimmingUnsupportedMessage)]
+    public SqlClientMetricInstrumentation()
+    {
+        this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
+           name => new SqlClientMetricDiagnosticListener(name),
+           listener => listener.Name == SqlClientDiagnosticListenerName,
+           this.isEnabled,
+           SqlClientInstrumentationEventSource.Log.UnknownErrorProcessingEvent);
+        this.diagnosticSourceSubscriber.Subscribe();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.diagnosticSourceSubscriber?.Dispose();
+    }
+}
+#endif

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientMetricsTests.cs
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+#if NET6_0_OR_GREATER
+[Collection("SqlClient")]
+public class SqlClientMetricsTests
+{
+    private const string TestConnectionString = "Data Source=(localdb)\\MSSQLLocalDB;Database=master";
+
+    [Fact]
+    public void SqlClient_BadArgs()
+    {
+        MeterProviderBuilder? builder = null;
+        Assert.Throws<ArgumentNullException>(() => builder!.AddSqlClientInstrumentation());
+    }
+}
+#endif

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Data;
+using OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+internal class SqlTestData
+{
+#if !NETFRAMEWORK
+    public static IEnumerable<object[]> SqlClientCallsAreCollectedSuccessfullyCases()
+    {
+        var bools = new[] { true, false };
+        return from beforeCommand in new[] { SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand }
+               from commandType in new[] { CommandType.StoredProcedure, CommandType.Text }
+               from captureTextCommandContent in bools
+               from shouldEnrich in bools
+               from tracingEnabled in bools
+               from metricsEnabled in bools
+               let endCommand = beforeCommand == SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand
+                   ? SqlClientDiagnosticListener.SqlDataAfterExecuteCommand
+                   : SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand
+               let commandText = commandType == CommandType.Text
+                   ? "select * from sys.databases"
+                   : "SP_GetOrders"
+               let captureStoredProcedureCommandName = beforeCommand == SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand
+               select new object[]
+               {
+                    beforeCommand,
+                    endCommand,
+                    commandType,
+                    commandText,
+                    captureStoredProcedureCommandName,
+                    captureTextCommandContent,
+                    shouldEnrich,
+                    tracingEnabled,
+                    metricsEnabled,
+               };
+    }
+#endif
+}


### PR DESCRIPTION
## Changes

Implements proposed `db.client.operation.duration` metric for SqlClient with required attributes.

Only implemented against .NET 6+ for now.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
