### PR TITLE
[geneva] Add missing XML docs for public APIs

### DIFF
--- a/build/OpenTelemetryContrib.prod.ruleset
+++ b/build/OpenTelemetryContrib.prod.ruleset
@@ -9,5 +9,7 @@
     <Rule Id="SA1401" Action="None" />
     <Rule Id="SA1512" Action="None" />
     <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
@@ -3,6 +3,9 @@
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// Contains the event name export mode defintions.
+/// </summary>
 [Flags]
 public enum EventNameExportMode
 {

--- a/src/OpenTelemetry.Exporter.Geneva/ExceptionStackExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/ExceptionStackExportMode.cs
@@ -3,9 +3,19 @@
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// Contains the exception stack trace export mode defintions.
+/// </summary>
 public enum ExceptionStackExportMode
 {
+    /// <summary>
+    /// Exception stack traces are dropped.
+    /// </summary>
     Drop,
+
+    /// <summary>
+    /// Exception stack traces are exported as strings.
+    /// </summary>
     ExportAsString,
 
     // ExportAsArrayOfStacks - future if stacks can be exported in more structured way

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaBaseExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaBaseExporter.cs
@@ -3,7 +3,11 @@
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// GenevaExporter base class.
+/// </summary>
+/// <typeparam name="T">The type of object to be exported.</typeparam>
 public abstract class GenevaBaseExporter<T> : BaseExporter<T>
-where T : class
+    where T : class
 {
 }

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterHelperExtensions.cs
@@ -9,6 +9,9 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// Contains extension methods to register the Geneva trace exporter.
+/// </summary>
 public static class GenevaExporterHelperExtensions
 {
     /// <summary>

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -6,6 +6,9 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// Contains Geneva exporter options.
+/// </summary>
 public class GenevaExporterOptions
 {
     private IReadOnlyDictionary<string, object> _fields = new Dictionary<string, object>(1)
@@ -15,16 +18,34 @@ public class GenevaExporterOptions
 
     private IReadOnlyDictionary<string, string> _tableNameMappings;
 
+    /// <summary>
+    /// Gets or sets the connection string.
+    /// </summary>
     public string ConnectionString { get; set; }
 
+    /// <summary>
+    /// Gets or sets custom fields.
+    /// </summary>
     public IEnumerable<string> CustomFields { get; set; }
 
+    /// <summary>
+    /// Gets or sets the exception stack trace export mode.
+    /// </summary>
     public ExceptionStackExportMode ExceptionStackExportMode { get; set; }
 
+    /// <summary>
+    /// Gets or sets the event name export mode.
+    /// </summary>
     public EventNameExportMode EventNameExportMode { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether or not trace state should be included when exporting traces.
+    /// </summary>
     public bool IncludeTraceStateForSpan { get; set; }
 
+    /// <summary>
+    /// Gets or sets table name mappings.
+    /// </summary>
     public IReadOnlyDictionary<string, string> TableNameMappings
     {
         get => this._tableNameMappings;
@@ -72,6 +93,9 @@ public class GenevaExporterOptions
         }
     }
 
+    /// <summary>
+    /// Gets or sets prepopulated fields.
+    /// </summary>
     public IReadOnlyDictionary<string, object> PrepopulatedFields
     {
         get => this._fields;

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -8,6 +8,9 @@ using OpenTelemetry.Logs;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// An exporter for Geneva logs.
+/// </summary>
 public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
 {
     internal bool IsUsingUnixDomainSocket;
@@ -20,6 +23,10 @@ public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
 
     private readonly IDisposable exporter;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenevaLogExporter"/> class.
+    /// </summary>
+    /// <param name="options"><see cref="GenevaExporterOptions"/>.</param>
     public GenevaLogExporter(GenevaExporterOptions options)
     {
         Guard.ThrowIfNull(options);
@@ -76,11 +83,13 @@ public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
         }
     }
 
+    /// <inheritdoc/>
     public override ExportResult Export(in Batch<LogRecord> batch)
     {
         return this.exportLogRecord(in batch);
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (this.isDisposed)

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
@@ -11,9 +11,20 @@ using OpenTelemetry.Logs;
 
 namespace Microsoft.Extensions.Logging;
 
+/// <summary>
+/// Contains extension methods to register the Geneva log exporter.
+/// </summary>
 public static class GenevaLoggingExtensions
 {
-    public static OpenTelemetryLoggerOptions AddGenevaLogExporter(this OpenTelemetryLoggerOptions options, Action<GenevaExporterOptions> configure)
+    /// <summary>
+    /// Adds <see cref="GenevaLogExporter"/> to the <see cref="OpenTelemetryLoggerOptions"/>.
+    /// </summary>
+    /// <param name="options"><see cref="OpenTelemetryLoggerOptions"/>.</param>
+    /// <param name="configure">Callback action for configuring <see cref="GenevaExporterOptions"/>.</param>
+    /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
+    public static OpenTelemetryLoggerOptions AddGenevaLogExporter(
+        this OpenTelemetryLoggerOptions options,
+        Action<GenevaExporterOptions> configure)
     {
         Guard.ThrowIfNull(options);
 
@@ -31,7 +42,7 @@ public static class GenevaLoggingExtensions
     }
 
     /// <summary>
-    /// Adds Geneva exporter to the LoggerProvider.
+    /// Adds <see cref="GenevaLogExporter"/> to the <see cref="LoggerProviderBuilder"/>.
     /// </summary>
     /// <param name="builder"><see cref="LoggerProviderBuilder"/> builder to use.</param>
     /// <returns>The instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
@@ -39,7 +50,7 @@ public static class GenevaLoggingExtensions
         => AddGenevaLogExporter(builder, name: null, configureExporter: null);
 
     /// <summary>
-    /// Adds Geneva exporter to the LoggerProvider.
+    /// Adds <see cref="GenevaLogExporter"/> to the <see cref="LoggerProviderBuilder"/>.
     /// </summary>
     /// <param name="builder"><see cref="LoggerProviderBuilder"/> builder to use.</param>
     /// <param name="configureExporter">Callback action for configuring <see cref="GenevaExporterOptions"/>.</param>
@@ -48,7 +59,7 @@ public static class GenevaLoggingExtensions
         => AddGenevaLogExporter(builder, name: null, configureExporter);
 
     /// <summary>
-    /// Adds Geneva exporter to the LoggerProvider.
+    /// Adds <see cref="GenevaLogExporter"/> to the <see cref="LoggerProviderBuilder"/>.
     /// </summary>
     /// <param name="builder"><see cref="LoggerProviderBuilder"/> builder to use.</param>
     /// <param name="name">Optional name which is used when retrieving options.</param>

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
@@ -8,6 +8,9 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// An exporter for Geneva traces.
+/// </summary>
 public class GenevaTraceExporter : GenevaBaseExporter<Activity>
 {
     internal readonly bool IsUsingUnixDomainSocket;
@@ -20,6 +23,10 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
 
     private readonly IDisposable exporter;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenevaTraceExporter"/> class.
+    /// </summary>
+    /// <param name="options"><see cref="GenevaExporterOptions"/>.</param>
     public GenevaTraceExporter(GenevaExporterOptions options)
     {
         Guard.ThrowIfNull(options);
@@ -76,11 +83,13 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
         }
     }
 
+    /// <inheritdoc/>
     public override ExportResult Export(in Batch<Activity> batch)
     {
         return this.exportActivity(in batch);
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (this.isDisposed)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -39,6 +39,10 @@ public partial class GenevaMetricExporter : BaseExporter<Metric>
 
     internal Resource Resource => this.resource ??= this.ParentProvider.GetResource();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GenevaMetricExporter"/> class.
+    /// </summary>
+    /// <param name="options"><see cref="GenevaMetricExporterOptions"/>.</param>
     public GenevaMetricExporter(GenevaMetricExporterOptions options)
     {
         Guard.ThrowIfNull(options);
@@ -72,11 +76,13 @@ public partial class GenevaMetricExporter : BaseExporter<Metric>
         }
     }
 
+    /// <inheritdoc/>
     public override ExportResult Export(in Batch<Metric> batch)
     {
         return this.exportMetrics(batch);
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (this.isDisposed)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterExtensions.cs
@@ -8,6 +8,9 @@ using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// Contains extension methods to register the Geneva metrics exporter.
+/// </summary>
 public static class GenevaMetricExporterExtensions
 {
     /// <summary>

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
@@ -6,6 +6,9 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
+/// <summary>
+/// Contains Geneva metrics exporter options.
+/// </summary>
 public class GenevaMetricExporterOptions
 {
     private IReadOnlyDictionary<string, object> _prepopulatedMetricDimensions;

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>An OpenTelemetry .NET exporter that exports to local ETW or UDS</Description>
     <Authors>OpenTelemetry Authors</Authors>
-    <NoWarn>$(NoWarn),CS1591,SA1123,SA1310,CA1810,CA1822,CA2000,CA2208,SA1201,SA1202,SA1308,SA1309,SA1311,SA1402,SA1602,SA1649,OTEL1002</NoWarn>
+    <NoWarn>$(NoWarn),SA1123,SA1310,CA1810,CA1822,CA2000,CA2208,SA1201,SA1202,SA1308,SA1309,SA1311,SA1402,SA1649,OTEL1002</NoWarn>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>


### PR DESCRIPTION
## Changes

* Enable CS1591 in GenevaExporter and add missing XML docs for public APIs.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
