### PR TITLE
[influxdb] Mitigate STJ vulnerabilities

### DIFF
--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Added a direct reference to `System.Text.Json` at `8.0.5` for the
   `netstandard2.0` target in response to
   [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#2202](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2202))
 
 ## 1.0.0-alpha.4
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Added a direct reference to `System.Text.Json` at `8.0.5` for the
+  `netstandard2.0` target in response to
+  [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.0.0-alpha.4
 
 Released 2024-Oct-02

--- a/src/OpenTelemetry.Exporter.InfluxDB/OpenTelemetry.Exporter.InfluxDB.csproj
+++ b/src/OpenTelemetry.Exporter.InfluxDB/OpenTelemetry.Exporter.InfluxDB.csproj
@@ -17,6 +17,9 @@
   <ItemGroup>
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
+
+    <!-- System.Text.Json is indirect reference through InfluxDB.Client package. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-8g4q-xg66-9fp4 -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonLatestNet8OutOfBandPkgVer)" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Add a direct reference to STJ at `8.0.5` in InfluxDB project for `netstandard2.0` target.

## Details

Only `netstandard2.0` because that is pulled in by RestSharp but not for `net8.0` (for whatever reason).

```
  [netstandard2.0]
   │
   └─ InfluxDB.Client (v4.18.0)
      └─ InfluxDB.Client.Core (v4.18.0)
         └─ RestSharp (v112.0.0)
            └─ System.Text.Json (v8.0.4)

  [net8.0]
   │
   └─ No dependency graph(s) found for this target framework.
```

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
