### PR TITLE
[examples] Use the OpenTelemetryCoreUnstableLatestVersion prop in AspNet example

### DIFF
--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.8.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="$(OpenTelemetryCoreUnstableLatestVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj" />


### PR DESCRIPTION
## Changes

* Use `OpenTelemetryCoreUnstableLatestVersion` for `OpenTelemetry.Exporter.Prometheus.HttpListener` reference in AspNet example app.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
