### PR TITLE
[Extensions] Replace .NET 6 target with .NET 8

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -12,7 +12,7 @@
     <Authors>OpenTelemetry Authors</Authors>
     <Copyright>Copyright The OpenTelemetry Authors</Copyright>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)/OpenTelemetryContrib.prod.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>$(NoWarn),1573,1712</NoWarn>
+    <NoWarn>$(NoWarn);1573;1712</NoWarn>
     <PackageOutputPath Condition="$(Build_ArtifactStagingDirectory) != ''">$(Build_ArtifactStagingDirectory)</PackageOutputPath>
     <!--<MinVerVerbosity>detailed</MinVerVerbosity>-->
     <PackageTags>Observability;OpenTelemetry;Monitoring;Telemetry</PackageTags>

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -16,6 +16,9 @@ rate per second. For details see
   [RateLimitingSampler](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Extensions#ratelimitingsampler).
   ([#1996](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1996))
 
+* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
+  ([#2124](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2124))
+
 ## 1.0.0-beta.5
 
 Released 2024-May-08

--- a/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
+++ b/src/OpenTelemetry.Extensions/OpenTelemetry.Extensions.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <Description>OpenTelemetry .NET SDK preview features and extensions</Description>
+    <Description>OpenTelemetry .NET SDK preview features and extensions.</Description>
     <MinVerTagPrefix>Extensions-</MinVerTagPrefix>
   </PropertyGroup>
 
-  <!--Do not run Package Baseline Validation as this package has never released a stable version.
-  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property.-->
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>

--- a/src/OpenTelemetry.Extensions/Trace/AutoFlushActivityProcessor.cs
+++ b/src/OpenTelemetry.Extensions/Trace/AutoFlushActivityProcessor.cs
@@ -39,10 +39,14 @@ internal sealed class AutoFlushActivityProcessor : BaseProcessor<Activity>
     internal AutoFlushActivityProcessor(Func<Activity, bool> predicate, int timeoutMilliseconds)
     {
         this.predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+#if NET
+        ArgumentOutOfRangeException.ThrowIfLessThan(timeoutMilliseconds, Timeout.Infinite);
+#else
         if (timeoutMilliseconds < Timeout.Infinite)
         {
             throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds));
         }
+#endif
 
         this.timeoutMilliseconds = timeoutMilliseconds;
     }

--- a/test/OpenTelemetry.Extensions.Tests/OpenTelemetry.Extensions.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Tests/OpenTelemetry.Extensions.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Unit test project for OpenTelemetry .NET SDK preview features and extensions</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <Description>Unit test project for OpenTelemetry .NET SDK preview features and extensions.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)