### PR TITLE
[extensions.aws & sampler.aws] Mitigate STJ vulnerabilities

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -5,8 +5,9 @@
 * Drop support for .NET 6 as this target is no longer supported.
   ([#2123](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2123))
 
-* Bumped `System.Text.Json` reference to `6.0.10` for runtimes older than
-  `net8.0` and bumped to `8.0.5` on `net8.0` in response to
+* Bumped the `System.Text.Json` reference to `6.0.10` for runtimes older than
+  `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
+  `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
   ([#2196](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2196))
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Bumped the `System.Text.Json` reference to `6.0.10` for runtimes older than
+  `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
+  `net8.0` in response to
+  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.3.0-beta.2
 
 Released 2024-Sep-24

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -6,7 +6,7 @@
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
+++ b/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS.</Description>
     <MinVerTagPrefix>Extensions.AWS-</MinVerTagPrefix>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonLatestNet6OutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.
@@ -16,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -9,8 +9,9 @@
   and add .NET Standard 2.0 target.
   ([#2164](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2164))
 
-* Bumped `System.Text.Json` reference to `6.0.10` for runtimes older than
-  `net8.0` and bumped to `8.0.5` on `net8.0` in response to
+* Bumped the `System.Text.Json` reference to `6.0.10` for runtimes older than
+  `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
+  `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
   ([#2196](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2196))
 

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -5,6 +5,15 @@
 * Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
   ([#2172](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2172))
 
+* Bumped the `System.Text.Json` reference to `6.0.10` for runtimes older than
+  `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
+  `net8.0` in response to
+  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
+* Removed the `System.Net.Http` package reference from all targets.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 0.1.0-alpha.2
 
 Released 2024-Sep-09

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -9,10 +9,10 @@
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))
 
 * Removed the `System.Net.Http` package reference from all targets.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))
 
 ## 0.1.0-alpha.2
 

--- a/src/OpenTelemetry.Sampler.AWS/OpenTelemetry.Sampler.AWS.csproj
+++ b/src/OpenTelemetry.Sampler.AWS/OpenTelemetry.Sampler.AWS.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry remote sampler for AWS X-Ray.</Description>
     <MinVerTagPrefix>Sampler.AWS-</MinVerTagPrefix>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonLatestNet6OutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.
@@ -16,8 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonLatestNet8OutOfBandPkgVer)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Mitigate security vulnerabilities in more projects which are today targeting `System.Text.Json` v6.0.0.
* In `OpenTelemetry.Sampler.AWS` reference `System.Net.Http` directly on `net462` and drop package reference. Not related to vulnerability just making it consistent with the rest of the repo.

## Details

### OpenTelemetry.Extensions.AWS

Before

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|6.0.0|Yes|
|net8.0|No|8.0.0 - 8.0.5|Depends on installed runtime patch level|
|netstandard2.0|Yes|6.0.0|Yes|

After

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|6.0.10|No|
|net8.0|Yes|8.0.5|No|
|netstandard2.0|Yes|6.0.10|No|

### OpenTelemetry.Sampler.AWS

Before

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|6.0.0|Yes|
|net8.0|No|8.0.0 - 8.0.5|Depends on installed runtime patch level|
|netstandard2.0|Yes|6.0.0|Yes|

After

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|6.0.10|No|
|net8.0|Yes|8.0.5|No|
|netstandard2.0|Yes|6.0.10|No|

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
