### PR TITLE
Enable collecting server.* attributes by default

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -30,11 +30,13 @@
   for the same information. Note that `server.address` is only included when
   the `EnableConnectionLevelAttributes` option is enabled.
   ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229))
-* When `EnableConnectionLevelAttributes` is enabled, the `server.port` attribute
-  will now be written as an integer to be compliant with the
-  [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/server.md).
+* **Breaking change**: When `EnableConnectionLevelAttributes` is enabled, the
+  `server.port` attribute will now be written as an integer to be compliant with
+  the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/server.md).
   Previously, it was written as a string.
   ([#2233](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2233))
+* The `EnableConnectionLevelAttributes` option is now enabled by default.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
 
 ## 1.9.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -165,8 +165,8 @@ command text will be captured.
 > [!NOTE]
 > EnableConnectionLevelAttributes is supported on all runtimes.
 
-By default, `EnabledConnectionLevelAttributes` is disabled.
-If `EnabledConnectionLevelAttributes` is enabled,
+By default, `EnabledConnectionLevelAttributes` is enabled.
+When `EnabledConnectionLevelAttributes` is enabled,
 the [`DataSource`](https://docs.microsoft.com/dotnet/api/system.data.common.dbconnection.datasource)
 will be parsed and the server name or IP address will be sent as
 the `server.address` attribute, the instance name will be sent as

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
@@ -81,21 +81,20 @@ public class SqlClientTraceInstrumentationOptions
     /// cref="SqlClientInstrumentation"/> should parse the DataSource on a
     /// SqlConnection into server name, instance name, and/or port
     /// connection-level attribute tags. Default value: <see
-    /// langword="false"/>.
+    /// langword="true"/>.
     /// </summary>
     /// <remarks>
     /// <para>
     /// <b>EnableConnectionLevelAttributes is supported on all runtimes.</b>
     /// </para>
     /// <para>
-    /// The default behavior is to set the SqlConnection DataSource as the <see cref="SemanticConventions.AttributePeerService"/> tag.
     /// If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the
-    /// <see cref="SemanticConventions.AttributeServerAddress"/> or <see cref="SemanticConventions.AttributeServerSocketAddress"/> tag,
+    /// <see cref="SemanticConventions.AttributeServerAddress"/> tag,
     /// the instance name will be sent as the <see cref="SemanticConventions.AttributeDbMsSqlInstanceName"/> tag,
     /// and the port will be sent as the <see cref="SemanticConventions.AttributeServerPort"/> tag if it is not 1433 (the default port).
     /// </para>
     /// </remarks>
-    public bool EnableConnectionLevelAttributes { get; set; }
+    public bool EnableConnectionLevelAttributes { get; set; } = true;
 
     /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with the


### PR DESCRIPTION
Fixes #2235

Confirmed with @lmolkova and @trask in the DB conventions SIG that the `server.address`/`server.port` attributes need to be collected by default.