### PR TITLE
[Exporter.Geneva] stress nullable

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Stress/DummyServer.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Stress/DummyServer.cs
@@ -33,7 +33,7 @@ internal class DummyServer
             this.serverSocket.Bind(this.endpoint);
             this.serverSocket.Listen(20);
 
-            Console.CancelKeyPress += (object sender, ConsoleCancelEventArgs args) =>
+            Console.CancelKeyPress += (object? sender, ConsoleCancelEventArgs args) =>
             {
                 Console.WriteLine("Program is terminating.");
                 this.serverSocket.Close();

--- a/test/OpenTelemetry.Exporter.Geneva.Stress/OpenTelemetry.Exporter.Geneva.Stress.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Stress/OpenTelemetry.Exporter.Geneva.Stress.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);SA1308;SA1201</NoWarn>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Geneva.Stress/Program.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Stress/Program.cs
@@ -39,14 +39,14 @@ internal class Program
     private class LinuxOptions
     {
         [Option('p', "path", Default = "/var/run/default_fluent.socket", HelpText = "Specify a path for Unix domain socket.")]
-        public string Path { get; set; }
+        public string? Path { get; set; }
     }
 
     [Verb("server", HelpText = "Start a dummy server on Linux.")]
     private class ServerOptions
     {
         [Option('p', "path", HelpText = "Specify a path for Unix domain socket.", Required = true)]
-        public string Path { get; set; }
+        public string? Path { get; set; }
     }
 
     [Verb("ExporterCreation", HelpText = "Validate exporter dispose behavior")]
@@ -78,12 +78,12 @@ internal class Program
 
     private static int RunLinux(LinuxOptions options)
     {
-        return EntryPoint(() => InitTracesOnLinux(options.Path), RunTraces);
+        return EntryPoint(() => InitTracesOnLinux(options.Path!), RunTraces);
     }
 
     private static int RunServer(ServerOptions options)
     {
-        var server = new DummyServer(options.Path);
+        var server = new DummyServer(options.Path!);
         server.Start();
         return 0;
     }


### PR DESCRIPTION
Towards #894

## Changes

[Exporter.Geneva] stress tests nullable
With fully nullable repository, it will be easier to accomplish #2251. Unneeded `#nullable enable` are treated as warnings -> errors in .NET9.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
