### PR TITLE
[Instrumentation.SqlClient] Update to follow new DB span conventions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 * Drop support for .NET 6 as this target is no longer supported.
   ([#2159](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2159))
+* The new database semantic conventions can be opted in to by setting
+  the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable. This allows for a
+  transition period for users to experiment with the new semantic conventions
+  and adapt as necessary. The environment variable supports the following
+  values:
+  * `database` - emit the new, frozen (proposed for stable) database
+  attributes, and stop emitting the old experimental database
+  attributes that the instrumentation emitted previously.
+  * `database/dup` - emit both the old and the frozen (proposed for stable) database
+  attributes, allowing for a more seamless transition.
+  * The default behavior (in the absence of one of these values) is to continue
+  emitting the same database semantic conventions that were emitted in
+  the previous version.
+  * Note: this option will be be removed after the new database
+  semantic conventions is marked stable. At which time this
+  instrumentation can receive a stable release, and the old database
+  semantic conventions will no longer be supported. Refer to the
+  specification for more information regarding the new database
+  semantic conventions for
+  [spans](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md).
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+* **Breaking change**: The `peer.service` and `server.socket.address` attributes
+  are no longer emitted. Users should rely on the `server.address` attribute
+  for the same information. Note that `server.address` is only included when
+  the `EnableConnectionLevelAttributes` option is enabled.
 
 ## 1.9.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -24,11 +24,12 @@
   specification for more information regarding the new database
   semantic conventions for
   [spans](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md).
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+  ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229))
 * **Breaking change**: The `peer.service` and `server.socket.address` attributes
   are no longer emitted. Users should rely on the `server.address` attribute
   for the same information. Note that `server.address` is only included when
   the `EnableConnectionLevelAttributes` option is enabled.
+  ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229))
 
 ## 1.9.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -94,10 +94,21 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                         _ = this.connectionFetcher.TryFetch(command, out var connection);
                         _ = this.databaseFetcher.TryFetch(connection, out var database);
 
+                        // TODO: Need to understand what scenario (if any) database will be null here
+                        // so that we set DisplayName and db.name/db.namespace correctly.
                         if (database != null)
                         {
                             activity.DisplayName = (string)database;
-                            activity.SetTag(SemanticConventions.AttributeDbName, database);
+
+                            if (this.options.EmitOldAttributes)
+                            {
+                                activity.SetTag(SemanticConventions.AttributeDbName, database);
+                            }
+
+                            if (this.options.EmitNewAttributes)
+                            {
+                                activity.SetTag(SemanticConventions.AttributeDbNamespace, database);
+                            }
                         }
 
                         _ = this.dataSourceFetcher.TryFetch(connection, out var dataSource);
@@ -115,7 +126,15 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                                 case CommandType.StoredProcedure:
                                     if (this.options.SetDbStatementForStoredProcedure)
                                     {
-                                        activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+                                        if (this.options.EmitOldAttributes)
+                                        {
+                                            activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+                                        }
+
+                                        if (this.options.EmitNewAttributes)
+                                        {
+                                            activity.SetTag(SemanticConventions.AttributeDbQueryText, commandText);
+                                        }
                                     }
 
                                     break;
@@ -123,7 +142,15 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                                 case CommandType.Text:
                                     if (this.options.SetDbStatementForText)
                                     {
-                                        activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+                                        if (this.options.EmitOldAttributes)
+                                        {
+                                            activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+                                        }
+
+                                        if (this.options.EmitNewAttributes)
+                                        {
+                                            activity.SetTag(SemanticConventions.AttributeDbQueryText, commandText);
+                                        }
                                     }
 
                                     break;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -130,14 +130,30 @@ internal sealed class SqlEventSourceListener : EventListener
 
         if (activity.IsAllDataRequested)
         {
-            activity.SetTag(SemanticConventions.AttributeDbName, databaseName);
+            if (this.options.EmitOldAttributes)
+            {
+                activity.SetTag(SemanticConventions.AttributeDbName, databaseName);
+            }
+
+            if (this.options.EmitNewAttributes)
+            {
+                activity.SetTag(SemanticConventions.AttributeDbNamespace, databaseName);
+            }
 
             this.options.AddConnectionLevelDetailsToActivity((string)eventData.Payload[1], activity);
 
             string commandText = (string)eventData.Payload[3];
             if (!string.IsNullOrEmpty(commandText) && this.options.SetDbStatementForText)
             {
-                activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+                if (this.options.EmitOldAttributes)
+                {
+                    activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+                }
+
+                if (this.options.EmitNewAttributes)
+                {
+                    activity.SetTag(SemanticConventions.AttributeQueryText, commandText);
+                }
             }
         }
     }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -152,7 +152,7 @@ internal sealed class SqlEventSourceListener : EventListener
 
                 if (this.options.EmitNewAttributes)
                 {
-                    activity.SetTag(SemanticConventions.AttributeQueryText, commandText);
+                    activity.SetTag(SemanticConventions.AttributeDbQueryText, commandText);
                 }
             }
         }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -17,8 +17,10 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ActivityInstrumentationHelper.cs" Link="Includes\ActivityInstrumentationHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\DatabaseSemanticConventionHelper.cs" Link="Includes\DatabaseSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\DiagnosticSourceListener.cs" Link="Includes\DiagnosticSourceListener.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\DiagnosticSourceSubscriber.cs" Link="Includes\DiagnosticSourceSubscriber.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
@@ -28,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPkgVer)"/>
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPkgVer)" />
     <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -165,12 +165,11 @@ command text will be captured.
 > [!NOTE]
 > EnableConnectionLevelAttributes is supported on all runtimes.
 
-By default, `EnabledConnectionLevelAttributes` is disabled and this
-instrumentation sets the `peer.service` attribute to the
-[`DataSource`](https://docs.microsoft.com/dotnet/api/system.data.common.dbconnection.datasource)
-property of the connection. If `EnabledConnectionLevelAttributes` is enabled,
-the `DataSource` will be parsed and the server name will be sent as the
-`net.peer.name` or `net.peer.ip` attribute, the instance name will be sent as
+By default, `EnabledConnectionLevelAttributes` is disabled.
+If `EnabledConnectionLevelAttributes` is enabled,
+the [`DataSource`](https://docs.microsoft.com/dotnet/api/system.data.common.dbconnection.datasource)
+will be parsed and the server name or IP address will be sent as
+the `server.address` attribute, the instance name will be sent as
 the `db.mssql.instance_name` attribute, and the port will be sent as the
 `net.peer.port` attribute if it is not 1433 (the default port).
 

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -44,7 +44,6 @@ internal static class SemanticConventions
     public const string AttributeHttpResponseContentLength = "http.response_content_length";
     public const string AttributeHttpResponseContentLengthUncompressed = "http.response_content_length_uncompressed";
 
-    public const string AttributeDbSystem = "db.system";
     public const string AttributeDbConnectionString = "db.connection_string";
     public const string AttributeDbUser = "db.user";
     public const string AttributeDbMsSqlInstanceName = "db.mssql.instance_name";
@@ -135,6 +134,17 @@ internal static class SemanticConventions
     public const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
     public const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
+
+    // New database conventions as of commit:
+    // https://github.com/open-telemetry/semantic-conventions/blob/25f74191d749645fdd5ec42ae661438cf2c1cf51/docs/database/database-spans.md#common-attributes
+    public const string AttributeDbSystem = "db.system";
+    public const string AttributeDbCollectionName = "db.collection.name";
+    public const string AttributeDbNamespace = "db.namespace";
+    public const string AttributeDbOperationName = "db.operation.name";
+    public const string AttributeResponseStatusCode = "db.response.status_code";
+    public const string AttributeDbOperationBatchSize = "db.operation.batch.size";
+    public const string AttributeDbQuerySummary = "db.query.summary";
+    public const string AttributeDbQueryText = "db.query.text";
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -91,7 +91,7 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
         Assert.Single(activities);
         var activity = activities[0];
 
-        SqlClientTests.VerifyActivityData(commandType, commandText, captureStoredProcedureCommandName, captureTextCommandContent, isFailure, recordException, shouldEnrich, dataSource, activity);
+        SqlClientTests.VerifyActivityData(commandType, commandText, captureStoredProcedureCommandName, captureTextCommandContent, isFailure, recordException, shouldEnrich, activity);
         SqlClientTests.VerifySamplingParameters(sampler.LatestSamplingParameters);
     }
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -165,7 +165,6 @@ public class SqlClientTests : IDisposable
             false,
             false,
             shouldEnrich,
-            sqlConnection.DataSource,
             activity,
             emitOldAttributes,
             emitNewAttributes);
@@ -235,7 +234,6 @@ public class SqlClientTests : IDisposable
             true,
             recordException,
             shouldEnrich,
-            sqlConnection.DataSource,
             activity);
     }
 
@@ -329,7 +327,6 @@ public class SqlClientTests : IDisposable
         bool isFailure,
         bool recordException,
         bool shouldEnrich,
-        string dataSource,
         Activity activity,
         bool emitOldAttributes = true,
         bool emitNewAttributes = false)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -73,6 +73,26 @@ public class SqlClientTests : IDisposable
     [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false)]
     [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true)]
     [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false)]
+
+    // Test cases when EmitOldAttributes = false and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database)
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false, false, true)]
+
+    // Test cases when EmitOldAttributes = true and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database/dup)
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false, true, true)]
     public void SqlClientCallsAreCollectedSuccessfully(
         string beforeCommand,
         string afterCommand,
@@ -80,7 +100,9 @@ public class SqlClientTests : IDisposable
         string commandText,
         bool captureStoredProcedureCommandName,
         bool captureTextCommandContent,
-        bool shouldEnrich = true)
+        bool shouldEnrich = true,
+        bool emitOldAttributes = true,
+        bool emitNewAttributes = false)
     {
         using var sqlConnection = new SqlConnection(TestConnectionString);
         using var sqlCommand = sqlConnection.CreateCommand();
@@ -96,6 +118,9 @@ public class SqlClientTests : IDisposable
                         {
                             opt.Enrich = ActivityEnrichment;
                         }
+
+                        opt.EmitOldAttributes = emitOldAttributes;
+                        opt.EmitNewAttributes = emitNewAttributes;
                     })
                 .AddInMemoryExporter(activities)
                 .Build())
@@ -141,7 +166,9 @@ public class SqlClientTests : IDisposable
             false,
             shouldEnrich,
             sqlConnection.DataSource,
-            activity);
+            activity,
+            emitOldAttributes,
+            emitNewAttributes);
     }
 
     [Theory]
@@ -303,7 +330,9 @@ public class SqlClientTests : IDisposable
         bool recordException,
         bool shouldEnrich,
         string dataSource,
-        Activity activity)
+        Activity activity,
+        bool emitOldAttributes = true,
+        bool emitNewAttributes = false)
     {
         Assert.Equal("master", activity.DisplayName);
         Assert.Equal(ActivityKind.Client, activity.Kind);
@@ -342,18 +371,36 @@ public class SqlClientTests : IDisposable
         }
 
         Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
-        Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
+
+        if (emitOldAttributes)
+        {
+            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
+        }
+
+        if (emitNewAttributes)
+        {
+            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
+        }
 
         switch (commandType)
         {
             case CommandType.StoredProcedure:
                 if (captureStoredProcedureCommandName)
                 {
-                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                    if (emitOldAttributes)
+                    {
+                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                    }
+
+                    if (emitNewAttributes)
+                    {
+                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
+                    }
                 }
                 else
                 {
                     Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                    Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
                 }
 
                 break;
@@ -361,17 +408,24 @@ public class SqlClientTests : IDisposable
             case CommandType.Text:
                 if (captureTextCommandContent)
                 {
-                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                    if (emitOldAttributes)
+                    {
+                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                    }
+
+                    if (emitNewAttributes)
+                    {
+                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
+                    }
                 }
                 else
                 {
                     Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                    Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
                 }
 
                 break;
         }
-
-        Assert.Equal(dataSource, activity.GetTagValue(SemanticConventions.AttributePeerService));
     }
 
     internal static void VerifySamplingParameters(SamplingParameters samplingParameters)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -123,6 +123,8 @@ public class SqlEventSourceTests
             {
                 options.SetDbStatementForText = captureText;
                 options.EnableConnectionLevelAttributes = enableConnectionLevelAttributes;
+                options.emitOldAttributes = emitOldAttributes;
+                options.emitNewAttributes = emitNewAttributes;
             })
             .Build();
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -278,7 +278,6 @@ public class SqlEventSourceTests
             Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
         }
 
-
         if (captureText)
         {
             if (emitOldAttributes)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -83,6 +83,26 @@ public class SqlEventSourceTests
     [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/0", false, true)]
     [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", false)]
     [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true)]
+
+    // Test cases when EmitOldAttributes = false and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database)
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/1", false, false, 0, false, false, true)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/0", false, true, 0, false, false, true)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", false, false, 0, false, false, true)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true, false, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/1", false, false, 0, false, false, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/0", false, true, 0, false, false, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", false, false, 0, false, false, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true, false, true)]
+
+    // Test cases when EmitOldAttributes = true and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database/dup)
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/1", false, false, 0, false, true, true)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/0", false, true, 0, false, true, true)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", false, false, 0, false, true, true)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true, true, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/1", false, false, 0, false, true, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/0", false, true, 0, false, true, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", false, false, 0, false, true, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true, true, true)]
     public void EventSourceFakeTests(
         Type eventSourceType,
         CommandType commandType,
@@ -90,7 +110,9 @@ public class SqlEventSourceTests
         bool captureText,
         bool isFailure = false,
         int sqlExceptionNumber = 0,
-        bool enableConnectionLevelAttributes = false)
+        bool enableConnectionLevelAttributes = false,
+        bool emitOldAttributes = true,
+        bool emitNewAttributes = false)
     {
         using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
@@ -125,7 +147,7 @@ public class SqlEventSourceTests
 
         var activity = exportedItems[0];
 
-        VerifyActivityData(commandText, captureText, isFailure, "127.0.0.1", activity, enableConnectionLevelAttributes);
+        VerifyActivityData(commandText, captureText, isFailure, "127.0.0.1", activity, enableConnectionLevelAttributes, emitOldAttributes, emitNewAttributes);
     }
 
     [Theory]
@@ -214,30 +236,28 @@ public class SqlEventSourceTests
         bool isFailure,
         string dataSource,
         Activity activity,
-        bool enableConnectionLevelAttributes = false)
+        bool enableConnectionLevelAttributes = false,
+        bool emitOldAttributes = true,
+        bool emitNewAttributes = false)
     {
         Assert.Equal("master", activity.DisplayName);
         Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
 
-        if (!enableConnectionLevelAttributes)
-        {
-            Assert.Equal(dataSource, activity.GetTagValue(SemanticConventions.AttributePeerService));
-        }
-        else
+        if (enableConnectionLevelAttributes)
         {
             var connectionDetails = SqlClientTraceInstrumentationOptions.ParseDataSource(dataSource);
 
             if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
             {
-                Assert.Equal(connectionDetails.ServerHostName, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
+                Assert.Equal(connectionDetails.ServerHostName, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
             }
             else
             {
-                Assert.Equal(connectionDetails.ServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
+                Assert.Equal(connectionDetails.ServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
             }
 
-            if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
+            if (emitOldAttributes && !string.IsNullOrEmpty(connectionDetails.InstanceName))
             {
                 Assert.Equal(connectionDetails.InstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
             }
@@ -248,15 +268,33 @@ public class SqlEventSourceTests
             }
         }
 
-        Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
+        if (emitOldAttributes)
+        {
+            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
+        }
+
+        if (emitNewAttributes)
+        {
+            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
+        }
+
 
         if (captureText)
         {
-            Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+            if (emitOldAttributes)
+            {
+                Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+            }
+
+            if (emitNewAttributes)
+            {
+                Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
+            }
         }
         else
         {
             Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
         }
 
         if (!isFailure)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -123,8 +123,8 @@ public class SqlEventSourceTests
             {
                 options.SetDbStatementForText = captureText;
                 options.EnableConnectionLevelAttributes = enableConnectionLevelAttributes;
-                options.emitOldAttributes = emitOldAttributes;
-                options.emitNewAttributes = emitNewAttributes;
+                options.EmitOldAttributes = emitOldAttributes;
+                options.EmitNewAttributes = emitNewAttributes;
             })
             .Build();
 


### PR DESCRIPTION
Fixes #2225

This PR is the first in a series of PRs. It introduces support for the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable to gate using the old or new conventions. It does not aim to fully adopt the new database conventions. It only updates conventions for the attributes currently reported by the instrumentation.

The documentation in the readme still only refers to the old attributes. I will update the readme in a different PR.