### PR TITLE
[Resources.Gcp] Replace .NET 6 target with .NET 8

### DIFF
--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -10,6 +10,3 @@ For more details, please refer to the [README](README.md).
 
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-
-* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
-  ([#2167](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2167))

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -10,3 +10,6 @@ For more details, please refer to the [README](README.md).
 
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+
+* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
+  ([#2167](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2167))

--- a/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
+++ b/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry Resource Detectors for Google Cloud Platform environments</Description>
     <PackageTags>$(PackageTags);ResourceDetector</PackageTags>
     <MinVerTagPrefix>Resources.Gcp-</MinVerTagPrefix>
   </PropertyGroup>
 
-  <!--Do not run Package Baseline Validation as this package has never released a stable version.
-  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property.-->
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
@@ -24,4 +25,5 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
   </ItemGroup>
+
 </Project>

--- a/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
+++ b/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
-    <Description>OpenTelemetry Resource Detectors for Google Cloud Platform environments</Description>
+    <Description>OpenTelemetry Resource Detectors for Google Cloud Platform environments.</Description>
     <PackageTags>$(PackageTags);ResourceDetector</PackageTags>
     <MinVerTagPrefix>Resources.Gcp-</MinVerTagPrefix>
   </PropertyGroup>

--- a/test/OpenTelemetry.Resources.Gcp.Tests/OpenTelemetry.Resources.Gcp.Tests.csproj
+++ b/test/OpenTelemetry.Resources.Gcp.Tests/OpenTelemetry.Resources.Gcp.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Unit test project for GCP Detector for OpenTelemetry</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <Description>Unit test project for GCP Detector for OpenTelemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)