### PR TITLE
[PersistentStorage.FileSystem] Replace .NET 6 target with .NET 8 for test project

### DIFF
--- a/src/OpenTelemetry.PersistentStorage.FileSystem/OpenTelemetry.PersistentStorage.FileSystem.csproj
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/OpenTelemetry.PersistentStorage.FileSystem.csproj
@@ -2,15 +2,12 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks>$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry Persistent Storage</Description>
+    <NoWarn>$(NoWarn);1591</NoWarn>
     <MinVerTagPrefix>PersistentStorage-</MinVerTagPrefix>
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <NoWarn>$(NoWarn),1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/OpenTelemetry.PersistentStorage.FileSystem.Tests.csproj
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/OpenTelemetry.PersistentStorage.FileSystem.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)