### PR TITLE
[extensions.aws + sampler.aws] Lower STJ version

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -9,7 +9,7 @@
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2196](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2196))
+  ([#2196](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2196))
 
 ## 1.10.0-alpha.1
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -9,8 +9,8 @@
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197),
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197),
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-* Bumped the `System.Text.Json` reference to `6.0.10` for runtimes older than
+* Lowered the `System.Text.Json` reference to `4.7.2` for runtimes older than
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197),
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -10,7 +10,7 @@
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
   ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197),
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  [#2199](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2199))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
+  ([#2125](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2125))
+
 * Lowered the `System.Text.Json` reference to `4.7.2` for runtimes older than
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
@@ -18,9 +21,6 @@ Released 2024-Sep-24
 
 * Updated OpenTelemetry core component version(s) to `1.9.0`.
   ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
-
-* Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
-  ([#2125](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2125))
 
 ## 1.3.0-beta.1
 

--- a/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
+++ b/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS.</Description>
     <MinVerTagPrefix>Extensions.AWS-</MinVerTagPrefix>
-    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonLatestNet6OutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Lowered the `System.Text.Json` reference to `4.7.2` for `net462` and
   `netstandard2.0` targets in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2198))
+  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2198))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -13,7 +13,7 @@
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2196](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2196))
+  ([#2196](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2196))
 
 ## 1.5.0-beta.1
 

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
   minimum version of `8.0.5` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2198))
+  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2198))
 
 ## 1.0.0-beta.9
 

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -15,4 +15,4 @@
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
   minimum version of `8.0.5` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2198))
+  ([#2198](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2198))

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -10,7 +10,7 @@
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
   ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197),
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  [#2199](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2199))
 
 * Removed the `System.Net.Http` package reference from all targets.
   ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -5,11 +5,12 @@
 * Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
   ([#2172](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2172))
 
-* Bumped the `System.Text.Json` reference to `6.0.10` for runtimes older than
+* Lowered the `System.Text.Json` reference to `4.7.2` for runtimes older than
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197),
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
 
 * Removed the `System.Net.Http` package reference from all targets.
   ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -9,8 +9,8 @@
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197),
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197),
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 * Removed the `System.Net.Http` package reference from all targets.
   ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))

--- a/src/OpenTelemetry.Sampler.AWS/OpenTelemetry.Sampler.AWS.csproj
+++ b/src/OpenTelemetry.Sampler.AWS/OpenTelemetry.Sampler.AWS.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry remote sampler for AWS X-Ray.</Description>
     <MinVerTagPrefix>Sampler.AWS-</MinVerTagPrefix>
-    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonLatestNet6OutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.


### PR DESCRIPTION
## Changes

* Lower STJ in AWS extensions and sampler projects for `net462` & `netstandard2.0` because they aren't using anything in the newer bits.
* Fix STJ mitigation CHANGELOG links pointing to main repo.

## Details

### OpenTelemetry.Extensions.AWS

Before

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|6.0.10|No|
|net8.0|Yes|8.0.5|No|
|netstandard2.0|Yes|6.0.10|No|

After

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|4.7.2|No|
|net8.0|Yes|8.0.5|No|
|netstandard2.0|Yes|4.7.2|No|

### OpenTelemetry.Sampler.AWS

Before

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|6.0.10|No|
|net8.0|Yes|8.0.5|No|
|netstandard2.0|Yes|6.0.10|No|

After

|Target|Direct reference|Version|Vulnerable|
|---|---|---|---|
|net462|Yes|4.7.2|No|
|net8.0|Yes|8.0.5|No|
|netstandard2.0|Yes|4.7.2|No|

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
