### PR TITLE
Add component status and owners information for individual projects

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run redis docker-compose
-        run: docker-compose --file=test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
+      - name: Run redis docker compose
+        run: docker compose --file=test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
 
   kafka-integration-test:
     if: inputs.job == 'all' || inputs.job == 'kafka-integration-test'
@@ -31,5 +31,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run kafka docker-compose
-        run: docker-compose --file=test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
+      - name: Run kafka docker compose
+        run: docker compose --file=test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ guidelines](./CONTRIBUTING.md).
 ## Project status
 
 This repository is a collection of unrelated components maintained by different
-authors and groups. As such components shipped from this repository (via
-[Nuget](https://www.nuget.org/))may be at different stability/maturity levels.
-The status for each individual component SHOULD be mentioned in its respective
-`README.md` file and SHOULD fall into one of the following categories:
+authors and groups. As such, components shipped from this repository (via
+[Nuget](https://www.nuget.org/)) may be at different stability/maturity levels.
+The status for each individual component is mentioned in its respective
+`README.md` file and will fall into one of the following categories:
 
 ### Development
 
@@ -35,12 +35,12 @@ authors of this component would welcome your feedback. Bugs and performance
 problems should be reported, but component owners might not work on them right
 away. Components can go through significant breaking changes and there are no
 backward compatibility guarantees. Package versions in this status have the
-`-alpha` extension.
+`-alpha` extension (eg: opentelemetry.exporter.abc-1.0.0-alpha.1).
 
 ### Beta
 
 Same as Alpha, but comparatively more stable. Package versions in this status
-have the `-beta` extension.
+have the `-beta` extension (eg: opentelemetry.exporter.abc-1.0.0-beta.1).
 
 ### Release candidate
 
@@ -48,7 +48,7 @@ Component is close to stability. There may be minimal breaking changes between
 releases. A component at this stage is expected to have had exposure to
 non-critical production workloads already during its **Alpha/Beta** phase(s),
 making it suitable for broader usage. Package versions in this status have the
-`-rc` extension.
+`-rc` extension (eg: opentelemetry.exporter.abc-1.0.0-rc.1).
 
 ### Stable
 
@@ -63,8 +63,8 @@ This repository is maintained by [.NET Contrib maintainers](#maintainers) team
 and [.NET Contrib approvers](#approvers) who can help with reviews and code
 approval. However, as individual components are developed by numerous
 contributors, approvers and maintainers are not expected to directly contribute
-to every component. The list of owners for each component can be found
-[here](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/.github/component_owners.yml).
+to every component. The list of owners for each component can be found in
+component's `Readme.md` file.
 
 ### Triagers
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ guidelines](./CONTRIBUTING.md).
 
 ## Project status
 
-Components shipped from this repository are at different maturity levels. The
-status for each component is mentioned in their respective Readme files. The
-component status falls under one of the following categories:
+This repository is a collection of unrelated components maintained by different
+authors and groups. As such components shipped from this repository (via
+[Nuget](https://www.nuget.org/))may be at different stability/maturity levels.
+The status for each individual component SHOULD be mentioned in its respective
+`README.md` file and SHOULD fall into one of the following categories:
 
 ### Development
 
-Component is currently in development and is not available on
+Component is currently in development and is NOT available on
 [Nuget](https://www.nuget.org/).
 
 ### Alpha
@@ -32,29 +34,28 @@ The component is ready to be used for limited non-critical workloads and the
 authors of this component would welcome your feedback. Bugs and performance
 problems should be reported, but component owners might not work on them right
 away. Components can go through significant breaking changes and there are no
-backward compatibility guarantees. Package in this status is appended by
+backward compatibility guarantees. Package versions in this status have the
 `-alpha` extension.
 
 ### Beta
 
-Same as Alpha, but comparatively more stable. Package in this status is appended
-by `-beta` extension.
+Same as Alpha, but comparatively more stable. Package versions in this status
+have the `-beta` extension.
 
-### RC
+### Release candidate
 
-Component is close to stability. There might be minimal breaking changes between
+Component is close to stability. There may be minimal breaking changes between
 releases. A component at this stage is expected to have had exposure to
-non-critical production workloads already during its **Alpha/Beta** phase,
-making it suitable for broader usage. Package in this status is appended by
+non-critical production workloads already during its **Alpha/Beta** phase(s),
+making it suitable for broader usage. Package versions in this status have the
 `-rc` extension.
 
 ### Stable
 
 The component is ready for general availability. Bugs and performance problems
-should be reported and there's an expectation that the component owners will
-work on them. Breaking changes, including configuration options and the
-component's output are not expected to happen without prior notice, unless under
-special circumstances such as security related fixes.
+should be reported and the component owner(s) SHOULD triage and/or resolve them
+in a timely manner. The package versions MUST follow [SemVer
+V2](https://semver.org/spec/v2.0.0.html).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ projects.
 For information on how to contribute, consult [the contributing
 guidelines](./CONTRIBUTING.md).
 
-### Project status
+## Project status
 
 Components shipped from this repository are at different maturity levels. The
 status for each component is mentioned in their respective Readme files. The
@@ -26,7 +26,7 @@ component status falls under one of the following categories:
 Component is currently in development and is not available on
 [Nuget](https://www.nuget.org/).
 
-#### Alpha
+### Alpha
 
 The component is ready to be used for limited non-critical workloads and the
 authors of this component would welcome your feedback. Bugs and performance
@@ -35,12 +35,12 @@ away. Components can go through significant breaking changes and there are no
 backward compatibility guarantees. Package in this status is appended by
 `-alpha` extension.
 
-#### Beta
+### Beta
 
 Same as Alpha, but comparatively more stable. Package in this status is appended
 by `-beta` extension.
 
-#### RC
+### RC
 
 Component is close to stability. There might be minimal breaking changes between
 releases. A component at this stage is expected to have had exposure to
@@ -48,7 +48,7 @@ non-critical production workloads already during its **Alpha/Beta** phase,
 making it suitable for broader usage. Package in this status is appended by
 `-rc` extension.
 
-#### Stable
+### Stable
 
 The component is ready for general availability. Bugs and performance problems
 should be reported and there's an expectation that the component owners will

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ component status falls under one of the following categories:
 Component is currently in development and is not available on
 [Nuget](https://www.nuget.org/).
 
-### Alpha
+#### Alpha
 
 The component is ready to be used for limited non-critical workloads and the
 authors of this component would welcome your feedback. Bugs and performance
@@ -35,12 +35,12 @@ away. Components can go through significant breaking changes and there are no
 backward compatibility guarantees. Package in this status is appended by
 `-alpha` extension.
 
-### Beta
+#### Beta
 
 Same as Alpha, but comparatively more stable. Package in this status is appended
 by `-beta` extension.
 
-### RC
+#### RC
 
 Component is close to stability. There might be minimal breaking changes between
 releases. A component at this stage is expected to have had exposure to
@@ -48,7 +48,7 @@ non-critical production workloads already during its **Alpha/Beta** phase,
 making it suitable for broader usage. Package in this status is appended by
 `-rc` extension.
 
-### Stable
+#### Stable
 
 The component is ready for general availability. Bugs and performance problems
 should be reported and there's an expectation that the component owners will

--- a/README.md
+++ b/README.md
@@ -15,6 +15,47 @@ projects.
 For information on how to contribute, consult [the contributing
 guidelines](./CONTRIBUTING.md).
 
+### Project status
+
+Components shipped from this repository are at different maturity levels. The
+status for each component is mentioned in their respective Readme files. The
+component status falls under one of the following categories:
+
+### Development
+
+Component is currently in development and is not available on
+[Nuget](https://www.nuget.org/).
+
+### Alpha
+
+The component is ready to be used for limited non-critical workloads and the
+authors of this component would welcome your feedback. Bugs and performance
+problems should be reported, but component owners might not work on them right
+away. Components can go through significant breaking changes and there are no
+backward compatibility guarantees. Package in this status is appended by
+`-alpha` extension.
+
+### Beta
+
+Same as Alpha, but comparatively more stable. Package in this status is appended
+by `-beta` extension.
+
+### RC
+
+Component is close to stability. There might be minimal breaking changes between
+releases. A component at this stage is expected to have had exposure to
+non-critical production workloads already during its **Alpha/Beta** phase,
+making it suitable for broader usage. Package in this status is appended by
+`-rc` extension.
+
+### Stable
+
+The component is ready for general availability. Bugs and performance problems
+should be reported and there's an expectation that the component owners will
+work on them. Breaking changes, including configuration options and the
+component's output are not expected to happen without prior notice, unless under
+special circumstances such as security related fixes.
+
 ## Support
 
 This repository is maintained by [.NET Contrib maintainers](#maintainers) team

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -1,5 +1,10 @@
 # Geneva Exporter for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Stable](..\..\Readme.md#stable)|
+| Code Owners   |  [@cijothomas](https://github.com/cijothomas),  [@codeblanch](https://github.com/codeblanch),  [@reyang](https://github.com/reyang),  [@utpilla](https://github.com/utpilla),  [@Yun-Ting](https://github.com/Yun-Ting)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Exporter.Geneva)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Exporter.Geneva)

--- a/src/OpenTelemetry.Exporter.InfluxDB/README.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/README.md
@@ -1,5 +1,10 @@
 # InfluxDB Exporter for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Alpha](..\..\Readme.md#alpha)|
+| Code Owners   |  [@havret](https://github.com/havret)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.InfluxDB)](https://www.nuget.org/packages/OpenTelemetry.Exporter.InfluxDB)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.InfluxDB)](https://www.nuget.org/packages/OpenTelemetry.Exporter.InfluxDB)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Exporter.InfluxDB)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Exporter.InfluxDB)

--- a/src/OpenTelemetry.Exporter.Instana/README.md
+++ b/src/OpenTelemetry.Exporter.Instana/README.md
@@ -1,5 +1,10 @@
 # Instana Exporter for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Stable](..\..\Readme.md#stable)|
+| Code Owners   |  [@zivaninstana](https://github.com/zivaninstana)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Instana)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Instana)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Instana)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Instana)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Exporter.Instana)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Exporter.Instana)

--- a/src/OpenTelemetry.Exporter.OneCollector/README.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/README.md
@@ -1,5 +1,10 @@
 # OneCollector Exporter for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Stable](..\..\Readme.md#stable)|
+| Code Owners   |  [@codeblanch](https://github.com/codeblanch), [@reyang](https://github.com/reyang)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.OneCollector)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OneCollector)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.OneCollector)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OneCollector)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Exporter.OneCollector)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Exporter.OneCollector)

--- a/src/OpenTelemetry.Exporter.Stackdriver/README.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/README.md
@@ -1,5 +1,10 @@
 # Stackdriver Exporter for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@SergeyKanzhelev](https://github.com/SergeyKanzhelev)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Stackdriver)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Stackdriver)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Stackdriver)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Stackdriver)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Exporter.Stackdriver)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Exporter.Stackdriver)

--- a/src/OpenTelemetry.Extensions.AWS/README.md
+++ b/src/OpenTelemetry.Extensions.AWS/README.md
@@ -1,5 +1,10 @@
 # Tracing with AWS Distro for OpenTelemetry .Net SDK
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@srprash](https://github.com/srprash), [@ppittle](https://github.com/ppittle)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions.AWS)](https://www.nuget.org/packages/OpenTelemetry.Extensions.AWS)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions.AWS)](https://www.nuget.org/packages/OpenTelemetry.Extensions.AWS)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Extensions.AWS)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Extensions.AWS)

--- a/src/OpenTelemetry.Extensions.Enrichment/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/README.md
@@ -1,5 +1,10 @@
 # OpenTelemetry .NET SDK telemetry enrichment framework
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Development](..\..\Readme.md#development)|
+| Code Owners   |  |
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions.Enrichment)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Enrichment)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions.Enrichment)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Enrichment)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Extensions.Enrichment)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Extensions.Enrichment)

--- a/src/OpenTelemetry.Extensions.Enrichment/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Development](..\..\Readme.md#development)|
-| Code Owners   |  |
+| Code Owners   |  [@xakep139](https://github.com/xakep139)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions.Enrichment)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Enrichment)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions.Enrichment)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Enrichment)

--- a/src/OpenTelemetry.Extensions/README.md
+++ b/src/OpenTelemetry.Extensions/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@codeblanch](https://github.com/codeblanch), [@mikegoldsmith](https://github.com/mikegoldsmith)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)

--- a/src/OpenTelemetry.Extensions/README.md
+++ b/src/OpenTelemetry.Extensions/README.md
@@ -1,5 +1,10 @@
 # OpenTelemetry .NET SDK preview features and extensions
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Extensions)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Extensions)

--- a/src/OpenTelemetry.Extensions/README.md
+++ b/src/OpenTelemetry.Extensions/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)

--- a/src/OpenTelemetry.Instrumentation.AWS/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/README.md
@@ -1,5 +1,10 @@
 # AWS SDK client instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@srprash](https://github.com/srprash), [@ppittle](https://github.com/ppittle)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AWS)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWS)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AWS)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWS)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.AWS)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.AWS)

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@srprash](https://github.com/srprash), [@ppittle](https://github.com/ppittle)|
+| Code Owners   |  [@rypdal](https://github.com/rypdal), [@Oberon00](https://github.com/Oberon00), [@ppittle](https://github.com/ppittle)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AWSLambda)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AWSLambda)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda)

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
@@ -1,5 +1,10 @@
 # AWS OTel .NET SDK for Lambda
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@srprash](https://github.com/srprash), [@ppittle](https://github.com/ppittle)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AWSLambda)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AWSLambda)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.AWSLambda)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.AWSLambda)

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
@@ -1,5 +1,10 @@
 # ASP.NET Telemetry HttpModule for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.AspNet)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.AspNet)

--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNet)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNet)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet)

--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -1,5 +1,10 @@
 # ASP.NET Instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNet)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNet)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.AspNet)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.AspNet)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Stable](..\..\Readme.md#stable)|
-| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNetCore.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNetCore.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -1,5 +1,10 @@
 # ASP.NET Core Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Stable](..\..\Readme.md#stable)|
+| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNetCore.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNetCore.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.AspNetCore)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.AspNetCore)

--- a/src/OpenTelemetry.Instrumentation.Cassandra/README.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/README.md
@@ -1,5 +1,10 @@
 # Cassandra Instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@xsoheilalizadeh](https://github.com/xsoheilalizadeh)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Cassandra)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Cassandra)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Cassandra)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Cassandra)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Cassandra)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Cassandra)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
@@ -1,5 +1,10 @@
 # Confluent.Kafka client instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Development](..\..\Readme.md#development)|
+| Code Owners   |  [@g7ed6e](https://github.com/g7ed6e)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.ConfluentKafka)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.ConfluentKafka)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.ConfluentKafka)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.ConfluentKafka)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.ConfluentKafka)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.ConfluentKafka)

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/README.md
@@ -1,5 +1,10 @@
 # Elasticsearch Client Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@ejsmith](https://github.com/ejsmith)|
+
 ## NEST/Elasticsearch.Net
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.ElasticsearchClient)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.ElasticsearchClient)

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/README.md
@@ -1,5 +1,10 @@
 # EntityFrameworkCore Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   ||
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.EntityFrameworkCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EntityFrameworkCore)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.EntityFrameworkCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EntityFrameworkCore)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.EntityFrameworkCore)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.EntityFrameworkCore)

--- a/src/OpenTelemetry.Instrumentation.EventCounters/README.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/README.md
@@ -1,5 +1,10 @@
 # EventCounters Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Alpha](..\..\Readme.md#alpha)|
+| Code Owners   |  [@hananiel](https://github.com/hananiel), [@mic-max](https://github.com/mic-max)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.EventCounters)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EventCounters)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.EventCounters)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EventCounters)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.EventCounters)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.EventCounters)

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@IliaBrahinets](https://github.com/IliaBrahinets), [@pcwiese](https://github.com/pcwieserajkumar-rangaraj)|
+| Code Owners   |  [@IliaBrahinets](https://github.com/IliaBrahinets), [@pcwiese](https://github.com/pcwiese)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.GrpcCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcCore)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.GrpcCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcCore)

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/README.md
@@ -1,5 +1,10 @@
 # gRPC Core-based Client and Server Interceptors for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@IliaBrahinets](https://github.com/IliaBrahinets), [@pcwiese](https://github.com/pcwieserajkumar-rangaraj)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.GrpcCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcCore)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.GrpcCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcCore)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.GrpcCore)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.GrpcCore)

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.GrpcNetClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcNetClient)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.GrpcNetClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcNetClient)

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
@@ -1,5 +1,10 @@
 # Grpc.Net.Client Instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.GrpcNetClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcNetClient)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.GrpcNetClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcNetClient)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.GrpcNetClient)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.GrpcNetClient)

--- a/src/OpenTelemetry.Instrumentation.Hangfire/README.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/README.md
@@ -1,5 +1,10 @@
 # Hangfire Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@fred2u](https://github.com/fred2u)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Hangfire)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Hangfire)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Hangfire)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Hangfire)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Hangfire)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Hangfire)

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#stable)|
-| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Http.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Http.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http)

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -1,5 +1,10 @@
 # HttpClient and HttpWebRequest instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#stable)|
+| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Http.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Http.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Http)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Http)

--- a/src/OpenTelemetry.Instrumentation.Owin/README.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/README.md
@@ -1,5 +1,10 @@
 # OWIN Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [RC](..\..\Readme.md#rc)|
+| Code Owners   |  [@codeblanch](https://github.com/codeblanch)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Owin)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Owin)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Owin)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Owin)

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -1,5 +1,10 @@
 # Process Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@Yun-Ting](https://github.com/Yun-Ting)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Process)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Process)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Process)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Process)

--- a/src/OpenTelemetry.Instrumentation.Quartz/README.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/README.md
@@ -1,5 +1,10 @@
 # QuartzNET Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@maldago](https://github.com/maldago)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Quartz)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Quartz)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Quartz)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Quartz)

--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -1,5 +1,10 @@
 # Runtime Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Stable](..\..\Readme.md#beta)|
+| Code Owners   |  [@twenzel](https://github.com/twenzel), [@xiang17](https://github.com/xiang17)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Runtime)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Runtime)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Runtime)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Runtime)

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.SqlClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.SqlClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient)

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -1,5 +1,10 @@
 # SqlClient Instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
+
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.SqlClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.SqlClient.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.SqlClient)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.SqlClient)

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
@@ -1,5 +1,10 @@
 # StackExchange.Redis Instrumentation for OpenTelemetry
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@matt-hensley](https://github.com/matt-hensley)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.StackExchangeRedis)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.StackExchangeRedis)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.StackExchangeRedis)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.StackExchangeRedis)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.StackExchangeRedis)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.StackExchangeRedis)

--- a/src/OpenTelemetry.Instrumentation.Wcf/README.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/README.md
@@ -1,5 +1,10 @@
 # WCF Instrumentation for OpenTelemetry .NET
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [RC](..\..\Readme.md#rc)|
+| Code Owners   |  [@codeblanch](https://github.com/codeblanch)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Wcf)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Wcf/)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Wcf)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Wcf/)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Instrumentation.Wcf)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Instrumentation.Wcf)

--- a/src/OpenTelemetry.PersistentStorage.Abstractions/README.md
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/README.md
@@ -1,5 +1,10 @@
 # Persistent Storage Abstractions
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Stable](..\..\Readme.md#stable)|
+| Code Owners   |  [@vishweshbankwar](https://github.com/vishweshbankwar)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.PersistentStorage.Abstractions)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.Abstractions)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.PersistentStorage.Abstractions)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.Abstractions)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-PersistentStorage)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-PersistentStorage)

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/README.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/README.md
@@ -1,5 +1,10 @@
 # Persistent Storage file based implementation
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Stable](..\..\Readme.md#stable)|
+| Code Owners   |  [@vishweshbankwar](https://github.com/vishweshbankwar)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.PersistentStorage.FileSystem)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.FileSystem)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.PersistentStorage.FileSystem)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.FileSystem)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-PersistentStorage)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-PersistentStorage)

--- a/src/OpenTelemetry.Resources.AWS/README.md
+++ b/src/OpenTelemetry.Resources.AWS/README.md
@@ -1,5 +1,10 @@
 # AWS Resource Detectors
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@srprash](https://github.com/srprash), [@ppittle](https://github.com/ppittle)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.AWS)](https://www.nuget.org/packages/OpenTelemetry.Resources.AWS)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.AWS)](https://www.nuget.org/packages/OpenTelemetry.Resources.AWS)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.AWS)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.AWS)

--- a/src/OpenTelemetry.Resources.Azure/README.md
+++ b/src/OpenTelemetry.Resources.Azure/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](..\..\Readme.md#beta)|
-| Code Owners   |  [@vibankwa](https://github.com/vishweshbankwar), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj)|
+| Code Owners   |  [@vishweshbankwar](https://github.com/vishweshbankwar), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Azure)](https://www.nuget.org/packages/OpenTelemetry.Resources.Azure)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Azure)](https://www.nuget.org/packages/OpenTelemetry.Resources.Azure)

--- a/src/OpenTelemetry.Resources.Azure/README.md
+++ b/src/OpenTelemetry.Resources.Azure/README.md
@@ -1,5 +1,10 @@
 # Resource Detectors for Azure cloud environments
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@vibankwa](https://github.com/vishweshbankwar), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Azure)](https://www.nuget.org/packages/OpenTelemetry.Resources.Azure)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Azure)](https://www.nuget.org/packages/OpenTelemetry.Resources.Azure)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.Azure)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.Azure)

--- a/src/OpenTelemetry.Resources.Container/README.md
+++ b/src/OpenTelemetry.Resources.Container/README.md
@@ -1,5 +1,10 @@
 # Container Resource Detectors
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@iskiselev](https://github.com/iskiselev)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Container)](https://www.nuget.org/packages/OpenTelemetry.Resources.Container)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Container)](https://www.nuget.org/packages/OpenTelemetry.Resources.Container)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.Container)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.Container)

--- a/src/OpenTelemetry.Resources.Gcp/README.md
+++ b/src/OpenTelemetry.Resources.Gcp/README.md
@@ -1,5 +1,10 @@
 # Resource Detectors for Google Cloud Platform environments
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Development](..\..\Readme.md#development)|
+| Code Owners   |  [@matt-hensley](https://github.com/matt-hensley), [@pyohannes](https://github.com/pyohannes)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Gcp)](https://www.nuget.org/packages/OpenTelemetry.Resources.Gcp)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Gcp)](https://www.nuget.org/packages/OpenTelemetry.Resources.Gcp)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.Gcp)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.Gcp)

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -1,5 +1,10 @@
 # Host Resource Detectors
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Host)](https://www.nuget.org/packages/OpenTelemetry.Resources.Host)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Host)](https://www.nuget.org/packages/OpenTelemetry.Resources.Host)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.Host)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.Host)

--- a/src/OpenTelemetry.Resources.OperatingSystem/README.md
+++ b/src/OpenTelemetry.Resources.OperatingSystem/README.md
@@ -1,5 +1,10 @@
 # Operating System Detectors
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Alpha](..\..\Readme.md#alpha)|
+| Code Owners   |  [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.OperatingSystem)](https://www.nuget.org/packages/OpenTelemetry.Resources.OperatingSystem)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.OperatingSystem)](https://www.nuget.org/packages/OpenTelemetry.Resources.OperatingSystem)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.OperatingSystem)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.OperatingSystem)

--- a/src/OpenTelemetry.Resources.Process/README.md
+++ b/src/OpenTelemetry.Resources.Process/README.md
@@ -1,5 +1,10 @@
 # Process Resource Detectors
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Process)](https://www.nuget.org/packages/OpenTelemetry.Resources.Process)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Process)](https://www.nuget.org/packages/OpenTelemetry.Resources.Process)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.Process)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.Process)

--- a/src/OpenTelemetry.Resources.ProcessRuntime/README.md
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/README.md
@@ -1,5 +1,10 @@
 # Process Runtime Resource Detectors
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Beta](..\..\Readme.md#beta)|
+| Code Owners   |  [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.ProcessRuntime)](https://www.nuget.org/packages/OpenTelemetry.Resources.ProcessRuntime)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.ProcessRuntime)](https://www.nuget.org/packages/OpenTelemetry.Resources.ProcessRuntime)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.ProcessRuntime)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.ProcessRuntime)

--- a/src/OpenTelemetry.Sampler.AWS/README.md
+++ b/src/OpenTelemetry.Sampler.AWS/README.md
@@ -1,5 +1,10 @@
 # AWS X-Ray Remote Sampler
 
+| Status        |           |
+| ------------- |-----------|
+| Stability     |  [Alpha](..\..\Readme.md#alpha)|
+| Code Owners   |  [@srprash](https://github.com/srprash), [@ppittle](https://github.com/ppittle)|
+
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Sampler.AWS)](https://www.nuget.org/packages/OpenTelemetry.Sampler.AWS)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Sampler.AWS)](https://www.nuget.org/packages/OpenTelemetry.Sampler.AWS)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Sampler.AWS)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Sampler.AWS)


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

* Added project status section in the main Readme for clarifying project status and definitions for alpha, beta, rc and stable versions.
* Updates individual readme to specify the status and individual owners (currently it is not easy to look up the owners).

if the direction looks good, will update the rest of the projects as well. This is manual right now but can be automated later.

Borrowed the idea and some content from https://github.com/open-telemetry/opentelemetry-collector-contrib

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
