### PR TITLE
[geneva] Remove reflection from tests to fix failures due to renames

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -15,9 +15,10 @@ namespace OpenTelemetry.Exporter.Geneva;
 
 internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
 {
+    internal static readonly ThreadLocal<byte[]> Buffer = new();
+
     private const int BUFFER_SIZE = 65360; // the maximum ETW payload (inclusive)
 
-    private static readonly ThreadLocal<byte[]> Buffer = new();
     private static readonly Action<LogRecordScope, MsgPackLogExporter> ProcessScopeForIndividualColumnsAction = OnProcessScopeForIndividualColumns;
     private static readonly Action<LogRecordScope, MsgPackLogExporter> ProcessScopeForEnvPropertiesAction = OnProcessScopeForEnvProperties;
     private static readonly string[] LogLevels = new string[7]

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackTraceExporter.cs
@@ -12,6 +12,24 @@ namespace OpenTelemetry.Exporter.Geneva;
 
 internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 {
+#if NET8_0_OR_GREATER
+    internal static readonly FrozenDictionary<string, string> CS40_PART_B_MAPPING = CS40_PART_B_MAPPING_DICTIONARY.ToFrozenDictionary();
+#else
+    internal static readonly Dictionary<string, string> CS40_PART_B_MAPPING = CS40_PART_B_MAPPING_DICTIONARY;
+#endif
+
+    internal static readonly ThreadLocal<byte[]> Buffer = new();
+
+#if NET8_0_OR_GREATER
+    internal readonly FrozenSet<string> CustomFields;
+
+    internal readonly FrozenSet<string> DedicatedFields;
+#else
+    internal readonly HashSet<string> CustomFields;
+
+    internal readonly HashSet<string> DedicatedFields;
+#endif
+
     private const int BUFFER_SIZE = 65360; // the maximum ETW payload (inclusive)
 
     private static readonly string INVALID_SPAN_ID = default(ActivitySpanId).ToHexString();
@@ -34,13 +52,6 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         ["messaging.url"] = "messagingUrl",
     };
 
-#if NET8_0_OR_GREATER
-    private static readonly FrozenDictionary<string, string> CS40_PART_B_MAPPING = CS40_PART_B_MAPPING_DICTIONARY.ToFrozenDictionary();
-#else
-    private static readonly Dictionary<string, string> CS40_PART_B_MAPPING = CS40_PART_B_MAPPING_DICTIONARY;
-#endif
-
-    private readonly ThreadLocal<byte[]> buffer = new();
     private readonly byte[] bufferPrologue;
     private readonly byte[] bufferEpilogue;
     private readonly ushort prepopulatedFieldsCount;
@@ -48,16 +59,6 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
     private readonly int mapSizePatchIndex;
     private readonly IDataTransport dataTransport;
     private readonly bool shouldIncludeTraceState;
-
-#if NET8_0_OR_GREATER
-    private readonly FrozenSet<string> customFields;
-
-    private readonly FrozenSet<string> dedicatedFields;
-#else
-    private readonly HashSet<string> customFields;
-
-    private readonly HashSet<string> dedicatedFields;
-#endif
 
     private bool isDisposed;
 
@@ -117,9 +118,9 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             }
 
 #if NET8_0_OR_GREATER
-            this.customFields = customFields.ToFrozenSet(StringComparer.Ordinal);
+            this.CustomFields = customFields.ToFrozenSet(StringComparer.Ordinal);
 #else
-            this.customFields = customFields;
+            this.CustomFields = customFields;
 #endif
 
             foreach (var name in CS40_PART_B_MAPPING.Keys)
@@ -131,9 +132,9 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             dedicatedFields.Add("otel.status_description");
 
 #if NET8_0_OR_GREATER
-            this.dedicatedFields = dedicatedFields.ToFrozenSet(StringComparer.Ordinal);
+            this.DedicatedFields = dedicatedFields.ToFrozenSet(StringComparer.Ordinal);
 #else
-            this.dedicatedFields = dedicatedFields;
+            this.DedicatedFields = dedicatedFields;
 #endif
         }
 
@@ -180,18 +181,15 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         }
 
         this.bufferPrologue = new byte[cursor - 0];
-        Buffer.BlockCopy(buffer, 0, this.bufferPrologue, 0, cursor - 0);
+        System.Buffer.BlockCopy(buffer, 0, this.bufferPrologue, 0, cursor - 0);
 
         cursor = MessagePackSerializer.Serialize(buffer, 0, new Dictionary<string, object> { { "TimeFormat", "DateTime" } });
 
         this.bufferEpilogue = new byte[cursor - 0];
-        Buffer.BlockCopy(buffer, 0, this.bufferEpilogue, 0, cursor - 0);
+        System.Buffer.BlockCopy(buffer, 0, this.bufferEpilogue, 0, cursor - 0);
     }
 
-    internal bool IsUsingUnixDomainSocket
-    {
-        get => this.dataTransport is UnixDomainSocketDataTransport;
-    }
+    internal bool IsUsingUnixDomainSocket => this.dataTransport is UnixDomainSocketDataTransport;
 
     public ExportResult Export(in Batch<Activity> batch)
     {
@@ -210,7 +208,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             try
             {
                 var cursor = this.SerializeActivity(activity);
-                this.dataTransport.Send(this.buffer.Value, cursor - 0);
+                this.dataTransport.Send(Buffer.Value, cursor - 0);
             }
             catch (Exception ex)
             {
@@ -234,7 +232,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         try
         {
             (this.dataTransport as IDisposable)?.Dispose();
-            this.buffer.Dispose();
+            Buffer.Dispose();
         }
         catch (Exception ex)
         {
@@ -246,12 +244,12 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
     internal int SerializeActivity(Activity activity)
     {
-        var buffer = this.buffer.Value;
+        var buffer = Buffer.Value;
         if (buffer == null)
         {
             buffer = new byte[BUFFER_SIZE]; // TODO: handle OOM
-            Buffer.BlockCopy(this.bufferPrologue, 0, buffer, 0, this.bufferPrologue.Length);
-            this.buffer.Value = buffer;
+            System.Buffer.BlockCopy(this.bufferPrologue, 0, buffer, 0, this.bufferPrologue.Length);
+            Buffer.Value = buffer;
         }
 
         var cursor = this.bufferPrologue.Length;
@@ -380,7 +378,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                 statusDescription = Convert.ToString(entry.Value, CultureInfo.InvariantCulture);
                 continue;
             }
-            else if (this.customFields == null || this.customFields.Contains(entry.Key))
+            else if (this.CustomFields == null || this.CustomFields.Contains(entry.Key))
             {
                 // TODO: the above null check can be optimized and avoided inside foreach.
                 cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
@@ -407,7 +405,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             foreach (ref readonly var entry in activity.EnumerateTagObjects())
             {
                 // TODO: check name collision
-                if (this.dedicatedFields.Contains(entry.Key))
+                if (this.DedicatedFields.Contains(entry.Key))
                 {
                     continue;
                 }
@@ -454,7 +452,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
         MessagePackSerializer.WriteUInt16(buffer, this.mapSizePatchIndex, cntFields);
 
-        Buffer.BlockCopy(this.bufferEpilogue, 0, buffer, cursor, this.bufferEpilogue.Length);
+        System.Buffer.BlockCopy(this.bufferEpilogue, 0, buffer, cursor, this.bufferEpilogue.Length);
         cursor += this.bufferEpilogue.Length;
 
         return cursor;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -173,7 +173,6 @@ public class GenevaLogExporterTests
             using var exporter = new MsgPackLogExporter(exporterOptions);
 
             ILogger logger;
-            ThreadLocal<byte[]> m_buffer;
             object fluentdData;
             string actualTableName;
             string defaultLogTable = "Log";
@@ -187,9 +186,8 @@ public class GenevaLogExporterTests
                         logger.LogError("this does not matter");
 
                         Assert.Single(logRecordList);
-                        m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
                         _ = exporter.SerializeLogRecord(logRecordList[0]);
-                        fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+                        fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
                         actualTableName = (fluentdData as object[])[0] as string;
                         Assert.Equal(mapping.Value, actualTableName);
                         logRecordList.Clear();
@@ -205,9 +203,8 @@ public class GenevaLogExporterTests
                 logger.LogError("this does not matter");
 
                 Assert.Single(logRecordList);
-                m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
                 _ = exporter.SerializeLogRecord(logRecordList[0]);
-                fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+                fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
                 actualTableName = (fluentdData as object[])[0] as string;
                 Assert.Equal(defaultLogTable, actualTableName);
                 logRecordList.Clear();
@@ -295,10 +292,9 @@ public class GenevaLogExporterTests
             using var exporter = new MsgPackLogExporter(exporterOptions);
 
             ILogger passThruTableMappingsLogger, userInitializedTableMappingsLogger;
-            ThreadLocal<byte[]> m_buffer;
+            ThreadLocal<byte[]> m_buffer = MsgPackLogExporter.Buffer;
             object fluentdData;
             string actualTableName;
-            m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
 
             // Verify that the category table mappings specified by the users in the Geneva Configuration are mapped correctly.
             foreach (var mapping in userInitializedCategoryToTableNameMappings)
@@ -417,8 +413,7 @@ public class GenevaLogExporterTests
             byte[] serializedData;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
-                serializedData = m_buffer.Value;
+                serializedData = MsgPackLogExporter.Buffer.Value;
             }
             else
             {
@@ -548,9 +543,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var body = GetField(fluentdData, "body");
 
             // Body gets populated as "Formatted Message" regardless of the value of `IncludeFormattedMessage`
@@ -573,9 +567,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             body = GetField(fluentdData, "body");
 
             // Body gets populated as "Formatted Message" regardless of the value of `IncludeFormattedMessage`
@@ -595,9 +588,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             body = GetField(fluentdData, "body");
 
             // Even though Formatter is null, body is populated with the state
@@ -620,9 +612,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             Assert.Equal("Value1", GetField(fluentdData, "Key1"));
 
             body = GetField(fluentdData, "body");
@@ -758,7 +749,7 @@ public class GenevaLogExporterTests
             // logRecordList should have 14 logRecord entries as there were 14 Log calls
             Assert.Equal(14, logRecordList.Count);
 
-            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
+            var m_buffer = MsgPackLogExporter.Buffer;
 
             foreach (var logRecord in logRecordList)
             {
@@ -961,9 +952,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var exceptionType = GetField(fluentdData, "env_ex_type");
             var exceptionMessage = GetField(fluentdData, "env_ex_msg");
             Assert.Equal("System.Exception", exceptionType);
@@ -1055,9 +1045,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var eventName = GetField(fluentdData, "env_name");
 
             if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsPartAName))
@@ -1077,7 +1066,7 @@ public class GenevaLogExporterTests
             logger.LogInformation(eventId: new EventId(1, "TestEventNameWithLogExtensionMethod"), "Hello from {Name} {Price}.", "tomato", 2.99);
 
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             eventName = GetField(fluentdData, "env_name");
 
             if (eventNameExportMode.HasFlag(EventNameExportMode.ExportAsPartAName))
@@ -1096,7 +1085,7 @@ public class GenevaLogExporterTests
             logger.LogInformation(eventId: 1, "Hello from {Name} {Price}.", "tomato", 2.99);
 
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             eventName = GetField(fluentdData, "env_name");
             Assert.Equal(hasTableNameMapping ? "CustomTableName" : "Log", eventName);
             #endregion
@@ -1200,9 +1189,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var signal = (fluentdData as object[])[0] as string;
             var TimeStampAndMappings = ((fluentdData as object[])[1] as object[])[0];
             var mapping = (TimeStampAndMappings as object[])[1] as Dictionary<object, object>;
@@ -1304,9 +1292,8 @@ public class GenevaLogExporterTests
 
             // VALIDATE
             Assert.Single(logRecordList);
-            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
             var TimeStampAndMappings = ((fluentdData as object[])[1] as object[])[0];
             var mapping = (TimeStampAndMappings as object[])[1] as Dictionary<object, object>;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -246,7 +246,7 @@ public class GenevaTraceExporterTests
 
             var dedicatedFields = exporter.DedicatedFields;
             var CS40_PART_B_MAPPING = MsgPackTraceExporter.CS40_PART_B_MAPPING;
-            var m_buffer = MsgPackTraceExporter.Buffer;
+            var m_buffer = exporter.Buffer;
 
             // Add an ActivityListener to serialize the activity and assert that it was valid on ActivityStopped event
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET8_0_OR_GREATER
-using System.Collections.Frozen;
-#endif
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Reflection;
@@ -246,13 +243,10 @@ public class GenevaTraceExporterTests
             }
 
             using var exporter = new MsgPackTraceExporter(exporterOptions);
-#if NET8_0_OR_GREATER
-            var dedicatedFields = typeof(MsgPackTraceExporter).GetField("m_dedicatedFields", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(exporter) as FrozenSet<string>;
-#else
-            var dedicatedFields = typeof(MsgPackTraceExporter).GetField("m_dedicatedFields", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(exporter) as HashSet<string>;
-#endif
-            var CS40_PART_B_MAPPING = typeof(MsgPackTraceExporter).GetField("CS40_PART_B_MAPPING", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as IReadOnlyDictionary<string, string>;
-            var m_buffer = typeof(MsgPackTraceExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(exporter) as ThreadLocal<byte[]>;
+
+            var dedicatedFields = exporter.DedicatedFields;
+            var CS40_PART_B_MAPPING = MsgPackTraceExporter.CS40_PART_B_MAPPING;
+            var m_buffer = MsgPackTraceExporter.Buffer;
 
             // Add an ActivityListener to serialize the activity and assert that it was valid on ActivityStopped event
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Net.Sockets;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
@@ -125,9 +124,8 @@ public class LogSerializationTests
             configureGeneva?.Invoke(exporterOptions);
 
             using var exporter = new MsgPackLogExporter(exporterOptions);
-            var m_buffer = typeof(MsgPackLogExporter).GetField("m_buffer", BindingFlags.NonPublic | BindingFlags.Static).GetValue(exporter) as ThreadLocal<byte[]>;
             _ = exporter.SerializeLogRecord(logRecordList[0]);
-            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            object fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(MsgPackLogExporter.Buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
             return GetFields(fluentdData);
         }


### PR DESCRIPTION
Follow-up to #2052

## Changes

* Fix up tests using reflection which broke due to renames

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
