### PR TITLE
[onecollector-1.9.2] Patch extension data fix

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed a bug causing extension data specified on `LogRecord`s in a batch to
+  also be applied to subsequent `LogRecord`s in the same batch.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.9.2
 
 Released 2024-Aug-12

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -6,6 +6,11 @@
   also be applied to subsequent `LogRecord`s in the same batch.
   ([#2208](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2208))
 
+* Bumped the `System.Text.Json` reference to `6.0.10` for the `net462`,
+  `netstandard2.0`, and `netstandard2.1` targets in response to
+  [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).
+  ([#2208](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2208))
+
 ## 1.9.2
 
 Released 2024-Aug-12

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed a bug causing extension data specified on `LogRecord`s in a batch to
   also be applied to subsequent `LogRecord`s in the same batch.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#2208](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2208))
 
 ## 1.9.2
 

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializationState.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializationState.cs
@@ -142,6 +142,14 @@ internal sealed class CommonSchemaJsonSerializationState
     {
         this.itemType = itemType;
         this.Writer = writer;
+    }
+
+    public void BeginItem()
+    {
+        if (this.allValues.Count <= 0)
+        {
+            return;
+        }
 
         for (int i = 0; i < this.nextKeysToAllValuesLookupIndex; i++)
         {

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializer.cs
@@ -53,6 +53,8 @@ internal abstract class CommonSchemaJsonSerializer<T> : ISerializer<T>
 
         while (state.TryGetNextItem(out var item))
         {
+            jsonSerializerState.BeginItem();
+
             this.SerializeItemToJson(resource, item!, jsonSerializerState);
 
             var currentItemSizeInBytes = writer.BytesCommitted + writer.BytesPending + 1;

--- a/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
+++ b/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OTelSdkVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPkgVer)" Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net6.0'" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPkgVer)" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationStateTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationStateTests.cs
@@ -17,6 +17,8 @@ public class CommonSchemaJsonSerializationStateTests
 
         var state = new CommonSchemaJsonSerializationState("Test", writer);
 
+        state.BeginItem();
+
         state.AddExtensionAttribute(new KeyValuePair<string, object?>("ext.something.field1", 1));
         state.AddExtensionAttribute(new KeyValuePair<string, object?>("ext.something.field2", 2));
         state.AddExtensionAttribute(new KeyValuePair<string, object?>("ext.something.field3", 3));
@@ -42,7 +44,10 @@ public class CommonSchemaJsonSerializationStateTests
 
         stream.SetLength(0);
         writer.Reset(stream);
+
         state.Reset("Test", writer);
+
+        state.BeginItem();
 
         Assert.Equal(0, state.ExtensionPropertyCount);
         Assert.Equal(0, state.ExtensionAttributeCount);

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
@@ -243,7 +243,7 @@ public class LogRecordCommonSchemaJsonSerializerTests
             .Build();
 
         string json = GetLogRecordJson(
-            1,
+            2,
             (index, logRecord) =>
             {
                 logRecord.Attributes = new List<KeyValuePair<string, object?>> { new KeyValuePair<string, object?>("ext.state.field", "stateValue1") };
@@ -252,7 +252,8 @@ public class LogRecordCommonSchemaJsonSerializerTests
             scopeProvider);
 
         Assert.Equal(
-            """{"ver":"4.0","name":"Namespace.Name","time":"2032-01-18T10:11:12Z","iKey":"o:tenant-token","data":{"severityText":"Trace","severityNumber":1},"ext":{"state":{"field":"stateValue1"},"resource":{"field":"resourceValue1"},"scope":{"field":"scopeValue1"}}}""" + "\n",
+            """{"ver":"4.0","name":"Namespace.Name","time":"2032-01-18T10:11:12Z","iKey":"o:tenant-token","data":{"severityText":"Trace","severityNumber":1},"ext":{"state":{"field":"stateValue1"},"resource":{"field":"resourceValue1"},"scope":{"field":"scopeValue1"}}}""" + "\n"
+            + """{"ver":"4.0","name":"Namespace.Name","time":"2032-01-18T10:11:12Z","iKey":"o:tenant-token","data":{"severityText":"Trace","severityNumber":1},"ext":{"state":{"field":"stateValue1"},"resource":{"field":"resourceValue1"},"scope":{"field":"scopeValue1"}}}""" + "\n",
             json);
     }
 


### PR DESCRIPTION
[Note: This PR is going into the `main-onecollector-1.9.2` branch which was created off of the `Exporter.OneCollector-1.9.2` tag.]

## Changes

* Prepare hot-fix for OneCollectorExporter `1.9.2` which includes #2205.
* Bump STJ from `6.0.0` to `6.0.10` for `net462`, `netstandard2.0`, and `netstandard2.1` targets to mitigate CVEs.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
