### PR TITLE
[Instrumentation.AWSLambda] Replace .NET 6 target with .NET 8 and add .NET Standard 2.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#2037](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2037))
 * Add HTTP server span attributes for Application Loadbalancer triggers
   ([#2033](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2033))
+* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
+  ([#2140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2140))
 
 ## 1.3.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Add HTTP server span attributes for Application Loadbalancer triggers
   ([#2033](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2033))
 * Drop support for .NET 6 as this target is no longer supported
-  and add .NET 8/NET Standard2.0 targets.
+  and add .NET 8/.NET Standard 2.0 targets.
   ([#2140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2140))
 
 ## 1.3.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -6,7 +6,8 @@
   ([#2037](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2037))
 * Add HTTP server span attributes for Application Loadbalancer triggers
   ([#2033](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2033))
-* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
+* Drop support for .NET 6 as this target is no longer supported
+  and add .NET 8/NET Standard2.0 targets.
   ([#2140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2140))
 
 ## 1.3.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSMessagingUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSMessagingUtils.cs
@@ -124,8 +124,13 @@ internal class AWSMessagingUtils
 
         var body = sqsMessage.Body;
         if (body != null &&
+#if NET
             body.TrimStart().StartsWith('{') &&
             body.Contains(SnsMessageAttributes, StringComparison.Ordinal))
+#else
+            body.TrimStart().StartsWith("{", StringComparison.Ordinal) &&
+            body.Contains(SnsMessageAttributes))
+#endif
         {
             try
             {

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Description>AWS Lambda tracing wrapper for OpenTelemetry .NET</Description>
+    <TargetFramework>net8.0</TargetFramework>
+    <Description>AWS Lambda tracing wrapper for OpenTelemetry .NET.</Description>
     <PackageTags>$(PackageTags);AWS Lambda</PackageTags>
     <MinVerTagPrefix>Instrumentation.AWSLambda-</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <Description>AWS Lambda tracing wrapper for OpenTelemetry .NET.</Description>
     <PackageTags>$(PackageTags);AWS Lambda</PackageTags>
     <MinVerTagPrefix>Instrumentation.AWSLambda-</MinVerTagPrefix>

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/OpenTelemetry.Instrumentation.AWSLambda.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/OpenTelemetry.Instrumentation.AWSLambda.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Unit test project of OpenTelemetry instrumentation for AWS Lambda</Description>
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
+    <Description>Unit test project of OpenTelemetry instrumentation for AWS Lambda.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8 and add support for .NET Standard 2.0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)