### PR TITLE
[Resources.Container] Replace .NET 6 target with .NET 8 and add .NET Standard 2.0 target

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -7,7 +7,6 @@
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <NetFrameworkMinimumSupportedVersion>net462</NetFrameworkMinimumSupportedVersion>
-    <NetMinimumSupportedVersion>net6.0</NetMinimumSupportedVersion>
     <NetStandardMinimumSupportedVersion>netstandard2.0</NetStandardMinimumSupportedVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AnalysisLevel>latest-all</AnalysisLevel>

--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Drop support for .NET 6 as this target is no longer supported
+  and add .NET 8/.NET Standard 2.0 targets.
+  ([#2166](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2166))
+
 ## 1.0.0-beta.9
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
+++ b/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
@@ -152,7 +152,11 @@ internal sealed class ContainerDetector : IResourceDetector
                     {
                         containerId = GetIdFromLineV1(line);
                     }
+#if NET
                     else if (cgroupVersion == ParseMode.V2 && line.Contains(Hostname, StringComparison.Ordinal))
+#else
+                    else if (cgroupVersion == ParseMode.V2 && line.Contains(Hostname))
+#endif              
                     {
                         containerId = GetIdFromLineV2(line);
                     }

--- a/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
+++ b/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
@@ -156,7 +156,7 @@ internal sealed class ContainerDetector : IResourceDetector
                     else if (cgroupVersion == ParseMode.V2 && line.Contains(Hostname, StringComparison.Ordinal))
 #else
                     else if (cgroupVersion == ParseMode.V2 && line.Contains(Hostname))
-#endif              
+#endif
                     {
                         containerId = GetIdFromLineV2(line);
                     }

--- a/src/OpenTelemetry.Resources.Container/OpenTelemetry.Resources.Container.csproj
+++ b/src/OpenTelemetry.Resources.Container/OpenTelemetry.Resources.Container.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(NetMinimumSupportedVersion)</TargetFrameworks>
-    <Description>OpenTelemetry Extensions - Container Resource Detector from Container environment.</Description>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
+    <Description>OpenTelemetry Resource Detectors for Container environment.</Description>
     <MinVerTagPrefix>Resources.Container-</MinVerTagPrefix>
   </PropertyGroup>
 
-  <!--Do not run Package Baseline Validation as this package has never released a stable version.
-  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property.-->
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
@@ -20,4 +21,5 @@
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Resources.Container.Tests/OpenTelemetry.Resources.Container.Tests.csproj
+++ b/test/OpenTelemetry.Resources.Container.Tests/OpenTelemetry.Resources.Container.Tests.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Unit test project for Container Detector for OpenTelemetry</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
+    <Description>Unit test project for Container Detector for OpenTelemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Resources.Container\OpenTelemetry.Resources.Container.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Resources\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8 and add support for .NET Standard 2.0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)