### PR TITLE
[geneva] Add support for sending metrics in OTLP format over UDS

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -5,14 +5,19 @@
 * Drop support for .NET 6 as this target is no longer supported.
   ([#2117](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2117))
 
-* Added support for exporting metrics via
-  [user_events](https://docs.kernel.org/trace/user_events.html) on Linux when
-  OTLP protobuf encoding is enabled via the
-  `PrivatePreviewEnableOtlpProtobufEncoding=true` connection string switch. With
-  this, `PrivatePreviewEnableOtlpProtobufEncoding=true` is now supported on both
-  Widows and Linux. Windows uses ETW as transport, while Linux uses user_events
-  as transport.
-  ([#2113](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2113))
+* Added support for exporting metrics on Linux when OTLP protobuf encoding is
+  enabled via the `PrivatePreviewEnableOtlpProtobufEncoding=true` connection
+  string switch. `PrivatePreviewEnableOtlpProtobufEncoding=true` is now
+  supported on both Widows and Linux.
+
+  * `user_events` transport:
+    [#2113](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2113).
+
+  * Unix domain socket transport:
+    [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX).
+
+  For configuration details see:
+  [OtlpProtobufEncoding](./README.md#otlpprotobufencoding).
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -14,7 +14,7 @@
     [#2113](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2113).
 
   * Unix domain socket transport:
-    [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX).
+    [#2261](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2261).
 
   For configuration details see:
   [OtlpProtobufEncoding](./README.md#otlpprotobufencoding).

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added support for exporting metrics on Linux when OTLP protobuf encoding is
   enabled via the `PrivatePreviewEnableOtlpProtobufEncoding=true` connection
   string switch. `PrivatePreviewEnableOtlpProtobufEncoding=true` is now
-  supported on both Widows and Linux.
+  supported on both Windows and Linux.
 
   * `user_events` transport:
     [#2113](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2113).

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
@@ -31,7 +31,8 @@ internal sealed class OtlpProtobufMetricExporter : IDisposable
             transport!,
             metricsAccount,
             metricsNamespace,
-            prepopulatedMetricDimensions);
+            prepopulatedMetricDimensions,
+            prefixBufferWithUInt32LittleEndianLength: transport is MetricUnixDomainSocketDataTransport);
     }
 
     public ExportResult Export(in Batch<Metric> batch)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
@@ -735,7 +735,7 @@ internal sealed class OtlpProtobufSerializer
 
         if (this.prefixBufferWithUInt32LittleEndianLength)
         {
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer, (uint)cursor);
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer, (uint)cursor - 4);
         }
     }
 

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
@@ -41,14 +41,15 @@ internal sealed class OtlpProtobufSerializer
         IMetricDataTransport metricDataTransport,
         string? metricsAccount,
         string? metricsNamespace,
-        IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions)
+        IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions,
+        bool prefixBufferWithUInt32LittleEndianLength = false)
     {
         Debug.Assert(metricDataTransport != null, "metricDataTransport was null");
 
         this.MetricDataTransport = metricDataTransport!;
         this.metricAccount = metricsAccount;
         this.metricNamespace = metricsNamespace;
-        this.prefixBufferWithUInt32LittleEndianLength = metricDataTransport is MetricUnixDomainSocketDataTransport;
+        this.prefixBufferWithUInt32LittleEndianLength = prefixBufferWithUInt32LittleEndianLength;
 
         // Taking a arbitrary number here for writing attributes.
         byte[] temp = new byte[20000];
@@ -220,9 +221,9 @@ internal sealed class OtlpProtobufSerializer
 
     internal void SerializeResourceMetrics(byte[] buffer, Resource resource)
     {
-        int cursor = 0;
+        int cursor = this.prefixBufferWithUInt32LittleEndianLength ? 4 : 0;
 
-        this.resourceMetricTagAndLengthIndex = cursor + (this.prefixBufferWithUInt32LittleEndianLength ? 4 : 0);
+        this.resourceMetricTagAndLengthIndex = cursor;
 
         this.resourceMetricValueIndex = cursor + TagAndLengthSize;
 

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
@@ -28,6 +28,11 @@ internal sealed class MetricUnixDomainSocketDataTransport : IMetricDataTransport
         this.udsDataTransport.Send(body, size + this.fixedPayloadLength);
     }
 
+    public void SendOtlpProtobufEvent(byte[] body, int size)
+    {
+        this.udsDataTransport.Send(body, size);
+    }
+
     public void Dispose()
     {
         if (this.isDisposed)
@@ -37,10 +42,5 @@ internal sealed class MetricUnixDomainSocketDataTransport : IMetricDataTransport
 
         this.udsDataTransport.Dispose();
         this.isDisposed = true;
-    }
-
-    public void SendOtlpProtobufEvent(byte[] body, int size)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -270,23 +270,42 @@ For example:
 
 ##### OtlpProtobufEncoding
 
-On Windows set `PrivatePreviewEnableOtlpProtobufEncoding=true` on the
-`ConnectionString` to opt-in to the experimental feature for changing the
-underlying serialization format to binary protobuf following the schema defined
-in [OTLP
+An experimental feature flag is available to opt-into changing the underlying
+serialization format to binary protobuf following the schema defined in [OTLP
 specification](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.1.0/opentelemetry/proto/metrics/v1/metrics.proto).
 
+###### Windows
+
+To send metric data over ETW in OTLP format set
+`PrivatePreviewEnableOtlpProtobufEncoding=true` on the `ConnectionString`:
+`Account={MetricAccount};Namespace={MetricNamespace};PrivatePreviewEnableOtlpProtobufEncoding=true`.
+
+###### Linux
+
 As of `1.10.0` `PrivatePreviewEnableOtlpProtobufEncoding=true` is also supported
-on Linux. On Linux when using `PrivatePreviewEnableOtlpProtobufEncoding=true` an
-`Endpoint` is **NOT** required to be provided on `ConnectionString`. For
-example: `Account={MetricAccount};Namespace={MetricNamespace}`.
+on Linux.
+
+###### When using unix domain socket
+
+To send metric data over UDS in OTLP format set the `Endpoint` to use the
+correct `OtlpSocketPath` path and set
+`PrivatePreviewEnableOtlpProtobufEncoding=true` on the `ConnectionString`:
+`Endpoint=unix:{OTLP UDS
+Path};Account={MetricAccount};Namespace={MetricNamespace};PrivatePreviewEnableOtlpProtobufEncoding=true`.
 
 > [!IMPORTANT]
-> When `PrivatePreviewEnableOtlpProtobufEncoding` is enabled on Linux metrics
-> are written using
-> [user_events](https://docs.kernel.org/trace/user_events.html). `user_events`
-> are a newer feature of the Linux kernel and require a distro with the feature
-> enabled.
+> OTLP over UDS requires a different socket path than TLV over UDS.
+
+###### When using user_events
+
+> [!IMPORTANT]
+> [user_events](https://docs.kernel.org/trace/user_events.html) are a newer
+> feature of the Linux kernel and require a distro with the feature enabled.
+
+To send metric data over user_events in OTLP format do **NOT** specify an
+`Endpoint` and set `PrivatePreviewEnableOtlpProtobufEncoding=true` on the
+`ConnectionString`:
+`Account={MetricAccount};Namespace={MetricNamespace};PrivatePreviewEnableOtlpProtobufEncoding=true`.
 
 #### `MetricExportIntervalMilliseconds` (optional)
 

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -279,7 +279,7 @@ specification](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.1.0
 As of `1.10.0` `PrivatePreviewEnableOtlpProtobufEncoding=true` is also supported
 on Linux. On Linux when using `PrivatePreviewEnableOtlpProtobufEncoding=true` an
 `Endpoint` is **NOT** required to be provided on `ConnectionString`. For
-example: `Endpoint=unix:Account={MetricAccount};Namespace={MetricNamespace}`.
+example: `Account={MetricAccount};Namespace={MetricNamespace}`.
 
 > [!IMPORTANT]
 > When `PrivatePreviewEnableOtlpProtobufEncoding` is enabled on Linux metrics

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -300,7 +300,7 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
             // Use Unix domain socket mode
             options.ConnectionString = "Endpoint=unix:{OTLP UDS Path};PrivatePreviewEnableOtlpProtobufEncoding=true";
 
-            // Use user_events mode (preferred but considered experimental)
+            // Use user_events mode (preferred but considered experimental as this is a new capability in Linux kernel)
             // options.ConnectionString = "PrivatePreviewEnableOtlpProtobufEncoding=true";
         }
     })

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -274,9 +274,9 @@ An experimental feature flag is available to opt-into changing the underlying
 serialization format to binary protobuf following the schema defined in [OTLP
 specification](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.1.0/opentelemetry/proto/metrics/v1/metrics.proto).
 
-When using OTLP format `Account` and `Namespace` are **NOT** required to be set
-on the `ConnectionString`. The recommended approach is to use OpenTelemetry
-Resource instead:
+When using OTLP protobuf encoding `Account` and `Namespace` are **NOT** required
+to be set on the `ConnectionString`. The recommended approach is to use
+OpenTelemetry Resource instead:
 
 ```csharp
 using var meterProvider = Sdk.CreateMeterProviderBuilder()
@@ -295,7 +295,7 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
         }
         else
         {
-            // Note: 1.10.0+ version required to use OTLP format on Linux
+            // Note: 1.10.0+ version required to use OTLP protobuf encoding on Linux
 
             // Use Unix domain socket mode
             options.ConnectionString = "Endpoint=unix:{OTLP UDS Path};PrivatePreviewEnableOtlpProtobufEncoding=true";
@@ -309,7 +309,7 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
 
 ###### Windows
 
-To send metric data over ETW in OTLP format set
+To send metric data over ETW using OTLP protobuf encoding set
 `PrivatePreviewEnableOtlpProtobufEncoding=true` on the `ConnectionString`.
 
 ###### Linux
@@ -319,8 +319,8 @@ on Linux.
 
 ###### When using unix domain socket
 
-To send metric data over UDS in OTLP format set the `Endpoint` to use the
-correct `OtlpSocketPath` path and set
+To send metric data over UDS using OTLP protobuf encoding set the `Endpoint` to
+use the correct `OtlpSocketPath` path and set
 `PrivatePreviewEnableOtlpProtobufEncoding=true` on the `ConnectionString`:
 `Endpoint=unix:{OTLP UDS Path};PrivatePreviewEnableOtlpProtobufEncoding=true`.
 
@@ -333,9 +333,9 @@ correct `OtlpSocketPath` path and set
 > [user_events](https://docs.kernel.org/trace/user_events.html) are a newer
 > feature of the Linux kernel and require a distro with the feature enabled.
 
-To send metric data over user_events in OTLP format do **NOT** specify an
-`Endpoint` and set `PrivatePreviewEnableOtlpProtobufEncoding=true` on the
-`ConnectionString`.
+To send metric data over user_events using OTLP protobuf encoding do **NOT**
+specify an `Endpoint` and set `PrivatePreviewEnableOtlpProtobufEncoding=true` on
+the `ConnectionString`.
 
 #### `MetricExportIntervalMilliseconds` (optional)
 

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
@@ -111,12 +111,12 @@ public class MetricExporterBenchmarks
         this.tlvMetricsExporter = new TlvMetricExporter(connectionStringBuilder, exporterOptions.PrepopulatedMetricDimensions);
 
         // Using test transport here with noop to benchmark just the serialization part.
-        this.otlpProtobufSerializer = new OtlpProtobufSerializer(new TestTransport(), null, null);
+        this.otlpProtobufSerializer = new OtlpProtobufSerializer(new TestTransport(), metricsAccount: null, metricsNamespace: null, prepopulatedMetricDimensions: null);
 
         var resourceBuilder = ResourceBuilder.CreateDefault().Clear()
            .AddAttributes(new[] { new KeyValuePair<string, object>("TestResourceKey", "TestResourceValue") });
         this.resource = resourceBuilder.Build();
-        this.otlpProtobufMetricExporter = new OtlpProtobufMetricExporter(() => { return this.resource; }, null, null);
+        this.otlpProtobufMetricExporter = new OtlpProtobufMetricExporter(() => { return this.resource; }, new TestTransport(), metricsAccount: null, metricsNamespace: null, prepopulatedMetricDimensions: null);
         this.buffer = new byte[GenevaMetricExporter.BufferSize];
 
         this.counterMetricPointWith3Dimensions = this.GenerateCounterMetricItemWith3Dimensions(out this.counterMetricDataWith3Dimensions);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -238,9 +238,11 @@ public class OtlpProtobufMetricExporterTests
 
         var testTransport = new TestTransport();
 
-        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder($"Account={expectedAccount};Namespace={expectedNamespace}");
-
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, addAccountAndNamespace ? connectionStringBuilder : null, addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(
+            testTransport,
+            addAccountAndNamespace ? expectedAccount : null,
+            addAccountAndNamespace ? expectedNamespace : null,
+            addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -410,7 +412,8 @@ public class OtlpProtobufMetricExporterTests
         var buffer = new byte[65360];
 
         var testTransport = new TestTransport();
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null);
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null, null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, Resource.Empty, new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -535,8 +538,12 @@ public class OtlpProtobufMetricExporterTests
         var buffer = new byte[65360];
 
         var testTransport = new TestTransport();
-        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder($"Account={expectedAccount};Namespace={expectedNamespace}");
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, addAccountAndNamespace ? connectionStringBuilder : null, addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(
+            testTransport,
+            addAccountAndNamespace ? expectedAccount : null,
+            addAccountAndNamespace ? expectedNamespace : null,
+            addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -656,7 +663,8 @@ public class OtlpProtobufMetricExporterTests
         var buffer = new byte[65360];
 
         var testTransport = new TestTransport();
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null);
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null, null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, Resource.Empty, new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -811,8 +819,12 @@ public class OtlpProtobufMetricExporterTests
         var buffer = new byte[65360];
 
         var testTransport = new TestTransport();
-        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder($"Account={expectedAccount};Namespace={expectedNamespace}");
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, addAccountAndNamespace ? connectionStringBuilder : null, addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(
+            testTransport,
+            addAccountAndNamespace ? expectedAccount : null,
+            addAccountAndNamespace ? expectedNamespace : null,
+            addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -982,7 +994,8 @@ public class OtlpProtobufMetricExporterTests
         var buffer = new byte[65360];
 
         var testTransport = new TestTransport();
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null);
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null, null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -1133,8 +1146,12 @@ public class OtlpProtobufMetricExporterTests
         var buffer = new byte[65360];
 
         var testTransport = new TestTransport();
-        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder($"Account={expectedAccount};Namespace={expectedNamespace}");
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, addAccountAndNamespace ? connectionStringBuilder : null, addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(
+            testTransport,
+            addAccountAndNamespace ? expectedAccount : null,
+            addAccountAndNamespace ? expectedNamespace : null,
+            addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -1264,7 +1281,8 @@ public class OtlpProtobufMetricExporterTests
         var buffer = new byte[65360];
 
         var testTransport = new TestTransport();
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null);
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, null, null, null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, Resource.Empty, new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 
@@ -1424,8 +1442,11 @@ public class OtlpProtobufMetricExporterTests
 
         var testTransport = new TestTransport();
 
-        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder($"Account={expectedAccount};Namespace={expectedNamespace}");
-        var otlpProtobufSerializer = new OtlpProtobufSerializer(testTransport, addAccountAndNamespace ? connectionStringBuilder : null, addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(
+            testTransport,
+            addAccountAndNamespace ? expectedAccount : null,
+            addAccountAndNamespace ? expectedNamespace : null,
+            addPrepopulatedDimensions ? prepopulatedMetricDimensions : null);
 
         otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count));
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithPrefixTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithPrefixTests.cs
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Geneva.Tests;
+
+[Collection("OtlpProtobufMetricExporterTests")]
+public class OtlpProtobufMetricExporterWithPrefixTests : OtlpProtobufMetricExporterTests
+{
+    protected override bool PrefixBufferWithUInt32LittleEndianLength => true;
+}

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithoutPrefixTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithoutPrefixTests.cs
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Geneva.Tests;
+
+[Collection("OtlpProtobufMetricExporterTests")]
+public class OtlpProtobufMetricExporterWithoutPrefixTests : OtlpProtobufMetricExporterTests
+{
+    protected override bool PrefixBufferWithUInt32LittleEndianLength => false;
+}


### PR DESCRIPTION
## Changes

* Adds support for sending metrics in OTLP format over Unix domain sockets.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
