### PR TITLE
Awslambda instrumentation support application loadbalancer events

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Web;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Implementation;
@@ -42,6 +43,13 @@ internal class AWSLambdaHttpUtils
                 var hostHeaderV2 = AWSLambdaUtils.GetHeaderValues(requestV2, HeaderHost)?.LastOrDefault();
                 (hostName, hostPort) = GetHostAndPort(httpScheme, hostHeaderV2);
                 break;
+            case ApplicationLoadBalancerRequest albRequest:
+                httpScheme = AWSLambdaUtils.GetHeaderValues(albRequest, HeaderXForwardedProto)?.LastOrDefault();
+                httpTarget = string.Concat(albRequest.Path ?? string.Empty, GetQueryString(albRequest));
+                httpMethod = albRequest.HttpMethod;
+                var albHostHeader = AWSLambdaUtils.GetHeaderValues(albRequest, HeaderHost)?.LastOrDefault();
+                (hostName, hostPort) = GetHostAndPort(httpScheme, albHostHeader);
+                break;
             default:
                 return tags;
         }
@@ -69,6 +77,9 @@ internal class AWSLambdaHttpUtils
                 break;
             case APIGatewayHttpApiV2ProxyResponse responseV2:
                 activity.SetTag(SemanticConventions.AttributeHttpStatusCode, responseV2.StatusCode);
+                break;
+            case ApplicationLoadBalancerResponse albResponse:
+                activity.SetTag(SemanticConventions.AttributeHttpStatusCode, albResponse.StatusCode);
                 break;
         }
     }
@@ -101,6 +112,51 @@ internal class AWSLambdaHttpUtils
 
     internal static string? GetQueryString(APIGatewayHttpApiV2ProxyRequest request) =>
         string.IsNullOrEmpty(request.RawQueryString) ? string.Empty : "?" + request.RawQueryString;
+
+    internal static string? GetQueryString(ApplicationLoadBalancerRequest request)
+    {
+        // If the request has a query string value, one of the following properties will be set, depending on if
+        // "Multi value headers" is disabled on ELB Target Group.
+        if (request.QueryStringParameters != null)
+        {
+            var queryString = new StringBuilder();
+            var separator = '?';
+            foreach (var parameterKvp in request.QueryStringParameters)
+            {
+                // TODO: Check if we need to handle multiple values differently here
+                queryString.Append(separator)
+                    .Append(HttpUtility.UrlEncode(parameterKvp.Key))
+                    .Append('=')
+                    .Append(HttpUtility.UrlEncode(parameterKvp.Value));
+                separator = '&';
+            }
+
+            return queryString.ToString();
+        }
+
+        if (request.MultiValueQueryStringParameters != null)
+        {
+            var queryString = new StringBuilder();
+            var separator = '?';
+            foreach (var parameterKvp in request.MultiValueQueryStringParameters)
+            {
+                // Multiple values for the same parameter will be added to query
+                // as ampersand separated: name=value1&name=value2
+                foreach (var value in parameterKvp.Value)
+                {
+                    queryString.Append(separator)
+                        .Append(HttpUtility.UrlEncode(parameterKvp.Key))
+                        .Append('=')
+                        .Append(HttpUtility.UrlEncode(value));
+                    separator = '&';
+                }
+            }
+
+            return queryString.ToString();
+        }
+
+        return string.Empty;
+    }
 
     internal static (string? Host, int? Port) GetHostAndPort(string? httpScheme, string? hostHeader)
     {

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
@@ -59,7 +59,7 @@ The parent extraction is supported for the input types listed in the table below
 
 | Type | Parent extraction source |
 |------|--------------------------|
-| `APIGatewayProxyRequest, APIGatewayHttpApiV2ProxyRequest` | HTTP headers of the request |
+| `APIGatewayProxyRequest, APIGatewayHttpApiV2ProxyRequest`, `ApplicationLoadBalancerRequest` | HTTP headers of the request |
 | `SQSEvent` | Attributes of the last `SQSMessage` (if `SetParentFromMessageBatch` is `true`) |
 | `SNSEvent` | Attributes of the last `SNSRecord` |
 


### PR DESCRIPTION
Fixes #1981
Design discussion issue #1981

## Changes

This change adds support for extracting parent context from Lambda functions configured as targets for Application Load Balancers. It follows the conventions from API gateway request types and extracts the same headers as those requests.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
