### PR TITLE
Allow skipping paths in sanity check script

### DIFF
--- a/build/scripts/sanitycheck.py
+++ b/build/scripts/sanitycheck.py
@@ -8,11 +8,20 @@ CR = b'\r'
 CRLF = b'\r\n'
 LF = b'\n'
 
+# Add paths to exclude from sanity checks here
+exclude_folders = [
+    "src/OpenTelemetry.SemanticConventions"
+]
+# Normalize paths so they work in windows/unix
+exclude_folders = [os.path.normpath(folder) for folder in exclude_folders]
+
 def sanitycheck(pattern, allow_utf8 = False, allow_eol = (CRLF, LF), indent = 1):
     error_count = 0
 
     for filename in glob.glob(pattern, recursive=True):
         if not os.path.isfile(filename):
+            continue
+        if any(filename.startswith(exclude_folder) for exclude_folder in exclude_folders):
             continue
         with open(filename, 'rb') as file:
             content = file.read()


### PR DESCRIPTION
Split from #1944 and #2040

Design discussion:

https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2040#issuecomment-2335206755

## Changes

Changes the sanitycheck python script to exclude paths from the checks. For a simple version, the directories to exclude as hardcoded. Let me know if you think this is a good start or if you want to make it more dynamic (e.g., passed via GH actions)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)

CC @cijothomas 
