### PR TITLE
[Exporter.InfluxDB] NugetAudit - fix dependencies with known vulnerabilities

### DIFF
--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 
+* Updated `InfluxDB.Client` to `4.18.0` to mitigate [CVE-2024-45302](https://github.com/advisories/GHSA-4rr6-2v9v-wcpc)
+  and [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w)
+  in transitive dependencies.
+  ([#2073](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2073))
+
 ## 1.0.0-alpha.3
 
 Released 2023-Oct-13

--- a/src/OpenTelemetry.Exporter.InfluxDB/OpenTelemetry.Exporter.InfluxDB.csproj
+++ b/src/OpenTelemetry.Exporter.InfluxDB/OpenTelemetry.Exporter.InfluxDB.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="InfluxDB.Client" Version="4.12.0" />
+    <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Follow up to #2034

## Changes

Bump InfluixDB.Client to 4.18.0 to mitigate CVEs in transitive dependencies.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
