### PR TITLE
[geneva] Nullable annotations for the internal folder

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/EventNameExportMode.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 namespace OpenTelemetry.Exporter.Geneva;
 
 /// <summary>

--- a/src/OpenTelemetry.Exporter.Geneva/ExceptionStackExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/ExceptionStackExportMode.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 namespace OpenTelemetry.Exporter.Geneva;
 
 /// <summary>

--- a/src/OpenTelemetry.Exporter.Geneva/External/TraceLoggingDynamic.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/External/TraceLoggingDynamic.cs
@@ -70,6 +70,9 @@ that is larger than the buffer size of the recording session.
 Most ETW decoding tools are unable to decode an event with more than 128
 fields.
 */
+
+#nullable enable
+
 namespace OpenTelemetry.Exporter.Geneva.External;
 
 using System;
@@ -315,7 +318,7 @@ internal sealed class EventProvider
 
             // Guid = Hash[0..15], with Hash[7] tweaked approximately following RFC 4122
             byte[] guidBytes = new byte[16];
-            Buffer.BlockCopy(sha1.Hash, 0, guidBytes, 0, 16);
+            Buffer.BlockCopy(sha1.Hash!, 0, guidBytes, 0, 16);
             guidBytes[7] = (byte)((guidBytes[7] & 0x0F) | 0x50);
             return new Guid(guidBytes);
         }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Globalization;
 using OpenTelemetry.Internal;
 
@@ -67,16 +69,22 @@ internal sealed class ConnectionStringBuilder
         set => this.parts[nameof(this.EtwSession)] = value;
     }
 
-    public string PrivatePreviewEnableTraceLoggingDynamic
+    public bool PrivatePreviewEnableTraceLoggingDynamic
     {
-        get => this.ThrowIfNotExists<string>(nameof(this.PrivatePreviewEnableTraceLoggingDynamic));
-        set => this.parts[nameof(this.PrivatePreviewEnableTraceLoggingDynamic)] = value;
+        get
+        {
+            return this.parts.TryGetValue(nameof(this.PrivatePreviewEnableTraceLoggingDynamic), out var value)
+                && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
-    public string PrivatePreviewEnableOtlpProtobufEncoding
+    public bool PrivatePreviewEnableOtlpProtobufEncoding
     {
-        get => this.parts.TryGetValue(nameof(this.PrivatePreviewEnableOtlpProtobufEncoding), out var value) ? value : null;
-        set => this.parts[nameof(this.PrivatePreviewEnableOtlpProtobufEncoding)] = value;
+        get
+        {
+            return this.parts.TryGetValue(nameof(this.PrivatePreviewEnableOtlpProtobufEncoding), out var value)
+                && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     public string Endpoint
@@ -94,8 +102,7 @@ internal sealed class ConnectionStringBuilder
                 // Checking Etw first, since it's preferred for Windows and enables fail fast on Linux
                 if (this.parts.ContainsKey(nameof(this.EtwSession)))
                 {
-                    _ = this.parts.TryGetValue(nameof(this.PrivatePreviewEnableTraceLoggingDynamic), out var privatePreviewEnableTraceLoggingDynamic);
-                    if (privatePreviewEnableTraceLoggingDynamic != null && privatePreviewEnableTraceLoggingDynamic.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+                    if (this.PrivatePreviewEnableTraceLoggingDynamic)
                     {
                         return TransportProtocol.EtwTld;
                     }
@@ -127,7 +134,7 @@ internal sealed class ConnectionStringBuilder
     {
         get
         {
-            if (!this.parts.TryGetValue(nameof(this.TimeoutMilliseconds), out string value))
+            if (!this.parts.TryGetValue(nameof(this.TimeoutMilliseconds), out string? value))
             {
                 return UnixDomainSocketDataTransport.DefaultTimeoutMilliseconds;
             }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ExporterEventSource.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantActivityExportProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantActivityExportProcessor.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Diagnostics;
 
 namespace OpenTelemetry.Exporter.Geneva;

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantExportProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantExportProcessor.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -29,7 +31,8 @@ internal class ReentrantExportProcessor<T> : BaseExportProcessor<T>
     private static Func<T, Batch<T>> BuildCreateBatchDelegate()
     {
         var flags = BindingFlags.Instance | BindingFlags.NonPublic;
-        var ctor = typeof(Batch<T>).GetConstructor(flags, null, new Type[] { typeof(T) }, null);
+        var ctor = typeof(Batch<T>).GetConstructor(flags, null, new Type[] { typeof(T) }, null)
+            ?? throw new InvalidOperationException("Batch ctor accepting a single item could not be found reflectively");
         var value = Expression.Parameter(typeof(T), null);
         var lambda = Expression.Lambda<Func<T, Batch<T>>>(Expression.New(ctor, value), value);
         return lambda.Compile();

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Schema.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Schema.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 namespace OpenTelemetry.Exporter.Geneva;
 
 internal static class Schema

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/TableNameSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/TableNameSerializer.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -23,7 +25,7 @@ internal sealed class TableNameSerializer
     private static readonly StringComparer DictionaryKeyComparer = StringComparer.Ordinal;
 
     private readonly byte[] defaultTableName;
-    private readonly Dictionary<string, byte[]> tableMappings;
+    private readonly Dictionary<string, byte[]>? tableMappings;
     private readonly bool shouldPassThruTableMappings;
     private readonly object lockObject = new();
     private TableNameCacheDictionary tableNameCache = new();
@@ -35,7 +37,7 @@ internal sealed class TableNameSerializer
 
         this.defaultTableName = BuildStr8BufferForAsciiString(defaultTableName);
 
-        if (options.TableNameMappings != null)
+        if (options!.TableNameMappings != null)
         {
             var tempTableMappings = new Dictionary<string, byte[]>(options.TableNameMappings.Count, DictionaryKeyComparer);
             foreach (var kv in options.TableNameMappings)
@@ -164,7 +166,7 @@ internal sealed class TableNameSerializer
     {
         var tableNameCache = this.tableNameCache;
 
-        if (tableNameCache.TryGetValue(categoryName, out byte[] tableName))
+        if (tableNameCache.TryGetValue(categoryName, out byte[]? tableName))
         {
             return tableName;
         }
@@ -174,7 +176,7 @@ internal sealed class TableNameSerializer
 
     private byte[] ResolveTableMappingForCategoryNameRare(string categoryName)
     {
-        byte[] mappedTableName = null;
+        byte[]? mappedTableName = null;
 
         // If user configured table name mappings run resolution logic.
         if (this.tableMappings != null
@@ -182,7 +184,7 @@ internal sealed class TableNameSerializer
         {
             // Find best match if an exact match was not found.
 
-            string currentKey = null;
+            string? currentKey = null;
 
             foreach (var mapping in this.tableMappings)
             {
@@ -230,7 +232,7 @@ internal sealed class TableNameSerializer
 
             // Check if another thread added the mapping while we waited on the
             // lock.
-            if (tableNameCache.TryGetValue(categoryName, out byte[] tableName))
+            if (tableNameCache.TryGetValue(categoryName, out byte[]? tableName))
             {
                 return tableName;
             }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -53,7 +53,7 @@ public partial class GenevaMetricExporter : BaseExporter<Metric>
             DisableOpenTelemetrySdkMetricNameValidation();
         }
 
-        if (connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding != null && connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        if (connectionStringBuilder.PrivatePreviewEnableOtlpProtobufEncoding)
         {
             var otlpProtobufExporter = new OtlpProtobufMetricExporter(
                 () => { return this.Resource; },


### PR DESCRIPTION
## Changes

* Nullable annotations for the internal folder (and a couple other misc things) in GenevaExporter

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
