### PR TITLE
[Instrumentation.Wcf] Add .NET6 as target framework

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add target for `net6.0`.
+  ([#2243](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2243))
+
 ## 1.0.0-rc.17
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Add target for `net6.0`.
+* Add target for `net6.0` to ensure that non-vulnerable transient
+  dependencies are referenced by default for .NET6+.
   ([#2243](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2243))
 
 ## 1.0.0-rc.17

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/AsyncResultWithTelemetryState.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/AsyncResultWithTelemetryState.cs
@@ -15,7 +15,7 @@ internal sealed class AsyncResultWithTelemetryState : IAsyncResult
 
     public RequestTelemetryState TelemetryState { get; }
 
-    object IAsyncResult.AsyncState => this.Inner.AsyncState;
+    object? IAsyncResult.AsyncState => this.Inner.AsyncState;
 
     WaitHandle IAsyncResult.AsyncWaitHandle => this.Inner.AsyncWaitHandle;
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
@@ -82,7 +82,7 @@ internal static class ClientChannelInstrumentation
         };
     }
 
-    public static void AfterRequestCompleted(Message? reply, RequestTelemetryState state)
+    public static void AfterRequestCompleted(Message? reply, RequestTelemetryState? state)
     {
         Guard.ThrowIfNull(state);
 
@@ -128,7 +128,7 @@ internal static class ClientChannelInstrumentation
         if (request.Properties.TryGetValue(TelemetryContextMessageProperty.Name, out object telemetryContextProperty))
         {
             var actionMappings = (telemetryContextProperty as TelemetryContextMessageProperty)?.ActionMappings;
-            if (actionMappings != null && actionMappings.TryGetValue(action, out ActionMetadata metadata))
+            if (actionMappings != null && actionMappings.TryGetValue(action, out var metadata))
             {
                 actionMetadata = metadata;
             }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/HttpRequestMessagePropertyWrapper.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/HttpRequestMessagePropertyWrapper.cs
@@ -20,7 +20,7 @@ internal static class HttpRequestMessagePropertyWrapper
 
     public static bool IsHttpFunctionalityEnabled => ReflectedValues != null;
 
-    public static string Name
+    public static string? Name
     {
         get
         {
@@ -29,13 +29,13 @@ internal static class HttpRequestMessagePropertyWrapper
         }
     }
 
-    public static object CreateNew()
+    public static object? CreateNew()
     {
         AssertHttpEnabled();
         return Activator.CreateInstance(ReflectedValues!.Type);
     }
 
-    public static WebHeaderCollection GetHeaders(object httpRequestMessageProperty)
+    public static WebHeaderCollection GetHeaders(object? httpRequestMessageProperty)
     {
         AssertHttpEnabled();
         AssertIsFrameworkMessageProperty(httpRequestMessageProperty);
@@ -51,6 +51,11 @@ internal static class HttpRequestMessagePropertyWrapper
                 "System.ServiceModel.Channels.HttpRequestMessageProperty, System.ServiceModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 true);
 
+            if (type == null)
+            {
+                throw new NotSupportedException("HttpRequestMessageProperty type not found");
+            }
+
             var headersProp = type.GetProperty("Headers", BindingFlags.Public | BindingFlags.Instance, null, typeof(WebHeaderCollection), Array.Empty<Type>(), null);
             if (headersProp == null)
             {
@@ -65,7 +70,7 @@ internal static class HttpRequestMessagePropertyWrapper
 
             return new ReflectedInfo(
                 type: type,
-                name: (string)nameProp.GetValue(null),
+                name: (string?)nameProp.GetValue(null),
                 headersFetcher: new PropertyFetcher<WebHeaderCollection>("Headers"));
         }
         catch (Exception ex)
@@ -86,7 +91,7 @@ internal static class HttpRequestMessagePropertyWrapper
     }
 
     [Conditional("DEBUG")]
-    private static void AssertIsFrameworkMessageProperty(object httpRequestMessageProperty)
+    private static void AssertIsFrameworkMessageProperty(object? httpRequestMessageProperty)
     {
         AssertHttpEnabled();
         if (httpRequestMessageProperty == null || !httpRequestMessageProperty.GetType().Equals(ReflectedValues!.Type))
@@ -98,10 +103,10 @@ internal static class HttpRequestMessagePropertyWrapper
     private sealed class ReflectedInfo
     {
         public Type Type;
-        public string Name;
+        public string? Name;
         public PropertyFetcher<WebHeaderCollection> HeadersFetcher;
 
-        public ReflectedInfo(Type type, string name, PropertyFetcher<WebHeaderCollection> headersFetcher)
+        public ReflectedInfo(Type type, string? name, PropertyFetcher<WebHeaderCollection> headersFetcher)
         {
             this.Type = type;
             this.Name = name;

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
@@ -178,20 +178,27 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
     private void SendInternal(Message message, TimeSpan timeout, Action<RequestTelemetryState> executeSend)
     {
         RequestTelemetryState? telemetryState = null;
-        ContextCallback executeInChildContext = _ =>
+
+        void ExecuteInChildContext(object? unused)
         {
             telemetryState = ClientChannelInstrumentation.BeforeSendRequest(message, this.RemoteAddress?.Uri);
             RequestTelemetryStateTracker.PushTelemetryState(message, telemetryState, timeout, OnTelemetryStateTimedOut);
             executeSend(telemetryState);
-        };
+        }
+
+        var executionContext = ExecutionContext.Capture();
+        if (executionContext == null)
+        {
+            throw new InvalidOperationException("Cannot fetch execution context");
+        }
 
         try
         {
-            ExecutionContext.Run(ExecutionContext.Capture(), executeInChildContext, null);
+            ExecutionContext.Run(executionContext, ExecuteInChildContext, null);
         }
         catch (Exception)
         {
-            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState!);
+            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState);
             throw;
         }
     }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
@@ -99,14 +99,21 @@ internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestC
     private IAsyncResult InternalBeginRequest(Message message, Func<AsyncCallback, object?, IAsyncResult> beginRequestDelegate, AsyncCallback callback, object? state)
     {
         IAsyncResult? result = null;
-        ContextCallback executeInChildContext = _ =>
+
+        void ExecuteInChildContext(object? unused)
         {
             var telemetryState = ClientChannelInstrumentation.BeforeSendRequest(message, ((IRequestChannel)this).RemoteAddress?.Uri);
             var asyncCallback = AsyncResultWithTelemetryState.GetAsyncCallback(callback, telemetryState);
             result = new AsyncResultWithTelemetryState(beginRequestDelegate(asyncCallback, state), telemetryState);
-        };
+        }
 
-        ExecutionContext.Run(ExecutionContext.Capture(), executeInChildContext, null);
+        var executionContext = ExecutionContext.Capture();
+        if (executionContext == null)
+        {
+            throw new InvalidOperationException("Cannot fetch execution context");
+        }
+
+        ExecutionContext.Run(executionContext, ExecuteInChildContext, null);
         return result!;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/RequestTelemetryStateTracker.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/RequestTelemetryStateTracker.cs
@@ -141,12 +141,11 @@ internal static class RequestTelemetryStateTracker
 
         public int CompareTo(object? obj)
         {
-            if (obj == null)
+            if (obj is not EntryTimeoutProperties other)
             {
                 return 1;
             }
 
-            var other = (EntryTimeoutProperties)obj;
             var result = this.ExpiresAt.CompareTo(other.ExpiresAt);
             if (result == 0)
             {

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/RequestTelemetryStateTracker.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/RequestTelemetryStateTracker.cs
@@ -9,8 +9,8 @@ internal static class RequestTelemetryStateTracker
 {
     private static readonly Dictionary<string, Entry> OutstandingRequestStates = new Dictionary<string, Entry>();
     private static readonly SortedSet<EntryTimeoutProperties> TimeoutQueue = new SortedSet<EntryTimeoutProperties>();
-    private static readonly object Sync = new object();
-    private static readonly Timer Timer = new Timer(OnTimer);
+    private static readonly object Sync = new();
+    private static readonly Timer Timer = new(OnTimer);
     private static long currentTimerDueAt = Timeout.Infinite;
 
     public static void PushTelemetryState(Message request, RequestTelemetryState telemetryState, TimeSpan timeout, Action<RequestTelemetryState> timeoutCallback)
@@ -50,7 +50,7 @@ internal static class RequestTelemetryStateTracker
         }
     }
 
-    private static void OnTimer(object state)
+    private static void OnTimer(object? state)
     {
         List<Tuple<EntryTimeoutProperties, Entry>>? timedOutEntries = null;
         lock (Sync)
@@ -139,8 +139,13 @@ internal static class RequestTelemetryStateTracker
             this.TimeoutCallback = timeoutCallback;
         }
 
-        public int CompareTo(object obj)
+        public int CompareTo(object? obj)
         {
+            if (obj == null)
+            {
+                return 1;
+            }
+
             var other = (EntryTimeoutProperties)obj;
             var result = this.ExpiresAt.CompareTo(other.ExpiresAt);
             if (result == 0)

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryPropagationWriter.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryPropagationWriter.cs
@@ -48,8 +48,7 @@ internal static class TelemetryPropagationWriter
             return;
         }
 
-        object prop;
-        if (!request.Properties.TryGetValue(HttpRequestMessagePropertyWrapper.Name, out prop))
+        if (!request.Properties.TryGetValue(HttpRequestMessagePropertyWrapper.Name, out var prop))
         {
             prop = HttpRequestMessagePropertyWrapper.CreateNew();
             request.Properties.Add(HttpRequestMessagePropertyWrapper.Name, prop);

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfInstrumentationActivitySource.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfInstrumentationActivitySource.cs
@@ -16,7 +16,7 @@ internal static class WcfInstrumentationActivitySource
 {
     internal static readonly Assembly Assembly = typeof(WcfInstrumentationActivitySource).Assembly;
     internal static readonly AssemblyName AssemblyName = Assembly.GetName();
-    internal static readonly string ActivitySourceName = AssemblyName.Name;
+    internal static readonly string ActivitySourceName = AssemblyName.Name!;
     internal static readonly string IncomingRequestActivityName = ActivitySourceName + ".IncomingRequest";
     internal static readonly string OutgoingRequestActivityName = ActivitySourceName + ".OutgoingRequest";
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
+++ b/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(NetStandardMinimumSupportedVersion);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
+    <TargetFrameworks>net6.0;$(NetStandardMinimumSupportedVersion);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>OpenTelemetry instrumentation for WCF.</Description>
     <PackageTags>$(PackageTags);distributed-tracing;WCF</PackageTags>
     <MinVerTagPrefix>Instrumentation.Wcf-</MinVerTagPrefix>
@@ -23,9 +23,10 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardMinimumSupportedVersion)'">
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardMinimumSupportedVersion)' OR '$(TargetFramework)' == 'net6.0' " >
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" Condition=" '$(TargetFramework)' == 'net6.0' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
@@ -20,12 +20,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetFrameworkMinimumSupportedVersion)'">
-    <PackageReference Include="System.ServiceModel.Http" Version="8.0.0" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="8.0.0" />
-    <!-- System.Security.Cryptography.Pkcs. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-555c-2p6r-68mm -->
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
-    <!-- System.Formats.Asn1 is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-447r-wph3-92pm -->
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/OpenTelemetry.Instrumentation.Wcf.Tests.csproj
@@ -20,10 +20,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetFrameworkMinimumSupportedVersion)'">
-    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.7.0" />
-    <!-- System.Drawing.Common is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-rxg9-xrhp-64gj -->
-    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+    <PackageReference Include="System.ServiceModel.Http" Version="8.0.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="8.0.0" />
+    <!-- System.Security.Cryptography.Pkcs. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-555c-2p6r-68mm -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <!-- System.Formats.Asn1 is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-447r-wph3-92pm -->
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes scenario when you referencing Instrumentation.Wcf package from .NET6+ with enabled NuGet Audit like for .NET9.
Without changes it was leading to the issues:

<img width="467" alt="image" src="https://github.com/user-attachments/assets/277a34af-d149-4778-8398-7274105aa038">

Workaround:
Manual referencing safe version of System.Drawing.Common, but it is not user friendly.

## Changes

* Added .NET6 target (temporary, just to make a release and be able to use new version in .NET AutoInstrumnetation, just after I will bring here .NET8).
* Nullability fixes after add .net6 as a target framework

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
