### PR TITLE
[Instrumentation.Cassandra] NugetAudit - fix dependencies with known vulnerabilities

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 
+* Added direct reference to `Newtonsoft.Json` with minimum version of
+  `13.0.1` in response to [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
+  ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2058))
+
 ## 1.0.0-beta.1
 
 Released 2023-Mar-30

--- a/src/OpenTelemetry.Instrumentation.Cassandra/OpenTelemetry.Instrumentation.Cassandra.csproj
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/OpenTelemetry.Instrumentation.Cassandra.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="CassandraCSharpDriver" Version="$(CassandraCSharpDriverPkgVer)" />
     <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <!-- Newtonsoft.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Cassandra.Tests/OpenTelemetry.Instrumentation.Cassandra.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Cassandra.Tests/OpenTelemetry.Instrumentation.Cassandra.Tests.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingPkgVer)" />
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Follow up to #2034

## Changes

``` 
    <!-- Newtonsoft.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
```
Changelog based on https://github.com/open-telemetry/opentelemetry-dotnet/blob/37535a5607ee7e4056c0e274ec01d1e0111a64be/src/OpenTelemetry.Exporter.Console/CHANGELOG.md#L112-L114

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
