### PR TITLE
[repo] Always execute build-test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,6 +590,7 @@ jobs:
       lint-misspell-sanitycheck,
       detect-changes,
       lint-md,
+      lint-yml,
       lint-dotnet-format,
       build-test-exporter-geneva,
       build-test-exporter-influxdb,
@@ -633,7 +634,8 @@ jobs:
       build-test-contrib-shared-tests,
       verify-aot-compat
     ]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    runs-on: windows-latest
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
     steps:
-    - run: echo 'build complete ✓'
+    - run: |
+          if ( ${{ contains(needs.*.result, 'failure') }} == true ); then echo 'build failed ✗'; exit 1; else echo 'build complete ✓'; fi


### PR DESCRIPTION
## Changes

Always execute build-tests step. It is used to determine if all steps passed.
Before changes there were possibility to merge changes even if previous steps were failing.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
