### PR TITLE
[repo] Add geneva integration test leg to CI

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -25,6 +25,17 @@ on:
         default: '[ "net462", "net8.0" ]'
         required: false
         type: string
+      test-case-filter:
+        required: false
+        type: string
+      test-require-elevated:
+        default: false
+        required: false
+        type: boolean
+      pack:
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   build-test:
@@ -92,10 +103,22 @@ jobs:
 
     - name: dotnet test ${{ steps.resolve-project.outputs.title }}
       if: ${{ inputs.run-tests }}
-      run: dotnet test ${{ steps.resolve-project.outputs.project }} --collect:"Code Coverage" --results-directory:TestResults --framework ${{ matrix.version }} --configuration Release --no-restore --no-build --logger:"console;verbosity=detailed" -- RunConfiguration.DisableAppDomain=true
+      run: >
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'sudo -E' || '' }}
+        dotnet test ${{ steps.resolve-project.outputs.project }}
+        --collect:"Code Coverage"
+        --results-directory:TestResults
+        --framework ${{ matrix.version }}
+        --configuration Release
+        --no-restore
+        --no-build
+        --logger:"console;verbosity=detailed"
+        --filter "${{ inputs.test-case-filter }}"
+        -- RunConfiguration.DisableAppDomain=true
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && '&& sudo chmod a+rw ./TestResults' || '' }}
 
     - name: dotnet pack ${{ steps.resolve-project.outputs.title }}
-      if: ${{ matrix.os == 'windows-latest' }}
+      if: ${{ matrix.os == 'windows-latest' && inputs.pack }}
       run: dotnet pack ${{ steps.resolve-project.outputs.project }} --configuration Release --no-restore --no-build -p:EnablePackageValidation=true
 
     - name: Install coverage tool
@@ -113,10 +136,11 @@ jobs:
       env:
         OS: ${{ matrix.os }}
         TFM: ${{ matrix.version }}
+        FILTER: ${{ inputs.test-case-filter }}
         token: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: TestResults/Cobertura.xml
-        env_vars: OS,TFM
+        env_vars: OS,TFM,FILTER
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Code Coverage for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
         codecov_yml_path: .github/codecov.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       project-name: Component[OpenTelemetry.Exporter.Geneva]
       code-cov-name: Exporter.Geneva
       os-list: '[ "ubuntu-24.04" ]' # Note: This may be switched to latest once ubuntu-latest has a kernel version >= 6.8.0-1014-azure
-      tfm-list: '[ net8.0 ]' # Note: Should be able to remove this once the above is using ubuntu-latest
+      tfm-list: '[ "net8.0" ]' # Note: Should be able to remove this once the above is using ubuntu-latest
       test-case-filter: CategoryName=Geneva:user_events:metrics
       test-require-elevated: true
       pack: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Exporter.Geneva]
       code-cov-name: Exporter.Geneva
-      os-list: '[ "ubuntu-latest" ]'
+      os-list: '[ "ubuntu-24.04" ]' # Note: This may be switched to latest once ubuntu-latest has a kernel version >= 6.8.0-1014-azure
       test-case-filter: CategoryName=Geneva:user_events:metrics
       test-require-elevated: true
       pack: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,21 @@ jobs:
       project-name: Component[OpenTelemetry.Exporter.Geneva]
       code-cov-name: Exporter.Geneva
 
+  build-test-exporter-geneva-integration:
+    needs: detect-changes
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'exporter-geneva')
+      || contains(needs.detect-changes.outputs.changes, 'build')
+      || contains(needs.detect-changes.outputs.changes, 'shared')
+    uses: ./.github/workflows/Component.BuildTest.yml
+    with:
+      project-name: Component[OpenTelemetry.Exporter.Geneva]
+      code-cov-name: Exporter.Geneva
+      os-list: '[ "ubuntu-latest" ]'
+      test-case-filter: CategoryName=Geneva:user_events:metrics
+      test-require-elevated: true
+      pack: false
+
   build-test-exporter-influxdb:
     needs: detect-changes
     if: |
@@ -573,6 +588,7 @@ jobs:
       lint-yml,
       lint-dotnet-format,
       build-test-exporter-geneva,
+      build-test-exporter-geneva-integration,
       build-test-exporter-influxdb,
       build-test-exporter-instana,
       build-test-exporter-onecollector,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
       project-name: Component[OpenTelemetry.Exporter.Geneva]
       code-cov-name: Exporter.Geneva
       os-list: '[ "ubuntu-24.04" ]' # Note: This may be switched to latest once ubuntu-latest has a kernel version >= 6.8.0-1014-azure
+      tfm-list: '[ net8.0 ]' # Note: Should be able to remove this once the above is using ubuntu-latest
       test-case-filter: CategoryName=Geneva:user_events:metrics
       test-require-elevated: true
       pack: false

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -34,6 +34,11 @@
       <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>
       <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</Version>
       <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</FileVersion>
+
+      <!-- Note: If MinVerVersion is set to the default value we disable
+      PackageValidation because this most likely means we are running on a fork
+      without a valid tag to use for versioning and it will fail. -->
+      <EnablePackageValidation Condition="$(MinVerVersion.StartsWith('0.0.0-alpha.0'))">false</EnablePackageValidation>
     </PropertyGroup>
 
     <!-- Note: The '$(TargetFramework)' != '' check here is to reduce log spam


### PR DESCRIPTION
Relates to #2113

## Changes

* Adds a CI leg for running geneva linux user_events tests when the code is changed.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
