### PR TITLE
[Instrumentation.ConfluentKafka] adding .netstandard2.0 target framework

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net8.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.0;net462</TargetFrameworks>
     <Description>Confluent.Kafka instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;Kafka;Confluent.Kafka</PackageTags>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -27,7 +27,7 @@ public static class OpenTelemetryConsumeResultExtensions
         this ConsumeResult<TKey, TValue> consumeResult,
         out PropagationContext propagationContext)
     {
-#if NETFRAMEWORK
+#if !NET6_0_OR_GREATER
         if (consumeResult == null)
         {
             throw new ArgumentNullException(nameof(consumeResult));
@@ -75,7 +75,7 @@ public static class OpenTelemetryConsumeResultExtensions
         OpenTelemetryConsumeAndProcessMessageHandler<TKey, TValue> handler,
         CancellationToken cancellationToken)
     {
-#if NETFRAMEWORK
+#if !NET6_0_OR_GREATER
         if (consumer == null)
         {
             throw new ArgumentNullException(nameof(consumer));
@@ -89,7 +89,7 @@ public static class OpenTelemetryConsumeResultExtensions
             throw new ArgumentException("Invalid consumer type.", nameof(consumer));
         }
 
-#if NETFRAMEWORK
+#if !NET6_0_OR_GREATER
         if (handler is null)
         {
             throw new ArgumentNullException(nameof(handler));

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumerBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenTelemetryConsumerBuilderExtensions
     /// <typeparam name="TValue">Type of the value.</typeparam>
     /// <param name="consumerBuilder">The <see cref="ConsumerBuilder{TKey, TValue}"/> instance.</param>
     /// <returns>An <see cref="InstrumentedConsumerBuilder{TKey, TValue}"/> instance.</returns>
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Use 'InstrumentedConsumerBuilder<TKey, TValue>' constructor to avoid reflection.")]
 #endif
     public static InstrumentedConsumerBuilder<TKey, TValue> AsInstrumentedConsumerBuilder<TKey, TValue>(this ConsumerBuilder<TKey, TValue> consumerBuilder)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryProducerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryProducerBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenTelemetryProducerBuilderExtensions
     /// <typeparam name="TValue">Type of the value.</typeparam>
     /// <param name="producerBuilder">The <see cref="ProducerBuilder{TKey, TValue}"/> instance.</param>
     /// <returns>An <see cref="InstrumentedProducerBuilder{TKey, TValue}"/> instance.</returns>
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Use 'InstrumentedProducerBuilder<TKey, TValue>' constructor to avoid reflection.")]
 #endif
     public static InstrumentedProducerBuilder<TKey, TValue> AsInstrumentedProducerBuilder<TKey, TValue>(this ProducerBuilder<TKey, TValue> producerBuilder)


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Adds .NetStandard2.0 as a target framework for the OpenTelemetry.Instrumentation.ConfluentKafka library so that other .Net Standard libraries may use this Nuget package. This is consistent with the [TargetFrameworksForLibraries](https://github.com/open-telemetry/opentelemetry-dotnet/blob/c1a1931319281197598d009ed531475e5a914de1/build/Common.props#L31) property in the main opentelemetry-dotnet repo.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
