### PR TITLE
[repo] Update CI for AWS projects sharing a tag

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -63,6 +63,13 @@ flags:
     paths:
       - src/OpenTelemetry.Instrumentation.AspNetCore
 
+  unittests-Instrumentation.AWS:
+    carryforward: true
+    paths:
+      - src/OpenTelemetry.Extensions.AWS
+      - src/OpenTelemetry.Instrumentation.AWS
+      - src/OpenTelemetry.Instrumentation.AWSLambda
+
   unittests-Instrumentation.ConfluentKafka:
     carryforward: true
     paths:
@@ -119,6 +126,11 @@ flags:
       - src/OpenTelemetry.PersistentStorage.Abstractions
       - src/OpenTelemetry.PersistentStorage.FileSystem
 
+  unittests-Resources.AWS:
+    carryforward: true
+    paths:
+      - src/OpenTelemetry.Resources.AWS
+
   unittests-Resources.Azure:
     carryforward: true
     paths:
@@ -148,6 +160,11 @@ flags:
     carryforward: true
     paths:
       - src/OpenTelemetry.Resources.ProcessRuntime
+
+  unittests-Sampler.AWS:
+    carryforward: true
+    paths:
+      - src/OpenTelemetry.Sampler.AWS
 
   unittests-SemanticConventions:
     carryforward: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,10 @@ jobs:
           exporter-onecollector: ['*/OpenTelemetry.Exporter.OneCollector*/**', '!**/*.md']
           exporter-stackdriver: ['*/OpenTelemetry.Exporter.Stackdriver*/**', '!**/*.md']
           extensions: ['*/OpenTelemetry.Extensions/**', '*/OpenTelemetry.Extensions.Tests/**', '!**/*.md']
-          extensions-aws: ['*/OpenTelemetry.Extensions.AWS*/**', '!**/*.md']
           extensions-enrichment: ['*/OpenTelemetry.Extensions.Enrichment*/**', '!**/*.md']
           instrumentation-aspnet: ['*/OpenTelemetry.Instrumentation.AspNet/**', '*/OpenTelemetry.Instrumentation.AspNet.Tests/**', '*/OpenTelemetry.Instrumentation.OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.*/**', 'examples/AspNet/**', '!**/*.md']
           instrumentation-aspnetcore: ['*/OpenTelemetry.Instrumentation.AspNetCore*/**', '!**/*.md']
-          instrumentation-aws: ['*/OpenTelemetry.Instrumentation.AWS/**', '*/OpenTelemetry.Instrumentation.AWS.Tests/**', '!**/*.md']
-          instrumentation-aws-lambda: ['*/OpenTelemetry.Instrumentation.AWSLambda/**', '*/OpenTelemetry.Instrumentation.AWSLambda.Tests/**', '!**/*.md']
+          instrumentation-aws: ['*/OpenTelemetry.Extensions.AWS*/**', '*/OpenTelemetry.Instrumentation.AWS*/**', '!**/*.md']
           instrumentation-cassandra: ['*/OpenTelemetry.Instrumentation.Cassandra*/**', '!**/*.md']
           instrumentation-confluentkafka: ['*/OpenTelemetry.Instrumentation.ConfluentKafka*/**', 'examples/kafka/**', '!**/*.md']
           instrumentation-elasticsearchclient: ['*/OpenTelemetry.Instrumentation.ElasticsearchClient*/**', '!**/*.md']
@@ -61,7 +59,7 @@ jobs:
           resources-operatingsystem: ['*/OpenTelemetry.Resources.OperatingSystem/**', '*/OpenTelemetry.Resources.OperatingSystem.Tests/**', '!**/*.md']
           resources-process: ['*/OpenTelemetry.Resources.Process/**', '*/OpenTelemetry.Resources.Process.Tests/**', '!**/*.md']
           resources-processruntime: ['*/OpenTelemetry.Resources.ProcessRuntime/**', '*/OpenTelemetry.Resources.ProcessRuntime.Tests/**', '!**/*.md']
-          sampler-aws: ['*/OpenTelemetry.Sampler.AWS**/**', '!**/*.md']
+          sampler-aws: ['*/OpenTelemetry.Sampler.AWS*/**', '!**/*.md']
           semanticconventions: ['*/OpenTelemetry.SemanticConventions*/**', '!**/*.md']
 
   lint-md:
@@ -151,17 +149,6 @@ jobs:
       project-name: Component[OpenTelemetry.Extensions]
       code-cov-name: Extensions
 
-  build-test-extensions-aws:
-    needs: detect-changes
-    if: |
-      contains(needs.detect-changes.outputs.changes, 'extensions-aws')
-      || contains(needs.detect-changes.outputs.changes, 'build')
-      || contains(needs.detect-changes.outputs.changes, 'shared')
-    uses: ./.github/workflows/Component.BuildTest.yml
-    with:
-      project-name: Component[OpenTelemetry.Extensions.AWS]
-      code-cov-name: Extensions.AWS
-
   build-test-extensions-enrichment:
     needs: detect-changes
     if: |
@@ -206,20 +193,8 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'shared')
     uses: ./.github/workflows/Component.BuildTest.yml
     with:
-      project-name: Component[OpenTelemetry.Instrumentation.AWS]
+      project-name: OpenTelemetry.Instrumentation.AWS
       code-cov-name: Instrumentation.AWS
-
-  build-test-instrumentation-awslambda:
-    needs: detect-changes
-    if: |
-      contains(needs.detect-changes.outputs.changes, 'instrumentation-awslambda')
-      || contains(needs.detect-changes.outputs.changes, 'build')
-      || contains(needs.detect-changes.outputs.changes, 'shared')
-    uses: ./.github/workflows/Component.BuildTest.yml
-    with:
-      project-name: Component[OpenTelemetry.Instrumentation.AWSLambda]
-      code-cov-name: Instrumentation.AWSLambda
-      tfm-list: '[ "net8.0" ]'
 
   build-test-instrumentation-cassandra:
     needs: detect-changes
@@ -524,7 +499,7 @@ jobs:
   build-test-sampler-aws:
     needs: detect-changes
     if: |
-      contains(needs.detect-changes.outputs.changes, 'resources-sampler-aws')
+      contains(needs.detect-changes.outputs.changes, 'sampler-aws')
       || contains(needs.detect-changes.outputs.changes, 'build')
       || contains(needs.detect-changes.outputs.changes, 'shared')
     uses: ./.github/workflows/Component.BuildTest.yml
@@ -563,7 +538,6 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'extensions-enrichment')
       || contains(needs.detect-changes.outputs.changes, 'instrumentation-aspnetcore')
       || contains(needs.detect-changes.outputs.changes, 'instrumentation-aws')
-      || contains(needs.detect-changes.outputs.changes, 'instrumentation-awslambda')
       || contains(needs.detect-changes.outputs.changes, 'instrumentation-confluentkafka')
       || contains(needs.detect-changes.outputs.changes, 'instrumentation-eventcounters')
       || contains(needs.detect-changes.outputs.changes, 'instrumentation-grpcnetclient')
@@ -598,12 +572,10 @@ jobs:
       build-test-exporter-onecollector,
       build-test-exporter-stackdriver,
       build-test-extensions,
-      build-test-extensions-aws,
       build-test-extensions-enrichment,
       build-test-instrumentation-aspnet,
       build-test-instrumentation-aspnetcore,
       build-test-instrumentation-aws,
-      build-test-instrumentation-awslambda,
       build-test-instrumentation-cassandra,
       build-test-instrumentation-confluentkafka,
       build-test-instrumentation-elasticsearchclient,

--- a/build/Projects/OpenTelemetry.Instrumentation.AWS.proj
+++ b/build/Projects/OpenTelemetry.Instrumentation.AWS.proj
@@ -1,0 +1,41 @@
+<Project>
+
+  <PropertyGroup>
+    <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.Parent.FullName)</RepoRoot>
+    <MinVerTagPrefix>Instrumentation.AWS-</MinVerTagPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.Extensions.AWS\OpenTelemetry.Extensions.AWS.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AWS\OpenTelemetry.Instrumentation.AWS.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AWSLambda\OpenTelemetry.Instrumentation.AWSLambda.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.Extensions.AWS.Tests\OpenTelemetry.Extensions.AWS.Tests.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.AWS.Tests\OpenTelemetry.Instrumentation.AWS.Tests.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.AWSLambda.Tests\OpenTelemetry.Instrumentation.AWSLambda.Tests.csproj" />
+
+    <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Extensions.AWS\OpenTelemetry.Extensions.AWS.csproj" />
+    <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AWS\OpenTelemetry.Instrumentation.AWS.csproj" />
+    <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AWSLambda\OpenTelemetry.Instrumentation.AWSLambda.csproj" />
+
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Extensions.AWS.Tests\OpenTelemetry.Extensions.AWS.Tests.csproj" />
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.AWS.Tests\OpenTelemetry.Instrumentation.AWS.Tests.csproj" />
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.AWSLambda.Tests\OpenTelemetry.Instrumentation.AWSLambda.Tests.csproj" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <MSBuild Projects="@(SolutionProjects)" Targets="Build" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(SolutionProjects)" Targets="Restore" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="Pack">
+    <MSBuild Projects="@(PackProjects)" Targets="Pack" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProjects)" Targets="VSTest" ContinueOnError="ErrorAndStop" />
+  </Target>
+
+</Project>

--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -292,6 +292,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{04
 		build\Projects\OpenTelemetry.Extensions.Enrichment.proj = build\Projects\OpenTelemetry.Extensions.Enrichment.proj
 		build\Projects\OpenTelemetry.Instrumentation.AspNet.proj = build\Projects\OpenTelemetry.Instrumentation.AspNet.proj
 		build\Projects\OpenTelemetry.Instrumentation.AspNetCore.proj = build\Projects\OpenTelemetry.Instrumentation.AspNetCore.proj
+		build\Projects\OpenTelemetry.Instrumentation.AWS.proj = build\Projects\OpenTelemetry.Instrumentation.AWS.proj
 		build\Projects\OpenTelemetry.Instrumentation.ConfluentKafka.proj = build\Projects\OpenTelemetry.Instrumentation.ConfluentKafka.proj
 		build\Projects\OpenTelemetry.Instrumentation.EventCounters.proj = build\Projects\OpenTelemetry.Instrumentation.EventCounters.proj
 		build\Projects\OpenTelemetry.Instrumentation.GrpcCore.proj = build\Projects\OpenTelemetry.Instrumentation.GrpcCore.proj


### PR DESCRIPTION
Follow-up to #2203

## Changes

* Updates CI for the AWS projects now sharing a tag.
* Adds missing codcov definitions for AWS projects.
* Fixes the sampler leg to run on the correct key.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
