### PR TITLE
[geneva] Enable nullable in GenevaExporter public API files

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
@@ -1,3 +1,4 @@
+#nullable enable
 Microsoft.Extensions.Logging.GenevaLoggingExtensions
 OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.EventNameExportMode.ExportAsPartAName = 1 -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
@@ -5,14 +6,9 @@ OpenTelemetry.Exporter.Geneva.EventNameExportMode.None = 0 -> OpenTelemetry.Expo
 OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
 OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
 OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode.ExportAsString = 1 -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
-OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>
 OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>.GenevaBaseExporter() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string>
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.get -> OpenTelemetry.Exporter.Geneva.ExceptionStackExportMode
@@ -20,38 +16,43 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ExceptionStackExportMode.set
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.GenevaExporterOptions() -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.IncludeTraceStateForSpan.get -> bool
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.IncludeTraceStateForSpan.set -> void
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.set -> void
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.TableNameMappings.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.TableNameMappings.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaLogExporter
-OpenTelemetry.Exporter.Geneva.GenevaLogExporter.GenevaLogExporter(OpenTelemetry.Exporter.Geneva.GenevaExporterOptions options) -> void
 OpenTelemetry.Exporter.Geneva.GenevaMetricExporter
-OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.GenevaMetricExporter(OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions options) -> void
 OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions
 OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions
-OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.ConnectionString.get -> string
-OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.GenevaMetricExporterOptions() -> void
 OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.MetricExportIntervalMilliseconds.get -> int
 OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.MetricExportIntervalMilliseconds.set -> void
-OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.PrepopulatedMetricDimensions.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
-OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.PrepopulatedMetricDimensions.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaTraceExporter
-OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.GenevaTraceExporter(OpenTelemetry.Exporter.Geneva.GenevaExporterOptions options) -> void
 override OpenTelemetry.Exporter.Geneva.GenevaLogExporter.Dispose(bool disposing) -> void
-override OpenTelemetry.Exporter.Geneva.GenevaLogExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) -> OpenTelemetry.ExportResult
 override OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.Dispose(bool disposing) -> void
-override OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> batch) -> OpenTelemetry.ExportResult
 override OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.Dispose(bool disposing) -> void
-override OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configureExporter) -> OpenTelemetry.Logs.LoggerProviderBuilder
-static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configureExporter) -> OpenTelemetry.Logs.LoggerProviderBuilder
-static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder) -> OpenTelemetry.Logs.LoggerProviderBuilder
-static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions options, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
-static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder
-static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder
-static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~OpenTelemetry.Exporter.Geneva.GenevaBaseExporter<T>
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string>
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.PrepopulatedFields.set -> void
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.TableNameMappings.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+~OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.TableNameMappings.set -> void
+~OpenTelemetry.Exporter.Geneva.GenevaLogExporter.GenevaLogExporter(OpenTelemetry.Exporter.Geneva.GenevaExporterOptions options) -> void
+~OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.GenevaMetricExporter(OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions options) -> void
+~OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.ConnectionString.get -> string
+~OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.ConnectionString.set -> void
+~OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.PrepopulatedMetricDimensions.get -> System.Collections.Generic.IReadOnlyDictionary<string, object>
+~OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.PrepopulatedMetricDimensions.set -> void
+~OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.GenevaTraceExporter(OpenTelemetry.Exporter.Geneva.GenevaExporterOptions options) -> void
+~override OpenTelemetry.Exporter.Geneva.GenevaLogExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) -> OpenTelemetry.ExportResult
+~override OpenTelemetry.Exporter.Geneva.GenevaMetricExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> batch) -> OpenTelemetry.ExportResult
+~override OpenTelemetry.Exporter.Geneva.GenevaTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+~static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder) -> OpenTelemetry.Logs.LoggerProviderBuilder
+~static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configureExporter) -> OpenTelemetry.Logs.LoggerProviderBuilder
+~static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.LoggerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configureExporter) -> OpenTelemetry.Logs.LoggerProviderBuilder
+~static Microsoft.Extensions.Logging.GenevaLoggingExtensions.AddGenevaLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions options, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+~static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder
+~static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
+~static OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions.AddGenevaTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaExporterOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
+~static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, string name, System.Action<OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~static OpenTelemetry.Exporter.Geneva.GenevaMetricExporterExtensions.AddGenevaMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder


### PR DESCRIPTION
## Changes

* Enable nullable in GenevaExporter public APIs files to get it ready for proper annotation

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
