### PR TITLE
[geneva] Nullable annotations for the metrics folder

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -244,6 +244,16 @@ internal sealed class ConnectionStringBuilder
         }
     }
 
+    public bool TryGetMetricsAccountAndNamespace(
+        [NotNullWhen(true)] out string? metricsAccount,
+        [NotNullWhen(true)] out string? metricsNamespace)
+    {
+        var hasAccount = this.parts.TryGetValue(nameof(this.Account), out metricsAccount);
+        var hasNamespace = this.parts.TryGetValue(nameof(this.Namespace), out metricsNamespace);
+
+        return hasAccount && hasNamespace;
+    }
+
     /// <summary>
     /// Replace first charater of string if it matches with <paramref name="oldChar"/> with <paramref name="newChar"/>.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/MetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/MetricSerializer.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -174,11 +176,11 @@ internal static class MetricSerializer
     /// <param name="bufferIndex">Index of the buffer.</param>
     /// <param name="value">The value.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void SerializeString(byte[] buffer, ref int bufferIndex, string value)
+    public static void SerializeString(byte[] buffer, ref int bufferIndex, string? value)
     {
         if (!string.IsNullOrEmpty(value))
         {
-            if (bufferIndex + value.Length + sizeof(short) >= buffer.Length)
+            if (bufferIndex + value!.Length + sizeof(short) >= buffer.Length)
             {
                 // TODO: What should we do when the data is invalid?
             }
@@ -391,12 +393,13 @@ internal static class MetricSerializer
     /// <param name="bufferIndex">Index of the buffer.</param>
     /// <param name="value">The value.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void SerializeBase128String(byte[] buffer, ref int bufferIndex, string value)
+    public static void SerializeBase128String(byte[] buffer, ref int bufferIndex, string? value)
     {
         if (!string.IsNullOrEmpty(value))
         {
-            if (bufferIndex + value.Length + sizeof(short) >= buffer.Length)
+            if (bufferIndex + value!.Length + sizeof(short) >= buffer.Length)
             {
+                // TODO: What should we do when the data is invalid?
             }
 
             var encodedValue = Encoding.UTF8.GetBytes(value);

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/FieldNumberConstants.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/FieldNumberConstants.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Metrics;
 

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using OpenTelemetry.Metrics;
@@ -19,11 +21,11 @@ internal sealed class OtlpProtobufMetricExporter : IDisposable
     public OtlpProtobufMetricExporter(
         Func<Resource> getResource,
         ConnectionStringBuilder connectionStringBuilder,
-        IReadOnlyDictionary<string, object> prepopulatedMetricDimensions)
+        IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions)
     {
         Debug.Assert(getResource != null, "getResource was null");
 
-        this.getResource = getResource;
+        this.getResource = getResource!;
 
 #if NET6_0_OR_GREATER
         IMetricDataTransport transport = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
+using System.Diagnostics;
 using System.Globalization;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -14,13 +17,13 @@ internal sealed class OtlpProtobufSerializer
     private const int TagAndLengthSize = 4;
 
     private readonly Dictionary<string, List<Metric>> scopeMetrics = new();
-    private readonly string metricNamespace;
-    private readonly string metricAccount;
-    private readonly byte[] prepopulatedNumberDataPointAttributes;
+    private readonly string? metricNamespace;
+    private readonly string? metricAccount;
+    private readonly byte[]? prepopulatedNumberDataPointAttributes;
     private readonly int prepopulatedNumberDataPointAttributesLength;
-    private readonly byte[] prepopulatedHistogramDataPointAttributes;
+    private readonly byte[]? prepopulatedHistogramDataPointAttributes;
     private readonly int prepopulatedHistogramDataPointAttributesLength;
-    private readonly byte[] prepopulatedExponentialHistogramDataPointAttributes;
+    private readonly byte[]? prepopulatedExponentialHistogramDataPointAttributes;
     private readonly int prepopulatedExponentialHistogramDataPointAttributesLength;
     private int resourceMetricTagAndLengthIndex;
     private int scopeMetricsTagAndLengthIndex;
@@ -34,9 +37,14 @@ internal sealed class OtlpProtobufSerializer
     private int metricPointValueIndex;
     private ExportResult metricExportResult;
 
-    public OtlpProtobufSerializer(IMetricDataTransport metricDataTransport, ConnectionStringBuilder connectionStringBuilder, IReadOnlyDictionary<string, object> prepopulatedMetricDimensions)
+    public OtlpProtobufSerializer(
+        IMetricDataTransport metricDataTransport,
+        ConnectionStringBuilder? connectionStringBuilder,
+        IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions)
     {
-        this.MetricDataTransport = metricDataTransport;
+        Debug.Assert(metricDataTransport != null, "metricDataTransport was null");
+
+        this.MetricDataTransport = metricDataTransport!;
 
         // Taking a arbitrary number here for writing attributes.
         byte[] temp = new byte[20000];
@@ -44,40 +52,31 @@ internal sealed class OtlpProtobufSerializer
         {
             // Initialize numberDataPoint attributes.
             int cursor = 0;
-            SerializeTags(temp, ref cursor, prepopulatedMetricDimensions, FieldNumberConstants.NumberDataPoint_attributes);
+            SerializeTags(temp, ref cursor, prepopulatedMetricDimensions!, FieldNumberConstants.NumberDataPoint_attributes);
             this.prepopulatedNumberDataPointAttributes = new byte[cursor];
             Array.Copy(temp, this.prepopulatedNumberDataPointAttributes, cursor);
             this.prepopulatedNumberDataPointAttributesLength = cursor;
 
             // Initialize histogramDataPoint attributes.
             cursor = 0;
-            SerializeTags(temp, ref cursor, prepopulatedMetricDimensions, FieldNumberConstants.HistogramDataPoint_attributes);
+            SerializeTags(temp, ref cursor, prepopulatedMetricDimensions!, FieldNumberConstants.HistogramDataPoint_attributes);
             this.prepopulatedHistogramDataPointAttributes = new byte[cursor];
             Array.Copy(temp, this.prepopulatedHistogramDataPointAttributes, cursor);
             this.prepopulatedHistogramDataPointAttributesLength = cursor;
 
             cursor = 0;
-            SerializeTags(temp, ref cursor, prepopulatedMetricDimensions, FieldNumberConstants.ExponentialHistogramDataPoint_attributes);
+            SerializeTags(temp, ref cursor, prepopulatedMetricDimensions!, FieldNumberConstants.ExponentialHistogramDataPoint_attributes);
             this.prepopulatedExponentialHistogramDataPointAttributes = new byte[cursor];
             Array.Copy(temp, this.prepopulatedExponentialHistogramDataPointAttributes, cursor);
             this.prepopulatedExponentialHistogramDataPointAttributesLength = cursor;
         }
 
-        try
+        if (connectionStringBuilder?.TryGetMetricsAccountAndNamespace(
+            out var metricsAccount,
+            out var metricsNamespace) == true)
         {
-            if (connectionStringBuilder != null && connectionStringBuilder.Namespace != null)
-            {
-                this.metricNamespace = connectionStringBuilder.Namespace;
-            }
-
-            if (connectionStringBuilder != null && connectionStringBuilder.Account != null)
-            {
-                this.metricAccount = connectionStringBuilder.Account;
-            }
-        }
-        catch
-        {
-            // TODO: add log.
+            this.metricAccount = metricsAccount;
+            this.metricNamespace = metricsNamespace;
         }
     }
 
@@ -99,7 +98,7 @@ internal sealed class OtlpProtobufSerializer
         }
     }
 
-    internal static void SerializeInstrumentationScope(byte[] buffer, ref int cursor, string name, IEnumerable<KeyValuePair<string, object>> meterTags)
+    internal static void SerializeInstrumentationScope(byte[] buffer, ref int cursor, string name, IEnumerable<KeyValuePair<string, object?>>? meterTags)
     {
         int tagAndLengthIndex = cursor;
         cursor += TagAndLengthSize;
@@ -145,7 +144,7 @@ internal sealed class OtlpProtobufSerializer
             {
                 case char:
                 case string:
-                    ProtobufSerializerHelper.WriteStringTag(buffer, ref cursor, FieldNumberConstants.AnyValue_string_value, Convert.ToString(value, CultureInfo.InvariantCulture));
+                    ProtobufSerializerHelper.WriteStringTag(buffer, ref cursor, FieldNumberConstants.AnyValue_string_value, Convert.ToString(value, CultureInfo.InvariantCulture)!);
                     break;
                 case bool b:
                     ProtobufSerializerHelper.WriteBoolWithTag(buffer, ref cursor, FieldNumberConstants.AnyValue_bool_value, (bool)value);
@@ -165,7 +164,17 @@ internal sealed class OtlpProtobufSerializer
                     ProtobufSerializerHelper.WriteDoubleWithTag(buffer, ref cursor, FieldNumberConstants.AnyValue_double_value, Convert.ToDouble(value, CultureInfo.InvariantCulture));
                     break;
                 default:
-                    ProtobufSerializerHelper.WriteStringTag(buffer, ref cursor, FieldNumberConstants.AnyValue_string_value, Convert.ToString(value, CultureInfo.InvariantCulture));
+                    string repr;
+                    try
+                    {
+                        repr = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+                    }
+                    catch
+                    {
+                        repr = $"ERROR: type {value.GetType().FullName} is not supported";
+                    }
+
+                    ProtobufSerializerHelper.WriteStringTag(buffer, ref cursor, FieldNumberConstants.AnyValue_string_value, repr);
                     break;
 
                     // TODO: Handle array type.
@@ -277,11 +286,11 @@ internal sealed class OtlpProtobufSerializer
         {
             // Casting to ulong is ok here as the bit representation for long versus ulong will be the same
             // The difference would in the way the bit representation is interpreted on decoding side (signed versus unsigned)
-            ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.Exemplar_as_int, (ulong)(long)(object)value);
+            ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.Exemplar_as_int, (ulong)(long)(object)value!);
         }
         else if (typeof(T) == typeof(double))
         {
-            ProtobufSerializerHelper.WriteDoubleWithTag(buffer, ref cursor, FieldNumberConstants.Exemplar_as_double, (double)(object)value);
+            ProtobufSerializerHelper.WriteDoubleWithTag(buffer, ref cursor, FieldNumberConstants.Exemplar_as_double, (double)(object)value!);
         }
 
         var time = (ulong)exemplar.Timestamp.ToUnixTimeNanoseconds();
@@ -306,11 +315,14 @@ internal sealed class OtlpProtobufSerializer
     {
         foreach (var tag in tags)
         {
-            SerializeTag(buffer, ref cursor, tag.Key, tag.Value, FieldNumberConstants.Exemplar_attributes);
+            if (tag.Value != null)
+            {
+                SerializeTag(buffer, ref cursor, tag.Key, tag.Value, FieldNumberConstants.Exemplar_attributes);
+            }
         }
     }
 
-    private static void SerializeTags(byte[] buffer, ref int cursor, IEnumerable<KeyValuePair<string, object>> attributes, int fieldNumber)
+    private static void SerializeTags(byte[] buffer, ref int cursor, IEnumerable<KeyValuePair<string, object?>>? attributes, int fieldNumber)
     {
         if (attributes != null)
         {
@@ -661,11 +673,11 @@ internal sealed class OtlpProtobufSerializer
         {
             // Casting to ulong is ok here as the bit representation for long versus ulong will be the same
             // The difference would in the way the bit representation is interpreted on decoding side (signed versus unsigned)
-            ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.NumberDataPoint_as_int, (ulong)(long)(object)value);
+            ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.NumberDataPoint_as_int, (ulong)(long)(object)value!);
         }
         else if (typeof(T) == typeof(double))
         {
-            ProtobufSerializerHelper.WriteDoubleWithTag(buffer, ref cursor, FieldNumberConstants.NumberDataPoint_as_double, (double)(object)value);
+            ProtobufSerializerHelper.WriteDoubleWithTag(buffer, ref cursor, FieldNumberConstants.NumberDataPoint_as_double, (double)(object)value!);
         }
 
         var startTime = (ulong)metricPoint.StartTime.ToUnixTimeNanoseconds();
@@ -740,7 +752,7 @@ internal sealed class OtlpProtobufSerializer
             cursor += TagAndLengthSize;
             int valueIndex = cursor;
 
-            SerializeTags(buffer, ref cursor, resource.Attributes, FieldNumberConstants.Resource_attributes);
+            SerializeTags(buffer, ref cursor, resource.Attributes!, FieldNumberConstants.Resource_attributes);
 
             // TODO: check to see if should de-dupe in case the values are also provided via resource attributes.
             if (this.metricAccount != null)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/ProtobufSerializerHelper.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/ProtobufSerializerHelper.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/TimestampHelpers.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/TimestampHelpers.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 namespace OpenTelemetry.Exporter.Geneva;
 
 /// <summary>

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/WireType.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/WireType.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 namespace OpenTelemetry.Exporter.Geneva;
 
 /// <summary>

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/IMetricDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/IMetricDataTransport.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 namespace OpenTelemetry.Exporter.Geneva;
 
 internal interface IMetricDataTransport : IDisposable

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using OpenTelemetry.Exporter.Geneva.Transports;
 
 namespace OpenTelemetry.Exporter.Geneva;

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricWindowsEventTracingDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricWindowsEventTracingDataTransport.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -102,7 +104,7 @@ internal sealed class MetricWindowsEventTracingDataTransport : EventSource, IMet
             // No managed resources to release.
             // The singleton instance is kept alive for the lifetime of the application.
             // Set the instance to null so that future calls to the singleton property can fail explicitly.
-            Instance = null;
+            Instance = null!;
         }
 
         this.isDisposed = true;


### PR DESCRIPTION
## Changes

* Nullable annotations for the metrics folder in GenevaExporter project.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
