### PR TITLE
[Instrumentation.Wcf] set the exception.stacktrace tag on error spans. 

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
@@ -82,12 +82,10 @@ internal static class ClientChannelInstrumentation
         };
     }
 
-    public static void AfterRequestCompleted(Message? reply, RequestTelemetryState state)
+    public static void AfterRequestCompleted(Message? reply, RequestTelemetryState state, Exception? exception = null)
     {
         Guard.ThrowIfNull(state);
-
         state.SuppressionScope?.Dispose();
-
         if (state.Activity is Activity activity)
         {
             if (activity.IsAllDataRequested)
@@ -95,6 +93,11 @@ internal static class ClientChannelInstrumentation
                 if (reply == null || reply.IsFault)
                 {
                     activity.SetStatus(Status.Error);
+                    if (exception != null)
+                    {
+                        activity.RecordException(exception);
+                        activity.SetTag("exception.stacktrace", exception.ToInvariantString());
+                    }
                 }
 
                 if (reply != null)

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
@@ -64,9 +64,9 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
         {
             this.Inner.EndSend(asyncResult.Inner);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            ClientChannelInstrumentation.AfterRequestCompleted(null, asyncResult.TelemetryState);
+            ClientChannelInstrumentation.AfterRequestCompleted(null, asyncResult.TelemetryState, ex);
             throw;
         }
     }
@@ -189,9 +189,9 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
         {
             ExecutionContext.Run(ExecutionContext.Capture(), executeInChildContext, null);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState!);
+            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState!, ex);
             throw;
         }
     }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
@@ -30,9 +30,9 @@ internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestC
         {
             reply = this.Inner.Request(message);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState);
+            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState, ex);
             throw;
         }
 
@@ -50,9 +50,9 @@ internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestC
         {
             reply = this.Inner.Request(message, timeout);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState);
+            ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState, ex);
             throw;
         }
 
@@ -86,9 +86,9 @@ internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestC
         {
             reply = this.Inner.EndRequest(asyncResult.Inner);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            ClientChannelInstrumentation.AfterRequestCompleted(null, asyncResult.TelemetryState);
+            ClientChannelInstrumentation.AfterRequestCompleted(null, asyncResult.TelemetryState, ex);
             throw;
         }
 


### PR DESCRIPTION
## Why?
The WCF instrumentation does not set the `exception.stacktrace` tag on error spans. 

## Changes

WCF instrumentation now sets the `exception.stacktrace` tag on error spans. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
