### PR TITLE
[geneva] Rename metric transports

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
@@ -25,7 +25,7 @@ internal sealed class OtlpProtobufMetricExporter : IDisposable
 
         this.getResource = getResource;
 
-        this.otlpProtobufSerializer = new OtlpProtobufSerializer(MetricEtwDataTransport.Instance, connectionStringBuilder, prepopulatedMetricDimensions);
+        this.otlpProtobufSerializer = new OtlpProtobufSerializer(MetricWindowsEventTracingDataTransport.Instance, connectionStringBuilder, prepopulatedMetricDimensions);
     }
 
     public ExportResult Export(in Batch<Metric> batch)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
@@ -43,12 +43,12 @@ internal sealed class TlvMetricExporter : IDisposable
                 }
 
                 var unixDomainSocketPath = connectionStringBuilder.ParseUnixDomainSocketPath();
-                this.metricDataTransport = new MetricUnixDataTransport(unixDomainSocketPath);
+                this.metricDataTransport = new MetricUnixDomainSocketDataTransport(unixDomainSocketPath);
                 break;
             case TransportProtocol.Unspecified:
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    this.metricDataTransport = MetricEtwDataTransport.Instance;
+                    this.metricDataTransport = MetricWindowsEventTracingDataTransport.Instance;
                     break;
                 }
                 else
@@ -77,7 +77,7 @@ internal sealed class TlvMetricExporter : IDisposable
         {
             // The ETW data transport singleton on Windows should NOT be disposed.
             // On Linux, Unix Domain Socket is used and should be disposed.
-            if (this.metricDataTransport != MetricEtwDataTransport.Instance)
+            if (this.metricDataTransport != MetricWindowsEventTracingDataTransport.Instance)
             {
                 this.metricDataTransport.Dispose();
             }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
@@ -5,13 +5,13 @@ using OpenTelemetry.Exporter.Geneva.Transports;
 
 namespace OpenTelemetry.Exporter.Geneva;
 
-internal sealed class MetricUnixDataTransport : IMetricDataTransport
+internal sealed class MetricUnixDomainSocketDataTransport : IMetricDataTransport
 {
     private readonly int fixedPayloadLength;
     private readonly UnixDomainSocketDataTransport udsDataTransport;
     private bool isDisposed;
 
-    public MetricUnixDataTransport(
+    public MetricUnixDomainSocketDataTransport(
         string unixDomainSocketPath,
         int timeoutMilliseconds = UnixDomainSocketDataTransport.DefaultTimeoutMilliseconds)
     {

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricWindowsEventTracingDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricWindowsEventTracingDataTransport.cs
@@ -9,13 +9,13 @@ using System.Diagnostics.Tracing;
 namespace OpenTelemetry.Exporter.Geneva;
 
 [EventSource(Name = "OpenTelemetryGenevaMetricExporter", Guid = "{edc24920-e004-40f6-a8e1-0e6e48f39d84}")]
-internal sealed class MetricEtwDataTransport : EventSource, IMetricDataTransport
+internal sealed class MetricWindowsEventTracingDataTransport : EventSource, IMetricDataTransport
 {
     private const int OtlpProtobufMetricEventId = 81;
     private readonly int fixedPayloadEndIndex;
     private bool isDisposed;
 
-    private MetricEtwDataTransport()
+    private MetricWindowsEventTracingDataTransport()
     {
         unsafe
         {
@@ -23,7 +23,7 @@ internal sealed class MetricEtwDataTransport : EventSource, IMetricDataTransport
         }
     }
 
-    public static MetricEtwDataTransport Instance { get; private set; } = new();
+    public static MetricWindowsEventTracingDataTransport Instance { get; private set; } = new();
 
     [NonEvent]
 #if NET

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -249,11 +249,11 @@ public class GenevaMetricExporterTests
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            var singleton = MetricEtwDataTransport.Instance;
+            var singleton = MetricWindowsEventTracingDataTransport.Instance;
             this.EmitMetrics("one");
-            Assert.Equal(singleton, MetricEtwDataTransport.Instance);
+            Assert.Equal(singleton, MetricWindowsEventTracingDataTransport.Instance);
             this.EmitMetrics("two");
-            Assert.Equal(singleton, MetricEtwDataTransport.Instance);
+            Assert.Equal(singleton, MetricWindowsEventTracingDataTransport.Instance);
         }
     }
 


### PR DESCRIPTION
[Split off from #2113]

## Changes

* Rename the metric transports in GenevaExporter to prepare for addition of `MetricUnixUserEventsDataTransport`

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
