### PR TITLE
[Resources.OperatingSystem] Replace .NET 6 target with .NET 8 and add .NET Standard 2.0 target

### DIFF
--- a/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Drop support for .NET 6 as this target is no longer supported
+  and add .NET 8/.NET Standard 2.0 targets.
+  ([#2169](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2169))
+
 ## 0.1.0-alpha.4
 
 Released 2024-Sep-09

--- a/src/OpenTelemetry.Resources.OperatingSystem/OpenTelemetry.Resources.OperatingSystem.csproj
+++ b/src/OpenTelemetry.Resources.OperatingSystem/OpenTelemetry.Resources.OperatingSystem.csproj
@@ -2,20 +2,21 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
-    <Description>OpenTelemetry Extensions - Operating System Resource Detector for .NET</Description>
+    <Description>OpenTelemetry Resource Detectors for Operating System.</Description>
     <MinVerTagPrefix>Resources.OperatingSystem-</MinVerTagPrefix>
   </PropertyGroup>
 
-  <!--Do not run Package Baseline Validation as this package has never released a stable version.
-  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property.-->
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Resources.OperatingSystem/OperatingSystemDetector.cs
+++ b/src/OpenTelemetry.Resources.OperatingSystem/OperatingSystemDetector.cs
@@ -1,11 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET
+#if !NETFRAMEWORK
 using System.Runtime.InteropServices;
+#endif
+#if NET
 using System.Xml.Linq;
 #endif
-
 using static OpenTelemetry.Resources.OperatingSystem.OperatingSystemSemanticConventions;
 
 namespace OpenTelemetry.Resources.OperatingSystem;
@@ -18,16 +19,16 @@ internal sealed class OperatingSystemDetector : IResourceDetector
     private const string RegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion";
     private const string KernelOsRelease = "/proc/sys/kernel/osrelease";
     private static readonly string[] DefaultEtcOsReleasePaths =
-        [
-            "/etc/os-release",
-            "/usr/lib/os-release"
-        ];
+    [
+        "/etc/os-release",
+        "/usr/lib/os-release"
+    ];
 
     private static readonly string[] DefaultPlistFilePaths =
-        [
-            "/System/Library/CoreServices/SystemVersion.plist",
-            "/System/Library/CoreServices/ServerVersion.plist"
-        ];
+    [
+        "/System/Library/CoreServices/SystemVersion.plist",
+        "/System/Library/CoreServices/ServerVersion.plist"
+    ];
 
     private readonly string? osType;
     private readonly string? registryKey;

--- a/test/OpenTelemetry.Resources.OperatingSystem.Tests/OpenTelemetry.Resources.OperatingSystem.Tests.csproj
+++ b/test/OpenTelemetry.Resources.OperatingSystem.Tests/OpenTelemetry.Resources.OperatingSystem.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Unit test project for Operating System Detector for OpenTelemetry</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <Description>Unit test project for Operating System Detector for OpenTelemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8 and add support for .NET Standard 2.0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)