### PR TITLE
[Resources.Host] Replace .NET 6 target with .NET 8 and add .NET Standard 2.0 target

### DIFF
--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Drop support for .NET 6 as this target is no longer supported
+  and add .NET 8/.NET Standard 2.0 targets.
+  ([#2168](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2168))
+
 ## 0.1.0-beta.3
 
 Released 2024-Aug-30

--- a/src/OpenTelemetry.Resources.Host/HostDetector.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetector.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-#if NET
+#if !NETFRAMEWORK
 using System.Runtime.InteropServices;
 #endif
 using System.Text;
@@ -18,7 +18,7 @@ internal sealed class HostDetector : IResourceDetector
 {
     private const string ETCMACHINEID = "/etc/machine-id";
     private const string ETCVARDBUSMACHINEID = "/var/lib/dbus/machine-id";
-#if NET
+#if !NETFRAMEWORK
     private readonly Func<OSPlatform, bool> isOsPlatform;
 #endif
     private readonly Func<IEnumerable<string>> getFilePaths;
@@ -30,7 +30,7 @@ internal sealed class HostDetector : IResourceDetector
     /// </summary>
     public HostDetector()
         : this(
-#if NET
+#if !NETFRAMEWORK
         RuntimeInformation.IsOSPlatform,
 #endif
         GetFilePaths,
@@ -39,7 +39,7 @@ internal sealed class HostDetector : IResourceDetector
     {
     }
 
-#if NET
+#if !NETFRAMEWORK
     public HostDetector(
         Func<IEnumerable<string>> getFilePaths,
         Func<string?> getMacOsMachineId,
@@ -54,21 +54,21 @@ internal sealed class HostDetector : IResourceDetector
 #endif
 
     internal HostDetector(
-#if NET
+#if !NETFRAMEWORK
         Func<OSPlatform, bool> isOsPlatform,
 #endif
         Func<IEnumerable<string>> getFilePaths,
         Func<string?> getMacOsMachineId,
         Func<string?> getWindowsMachineId)
     {
-#if NET
+#if !NETFRAMEWORK
         Guard.ThrowIfNull(isOsPlatform);
 #endif
         Guard.ThrowIfNull(getFilePaths);
         Guard.ThrowIfNull(getMacOsMachineId);
         Guard.ThrowIfNull(getWindowsMachineId);
 
-#if NET
+#if !NETFRAMEWORK
         this.isOsPlatform = isOsPlatform;
 #endif
         this.getFilePaths = getFilePaths;
@@ -117,10 +117,10 @@ internal sealed class HostDetector : IResourceDetector
 
         foreach (var line in lines)
         {
-#if NETFRAMEWORK
-            if (line.IndexOf("IOPlatformUUID", StringComparison.OrdinalIgnoreCase) >= 0)
-#else
+#if NET
             if (line.Contains("IOPlatformUUID", StringComparison.OrdinalIgnoreCase))
+#else
+            if (line.IndexOf("IOPlatformUUID", StringComparison.OrdinalIgnoreCase) >= 0)
 #endif
             {
                 var parts = line.Split('"');

--- a/src/OpenTelemetry.Resources.Host/OpenTelemetry.Resources.Host.csproj
+++ b/src/OpenTelemetry.Resources.Host/OpenTelemetry.Resources.Host.csproj
@@ -1,24 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
-    <Description>OpenTelemetry Extensions - Host Resource Detector.</Description>
+    <Description>OpenTelemetry Resource Detectors for Host.</Description>
     <MinVerTagPrefix>Resources.Host-</MinVerTagPrefix>
   </PropertyGroup>
 
-  <!--Do not run Package Baseline Validation as this package has never released a stable version.
-  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property.-->
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Resources.Host.Tests/OpenTelemetry.Resources.Host.Tests.csproj
+++ b/test/OpenTelemetry.Resources.Host.Tests/OpenTelemetry.Resources.Host.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Unit test project for Host Detector for OpenTelemetry</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <Description>Unit test project for Host Detector for OpenTelemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8 and add support for .NET Standard 2.0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)