### PR TITLE
[Instrumentation.ConfluentKafka] Remove .NET 6 target and add .NET Standard 2.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [net6.0, net8.0]
+        version: [net8.0]
     steps:
       - uses: actions/checkout@v4
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -9,11 +9,11 @@
 
 Released 2024-Sep-18
 
-- Add named instrumentation support
+* Add named instrumentation support
   ([#2074](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2074))
 
 ## 0.1.0-alpha.1
 
 Released 2024-Sep-16
 
-- Initial release
+* Initial release

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Drop support for .NET 6 as this target is no longer supported.
+* Drop support for .NET 6 as this target is no longer supported
+  and add .NET Standard 2.0 target.
   ([#2142](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2142))
 
 ## 0.1.0-alpha.2

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Drop support for .NET 6 as this target is no longer supported.
+  ([#2142](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2142))
+
 ## 0.1.0-alpha.2
 
 Released 2024-Sep-18

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion);net462</TargetFrameworks>
     <Description>Confluent.Kafka instrumentation for OpenTelemetry .NET.</Description>
     <PackageTags>$(PackageTags);distributed-tracing;Kafka;Confluent.Kafka</PackageTags>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion);net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>Confluent.Kafka instrumentation for OpenTelemetry .NET.</Description>
     <PackageTags>$(PackageTags);distributed-tracing;Kafka;Confluent.Kafka</PackageTags>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net8.0;net6.0;net462</TargetFrameworks>
-    <Description>Confluent.Kafka instrumentation for OpenTelemetry .NET</Description>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <Description>Confluent.Kafka instrumentation for OpenTelemetry .NET.</Description>
     <PackageTags>$(PackageTags);distributed-tracing;Kafka;Confluent.Kafka</PackageTags>
     <IncludeSharedExceptionExtensionsSource>true</IncludeSharedExceptionExtensionsSource>
     <MinVerTagPrefix>Instrumentation.ConfluentKafka-</MinVerTagPrefix>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
-  <!--Do not run Package Baseline Validation as this package has never released a stable version.
-  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property.-->
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -27,13 +27,13 @@ public static class OpenTelemetryConsumeResultExtensions
         this ConsumeResult<TKey, TValue> consumeResult,
         out PropagationContext propagationContext)
     {
-#if NETFRAMEWORK
+#if NET
+        ArgumentNullException.ThrowIfNull(consumeResult);
+#else
         if (consumeResult == null)
         {
             throw new ArgumentNullException(nameof(consumeResult));
         }
-#else
-        ArgumentNullException.ThrowIfNull(consumeResult);
 #endif
 
         try
@@ -75,13 +75,13 @@ public static class OpenTelemetryConsumeResultExtensions
         OpenTelemetryConsumeAndProcessMessageHandler<TKey, TValue> handler,
         CancellationToken cancellationToken)
     {
-#if NETFRAMEWORK
+#if NET
+        ArgumentNullException.ThrowIfNull(consumer);
+#else
         if (consumer == null)
         {
             throw new ArgumentNullException(nameof(consumer));
         }
-#else
-        ArgumentNullException.ThrowIfNull(consumer);
 #endif
 
         if (consumer is not InstrumentedConsumer<TKey, TValue> instrumentedConsumer)
@@ -89,13 +89,13 @@ public static class OpenTelemetryConsumeResultExtensions
             throw new ArgumentException("Invalid consumer type.", nameof(consumer));
         }
 
-#if NETFRAMEWORK
-        if (handler is null)
+#if NET
+        ArgumentNullException.ThrowIfNull(handler);
+#else
+        if (handler == null)
         {
             throw new ArgumentNullException(nameof(handler));
         }
-#else
-        ArgumentNullException.ThrowIfNull(handler);
 #endif
 
         var consumeResult = instrumentedConsumer.Consume(cancellationToken);

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumerBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenTelemetryConsumerBuilderExtensions
     /// <typeparam name="TValue">Type of the value.</typeparam>
     /// <param name="consumerBuilder">The <see cref="ConsumerBuilder{TKey, TValue}"/> instance.</param>
     /// <returns>An <see cref="InstrumentedConsumerBuilder{TKey, TValue}"/> instance.</returns>
-#if !NETFRAMEWORK
+#if !NETFRAMEWORK && !NETSTANDARD
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Use 'InstrumentedConsumerBuilder<TKey, TValue>' constructor to avoid reflection.")]
 #endif
     public static InstrumentedConsumerBuilder<TKey, TValue> AsInstrumentedConsumerBuilder<TKey, TValue>(this ConsumerBuilder<TKey, TValue> consumerBuilder)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryProducerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryProducerBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenTelemetryProducerBuilderExtensions
     /// <typeparam name="TValue">Type of the value.</typeparam>
     /// <param name="producerBuilder">The <see cref="ProducerBuilder{TKey, TValue}"/> instance.</param>
     /// <returns>An <see cref="InstrumentedProducerBuilder{TKey, TValue}"/> instance.</returns>
-#if !NETFRAMEWORK
+#if !NETFRAMEWORK && !NETSTANDARD
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Use 'InstrumentedProducerBuilder<TKey, TValue>' constructor to avoid reflection.")]
 #endif
     public static InstrumentedProducerBuilder<TKey, TValue> AsInstrumentedProducerBuilder<TKey, TValue>(this ProducerBuilder<TKey, TValue> producerBuilder)

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetry.Instrumentation.ConfluentKafka.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetry.Instrumentation.ConfluentKafka.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Description>Unit test project for OpenTelemetry ConfluentKafka instrumentation</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <Description>Unit test project for OpenTelemetry ConfluentKafka instrumentation.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Remove .NET 6 target which will be very soon out of support and add support for .NET Standard 2.0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)