### PR TITLE
[Instrumentation.AspNet] Fix multiple routes of same template in attribute-based routing

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
+* Fixed an issue in ASP.NET instrumentation where route extraction failed for
+  attribute-based routing with multiple HTTP methods sharing the same route template.
+  ([#2250](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2250))
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
@@ -28,18 +28,15 @@ internal sealed class HttpRequestRouteHelper
         {
             // WebAPI attribute routing flows here. Use reflection to not take a dependency on microsoft.aspnet.webapi.core\[version]\lib\[framework]\System.Web.Http.
 
-            if (msSubRoutes is Array attributeRouting)
+            if (msSubRoutes is Array attributeRouting && attributeRouting.Length >= 1)
             {
                 // There could be more than one subroute, each with a different method.
                 // But the template is the same across them, so we simply take the template
                 // from the first route.
-                if (attributeRouting.Length >= 1)
-                {
-                    var subRouteData = attributeRouting.GetValue(0);
+                var subRouteData = attributeRouting.GetValue(0);
 
-                    _ = this.routeFetcher.TryFetch(subRouteData, out var route);
-                    _ = this.routeTemplateFetcher.TryFetch(route, out template);
-                }
+                _ = this.routeFetcher.TryFetch(subRouteData, out var route);
+                _ = this.routeTemplateFetcher.TryFetch(route, out template);
             }
         }
         else if (routeData.Route is Route route)

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
@@ -28,12 +28,18 @@ internal sealed class HttpRequestRouteHelper
         {
             // WebAPI attribute routing flows here. Use reflection to not take a dependency on microsoft.aspnet.webapi.core\[version]\lib\[framework]\System.Web.Http.
 
-            if (msSubRoutes is Array attributeRouting && attributeRouting.Length == 1)
+            if (msSubRoutes is Array attributeRouting)
             {
-                var subRouteData = attributeRouting.GetValue(0);
+                // There could be more than one subroute, each with a different method.
+                // But the template is the same across them, so we simply take the template
+                // from the first route.
+                if (attributeRouting.Length >= 1)
+                {
+                    var subRouteData = attributeRouting.GetValue(0);
 
-                _ = this.routeFetcher.TryFetch(subRouteData, out var route);
-                _ = this.routeTemplateFetcher.TryFetch(route, out template);
+                    _ = this.routeFetcher.TryFetch(subRouteData, out var route);
+                    _ = this.routeTemplateFetcher.TryFetch(route, out template);
+                }
             }
         }
         else if (routeData.Route is Route route)

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -41,6 +41,7 @@ public class HttpInListenerTests
     [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null, null, "localhost", 443, "HEAD", "HEAD", null, 2, "about_attr_route/{customerId}", "HEAD about_attr_route/{customerId}")]
     [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", null, null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}", "GET api/{controller}/{id}")]
     [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}", "GET subroute/{customerId}")]
+    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 5, "subroute/{customerId}", "GET subroute/{customerId}")]
     [InlineData("http://localhost/api/value", "http", "/api/value", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, "/api/value")] // Request will be filtered
     [InlineData("http://localhost/api/value", "http", "/api/value", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, "{ThrowException}")] // Filter user code will throw an exception
     [InlineData("http://localhost/", "http", "/", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, null, true, "System.InvalidOperationException")] // Test RecordException option

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Net.Http;
 using System.Web;
 using System.Web.Routing;
 
@@ -39,6 +40,75 @@ internal static class RouteTestHelper
                 routeData.Values.Add(
                     "MS_SubRoutes",
                     value);
+                break;
+            case 5: // Multi-method attribute routing WebAPI.
+                routeData = new RouteData();
+                var multiMethodSubroutes = new[]
+                {
+                    new
+                    {
+                        Route = new
+                        {
+                            RouteTemplate = routeTemplate,
+                            DataTokens = new Dictionary<string, object>
+                            {
+                                ["actions"] = new[]
+                                {
+                                    new
+                                    {
+                                        SupportedHttpMethods = new[]
+                                        {
+                                            HttpMethod.Get,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    new
+                    {
+                        Route = new
+                        {
+                            RouteTemplate = routeTemplate,
+                            DataTokens = new Dictionary<string, object>
+                            {
+                                ["actions"] = new[]
+                                {
+                                    new
+                                    {
+                                        SupportedHttpMethods = new[]
+                                        {
+                                            HttpMethod.Put,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    new
+                    {
+                        Route = new
+                        {
+                            RouteTemplate = routeTemplate,
+                            DataTokens = new Dictionary<string, object>
+                            {
+                                ["actions"] = new[]
+                                {
+                                    new
+                                    {
+                                        SupportedHttpMethods = new[]
+                                        {
+                                            HttpMethod.Delete,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+                routeData.Values.Add(
+                    "MS_SubRoutes",
+                    multiMethodSubroutes);
                 break;
             default:
                 throw new NotSupportedException();

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RouteTestHelper.cs
@@ -43,69 +43,26 @@ internal static class RouteTestHelper
                 break;
             case 5: // Multi-method attribute routing WebAPI.
                 routeData = new RouteData();
-                var multiMethodSubroutes = new[]
+                var httpMethods = new[] { HttpMethod.Get, HttpMethod.Put, HttpMethod.Delete };
+
+                var multiMethodSubroutes = httpMethods.Select(method => new
                 {
-                    new
+                    Route = new
                     {
-                        Route = new
+                        RouteTemplate = routeTemplate,
+                        DataTokens = new Dictionary<string, object>
                         {
-                            RouteTemplate = routeTemplate,
-                            DataTokens = new Dictionary<string, object>
+                            ["actions"] = new[]
                             {
-                                ["actions"] = new[]
+                                new
                                 {
-                                    new
-                                    {
-                                        SupportedHttpMethods = new[]
-                                        {
-                                            HttpMethod.Get,
-                                        },
-                                    },
+                                    SupportedHttpMethods = new[] { method },
                                 },
                             },
                         },
                     },
-                    new
-                    {
-                        Route = new
-                        {
-                            RouteTemplate = routeTemplate,
-                            DataTokens = new Dictionary<string, object>
-                            {
-                                ["actions"] = new[]
-                                {
-                                    new
-                                    {
-                                        SupportedHttpMethods = new[]
-                                        {
-                                            HttpMethod.Put,
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    new
-                    {
-                        Route = new
-                        {
-                            RouteTemplate = routeTemplate,
-                            DataTokens = new Dictionary<string, object>
-                            {
-                                ["actions"] = new[]
-                                {
-                                    new
-                                    {
-                                        SupportedHttpMethods = new[]
-                                        {
-                                            HttpMethod.Delete,
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                };
+                }).ToArray();
+
                 routeData.Values.Add(
                     "MS_SubRoutes",
                     multiMethodSubroutes);


### PR DESCRIPTION
## Changes

ASP.NET instrumentation fails to extract route for attribute-based routing, if multiple HTTP methods use the same route template--a common scenario for RESTful APIs. For example:

```csharp
public class WidgetsController : ApiController
{
    [Route("api/widgets/{id}")]
    public string Get(int id) {...}

    [Route("api/widgets/{id}")]
    public void Put(int id, [FromBody]string value) {...}

    [Route("api/widgets/{id}")]
    public void Delete(int id) {...}
}
```

In this case, the `MS_Subroutes` array will have multiple elements, each corresponding to a different HTTP method.

The original code only extracts the route template if there's only one element in the array. The correct thing to do is to just extract the template from the first subroute, since all subroutes have the same template.

It's not possible for MS_Subroutes array to have different templates in its elements. WebAPI would fail to route and throw an exception, if you declare multiple actions for the same method/template

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
