### PR TITLE
[onecollector] Use HttpClient.SendAsync on mobile platforms to avoid PlatformNotSupportedExceptions

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed `PlatformNotSupportedException`s being thrown during export when running
+  on mobile platforms which caused telemetry to be dropped silently.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.9.1
 
 Released 2024-Aug-01

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed `PlatformNotSupportedException`s being thrown during export when running
   on mobile platforms which caused telemetry to be dropped silently.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1992](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1992))
 
 ## 1.9.1
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/HttpJsonPostTransport.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/HttpJsonPostTransport.cs
@@ -105,7 +105,10 @@ internal sealed class HttpJsonPostTransport : ITransport, IDisposable
                 request.Headers.TryAddWithoutValidation("NoResponseBody", "true");
             }
 
-            using var response = this.httpClient.Send(request, CancellationToken.None);
+            using var response = this.httpClient.Send(
+                request,
+                infoLoggingEnabled ? HttpCompletionOption.ResponseContentRead : HttpCompletionOption.ResponseHeadersRead,
+                CancellationToken.None);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/IHttpClient.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/IHttpClient.cs
@@ -9,24 +9,43 @@ namespace OpenTelemetry.Exporter.OneCollector;
 
 internal interface IHttpClient
 {
-    HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken);
+    HttpResponseMessage Send(
+        HttpRequestMessage request,
+        HttpCompletionOption completionOption,
+        CancellationToken cancellationToken);
 }
 
 internal sealed class HttpClientWrapper : IHttpClient
 {
     private readonly HttpClient httpClient;
+#if NET
+    private readonly bool synchronousSendSupportedByCurrentPlatform;
+#endif
 
     public HttpClientWrapper(HttpClient httpClient)
     {
         this.httpClient = httpClient;
+
+#if NET
+        // See: https://github.com/dotnet/runtime/blob/280f2a0c60ce0378b8db49adc0eecc463d00fe5d/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs#L767
+        this.synchronousSendSupportedByCurrentPlatform = !OperatingSystem.IsAndroid()
+            && !OperatingSystem.IsIOS()
+            && !OperatingSystem.IsTvOS()
+            && !OperatingSystem.IsBrowser();
+#endif
     }
 
-    public HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    public HttpResponseMessage Send(
+        HttpRequestMessage request,
+        HttpCompletionOption completionOption,
+        CancellationToken cancellationToken)
     {
 #if NET
-        return this.httpClient.Send(request, CancellationToken.None);
+        return this.synchronousSendSupportedByCurrentPlatform
+            ? this.httpClient.Send(request, completionOption, cancellationToken)
+            : this.httpClient.SendAsync(request, completionOption, cancellationToken).GetAwaiter().GetResult();
 #else
-        return this.httpClient.SendAsync(request, CancellationToken.None).GetAwaiter().GetResult();
+        return this.httpClient.SendAsync(request, completionOption, cancellationToken).GetAwaiter().GetResult();
 #endif
     }
 }

--- a/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/LogRecordCommonSchemaJsonHttpPostBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Benchmarks/LogRecordCommonSchemaJsonHttpPostBenchmarks.cs
@@ -153,7 +153,10 @@ public class LogRecordCommonSchemaJsonHttpPostBenchmarks
 
     private sealed class NoopHttpClient : IHttpClient
     {
-        public HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        public HttpResponseMessage Send(
+            HttpRequestMessage request,
+            HttpCompletionOption completionOption,
+            CancellationToken cancellationToken)
         {
             return new HttpResponseMessage
             {


### PR DESCRIPTION
## Changes

* Use `HttpClient.SendAsync` on mobile platforms to avoid `PlatformNotSupportedException`s thrown calling `HttpClient.Send`

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
