### PR TITLE
[geneva] Bump MessagePack version in test project to fix vulnerability warning

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.25.3" />
     <PackageReference Include="Grpc.Tools" Version="2.62.0" PrivateAssets="All" />
     <PackageReference Include="Grpc" Version="2.46.6" />
-    <PackageReference Include="MessagePack" Version="2.5.172" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OTelSdkVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Following up on https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2220#issuecomment-2422887815

## Changes

* Bump MessagePack version in Geneva test project to fix vulnerability warning

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
