### PR TITLE
[repo] Add Mothra as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ component's `Readme.md` file.
 [@open-telemetry/dotnet-contrib-triagers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-triagers):
 
 * [Martin Thwaites](https://github.com/martinjt), Honeycomb
+* [Timothy "Mothra" Lee](https://github.com/TimothyMothra), Microsoft
 
 *Find more about the triager role in [community
 repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).*


### PR DESCRIPTION
@TimothyMothra has been working to establish a triage process for the components owned by the Microsoft team (Geneva Exporter, OneCollector Exporter, AspNetCore Instrumentation, Runtime Instrumentation, and PersistentStorage) using milestones (ex: [Future](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/milestone/2), [1.10.0](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/milestone/3)). Adding him as a repo triager will enable him to more easily work with the issues. This was discussed and approved on the 9/24/2024 SIG meeting.