### PR TITLE
[geneva] Remove remaining project-level warning suppressions and update code to be compliant

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterHelperExtensions.cs
@@ -91,7 +91,10 @@ public static class GenevaExporterHelperExtensions
 
     private static BaseProcessor<Activity> BuildGenevaTraceExporter(GenevaExporterOptions options, BatchExportActivityProcessorOptions batchActivityExportProcessor)
     {
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var exporter = new GenevaTraceExporter(options);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
         if (exporter.IsUsingUnixDomainSocket)
         {
             return new BatchActivityExportProcessor(

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -61,7 +61,7 @@ public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
                 break;
 
             default:
-                throw new ArgumentOutOfRangeException(nameof(connectionStringBuilder.Protocol));
+                throw new NotSupportedException($"Protocol '{connectionStringBuilder.Protocol}' is not supported");
         }
 
         if (useMsgPackExporter)

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLoggingExtensions.cs
@@ -30,14 +30,18 @@ public static class GenevaLoggingExtensions
 
         var genevaOptions = new GenevaExporterOptions();
         configure?.Invoke(genevaOptions);
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var exporter = new GenevaLogExporter(genevaOptions);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
         if (exporter.IsUsingUnixDomainSocket)
         {
-            return options.AddProcessor(new BatchLogRecordExportProcessor(exporter));
+            return options.AddProcessor(sp => new BatchLogRecordExportProcessor(exporter));
         }
         else
         {
-            return options.AddProcessor(new ReentrantExportProcessor<LogRecord>(exporter));
+            return options.AddProcessor(sp => new ReentrantExportProcessor<LogRecord>(exporter));
         }
     }
 
@@ -123,7 +127,10 @@ public static class GenevaLoggingExtensions
     {
         Debug.Assert(exporterOptions != null, "exporterOptions was null");
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var exporter = new GenevaLogExporter(exporterOptions);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
         if (exporter.IsUsingUnixDomainSocket)
         {
             return new BatchLogRecordExportProcessor(

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
@@ -61,7 +61,7 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
                 break;
 
             default:
-                throw new ArgumentOutOfRangeException(nameof(connectionStringBuilder.Protocol));
+                throw new NotSupportedException($"Protocol '{connectionStringBuilder.Protocol}' is not supported");
         }
 
         if (useMsgPackExporter)

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantExportProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantExportProcessor.cs
@@ -14,16 +14,7 @@ namespace OpenTelemetry.Exporter.Geneva;
 internal class ReentrantExportProcessor<T> : BaseExportProcessor<T>
     where T : class
 {
-    private static readonly Func<T, Batch<T>> CreateBatch;
-
-    static ReentrantExportProcessor()
-    {
-        var flags = BindingFlags.Instance | BindingFlags.NonPublic;
-        var ctor = typeof(Batch<T>).GetConstructor(flags, null, new Type[] { typeof(T) }, null);
-        var value = Expression.Parameter(typeof(T), null);
-        var lambda = Expression.Lambda<Func<T, Batch<T>>>(Expression.New(ctor, value), value);
-        CreateBatch = lambda.Compile();
-    }
+    private static readonly Func<T, Batch<T>> CreateBatch = BuildCreateBatchDelegate();
 
     public ReentrantExportProcessor(BaseExporter<T> exporter)
         : base(exporter)
@@ -33,5 +24,14 @@ internal class ReentrantExportProcessor<T> : BaseExportProcessor<T>
     protected override void OnExport(T data)
     {
         this.exporter.Export(CreateBatch(data));
+    }
+
+    private static Func<T, Batch<T>> BuildCreateBatchDelegate()
+    {
+        var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        var ctor = typeof(Batch<T>).GetConstructor(flags, null, new Type[] { typeof(T) }, null);
+        var value = Expression.Parameter(typeof(T), null);
+        var lambda = Expression.Lambda<Func<T, Batch<T>>>(Expression.New(ctor, value), value);
+        return lambda.Compile();
     }
 }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterExtensions.cs
@@ -67,8 +67,8 @@ public static class GenevaMetricExporterExtensions
         return new PeriodicExportingMetricReader(
             exporter,
             options.MetricExportIntervalMilliseconds)
-            {
-                TemporalityPreference = MetricReaderTemporalityPreference.Delta,
-            };
+        {
+            TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+        };
     }
 }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterExtensions.cs
@@ -59,7 +59,16 @@ public static class GenevaMetricExporterExtensions
     private static PeriodicExportingMetricReader BuildGenevaMetricExporter(GenevaMetricExporterOptions options, Action<GenevaMetricExporterOptions> configure = null)
     {
         configure?.Invoke(options);
-        return new PeriodicExportingMetricReader(new GenevaMetricExporter(options), options.MetricExportIntervalMilliseconds)
-        { TemporalityPreference = MetricReaderTemporalityPreference.Delta };
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        var exporter = new GenevaMetricExporter(options);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+        return new PeriodicExportingMetricReader(
+            exporter,
+            options.MetricExportIntervalMilliseconds)
+            {
+                TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+            };
     }
 }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
@@ -57,7 +57,7 @@ internal sealed class TlvMetricExporter : IDisposable
                 }
 
             default:
-                throw new ArgumentOutOfRangeException(nameof(connectionStringBuilder.Protocol));
+                throw new NotSupportedException($"Protocol '{connectionStringBuilder.Protocol}' is not supported");
         }
 
         unsafe

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricEtwDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricEtwDataTransport.cs
@@ -61,6 +61,8 @@ internal sealed class MetricEtwDataTransport : EventSource, IMetricDataTransport
         }
     }
 
+#pragma warning disable CA1822 // Mark members as static
+
     [Event(OtlpProtobufMetricEventId)]
     public void OtlpProtobufEvent()
     {
@@ -85,6 +87,8 @@ internal sealed class MetricEtwDataTransport : EventSource, IMetricDataTransport
     public void TLVMetricEvent()
     {
     }
+
+#pragma warning restore CA1822 // Mark members as static
 
     protected override void Dispose(bool disposing)
     {

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackLogExporter.cs
@@ -75,7 +75,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
                 this.dataTransport = new UnixDomainSocketDataTransport(unixDomainSocketPath);
                 break;
             default:
-                throw new ArgumentOutOfRangeException(nameof(connectionStringBuilder.Protocol));
+                throw new NotSupportedException($"Protocol '{connectionStringBuilder.Protocol}' is not supported");
         }
 
         if (options.PrepopulatedFields != null)

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/MsgPackTraceExporter.cs
@@ -92,7 +92,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                 this.dataTransport = new UnixDomainSocketDataTransport(unixDomainSocketPath);
                 break;
             default:
-                throw new ArgumentOutOfRangeException(nameof(connectionStringBuilder.Protocol));
+                throw new NotSupportedException($"Protocol '{connectionStringBuilder.Protocol}' is not supported");
         }
 
         // TODO: Validate custom fields (reserved name? etc).

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/EtwDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/EtwDataTransport.cs
@@ -52,10 +52,14 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
             TraceEvent = 100,
         }
 
+#pragma warning disable CA1822 // Mark members as static
+
         [Event((int)EtwEventId.TraceEvent, Version = 1, Level = EventLevel.Informational)]
         public void InformationalEvent()
         {
         }
+
+#pragma warning restore CA1822 // Mark members as static
 
         [NonEvent]
 #if NET

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/UnixDomainSocketEndPoint.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/UnixDomainSocketEndPoint.cs
@@ -27,7 +27,7 @@ internal sealed class UnixDomainSocketEndPoint : EndPoint
         this.nativePath = Encoding.UTF8.GetBytes(path);
         if (this.nativePath.Length == 0 || this.nativePath.Length > MaximumNativePathLength)
         {
-            throw new ArgumentOutOfRangeException(nameof(this.nativePath), "Path is of an invalid length for use with domain sockets.");
+            throw new ArgumentOutOfRangeException(nameof(path), "Path is of an invalid length for use with domain sockets.");
         }
     }
 

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -5,7 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>An OpenTelemetry .NET exporter that exports to local ETW or UDS</Description>
     <Authors>OpenTelemetry Authors</Authors>
-    <NoWarn>$(NoWarn),CA1810,CA1822,CA2000,CA2208</NoWarn>
     <!-- Tweak style rules for Geneva: Allow underscores in constant names and allow regions inside code blocks -->
     <NoWarn>$(NoWarn);SA1123;SA1310</NoWarn>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->

--- a/src/OpenTelemetry.Exporter.Geneva/TLDExporter/JsonSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/TLDExporter/JsonSerializer.cs
@@ -22,23 +22,8 @@ internal static class JsonSerializer
     private const int MAX_STACK_ALLOC_SIZE_IN_BYTES = 256;
 #endif
 
-    private static readonly byte[] HEX_CODE;
+    private static readonly byte[] HEX_CODE = InitializeHexCodeLookup();
     private static readonly ThreadLocal<byte[]> ThreadLocalBuffer = new();
-
-    static JsonSerializer()
-    {
-        var mapping = new byte[]
-        {
-            0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
-            0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
-        };
-        HEX_CODE = new byte[512];
-        for (int i = 0; i < 256; i++)
-        {
-            HEX_CODE[i] = mapping[i >> 4];
-            HEX_CODE[i + 256] = mapping[i & 0x0F];
-        }
-    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string SerializeNull()
@@ -341,6 +326,24 @@ internal static class JsonSerializer
 
                 return SerializeString(buffer, cursor, repr);
         }
+    }
+
+    private static byte[] InitializeHexCodeLookup()
+    {
+        var mapping = new byte[]
+        {
+            0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
+            0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        };
+
+        var hexCodeLookup = new byte[512];
+        for (int i = 0; i < 256; i++)
+        {
+            hexCodeLookup[i] = mapping[i >> 4];
+            hexCodeLookup[i + 256] = mapping[i & 0x0F];
+        }
+
+        return hexCodeLookup;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -98,7 +98,7 @@ public class GenevaTraceExporterTests
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             // no ETW session name
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Assert.Throws<NotSupportedException>(() =>
             {
                 using var exporter = new GenevaTraceExporter(new GenevaExporterOptions
                 {


### PR DESCRIPTION
## Changes

* Remove the remaining project-level warning suppressions and update code to be compliant with repo rules

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
