### PR TITLE
[repo] Tag component owners on issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,5 @@
 name: Bug report
+title: "[bug] "
 description: Create a report to help us improve
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,5 @@
 name: Feature request
+title: "[feature request] "
 description: Suggest an idea for this project
 labels: ["enhancement"]
 body:

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -27,6 +27,7 @@ jobs:
 
           AddLabelsOnIssuesForComponentFoundInBody `
             -issueNumber ${{ github.event.issue.number }} `
+            -issueLabels '${{ join(github.event.issue.labels.*.name, ', ') }}' `
             -issueBody $env:ISSUE_BODY
         env:
           GH_TOKEN: ${{ github.token }}

--- a/build/scripts/add-labels.psm1
+++ b/build/scripts/add-labels.psm1
@@ -13,7 +13,7 @@ function AddLabelsOnIssuesForComponentFoundInBody {
       Return
   }
 
-  $component = $match.Groups[1].Value;
+  $component = $match.Groups[1].Value.Trim()
 
   gh issue edit $issueNumber --add-label $("comp:" + $component.ToLower())
 
@@ -22,7 +22,7 @@ function AddLabelsOnIssuesForComponentFoundInBody {
      $componentOwners = $null
 
      FindComponentOwners `
-         -component $component `
+         -component "OpenTelemetry.$component" `
          -componentOwners ([ref]$componentOwners)
 
      if ($componentOwners.Count -gt 0)

--- a/build/scripts/add-labels.psm1
+++ b/build/scripts/add-labels.psm1
@@ -1,4 +1,4 @@
-Import-Module .\build.psm1
+Import-Module $PSScriptRoot\build.psm1
 
 function AddLabelsOnIssuesForComponentFoundInBody {
   param(

--- a/build/scripts/build.psm1
+++ b/build/scripts/build.psm1
@@ -80,3 +80,62 @@ function ResolveProject {
 }
 
 Export-ModuleMember -Function ResolveProject
+
+function FindComponentOwners {
+  param(
+    [Parameter(Mandatory=$true)][string]$component,
+    [Parameter()][string]$issueNumber,
+    [Parameter()][ref]$componentOwners
+  )
+
+  $projectPath = "src/$component/$component.csproj"
+
+  if ((Test-Path -Path $projectPath) -eq $false)
+  {
+      if ([string]::IsNullOrEmpty($issueNumber) -eq $false)
+      {
+        gh issue comment $issueNumber `
+          --body "I couldn't find the project file for the requested component. Please create a new release request and select a valid component or edit the description and set a valid component."
+      }
+      Return
+  }
+
+  $projectContent = Get-Content -Path $projectPath
+
+  $match = [regex]::Match($projectContent, '<MinVerTagPrefix>(.*)<\/MinVerTagPrefix>')
+  if ($match.Success -eq $false)
+  {
+      if ([string]::IsNullOrEmpty($issueNumber) -eq $false)
+      {
+        gh issue comment $issueNumber `
+          --body "I couldn't find ``MinVerTagPrefix`` in the project file for the requested component. Please create a new release request and select a valid component or edit the description and set a valid component."
+      }
+      Return
+  }
+
+  $minVerTagPrefix = $match.Groups[1].Value
+
+  $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+
+  $componentOwnersContent = Get-Content '.github/component_owners.yml' -Raw
+
+  $componentOwners.Value = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+  foreach ($projectDir in $projectDirs)
+  {
+    $projectName = [System.IO.Path]::GetFileName($projectDir)
+
+    $match = [regex]::Match($componentOwnersContent, "src\/$projectName\/:([\w\W\s]*?)src")
+    if ($match.Success -eq $true)
+    {
+      $matches = [regex]::Matches($match.Groups[1].Value, "-\s*(.*)")
+      foreach ($match in $matches)
+      {
+        $owner = $match.Groups[1].Value
+        $_ = $componentOwners.Value.Add($owner.Trim())
+      }
+    }
+  }
+}
+
+Export-ModuleMember -Function FindComponentOwners

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -1,4 +1,4 @@
-Import-Module .\build.psm1
+Import-Module $PSScriptRoot\build.psm1
 
 function CreatePullRequestToUpdateChangelogsAndPublicApis {
   param(

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -1,3 +1,5 @@
+Import-Module .\build.psm1
+
 function CreatePullRequestToUpdateChangelogsAndPublicApis {
   param(
     [Parameter(Mandatory=$true)][string]$gitRepository,
@@ -354,48 +356,12 @@ function TagCodeOwnersOnOrRunWorkflowForRequestReleaseIssue {
       Return
   }
 
-  $projectPath = "src/$component/$component.csproj"
+  $componentOwners = $null
 
-  if ((Test-Path -Path $projectPath) -eq $false)
-  {
-      gh issue comment $issueNumber `
-        --body "I couldn't find the project file for the requested component. Please create a new release request and select a valid component or edit the description and set a valid component."
-      Return
-  }
-
-  $projectContent = Get-Content -Path $projectPath
-
-  $match = [regex]::Match($projectContent, '<MinVerTagPrefix>(.*)<\/MinVerTagPrefix>')
-  if ($match.Success -eq $false)
-  {
-      gh issue comment $issueNumber `
-        --body "I couldn't find ``MinVerTagPrefix`` in the project file for the requested component. Please create a new release request and select a valid component or edit the description and set a valid component."
-      Return
-  }
-
-  $minVerTagPrefix = $match.Groups[1].Value
-
-  $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
-
-  $componentOwnersContent = Get-Content '.github/component_owners.yml' -Raw
-
-  $componentOwners = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-
-  foreach ($projectDir in $projectDirs)
-  {
-    $projectName = [System.IO.Path]::GetFileName($projectDir)
-
-    $match = [regex]::Match($componentOwnersContent, "src\/$projectName\/:([\w\W\s]*?)src")
-    if ($match.Success -eq $true)
-    {
-      $matches = [regex]::Matches($match.Groups[1].Value, "-\s*(.*)")
-      foreach ($match in $matches)
-      {
-        $owner = $match.Groups[1].Value
-        $_ = $componentOwners.Add($owner.Trim())
-      }
-    }
-  }
+  FindComponentOwners `
+      -component $component `
+      -issueNumber $issueNumber `
+      -componentOwners ([ref]$componentOwners)
 
   $requestedByUserPermission = gh api "repos/$gitRepository/collaborators/$requestedByUserName/permission" | ConvertFrom-Json
 


### PR DESCRIPTION
Fixes #2110

## Changes

* Refactors the code/script to find owners for a given component out of `prepare-release.psm1` and drops it into `build.psm1` as a function so that it can be imported/called from `add-labels.psm1` to tag owners when bugs/feature requests are created.

## Tests

* Bug: https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/issues/49
* Feature Request: https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/issues/50
* Release Request: https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/issues/51 (special care had to be taken so these are NOT tagged by `add-labels.psm1` as `prepare-release.psm1` already has logic for working with these)

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
