### PR TITLE
[Exporter.Geneva] benchmarks nullable

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
@@ -18,7 +18,7 @@ internal sealed class OtlpProtobufMetricExporter : IDisposable
 
     public OtlpProtobufMetricExporter(
         Func<Resource> getResource,
-        ConnectionStringBuilder connectionStringBuilder,
+        ConnectionStringBuilder? connectionStringBuilder,
         IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions)
     {
         Debug.Assert(getResource != null, "getResource was null");

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
@@ -51,16 +51,16 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmarks;
 [MemoryDiagnoser]
 public class MetricExporterBenchmarks
 {
-    private Metric counterMetricWith3Dimensions;
-    private Metric counterMetricWith4Dimensions;
+    private Metric? counterMetricWith3Dimensions;
+    private Metric? counterMetricWith4Dimensions;
     private MetricPoint counterMetricPointWith3Dimensions;
     private MetricPoint counterMetricPointWith4Dimensions;
     private MetricData counterMetricDataWith3Dimensions;
     private MetricData counterMetricDataWith4Dimensions;
     private Batch<Metric> counterMetricBatchWith3Dimensions;
     private Batch<Metric> counterMetricBatchWith4Dimensions;
-    private Metric histogramMetricWith3Dimensions;
-    private Metric histogramMetricWith4Dimensions;
+    private Metric? histogramMetricWith3Dimensions;
+    private Metric? histogramMetricWith4Dimensions;
     private MetricPoint histogramMetricPointWith3Dimensions;
     private MetricPoint histogramMetricPointWith4Dimensions;
     private ulong histogramSumWith3Dimensions;
@@ -77,23 +77,23 @@ public class MetricExporterBenchmarks
     private Meter meterWithListener = new Meter("MeterWithListener", "0.0.1");
     private Meter meterWithDummyReader = new Meter("MeterWithDummyReader", "0.0.1");
     private Meter meterWithGenevaMetricExporter = new Meter("MeterWithGenevaMetricExporter", "0.0.1");
-    private Counter<long> counterWithNoListener;
-    private Counter<long> counterWithListener;
-    private Counter<long> counterWithDummyReader;
-    private Counter<long> counterWithGenevaMetricExporter;
-    private MeterListener listener;
-    private MeterProvider meterProviderWithDummyReader;
-    private MeterProvider meterProviderWithGenevaMetricExporter;
-    private MeterProvider meterProviderForCounterBatchWith3Dimensions;
-    private MeterProvider meterProviderForCounterBatchWith4Dimensions;
-    private MeterProvider meterProviderForHistogramBatchWith3Dimensions;
-    private MeterProvider meterProviderForHistogramBatchWith4Dimensions;
-    private TlvMetricExporter tlvMetricsExporter;
-    private OtlpProtobufMetricExporter otlpProtobufMetricExporter;
-    private OtlpProtobufSerializer otlpProtobufSerializer;
-    private Resource resource;
-    private byte[] buffer;
-    private ThreadLocal<Random> random = new ThreadLocal<Random>(() => new Random());
+    private Counter<long>? counterWithNoListener;
+    private Counter<long>? counterWithListener;
+    private Counter<long>? counterWithDummyReader;
+    private Counter<long>? counterWithGenevaMetricExporter;
+    private MeterListener? listener;
+    private MeterProvider? meterProviderWithDummyReader;
+    private MeterProvider? meterProviderWithGenevaMetricExporter;
+    private MeterProvider? meterProviderForCounterBatchWith3Dimensions;
+    private MeterProvider? meterProviderForCounterBatchWith4Dimensions;
+    private MeterProvider? meterProviderForHistogramBatchWith3Dimensions;
+    private MeterProvider? meterProviderForHistogramBatchWith4Dimensions;
+    private TlvMetricExporter? tlvMetricsExporter;
+    private OtlpProtobufMetricExporter? otlpProtobufMetricExporter;
+    private OtlpProtobufSerializer? otlpProtobufSerializer;
+    private Resource? resource;
+    private byte[]? buffer;
+    private ThreadLocal<Random> random = new(() => new Random());
 
     private static readonly Random randomForHistogram = new Random(); // Use the same seed for all the benchmarks to have the same data exported
     private static readonly string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
@@ -192,7 +192,7 @@ public class MetricExporterBenchmarks
 
         counter.Add(
             100,
-            new("DimName1", dimensionValues[this.random.Value.Next(0, 10)]),
+            new("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]),
             new("DimName2", dimensionValues[this.random.Value.Next(0, 10)]),
             new("DimName3", dimensionValues[this.random.Value.Next(0, 10)]));
 
@@ -226,7 +226,7 @@ public class MetricExporterBenchmarks
 
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -264,7 +264,7 @@ public class MetricExporterBenchmarks
 
         counter.Add(
             100,
-            new("DimName1", dimensionValues[this.random.Value.Next(0, 10)]),
+            new("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]),
             new("DimName2", dimensionValues[this.random.Value.Next(0, 10)]),
             new("DimName3", dimensionValues[this.random.Value.Next(0, 10)]));
 
@@ -290,7 +290,7 @@ public class MetricExporterBenchmarks
 
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -318,7 +318,7 @@ public class MetricExporterBenchmarks
             .AddReader(inMemoryReader)
             .Build();
 
-        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]);
         var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
         var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
 
@@ -363,7 +363,7 @@ public class MetricExporterBenchmarks
 
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -408,7 +408,7 @@ public class MetricExporterBenchmarks
             .AddReader(batchGeneratorReader)
             .Build();
 
-        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]);
         var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
         var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
 
@@ -439,7 +439,7 @@ public class MetricExporterBenchmarks
 
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -475,7 +475,7 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithNoListener3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]);
         var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
         var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithNoListener?.Add(100, tag1, tag2, tag3);
@@ -486,7 +486,7 @@ public class MetricExporterBenchmarks
     {
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -499,7 +499,7 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithWithListener3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]);
         var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
         var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithListener?.Add(100, tag1, tag2, tag3);
@@ -510,7 +510,7 @@ public class MetricExporterBenchmarks
     {
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -523,7 +523,7 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithWithDummyReader3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]);
         var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
         var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithDummyReader?.Add(100, tag1, tag2, tag3);
@@ -534,7 +534,7 @@ public class MetricExporterBenchmarks
     {
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -547,7 +547,7 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithWithGenevaCounterMetricExporter3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value!.Next(0, 10)]);
         var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
         var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithGenevaMetricExporter?.Add(100, tag1, tag2, tag3);
@@ -558,7 +558,7 @@ public class MetricExporterBenchmarks
     {
         var tags = new TagList
         {
-            { "DimName1", dimensionValues[this.random.Value.Next(0, 2)] },
+            { "DimName1", dimensionValues[this.random.Value!.Next(0, 2)] },
             { "DimName2", dimensionValues[this.random.Value.Next(0, 5)] },
             { "DimName3", dimensionValues[this.random.Value.Next(0, 10)] },
             { "DimName4", dimensionValues[this.random.Value.Next(0, 10)] },
@@ -573,9 +573,9 @@ public class MetricExporterBenchmarks
     {
         this.counterMetricPointWith3Dimensions.TryGetExemplars(out var exemplars);
 
-        this.tlvMetricsExporter.SerializeMetricWithTLV(
+        this.tlvMetricsExporter!.SerializeMetricWithTLV(
             MetricEventType.ULongMetric,
-            this.counterMetricWith3Dimensions.Name,
+            this.counterMetricWith3Dimensions!.Name,
             this.counterMetricPointWith3Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith3Dimensions.Tags,
             this.counterMetricDataWith3Dimensions,
@@ -589,9 +589,9 @@ public class MetricExporterBenchmarks
     public void SerializeCounterMetricItemWith4Dimensions()
     {
         this.counterMetricPointWith4Dimensions.TryGetExemplars(out var exemplars);
-        this.tlvMetricsExporter.SerializeMetricWithTLV(
+        this.tlvMetricsExporter!.SerializeMetricWithTLV(
             MetricEventType.ULongMetric,
-            this.counterMetricWith4Dimensions.Name,
+            this.counterMetricWith4Dimensions!.Name,
             this.counterMetricPointWith4Dimensions.EndTime.ToFileTime(),
             this.counterMetricPointWith4Dimensions.Tags,
             this.counterMetricDataWith4Dimensions,
@@ -604,21 +604,21 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void ExportCounterMetricItemWith3Dimensions()
     {
-        this.tlvMetricsExporter.Export(this.counterMetricBatchWith3Dimensions);
+        this.tlvMetricsExporter!.Export(this.counterMetricBatchWith3Dimensions);
     }
 
     [Benchmark]
     public void ExportCounterMetricItemWith4Dimensions()
     {
-        this.tlvMetricsExporter.Export(this.counterMetricBatchWith4Dimensions);
+        this.tlvMetricsExporter!.Export(this.counterMetricBatchWith4Dimensions);
     }
 
     [Benchmark]
     public void SerializeHistogramMetricItemWith3Dimensions()
     {
         this.histogramMetricPointWith3Dimensions.TryGetExemplars(out var exemplars);
-        this.tlvMetricsExporter.SerializeHistogramMetricWithTLV(
-            this.histogramMetricWith3Dimensions.Name,
+        this.tlvMetricsExporter!.SerializeHistogramMetricWithTLV(
+            this.histogramMetricWith3Dimensions!.Name,
             this.histogramMetricPointWith3Dimensions.EndTime.ToFileTime(),
             this.histogramMetricPointWith3Dimensions.Tags,
             this.histogramMetricPointWith3Dimensions.GetHistogramBuckets(),
@@ -636,8 +636,8 @@ public class MetricExporterBenchmarks
     public void SerializeHistogramMetricItemWith4Dimensions()
     {
         this.histogramMetricPointWith4Dimensions.TryGetExemplars(out var exemplars);
-        this.tlvMetricsExporter.SerializeHistogramMetricWithTLV(
-            this.histogramMetricWith4Dimensions.Name,
+        this.tlvMetricsExporter!.SerializeHistogramMetricWithTLV(
+            this.histogramMetricWith4Dimensions!.Name,
             this.histogramMetricPointWith4Dimensions.EndTime.ToFileTime(),
             this.histogramMetricPointWith4Dimensions.Tags,
             this.histogramMetricPointWith4Dimensions.GetHistogramBuckets(),
@@ -654,61 +654,61 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void ExportHistogramMetricItemWith3Dimensions()
     {
-        this.tlvMetricsExporter.Export(this.histogramMetricBatchWith3Dimensions);
+        this.tlvMetricsExporter!.Export(this.histogramMetricBatchWith3Dimensions);
     }
 
     [Benchmark]
     public void ExportHistogramMetricItemWith4Dimensions()
     {
-        this.tlvMetricsExporter.Export(this.histogramMetricBatchWith4Dimensions);
+        this.tlvMetricsExporter!.Export(this.histogramMetricBatchWith4Dimensions);
     }
 
     [Benchmark]
     public void SerializeCounterMetricItemWith3Dimensions_Otlp()
     {
-        this.otlpProtobufSerializer.SerializeAndSendMetrics(this.buffer, this.resource, this.counterMetricBatchWith3Dimensions);
+        this.otlpProtobufSerializer!.SerializeAndSendMetrics(this.buffer!, this.resource!, this.counterMetricBatchWith3Dimensions);
     }
 
     [Benchmark]
     public void SerializeCounterMetricItemWith4Dimensions_Otlp()
     {
-        this.otlpProtobufSerializer.SerializeAndSendMetrics(this.buffer, this.resource, this.counterMetricBatchWith4Dimensions);
+        this.otlpProtobufSerializer!.SerializeAndSendMetrics(this.buffer!, this.resource!, this.counterMetricBatchWith4Dimensions);
     }
 
     [Benchmark]
     public void ExportCounterMetricItemWith3Dimensions_Otlp()
     {
-        this.otlpProtobufMetricExporter.Export(this.counterMetricBatchWith3Dimensions);
+        this.otlpProtobufMetricExporter!.Export(this.counterMetricBatchWith3Dimensions);
     }
 
     [Benchmark]
     public void ExportCounterMetricItemWith4Dimensions_Otlp()
     {
-        this.otlpProtobufMetricExporter.Export(this.counterMetricBatchWith4Dimensions);
+        this.otlpProtobufMetricExporter!.Export(this.counterMetricBatchWith4Dimensions);
     }
 
     [Benchmark]
     public void SerializeHistogramMetricItemWith3Dimensions_Otlp()
     {
-        this.otlpProtobufSerializer.SerializeAndSendMetrics(this.buffer, this.resource, this.histogramMetricBatchWith3Dimensions);
+        this.otlpProtobufSerializer!.SerializeAndSendMetrics(this.buffer!, this.resource!, this.histogramMetricBatchWith3Dimensions);
     }
 
     [Benchmark]
     public void SerializeHistogramMetricItemWith4Dimensions_Otlp()
     {
-        this.otlpProtobufSerializer.SerializeAndSendMetrics(this.buffer, this.resource, this.histogramMetricBatchWith4Dimensions);
+        this.otlpProtobufSerializer!.SerializeAndSendMetrics(this.buffer!, this.resource!, this.histogramMetricBatchWith4Dimensions);
     }
 
     [Benchmark]
     public void ExportHistogramMetricItemWith3Dimensions_Otlp()
     {
-        this.otlpProtobufMetricExporter.Export(this.histogramMetricBatchWith3Dimensions);
+        this.otlpProtobufMetricExporter!.Export(this.histogramMetricBatchWith3Dimensions);
     }
 
     [Benchmark]
     public void ExportHistogramMetricItemWith4Dimensions_Otlp()
     {
-        this.otlpProtobufMetricExporter.Export(this.histogramMetricBatchWith4Dimensions);
+        this.otlpProtobufMetricExporter!.Export(this.histogramMetricBatchWith4Dimensions);
     }
 
     private class DummyReader : BaseExportingMetricReader

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
@@ -318,9 +318,9 @@ public class MetricExporterBenchmarks
             .AddReader(inMemoryReader)
             .Build();
 
-        var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
 
         for (int i = 0; i < 1000; i++)
         {
@@ -408,9 +408,9 @@ public class MetricExporterBenchmarks
             .AddReader(batchGeneratorReader)
             .Build();
 
-        var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
 
         for (int i = 0; i < 1000; i++)
         {
@@ -475,9 +475,9 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithNoListener3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithNoListener?.Add(100, tag1, tag2, tag3);
     }
 
@@ -499,9 +499,9 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithWithListener3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithListener?.Add(100, tag1, tag2, tag3);
     }
 
@@ -523,9 +523,9 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithWithDummyReader3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithDummyReader?.Add(100, tag1, tag2, tag3);
     }
 
@@ -547,9 +547,9 @@ public class MetricExporterBenchmarks
     [Benchmark]
     public void InstrumentWithWithGenevaCounterMetricExporter3Dimensions()
     {
-        var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
-        var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag1 = new KeyValuePair<string, object?>("DimName1", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag2 = new KeyValuePair<string, object?>("DimName2", dimensionValues[this.random.Value.Next(0, 10)]);
+        var tag3 = new KeyValuePair<string, object?>("DimName3", dimensionValues[this.random.Value.Next(0, 10)]);
         this.counterWithGenevaMetricExporter?.Add(100, tag1, tag2, tag3);
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDTraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDTraceExporterBenchmarks.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Exporter.Geneva.Benchmarks;
 [MemoryDiagnoser]
 public class TLDTraceExporterBenchmarks
 {
-    private readonly Activity activity;
+    private readonly Activity? activity;
     private readonly Batch<Activity> batch;
     private readonly MsgPackTraceExporter msgPackExporter;
     private readonly TldTraceExporter tldExporter;
@@ -52,10 +52,10 @@ public class TLDTraceExporterBenchmarks
 
         using (var testActivity = this.activitySource.StartActivity("Benchmark"))
         {
-            this.activity = testActivity;
-            this.activity?.SetTag("tagString", "value");
-            this.activity?.SetTag("tagInt", 100);
-            this.activity?.SetStatus(Status.Error);
+            this.activity = testActivity!;
+            this.activity.SetTag("tagString", "value");
+            this.activity.SetTag("tagInt", 100);
+            this.activity.SetStatus(Status.Error);
         }
 
         this.msgPackExporter = new MsgPackTraceExporter(new GenevaExporterOptions
@@ -84,13 +84,13 @@ public class TLDTraceExporterBenchmarks
     [Benchmark]
     public void MsgPack_SerializeActivity()
     {
-        this.msgPackExporter.SerializeActivity(this.activity);
+        this.msgPackExporter.SerializeActivity(this.activity!);
     }
 
     [Benchmark]
     public void TLD_SerializeActivity()
     {
-        this.tldExporter.SerializeActivity(this.activity);
+        this.tldExporter.SerializeActivity(this.activity!);
     }
 
     [Benchmark]
@@ -108,7 +108,7 @@ public class TLDTraceExporterBenchmarks
     [GlobalCleanup]
     public void Cleanup()
     {
-        this.activity.Dispose();
+        this.activity?.Dispose();
         this.batch.Dispose();
         this.activitySource.Dispose();
         this.msgPackExporter.Dispose();
@@ -124,7 +124,7 @@ public class TLDTraceExporterBenchmarks
             .AddProcessor(new SimpleActivityExportProcessor(batchGeneratorExporter))
             .Build();
 
-        using (var activity = this.activitySource.StartActivity("Benchmark"))
+        using (var activity = this.activitySource.StartActivity("Benchmark")!)
         {
             activity.SetTag("tagString", "value");
             activity.SetTag("tagInt", 100);

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TraceExporterBenchmarks.cs
@@ -51,7 +51,7 @@ public class TraceExporterBenchmarks
 
         using (var testActivity = this.activitySource.StartActivity("Benchmark"))
         {
-            this.activity = testActivity;
+            this.activity = testActivity!;
             this.activity.SetTag("tagString", "value");
             this.activity.SetTag("tagInt", 100);
             this.activity.SetStatus(Status.Error);
@@ -125,7 +125,7 @@ public class TraceExporterBenchmarks
             .AddProcessor(new SimpleActivityExportProcessor(batchGeneratorExporter))
             .Build();
 
-        using (var activity = this.activitySource.StartActivity("Benchmark"))
+        using (var activity = this.activitySource.StartActivity("Benchmark")!)
         {
             activity.SetTag("tagString", "value");
             activity.SetTag("tagInt", 100);

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/OpenTelemetry.Exporter.Geneva.Benchmarks.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/OpenTelemetry.Exporter.Geneva.Benchmarks.csproj
@@ -8,7 +8,6 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);SA1201;SA1202;SA1204;SA1311;SA1123</NoWarn>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Towards #894

## Changes

[Exporter.Geneva] benchmarks nullable
With fully nullable repository, it will be easier to accomplish #2251. Unneeded `#nullable enable` are treated as warnings -> errors in .NET9.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
