### PR TITLE
[elastic. azure, gcp] Mitigate STJ vulnerabilities

### DIFF
--- a/build/Common.targets
+++ b/build/Common.targets
@@ -10,7 +10,7 @@
     -->
     <PackageReference Include="System.Text.Encodings.Web"
                       Version="$(SystemTextEncodingsWebMinimumOutOfBandPkgVer)"
-                      Condition="'$(SystemTextJsonMinimumRequiredPkgVer)' == '4.7.2' AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+                      Condition="($(SystemTextJsonMinimumRequiredPkgVer.StartsWith('[4.7.2')) OR '$(SystemTextJsonMinimumRequiredPkgVer)' == '4.7.2') AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Text.Json"
                       Version="$(SystemTextJsonMinimumRequiredPkgVer)"
                       Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -15,6 +15,11 @@
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
 
+* Lowered the `System.Text.Json` reference to `4.7.2` for `net462` and
+  `netstandard2.0` targets in response to
+  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.0.0-beta.5
 
 Released 2023-Oct-24

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Lowered the `System.Text.Json` reference to `4.7.2` for `net462` and
   `netstandard2.0` targets in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2198))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/OpenTelemetry.Instrumentation.ElasticsearchClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/OpenTelemetry.Instrumentation.ElasticsearchClient.csproj
@@ -7,9 +7,10 @@
     <Description>Elasticsearch instrumentation for OpenTelemetry .NET.</Description>
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
     <MinVerTagPrefix>Instrumentation.ElasticsearchClient-</MinVerTagPrefix>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
-	<!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
   Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
@@ -17,7 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="System.Text.Json" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
   minimum version of `8.0.5` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2198))
 
 ## 1.0.0-beta.9
 

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
   ([#2165](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2165))
 
+* Added direct reference to `System.Text.Json` for the `net8.0` target with
+  minimum version of `8.0.5` in response to
+  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.0.0-beta.9
 
 Released 2024-Sep-24

--- a/src/OpenTelemetry.Resources.Azure/OpenTelemetry.Resources.Azure.csproj
+++ b/src/OpenTelemetry.Resources.Azure/OpenTelemetry.Resources.Azure.csproj
@@ -5,6 +5,7 @@
     <Description>OpenTelemetry Resource Detectors for Azure cloud environments.</Description>
     <PackageTags>$(PackageTags);ResourceDetector</PackageTags>
     <MinVerTagPrefix>Resources.Azure-</MinVerTagPrefix>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.
@@ -15,9 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <!-- System.Text.Encodings.Web is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-ghhp-997w-qr28 -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -6,7 +6,13 @@
   is accessible via `AddGcpDetector` extension method on `ResourceBuilder`.
   ([#1691](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1691))
 
-For more details, please refer to the [README](README.md).
-
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+
+* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
+  ([#2167](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2167))
+
+* Added direct reference to `System.Text.Json` for the `net8.0` target with
+  minimum version of `8.0.5` in response to
+  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -15,4 +15,4 @@
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
   minimum version of `8.0.5` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2198))

--- a/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
+++ b/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
@@ -5,6 +5,7 @@
     <Description>OpenTelemetry Resource Detectors for Google Cloud Platform environments.</Description>
     <PackageTags>$(PackageTags);ResourceDetector</PackageTags>
     <MinVerTagPrefix>Resources.Gcp-</MinVerTagPrefix>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.
@@ -16,9 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax" Version="4.8.0" />
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <!-- System.Text.Encodings.Web is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-ghhp-997w-qr28 -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Mitigate security vulnerabilities in more remaining projects with a direct reference to STJ.

## Details

### OpenTelemetry.Instrumentation.ElasticsearchClient

Before

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|6.0.4|Yes|
|netstandard2.0|Yes|6.0.4|Yes|

After

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|4.7.2|No|
|netstandard2.0|Yes|4.7.2|No|

### OpenTelemetry.Resources.Azure

Before

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|4.7.2|No|
|net8.0|Yes|4.7.2|No|
|netstandard2.0|Yes|4.7.2|No|

After

|Target|Direct reference|Version|Vulnerable|Notes|
|---|---|---|---|---|
|net462|Yes|4.7.2|No||
|net8.0|Yes|8.0.5|No|Wasn't vulnerable before, but also wasn't standard with everything else. Decided to make this standard.|
|netstandard2.0|Yes|4.7.2|No||

### OpenTelemetry.Resources.Gcp

Before

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|4.7.2|No|
|net8.0|Yes|4.7.2|No|
|netstandard2.0|Yes|4.7.2|No|

After

|Target|Direct reference|Version|Vulnerable|Notes|
|---|---|---|---|---|
|net462|Yes|4.7.2|No||
|net8.0|Yes|8.0.5|No|Wasn't vulnerable before, but also wasn't standard with everything else. Decided to make this standard.|
|netstandard2.0|Yes|4.7.2|No||

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
