### PR TITLE
[repo] Simplify preprocessor directives after dropping support for .NET 6

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/TransportSendRequest.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Transports/TransportSendRequest.cs
@@ -13,7 +13,7 @@ internal readonly struct TransportSendRequest
 {
     public TransportSendRequest()
     {
-#if !NET8_0_OR_GREATER
+#if !NET
         // Note: This is needed because < NET7 doesn't understand required.
         this.ItemType = string.Empty;
         this.ItemStream = default!;

--- a/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterValidationException.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/OneCollectorExporterValidationException.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if !NET8_0_OR_GREATER
+#if !NET
 using System.Runtime.Serialization;
 #endif
 
@@ -43,7 +43,7 @@ public sealed class OneCollectorExporterValidationException : Exception
     {
     }
 
-#if !NET8_0_OR_GREATER
+#if !NET
     private OneCollectorExporterValidationException(SerializationInfo serializationInfo, StreamingContext streamingContext)
         : base(serializationInfo, streamingContext)
     {

--- a/src/OpenTelemetry.Extensions.AWS/AWSXRayIdGenerator.net.cs
+++ b/src/OpenTelemetry.Extensions.AWS/AWSXRayIdGenerator.net.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET6_0_OR_GREATER
+#if NET
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Security.Cryptography;

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if !NET8_0_OR_GREATER
+#if !NET
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 #endif
@@ -24,7 +24,7 @@ public static class AspNetCoreInstrumentationMeterProviderBuilderExtensions
     {
         Guard.ThrowIfNull(builder);
 
-#if NET8_0_OR_GREATER
+#if NET
         return builder.ConfigureMeters();
 #else
         // Note: Warm-up the status code and method mapping.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if !NET8_0_OR_GREATER
+#if !NET
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore;

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumerBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenTelemetryConsumerBuilderExtensions
     /// <typeparam name="TValue">Type of the value.</typeparam>
     /// <param name="consumerBuilder">The <see cref="ConsumerBuilder{TKey, TValue}"/> instance.</param>
     /// <returns>An <see cref="InstrumentedConsumerBuilder{TKey, TValue}"/> instance.</returns>
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Use 'InstrumentedConsumerBuilder<TKey, TValue>' constructor to avoid reflection.")]
 #endif
     public static InstrumentedConsumerBuilder<TKey, TValue> AsInstrumentedConsumerBuilder<TKey, TValue>(this ConsumerBuilder<TKey, TValue> consumerBuilder)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryProducerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryProducerBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenTelemetryProducerBuilderExtensions
     /// <typeparam name="TValue">Type of the value.</typeparam>
     /// <param name="producerBuilder">The <see cref="ProducerBuilder{TKey, TValue}"/> instance.</param>
     /// <returns>An <see cref="InstrumentedProducerBuilder{TKey, TValue}"/> instance.</returns>
-#if !NETFRAMEWORK && !NETSTANDARD
+#if NET
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Use 'InstrumentedProducerBuilder<TKey, TValue>' constructor to avoid reflection.")]
 #endif
     public static InstrumentedProducerBuilder<TKey, TValue> AsInstrumentedProducerBuilder<TKey, TValue>(this ProducerBuilder<TKey, TValue> producerBuilder)

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationMeterProviderBuilderExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if !NET8_0_OR_GREATER
+#if !NET
 #if !NETFRAMEWORK
 using OpenTelemetry.Instrumentation.Http;
 #endif
@@ -27,7 +27,7 @@ public static class HttpClientInstrumentationMeterProviderBuilderExtensions
     {
         Guard.ThrowIfNull(builder);
 
-#if NET8_0_OR_GREATER
+#if NET
         return builder
             .AddMeter("System.Net.Http")
             .AddMeter("System.Net.NameResolution");

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -310,7 +310,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 
     private static string? GetErrorType(Exception exc)
     {
-#if NET8_0_OR_GREATER
+#if NET
         // For net8.0 and above exception type can be found using HttpRequestError.
         // https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0
         if (exc is HttpRequestException httpRequestException)

--- a/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
+++ b/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
@@ -4,7 +4,7 @@
 #nullable enable
 
 using System.Diagnostics;
-#if !NETFRAMEWORK && !NETSTANDARD2_0
+#if NET || NETSTANDARD2_1
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Globalization;
@@ -15,7 +15,7 @@ internal static class OpenTelemetryConfigurationExtensions
 {
     public delegate bool TryParseFunc<T>(
         string value,
-#if !NETFRAMEWORK && !NETSTANDARD2_0
+#if NET || NETSTANDARD2_1
         [NotNullWhen(true)]
 #endif
         out T? parsedValue);
@@ -23,7 +23,7 @@ internal static class OpenTelemetryConfigurationExtensions
     public static bool TryGetStringValue(
         this IConfiguration configuration,
         string key,
-#if !NETFRAMEWORK && !NETSTANDARD2_0
+#if NET || NETSTANDARD2_1
         [NotNullWhen(true)]
 #endif
         out string? value)
@@ -39,7 +39,7 @@ internal static class OpenTelemetryConfigurationExtensions
         this IConfiguration configuration,
         IConfigurationExtensionsLogger logger,
         string key,
-#if !NETFRAMEWORK && !NETSTANDARD2_0
+#if NET || NETSTANDARD2_1
         [NotNullWhen(true)]
 #endif
         out Uri? value)
@@ -112,7 +112,7 @@ internal static class OpenTelemetryConfigurationExtensions
         IConfigurationExtensionsLogger logger,
         string key,
         TryParseFunc<T> tryParseFunc,
-#if !NETFRAMEWORK && !NETSTANDARD2_0
+#if NET || NETSTANDARD2_1
         [NotNullWhen(true)]
 #endif
         out T? value)

--- a/src/Shared/RequestDataHelper.cs
+++ b/src/Shared/RequestDataHelper.cs
@@ -3,7 +3,7 @@
 
 #nullable enable
 
-#if NET8_0_OR_GREATER
+#if NET
 using System.Collections.Frozen;
 #endif
 using System.Diagnostics;
@@ -21,7 +21,7 @@ internal sealed class RequestDataHelper
 
     private static readonly char[] SplitChars = new[] { ',' };
 
-#if NET8_0_OR_GREATER
+#if NET
     private readonly FrozenDictionary<string, string> knownHttpMethods;
 #else
     private readonly Dictionary<string, string> knownHttpMethods;
@@ -46,7 +46,7 @@ internal sealed class RequestDataHelper
                 ["CONNECT"] = "CONNECT",
             };
 
-#if NET8_0_OR_GREATER
+#if NET
         this.knownHttpMethods = knownMethodSet.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 #else
         this.knownHttpMethods = knownMethodSet;

--- a/src/Shared/RequestDataHelper.cs
+++ b/src/Shared/RequestDataHelper.cs
@@ -3,7 +3,7 @@
 
 #nullable enable
 
-#if NET
+#if NET8_0_OR_GREATER
 using System.Collections.Frozen;
 #endif
 using System.Diagnostics;
@@ -21,7 +21,7 @@ internal sealed class RequestDataHelper
 
     private static readonly char[] SplitChars = new[] { ',' };
 
-#if NET
+#if NET8_0_OR_GREATER
     private readonly FrozenDictionary<string, string> knownHttpMethods;
 #else
     private readonly Dictionary<string, string> knownHttpMethods;
@@ -46,7 +46,7 @@ internal sealed class RequestDataHelper
                 ["CONNECT"] = "CONNECT",
             };
 
-#if NET
+#if NET8_0_OR_GREATER
         this.knownHttpMethods = knownMethodSet.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 #else
         this.knownHttpMethods = knownMethodSet;

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationHelperTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationHelperTests.cs
@@ -99,9 +99,7 @@ public class CommonSchemaJsonSerializationHelperTests
 
         var typeWithISpanFormattableOverflow = new TypeWithISpanFormattable(overflow: true);
         this.SerializeValueToJsonTest(typeWithISpanFormattableOverflow, "\"Overflow\"");
-#endif
 
-#if NET8_0_OR_GREATER
         var dateOnly = DateOnly.FromDateTime(dt);
         this.SerializeValueToJsonTest(dateOnly, $"\"{dateOnly:O}\"");
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -738,7 +738,7 @@ public sealed class BasicTests
         Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", aspnetcoreframeworkactivity.OperationName);
     }
 
-#if NET8_0_OR_GREATER
+#if NET
     [Fact]
     public async Task UserRegisteredActivitySourceIsUsedForActivityCreationByAspNetCore()
     {
@@ -1150,7 +1150,7 @@ public sealed class BasicTests
     private static void ValidateAspNetCoreActivity(Activity activityToValidate, string expectedHttpPath)
     {
         Assert.Equal(ActivityKind.Server, activityToValidate.Kind);
-#if NET8_0_OR_GREATER
+#if NET
         Assert.Equal(HttpInListener.AspNetCoreActivitySourceName, activityToValidate.Source.Name);
         Assert.NotNull(activityToValidate.Source.Version);
         Assert.Empty(activityToValidate.Source.Version);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -1,19 +1,19 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET8_0_OR_GREATER
+#if NET
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Builder;
 #endif
 using Microsoft.AspNetCore.Hosting;
-#if NET8_0_OR_GREATER
+#if NET
 using Microsoft.AspNetCore.Http;
 #endif
 using Microsoft.AspNetCore.Mvc.Testing;
-#if NET8_0_OR_GREATER
+#if NET
 using Microsoft.AspNetCore.RateLimiting;
 #endif
-#if NET8_0_OR_GREATER
+#if NET
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 #endif
@@ -38,7 +38,7 @@ public class MetricTests(WebApplicationFactory<Program> factory)
         Assert.Throws<ArgumentNullException>(builder!.AddAspNetCoreInstrumentation);
     }
 
-#if NET8_0_OR_GREATER
+#if NET
     [Fact]
     public async Task ValidateNet8MetricsAsync()
     {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/RouteInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/RouteInfo.cs
@@ -5,7 +5,7 @@
 
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
-#if NET8_0_OR_GREATER
+#if NET
 using Microsoft.AspNetCore.Http.Metadata;
 #endif
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -40,7 +40,7 @@ public class RouteInfo
         this.Path = $"{context.Request.Path}{context.Request.QueryString}";
         var endpoint = context.GetEndpoint();
         this.RawText = (endpoint as RouteEndpoint)?.RoutePattern.RawText;
-#if NET8_0_OR_GREATER
+#if NET
         this.RouteDiagnosticMetadata = endpoint?.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route;
 #endif
         this.RouteData = new Dictionary<string, string?>();

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
@@ -131,7 +131,7 @@ internal class TestApplicationFactory
         app.MapGet("/MinimalApi", () => Results.Ok());
         app.MapGet("/MinimalApi/{id}", (int id) => Results.Ok());
 
-#if NET8_0_OR_GREATER
+#if NET
         var api = app.MapGroup("/MinimalApiUsingMapGroup");
         api.MapGet("/", () => Results.Ok());
         api.MapGet("/{id}", (int id) => Results.Ok());
@@ -188,7 +188,7 @@ internal class TestApplicationFactory
         // This is because ASP.NET Core 8+ has native metric instrumentation.
         // When ASP.NET Core 8.0.2 is released then its behavior will align with .NET 6/7.
         // See: https://github.com/dotnet/aspnetcore/issues/52648#issuecomment-1853432776
-#if !NET8_0_OR_GREATER
+#if !NET
         app.MapGet("/Exception", (ctx) => throw new ApplicationException());
 #else
         app.MapGet("/Exception", () => Results.Content(content: "Error", contentType: null, contentEncoding: null, statusCode: 500));

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
-#if !NET8_0_OR_GREATER
+#if !NET
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
@@ -21,7 +21,7 @@ public partial class HttpClientTests
 {
     public static readonly IEnumerable<object[]> TestData = HttpTestData.ReadTestCases();
 
-#if !NET8_0_OR_GREATER
+#if !NET
     private static readonly JsonSerializerOptions JsonSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 #endif
 
@@ -73,7 +73,7 @@ public partial class HttpClientTests
             enableMetrics: false);
     }
 
-#if !NET8_0_OR_GREATER
+#if !NET
     [Fact]
     public async Task DebugIndividualTestAsync()
     {
@@ -115,7 +115,7 @@ public partial class HttpClientTests
         await CheckEnrichment(new AlwaysOnSampler(), true, this.url);
     }
 
-#if NET8_0_OR_GREATER
+#if NET
     [Theory]
     [MemberData(nameof(TestData))]
     public async Task ValidateNet8MetricsAsync(HttpOutTestCase tc)
@@ -172,7 +172,7 @@ public partial class HttpClientTests
     }
 #endif
 
-#if NET8_0_OR_GREATER
+#if NET
     [Fact]
     public async Task HttpCancellationLogsError()
     {
@@ -362,7 +362,7 @@ public partial class HttpClientTests
                 Assert.DoesNotContain(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode);
                 Assert.DoesNotContain(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion);
 
-#if NET8_0_OR_GREATER
+#if NET
                 // we are using fake address so it will be "name_resolution_error"
                 // TODO: test other error types.
                 Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "name_resolution_error");
@@ -410,7 +410,7 @@ public partial class HttpClientTests
             if (enableTracing)
             {
                 var activity = Assert.Single(activities);
-#if !NET8_0_OR_GREATER
+#if !NET
                 Assert.Equal(activity.Duration.TotalSeconds, sum);
 #endif
             }
@@ -461,7 +461,7 @@ public partial class HttpClientTests
                 Assert.DoesNotContain(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion);
                 Assert.DoesNotContain(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode);
 
-#if NET8_0_OR_GREATER
+#if NET
                 // we are using fake address so it will be "name_resolution_error"
                 // TODO: test other error types.
                 Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value?.ToString() == "name_resolution_error");


### PR DESCRIPTION
## Changes

Remove versions from preprocessor directives where possible.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
