### PR TITLE
add http method tag to sampler

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -66,9 +66,10 @@ internal static class ActivityHelper
         KeyValuePair<string, object?>[]? tags;
         if (context.Request?.Unvalidated?.Path is string path)
         {
-            tags = cachedTagsStorage ??= new KeyValuePair<string, object?>[1];
+            tags = cachedTagsStorage ??= new KeyValuePair<string, object?>[2];
 
             tags[0] = new KeyValuePair<string, object?>("url.path", path);
+            tags[1] = new KeyValuePair<string, object?>("http.request.method", path);
         }
         else
         {
@@ -80,6 +81,7 @@ internal static class ActivityHelper
         if (tags is not null)
         {
             tags[0] = default;
+            tags[1] = default;
         }
 
         if (activity != null)


### PR DESCRIPTION
Fixes #
#57287
Design discussion issue #

## Changes

Added the tag `http.request.method` alongside `url.path` in #1871

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
