### PR TITLE
[Resources.ProcessRuntime] Replace .NET 6 target with .NET 8 and add .NET Standard 2.0 target

### DIFF
--- a/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Drop support for .NET 6 as this target is no longer supported
+  and add .NET 8/.NET Standard 2.0 targets.
+  ([#2171](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2171))
+
 ## 0.1.0-beta.2
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Resources.ProcessRuntime/OpenTelemetry.Resources.ProcessRuntime.csproj
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/OpenTelemetry.Resources.ProcessRuntime.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
-    <Description>OpenTelemetry Extensions - Process Runtime Resource Detector for .NET runtime.</Description>
+    <Description>OpenTelemetry Resource Detectors for Process Runtime.</Description>
     <MinVerTagPrefix>Resources.ProcessRuntime-</MinVerTagPrefix>
   </PropertyGroup>
 
-  <!--Do not run Package Baseline Validation as this package has never released a stable version.
-  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property.-->
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
@@ -21,4 +22,5 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Resources.ProcessRuntime.Tests/OpenTelemetry.Resources.ProcessRuntime.Tests.csproj
+++ b/test/OpenTelemetry.Resources.ProcessRuntime.Tests/OpenTelemetry.Resources.ProcessRuntime.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Unit test project for Process Runtime Detector for OpenTelemetry</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargetsWithoutNet6)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <Description>Unit test project for Process Runtime Detector for OpenTelemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Replace .NET 6 target, which will be very soon out of support, with .NET 8 and add support for .NET Standard 2.0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)