### PR TITLE
[onecollector] Serialization fixes

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -6,6 +6,11 @@
   on mobile platforms which caused telemetry to be dropped silently.
   ([#1992](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1992))
 
+* Fixed a bug which caused remaining records in a batch to be dropped silently
+  once the max payload size for a transmission (default 4 KiB) has been
+  reached.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.9.1
 
 Released 2024-Aug-01

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed a bug which caused remaining records in a batch to be dropped silently
   once the max payload size for a transmission (default 4 KiB) has been
   reached.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#1999](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1999))
 
 ## 1.9.1
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
@@ -87,10 +87,10 @@ internal sealed class OneCollectorExporterEventSource : EventSource
         this.WriteEvent(3, itemType, numberOfRecords, sinkDescription);
     }
 
-    [Event(4, Message = "Dropped {1} '{0}' item(s).", Level = EventLevel.Warning)]
-    public void DataDropped(string itemType, int numberOfRecords)
+    [Event(4, Message = "Dropped {1} '{0}' item(s). {2} item(s) dropped during serialization. {3} item(s) dropped due to transmission failure.", Level = EventLevel.Warning)]
+    public void DataDropped(string itemType, int numberOfRecords, int numberOfRecordsDroppedDuringSerialization, int numberOfRecordsDroppedDuringTransmission)
     {
-        this.WriteEvent(4, itemType, numberOfRecords);
+        this.WriteEvent(4, itemType, numberOfRecords, numberOfRecordsDroppedDuringSerialization, numberOfRecordsDroppedDuringTransmission);
     }
 
     [Event(5, Message = "Exception thrown by '{0}' transport: {1}", Level = EventLevel.Error)]

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/OneCollectorExporterEventSource.cs
@@ -88,6 +88,9 @@ internal sealed class OneCollectorExporterEventSource : EventSource
     }
 
     [Event(4, Message = "Dropped {1} '{0}' item(s). {2} item(s) dropped during serialization. {3} item(s) dropped due to transmission failure.", Level = EventLevel.Warning)]
+#if NET
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Parameters passed to WriteEvent are all primitive values.")]
+#endif
     public void DataDropped(string itemType, int numberOfRecords, int numberOfRecordsDroppedDuringSerialization, int numberOfRecordsDroppedDuringTransmission)
     {
         this.WriteEvent(4, itemType, numberOfRecords, numberOfRecordsDroppedDuringSerialization, numberOfRecordsDroppedDuringTransmission);

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationResult.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationResult.cs
@@ -8,9 +8,13 @@ internal readonly struct BatchSerializationResult
 #if NET7_0_OR_GREATER
     public required int NumberOfItemsSerialized { get; init; }
 
+    public required int NumberOfItemsDropped { get; init; }
+
     public required long PayloadSizeInBytes { get; init; }
 #else
     public int NumberOfItemsSerialized { get; init; }
+
+    public int NumberOfItemsDropped { get; init; }
 
     public long PayloadSizeInBytes { get; init; }
 #endif

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationResult.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationResult.cs
@@ -1,12 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Note: StyleCop doesn't understand the C#11 "required" modifier yet. Remove
-// this in the future once StyleCop is updated. See:
-// https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3527
-
-#pragma warning disable SA1206 // Declaration keywords should follow order
-
 namespace OpenTelemetry.Exporter.OneCollector;
 
 internal readonly struct BatchSerializationResult

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationState.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationState.cs
@@ -1,0 +1,39 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Note: StyleCop doesn't understand the C#11 "required" modifier yet. Remove
+// this in the future once StyleCop is updated. See:
+// https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3527
+
+#if NETSTANDARD2_1_OR_GREATER || NET
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace OpenTelemetry.Exporter.OneCollector;
+
+internal ref struct BatchSerializationState<T>
+    where T : class
+{
+    private Batch<T>.Enumerator enumerator;
+
+    public BatchSerializationState(in Batch<T> batch)
+    {
+        this.enumerator = batch.GetEnumerator();
+    }
+
+    public bool TryGetNextItem(
+#if NETSTANDARD2_1_OR_GREATER || NET
+        [NotNullWhen(true)]
+#endif
+        out T? item)
+    {
+        if (this.enumerator.MoveNext())
+        {
+            item = this.enumerator.Current;
+            return true;
+        }
+
+        item = null;
+        return false;
+    }
+}

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationState.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/BatchSerializationState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 // Note: StyleCop doesn't understand the C#11 "required" modifier yet. Remove

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/ISerializer.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/ISerializer.cs
@@ -14,8 +14,8 @@ internal interface ISerializer<T>
 
     void SerializeBatchOfItemsToStream(
         Resource resource,
-        in Batch<T> batch,
+        ref BatchSerializationState<T> state,
         Stream stream,
         int initialSizeOfPayloadInBytes,
-        out BatchSerializationResult serializationResult);
+        out BatchSerializationResult result);
 }

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
@@ -302,9 +302,11 @@ public class LogRecordCommonSchemaJsonSerializerTests
 
         var batch = new Batch<LogRecord>(logRecords, numberOfLogRecords);
 
+        var state = new BatchSerializationState<LogRecord>(in batch);
+
         serializer.SerializeBatchOfItemsToStream(
             resource ?? Resource.Empty,
-            in batch,
+            ref state,
             stream,
             initialSizeOfPayloadInBytes: 0,
             out var result);

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/WriteDirectlyToTransportSinkTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/WriteDirectlyToTransportSinkTests.cs
@@ -132,6 +132,62 @@ public class WriteDirectlyToTransportSinkTests
         Assert.Equal("\"item4\"\n\"item5\"\n", Encoding.ASCII.GetString(data));
     }
 
+    [Fact]
+    public void SingleItem_MaxPayloadSize_Test()
+    {
+        var maxPayloadSizeInBytes = 100;
+
+        var transport = new TestTransport();
+
+        using var sink = new WriteDirectlyToTransportSink<string>(
+            new TestSerializer(maxPayloadSizeInBytes),
+            transport);
+
+        var items = new string[]
+        {
+            new('a', maxPayloadSizeInBytes - 3), // 3 characters added for "s and \n in JSON
+        };
+
+        var numberOfRecordsWritten = sink.Write(Resource.Empty, new(items, items.Length));
+
+        Assert.Equal(0, sink.Buffer.Length);
+        Assert.Equal(0, numberOfRecordsWritten);
+        Assert.Empty(transport.ExportedData);
+    }
+
+    [Fact]
+    public void MultipleItems_MaxPayloadSize_Test()
+    {
+        var expectedPayloadSizeInBytes = "\"item1\"\n\"item2\"\n".Length;
+
+        var maxPayloadSizeInBytes = 100;
+
+        var transport = new TestTransport();
+
+        using var sink = new WriteDirectlyToTransportSink<string>(
+            new TestSerializer(maxPayloadSizeInBytes),
+            transport);
+
+        var items = new string[]
+        {
+            "item1",
+            new('a', maxPayloadSizeInBytes - 3), // 3 characters added for "s and \n in JSON
+            "item3",
+        };
+
+        var numberOfRecordsWritten = sink.Write(Resource.Empty, new(items, items.Length));
+
+        Assert.Equal(0, sink.Buffer.Length);
+        Assert.Equal(2, numberOfRecordsWritten);
+        Assert.Single(transport.ExportedData);
+
+        var data = transport.ExportedData[0];
+
+        Assert.NotNull(data);
+        Assert.Equal(expectedPayloadSizeInBytes, data.Length);
+        Assert.Equal("\"item1\"\n\"item3\"\n", Encoding.ASCII.GetString(data));
+    }
+
     private sealed class TestSerializer : CommonSchemaJsonSerializer<string>
     {
         public TestSerializer(


### PR DESCRIPTION
## Changes

* Change `WriteDirectlyToTransportSink` logic so it sends multiple requests to OneCollector until the batch is drained
* Update `CommonSchemaJsonSerializer` logic to drop any individual item which cannot fit into the max payload size

## Details

OneCollector is strict about the amount of data it will process. Given a batch `OneCollectorExporter` will serialize items until it reaches the max payload size. The previous behavior was it would leave anything remaining in the batch expecting to process those records as part of the next batch. This leads to dropped telemetry though because [BatchExportProcessor disposes\drains the batch after calling the exporter](https://github.com/open-telemetry/opentelemetry-dotnet/blob/32c64d04defb5c92d056fd8817638151168b10da/src/OpenTelemetry/BatchExportProcessor.cs#L266). The fix for this is `OneCollectorExporter` will now just make multiple transmissions until it has drained the batch itself. It will now also drop any single item which itself cannot fit into the max payload size.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
