### PR TITLE
Request to release OpenTelemetry.Instrumentation.AWS package

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.0-beta.5
+
+Released 2024-Aug-22
+
 * BREAKING: Update the instrumentation logic to use AWS TracerProvider.
   ([#1974](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1974))
 * Add AWS metrics instrumentation.


### PR DESCRIPTION
## Changes

Requesting to release OpenTelemetry.Instrumentation.AWS which includes adding [AWS metrics instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1980) and [update the tracing instrumentation logic](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1974). 

@open-telemetry/dotnet-contrib-maintainers

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
