### PR TITLE
[repo] Some cleanup after dropping support for .NET 6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -79,7 +79,7 @@ body:
   - type: input
     attributes:
       label: Runtime Version
-      description: What .NET runtime version did you use? (e.g. `net462`, `net48`, `netcoreapp3.1`, `net6.0` etc. You can find this information from the `*.csproj` file)
+      description: What .NET runtime version did you use? (e.g. `net462`, `net48`, `net8.0` etc. You can find this information from the `*.csproj` file)
     validations:
       required: true
 

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       tfm-list:
-        default: '[ "net462", "net6.0", "net8.0" ]'
+        default: '[ "net462", "net8.0" ]'
         required: false
         type: string
 

--- a/.github/workflows/ci-Exporter.OneCollector-Integration.yml
+++ b/.github/workflows/ci-Exporter.OneCollector-Integration.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        version: [ net462, net6.0, net8.0 ]
+        version: [ net462, net8.0 ]
         exclude:
         - os: ubuntu-latest
           version: net462

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
     with:
       project-name: OpenTelemetry.Instrumentation.AspNetCore
       code-cov-name: Instrumentation.AspNetCore
-      tfm-list: '[ "net6.0", "net8.0" ]'
+      tfm-list: '[ "net8.0" ]'
 
   build-test-instrumentation-aws:
     needs: detect-changes
@@ -219,7 +219,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Instrumentation.AWSLambda]
       code-cov-name: Instrumentation.AWSLambda
-      tfm-list: '[ "net6.0", "net8.0" ]'
+      tfm-list: '[ "net8.0" ]'
 
   build-test-instrumentation-cassandra:
     needs: detect-changes
@@ -285,7 +285,7 @@ jobs:
     with:
       project-name: OpenTelemetry.Instrumentation.EventCounters
       code-cov-name: Instrumentation.EventCounters
-      tfm-list: '[ "net6.0", "net8.0" ]'
+      tfm-list: '[ "net8.0" ]'
 
   build-test-instrumentation-grpccore:
     needs: detect-changes

--- a/build/docker-compose.net6.0.yml
+++ b/build/docker-compose.net6.0.yml
@@ -1,9 +1,0 @@
-version: '3.7'
-
-services:
-  tests:
-    build:
-      args:
-        PUBLISH_FRAMEWORK: net6.0
-        TEST_SDK_VERSION: "6.0"
-        BUILD_SDK_VERSION: "8.0"

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -55,7 +55,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{824BD1DE
 		build\Common.props = build\Common.props
 		build\Common.targets = build\Common.targets
 		build\debug.snk = build\debug.snk
-		build\docker-compose.net6.0.yml = build\docker-compose.net6.0.yml
 		build\docker-compose.net8.0.yml = build\docker-compose.net8.0.yml
 		build\opentelemetry-icon-color.png = build\opentelemetry-icon-color.png
 		build\OpenTelemetryContrib.prod.ruleset = build\OpenTelemetryContrib.prod.ruleset

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
@@ -15,7 +15,7 @@ public class LogSerializationTests
 {
     /*
     Run from the current directory:
-    dotnet test -f net6.0 --filter FullyQualifiedName~LogSerializationTests -l "console;verbosity=detailed"
+    dotnet test -f net8.0 --filter FullyQualifiedName~LogSerializationTests -l "console;verbosity=detailed"
     */
     private readonly ITestOutputHelper output;
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)" Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net8.0'" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

This PR removes some occurrences of `net6.0` through the repo.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
