### PR TITLE
[aws] Combine Extensions.AWS, Instrumentation.AWS, & Instrumentation.AWSLambda into a single tag

### DIFF
--- a/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
+++ b/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS.</Description>
-    <MinVerTagPrefix>Extensions.AWS-</MinVerTagPrefix>
+    <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
     <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>AWS client instrumentation for OpenTelemetry .NET.</Description>
-	  <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
+    <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.
@@ -15,16 +15,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.AWS\OpenTelemetry.Extensions.AWS.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.400" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.400" />
-    <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs"/>
+    <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#2140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2140))
 * Add a direct reference to `System.Text.Json` at `6.0.10` for the
   `netstandard2.0` target and at `8.0.5` for the `net8.0` target.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#2203](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2203))
 
 ## 1.3.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Drop support for .NET 6 as this target is no longer supported
   and add .NET 8/.NET Standard 2.0 targets.
   ([#2140](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2140))
+* Add a direct reference to `System.Text.Json` at `6.0.10` for the
+  `netstandard2.0` target and at `8.0.5` for the `net8.0` target.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.3.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -4,7 +4,8 @@
     <TargetFrameworks>net8.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <Description>AWS Lambda tracing wrapper for OpenTelemetry .NET.</Description>
     <PackageTags>$(PackageTags);AWS Lambda</PackageTags>
-    <MinVerTagPrefix>Instrumentation.AWSLambda-</MinVerTagPrefix>
+    <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonLatestNet6OutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.
@@ -14,12 +15,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.AWS\OpenTelemetry.Extensions.AWS.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
     <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Use the same tag prefix (`MinVerTagPrefix`) for `OpenTelemetry.Extensions.AWS`, `OpenTelemetry.Instrumentation.AWS`, & `OpenTelemetry.Instrumentation.AWSLambda`.

* Add STJ reference at `6.0.10` / `8.0.5` for `OpenTelemetry.Instrumentation.AWSLambda` since it uses the source generator.

## Details

@srprash @ppittle @Oberon00 @rypdal

My goal here is to resolve the last build breaks due to vulnerable STJ package versions:

```
OpenTelemetry.Instrumentation.AWSLambda.csproj : error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability
OpenTelemetry.Instrumentation.AWS.csproj : error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability
```

The reason this is happening is `OpenTelemetry.Instrumentation.AWS` and `OpenTelemetry.Instrumentation.AWSLambda` reference `OpenTelemetry.Extensions.AWS` through NuGet, they don't use `ProjectReference`.

There isn't anything necessarily wrong with that, but it is a code smell IMO. Tightly coupled projects should be released together.

Examples:

* [OpenTelemetry.Instrumentation.AspNet](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj#L9) & [OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/f6bd1a7d391481ac9359e5c30177c69490ce1ee6/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj#L8)

* [OpenTelemetry.PersistentStorage.Abstractions](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/f6bd1a7d391481ac9359e5c30177c69490ce1ee6/src/OpenTelemetry.PersistentStorage.Abstractions/OpenTelemetry.PersistentStorage.Abstractions.csproj#L9) & [OpenTelemetry.PersistentStorage.FileSystem](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/f6bd1a7d391481ac9359e5c30177c69490ce1ee6/src/OpenTelemetry.PersistentStorage.FileSystem/OpenTelemetry.PersistentStorage.FileSystem.csproj#L9)

What this PR is doing is using the same `MinVerTagPrefix` for `OpenTelemetry.Extensions.AWS`, `OpenTelemetry.Instrumentation.AWS`, & `OpenTelemetry.Instrumentation.AWSLambda` so they will always be versioned and released together.

We could just put out a NuGet for `OpenTelemetry.Extensions.AWS` to resolve the issue but I feel this is better design and overall better for users. Less chance for mismatched versions and conflicts for the coupled projects and their dependencies.

Please approve this PR if this works for AWS group!

PS: We could version _all_ of the AWS packages together. Might simplify the versioning/upgrade story for everything. But I only did the coupled ones here. Happy to do them all if that is something AWS group wants.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
