### PR TITLE
[Instrumentation.Hangfire] NugetAudit - fix dependencies with known vulnerabilities

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 
+* Added direct reference to `Newtonsoft.Json` with minimum version of
+  `13.0.1` in response to [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
+  ([#2057](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2057))
+
 ## 1.6.0-beta.1
 
 Released 2023-Dec-20

--- a/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Hangfire.Core" Version="[1.7.0,1.9.0)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPkgVer)" />
     <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <!-- Newtonsoft.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />


### PR DESCRIPTION
Follow up to #2034

## Changes

``` 
    <!-- Newtonsoft.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
```
Changelog based on https://github.com/open-telemetry/opentelemetry-dotnet/blob/37535a5607ee7e4056c0e274ec01d1e0111a64be/src/OpenTelemetry.Exporter.Console/CHANGELOG.md#L112-L114

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
