### PR TITLE
[onecollector] Updates for 1.9.3 patch

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -15,6 +15,19 @@
   also be applied to subsequent `LogRecord`s in the same batch.
   ([#2205](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2205))
 
+## 1.9.3
+
+Released 2024-Oct-11
+
+* Fixed a bug causing extension data specified on `LogRecord`s in a batch to
+  also be applied to subsequent `LogRecord`s in the same batch.
+  ([#2208](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2208))
+
+* Bumped the `System.Text.Json` reference to `6.0.10` for the `net462`,
+  `netstandard2.0`, and `netstandard2.1` targets in response to
+  [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).
+  ([#2208](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2208))
+
 ## 1.10.0-alpha.1
 
 Released 2024-Sep-06

--- a/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
+++ b/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
@@ -13,7 +13,7 @@
     this at the call site but there is a bug. This could possibly be cleaned up
     in the future (hopefully .NET 9) see https://github.com/dotnet/runtime/issues/92509 -->
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
-    <PackageValidationBaselineVersion>1.9.2</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.9.3</PackageValidationBaselineVersion>
     <SystemTextJsonMinimumRequiredPkgVer>$(SystemTextJsonLatestNet6OutOfBandPkgVer)</SystemTextJsonMinimumRequiredPkgVer>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationStateTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationStateTests.cs
@@ -17,6 +17,8 @@ public class CommonSchemaJsonSerializationStateTests
 
         var state = new CommonSchemaJsonSerializationState("Test", writer);
 
+        state.BeginItem();
+
         state.AddExtensionAttribute(new KeyValuePair<string, object?>("ext.something.field1", 1));
         state.AddExtensionAttribute(new KeyValuePair<string, object?>("ext.something.field2", 2));
         state.AddExtensionAttribute(new KeyValuePair<string, object?>("ext.something.field3", 3));
@@ -42,7 +44,10 @@ public class CommonSchemaJsonSerializationStateTests
 
         stream.SetLength(0);
         writer.Reset(stream);
+
         state.Reset("Test", writer);
+
+        state.BeginItem();
 
         Assert.Equal(0, state.ExtensionPropertyCount);
         Assert.Equal(0, state.ExtensionAttributeCount);


### PR DESCRIPTION
## Changes

* Updates OneCollectorExporter project in main branch for `1.9.3` patch (#2208, #2211).

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
