### PR TITLE
[extensions.aws & sampler.aws] STJ tweaks

### DIFF
--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -5,12 +5,8 @@
 * Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
   ([#2125](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2125))
 
-* Lowered the `System.Text.Json` reference to `4.7.2` for runtimes older than
-  `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
-  `net8.0` in response to
-  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197),
-  [#2199](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2199))
+* Removed the unused `System.Text.Json` reference.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#2125](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2125))
 
 * Removed the unused `System.Text.Json` reference.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#2209](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2209))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
+++ b/src/OpenTelemetry.Extensions.AWS/OpenTelemetry.Extensions.AWS.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry extensions for AWS.</Description>
     <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
-    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -5,15 +5,14 @@
 * Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.
   ([#2172](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2172))
 
-* Lowered the `System.Text.Json` reference to `4.7.2` for runtimes older than
+* Bumped the `System.Text.Json` reference to `6.0.10` for runtimes older than
   `net8.0` and added a direct reference for `System.Text.Json` at `8.0.5` on
   `net8.0` in response to
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
-  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197),
-  [#2199](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2199))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197))
 
 * Removed the `System.Net.Http` package reference from all targets.
-  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2197))
+  ([#2197](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2197))
 
 ## 0.1.0-alpha.2
 

--- a/src/OpenTelemetry.Sampler.AWS/OpenTelemetry.Sampler.AWS.csproj
+++ b/src/OpenTelemetry.Sampler.AWS/OpenTelemetry.Sampler.AWS.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry remote sampler for AWS X-Ray.</Description>
     <MinVerTagPrefix>Sampler.AWS-</MinVerTagPrefix>
-    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonMinimumOutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
+    <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonLatestNet6OutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 
   <!-- Do not run Package Baseline Validation as this package has never released a stable version.


### PR DESCRIPTION
[This PR effectively reverts #2199]

## Changes

* Remove STJ from `OpenTelemetry.Extensions.AWS` completely as it isn't used by any of the code.
* Put STJ back to `6.0.10` for `net462` and `netstandard2.0` targets in `OpenTelemetry.Sampler.AWS` because it relies on some of its behaviors (being able to deserialize to classes which do not have a public parameterless ctor).

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
