### PR TITLE
[onecollector] Fix duplicate extension field bug

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -11,6 +11,10 @@
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
   ([#2196](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2196))
 
+* Fixed a bug causing extension data specified on `LogRecord`s in a batch to
+  also be applied to subsequent `LogRecord`s in the same batch.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.10.0-alpha.1
 
 Released 2024-Sep-06

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 * Fixed a bug causing extension data specified on `LogRecord`s in a batch to
   also be applied to subsequent `LogRecord`s in the same batch.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#2205](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2205))
 
 ## 1.10.0-alpha.1
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializationState.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializationState.cs
@@ -142,6 +142,14 @@ internal sealed class CommonSchemaJsonSerializationState
     {
         this.itemType = itemType;
         this.Writer = writer;
+    }
+
+    public void BeginItem()
+    {
+        if (this.allValues.Count <= 0)
+        {
+            return;
+        }
 
         for (int i = 0; i < this.nextKeysToAllValuesLookupIndex; i++)
         {

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializer.cs
@@ -53,6 +53,8 @@ internal abstract class CommonSchemaJsonSerializer<T> : ISerializer<T>
 
         while (state.TryGetNextItem(out var item))
         {
+            jsonSerializerState.BeginItem();
+
             this.SerializeItemToJson(resource, item!, jsonSerializerState);
 
             var currentItemSizeInBytes = writer.BytesCommitted + writer.BytesPending + 1;

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
@@ -274,7 +274,7 @@ public class LogRecordCommonSchemaJsonSerializerTests
             .Build();
 
         string json = GetLogRecordJson(
-            1,
+            2,
             (index, logRecord) =>
             {
                 logRecord.Attributes = new List<KeyValuePair<string, object?>> { new KeyValuePair<string, object?>("ext.state.field", "stateValue1") };
@@ -283,7 +283,8 @@ public class LogRecordCommonSchemaJsonSerializerTests
             scopeProvider);
 
         Assert.Equal(
-            """{"ver":"4.0","name":"Namespace.Name","time":"2032-01-18T10:11:12Z","iKey":"o:tenant-token","data":{"severityText":"Trace","severityNumber":1},"ext":{"state":{"field":"stateValue1"},"resource":{"field":"resourceValue1"},"scope":{"field":"scopeValue1"}}}""" + "\n",
+            """{"ver":"4.0","name":"Namespace.Name","time":"2032-01-18T10:11:12Z","iKey":"o:tenant-token","data":{"severityText":"Trace","severityNumber":1},"ext":{"state":{"field":"stateValue1"},"resource":{"field":"resourceValue1"},"scope":{"field":"scopeValue1"}}}""" + "\n"
+            + """{"ver":"4.0","name":"Namespace.Name","time":"2032-01-18T10:11:12Z","iKey":"o:tenant-token","data":{"severityText":"Trace","severityNumber":1},"ext":{"state":{"field":"stateValue1"},"resource":{"field":"resourceValue1"},"scope":{"field":"scopeValue1"}}}""" + "\n",
             json);
     }
 


### PR DESCRIPTION
## Changes

* Reset the extension field serialization state for each item being serialized to fix a bug causing extension fields from earlier records to be applied to later records in a batch.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
