### PR TITLE
Update Component Ownership for Components

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -93,21 +93,21 @@ components:
   test/OpenTelemetry.Exporter.Geneva.Benchmarks/:
     - cijothomas
     - codeblanch
+    - rajkumar-rangaraj
     - reyang
     - utpilla
-    - Yun-Ting
   test/OpenTelemetry.Exporter.Geneva.Stress/:
     - cijothomas
     - codeblanch
+    - rajkumar-rangaraj
     - reyang
     - utpilla
-    - Yun-Ting
   test/OpenTelemetry.Exporter.Geneva.Tests/:
     - cijothomas
     - codeblanch
+    - rajkumar-rangaraj
     - reyang
     - utpilla
-    - Yun-Ting
   test/OpenTelemetry.Exporter.InfluxDB.Tests/:
     - havret
   test/OpenTelemetry.Exporter.Instana.Tests/:

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -6,9 +6,9 @@ components:
   src/OpenTelemetry.Exporter.Geneva/:
     - cijothomas
     - codeblanch
+    - rajkumar-rangaraj
     - reyang
     - utpilla
-    - Yun-Ting
   src/OpenTelemetry.Exporter.InfluxDB/:
     - havret
   src/OpenTelemetry.Exporter.Instana/:
@@ -61,15 +61,15 @@ components:
   src/OpenTelemetry.Instrumentation.Wcf/:
     - codeblanch
   src/OpenTelemetry.PersistentStorage.Abstractions/:
-    - vishweshbankwar
+    - rajkumar-rangaraj
   src/OpenTelemetry.PersistentStorage.FileSystem/:
-    - vishweshbankwar
+    - rajkumar-rangaraj
   src/OpenTelemetry.Resources.AWS/:
     - srprash
     - ppittle
   src/OpenTelemetry.Resources.Azure/:
     - rajkumar-rangaraj
-    - vishweshbankwar
+    - TimothyMothra
   src/OpenTelemetry.Resources.Container/:
     - iskiselev
   src/OpenTelemetry.Resources.Host/:
@@ -161,13 +161,13 @@ components:
   test/OpenTelemetry.Instrumentation.Wcf.Tests/:
     - codeblanch
   test/OpenTelemetry.PersistentStorage.FileSystem.Tests/:
-    - vishweshbankwar
+    - rajkumar-rangaraj
   test/OpenTelemetry.Resources.AWS.Tests/:
     - srprash
     - ppittle
   test/OpenTelemetry.Resources.Azure.Tests/:
     - rajkumar-rangaraj
-    - vishweshbankwar
+    - TimothyMothra
   test/OpenTelemetry.Resources.Container.Tests/:
     - iskiselev
   test/OpenTelemetry.Resources.Host.Tests/:

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Stable](../../README.md#stable)|
-| Code Owners   |  [@cijothomas](https://github.com/cijothomas),  [@codeblanch](https://github.com/codeblanch),  [@reyang](https://github.com/reyang),  [@utpilla](https://github.com/utpilla),  [@Yun-Ting](https://github.com/Yun-Ting)|
+| Code Owners   |  [@cijothomas](https://github.com/cijothomas), [@codeblanch](https://github.com/codeblanch), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/), [@reyang](https://github.com/reyang), [@utpilla](https://github.com/utpilla)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)

--- a/src/OpenTelemetry.PersistentStorage.Abstractions/README.md
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Stable](../../README.md#stable)|
-| Code Owners   |  [@vishweshbankwar](https://github.com/vishweshbankwar)|
+| Code Owners   |  [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.PersistentStorage.Abstractions)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.Abstractions)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.PersistentStorage.Abstractions)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.Abstractions)

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/README.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Stable](../../README.md#stable)|
-| Code Owners   |  [@vishweshbankwar](https://github.com/vishweshbankwar)|
+| Code Owners   |  [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.PersistentStorage.FileSystem)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.FileSystem)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.PersistentStorage.FileSystem)](https://www.nuget.org/packages/OpenTelemetry.PersistentStorage.FileSystem)

--- a/src/OpenTelemetry.Resources.Azure/README.md
+++ b/src/OpenTelemetry.Resources.Azure/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](../../README.md#beta)|
-| Code Owners   |  [@vishweshbankwar](https://github.com/vishweshbankwar), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj)|
+| Code Owners   |  [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj), [@TimothyMothra](https://github.com/TimothyMothra)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Azure)](https://www.nuget.org/packages/OpenTelemetry.Resources.Azure)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Azure)](https://www.nuget.org/packages/OpenTelemetry.Resources.Azure)


### PR DESCRIPTION
Vishwesh has transitioned out of OpenTelemetry (see [#2041](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2041)). This PR updates the `component_owners.yml` file to replace Vishwesh’s GitHub handle with either Raj's or Mothra’s for below components. 

* `OpenTelemetry.PersistentStorage.Abstractions`
* `OpenTelemetry.PersistentStorage.FileSystem`
* `OpenTelemetry.Resources.Azure`
* `OpenTelemetry.PersistentStorage.FileSystem.Tests`
* `OpenTelemetry.Resources.Azure.Tests`

Additionally, this PR replaces Yun-Ting with Raj as the owner for the `OpenTelemetry.Exporter.Geneva` component.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
