### PR TITLE
Request to release OpenTelemetry.Instrumentation.AWS package

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.0-beta.7
+
+Released 2024-Oct-25
+
 * Move adding request and response info to AWSTracingPipelineHandler
   ([#2137](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2137))
 * Drop support for .NET 6 as this target is no longer supported and add .NET 8 target.


### PR DESCRIPTION
## Changes

Requesting to release OpenTelemetry.Instrumentation.AWS which includes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2137 and https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2139.

@open-telemetry/dotnet-contrib-maintainers

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)