### PR TITLE
[SqlClient] Include instance in `db.namespace` and activity name, start activity with required tags

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -24,7 +24,8 @@
   specification for more information regarding the new database
   semantic conventions for
   [spans](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md).
-  ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229))
+  ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229),
+   [#2277])
 * **Breaking change**: The `peer.service` and `server.socket.address` attributes
   are no longer emitted. Users should rely on the `server.address` attribute
   for the same information. Note that `server.address` is only included when
@@ -37,6 +38,11 @@
   ([#2233](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2233))
 * The `EnableConnectionLevelAttributes` option is now enabled by default.
   ([#2249](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2249))
+* The following attributes are now provided when starting an activity for a database
+  call: `db.system`, `db.name` (old conventions), `db.namespace` (new conventions),
+  `server.address`, and `server.port`. These attributes are now available for sampling
+  decisions.
+  ([#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
 
 ## 1.9.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -25,7 +25,7 @@
   semantic conventions for
   [spans](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md).
   ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229),
-   [#2277])
+   [#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
 * **Breaking change**: The `peer.service` and `server.socket.address` attributes
   are no longer emitted. Users should rely on the `server.address` attribute
   for the same information. Note that `server.address` is only included when

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -27,8 +27,8 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
 
     private readonly PropertyFetcher<object> commandFetcher = new("Command");
     private readonly PropertyFetcher<object> connectionFetcher = new("Connection");
-    private readonly PropertyFetcher<object> dataSourceFetcher = new("DataSource");
-    private readonly PropertyFetcher<object> databaseFetcher = new("Database");
+    private readonly PropertyFetcher<string> dataSourceFetcher = new("DataSource");
+    private readonly PropertyFetcher<string> databaseFetcher = new("Database");
     private readonly PropertyFetcher<CommandType> commandTypeFetcher = new("CommandType");
     private readonly PropertyFetcher<object> commandTextFetcher = new("CommandText");
     private readonly PropertyFetcher<Exception> exceptionFetcher = new("Exception");
@@ -50,24 +50,27 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
             case SqlDataBeforeExecuteCommand:
             case SqlMicrosoftBeforeExecuteCommand:
                 {
-                    // SqlClient does not create an Activity. So the activity coming in here will be null or the root span.
-                    activity = SqlActivitySourceHelper.ActivitySource.StartActivity(
-                        SqlActivitySourceHelper.ActivityName,
-                        ActivityKind.Client,
-                        default(ActivityContext),
-                        SqlActivitySourceHelper.CreationTags);
-
-                    if (activity == null)
-                    {
-                        // There is no listener or it decided not to sample the current request.
-                        return;
-                    }
-
                     _ = this.commandFetcher.TryFetch(payload, out var command);
                     if (command == null)
                     {
                         SqlClientInstrumentationEventSource.Log.NullPayload(nameof(SqlClientDiagnosticListener), name);
-                        activity.Stop();
+                        return;
+                    }
+
+                    _ = this.connectionFetcher.TryFetch(command, out var connection);
+                    _ = this.databaseFetcher.TryFetch(connection, out var databaseName);
+                    _ = this.dataSourceFetcher.TryFetch(connection, out var dataSource);
+
+                    var startTags = SqlActivitySourceHelper.GetTagListFromConnectionInfo(dataSource, databaseName, this.options, out var activityName);
+                    activity = SqlActivitySourceHelper.ActivitySource.StartActivity(
+                        activityName,
+                        ActivityKind.Client,
+                        default(ActivityContext),
+                        startTags);
+
+                    if (activity == null)
+                    {
+                        // There is no listener or it decided not to sample the current request.
                         return;
                     }
 
@@ -91,33 +94,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                             return;
                         }
 
-                        _ = this.connectionFetcher.TryFetch(command, out var connection);
-                        _ = this.databaseFetcher.TryFetch(connection, out var database);
-
-                        // TODO: Need to understand what scenario (if any) database will be null here
-                        // so that we set DisplayName and db.name/db.namespace correctly.
-                        if (database != null)
-                        {
-                            activity.DisplayName = (string)database;
-
-                            if (this.options.EmitOldAttributes)
-                            {
-                                activity.SetTag(SemanticConventions.AttributeDbName, database);
-                            }
-
-                            if (this.options.EmitNewAttributes)
-                            {
-                                activity.SetTag(SemanticConventions.AttributeDbNamespace, database);
-                            }
-                        }
-
-                        _ = this.dataSourceFetcher.TryFetch(connection, out var dataSource);
                         _ = this.commandTextFetcher.TryFetch(command, out var commandText);
-
-                        if (dataSource != null)
-                        {
-                            SqlActivitySourceHelper.AddConnectionLevelDetailsToActivity((string)dataSource, activity, this.options);
-                        }
 
                         if (this.commandTypeFetcher.TryFetch(command, out CommandType commandType))
                         {

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTestCase.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTestCase.cs
@@ -22,24 +22,24 @@ public class SqlClientTestCase : IEnumerable<object[]>
     private static SqlClientTestCase[] TestCases =>
     [
         new SqlClientTestCase
-            {
-                ConnectionString = @"Data Source=SomeServer",
-                ExpectedActivityName = "SomeServer",
-                ExpectedServerAddress = "SomeServer",
-                ExpectedPort = null,
-                ExpectedDbNamespace = null,
-                ExpectedInstanceName = null,
-            },
-            new SqlClientTestCase
-            {
-                ConnectionString = @"Data Source=SomeServer,1434",
-                ExpectedActivityName = "SomeServer:1434",
-                ExpectedServerAddress = "SomeServer",
-                ExpectedPort = 1434,
-                ExpectedDbNamespace = null,
-                ExpectedInstanceName = null,
-            },
-        ];
+        {
+            ConnectionString = @"Data Source=SomeServer",
+            ExpectedActivityName = "SomeServer",
+            ExpectedServerAddress = "SomeServer",
+            ExpectedPort = null,
+            ExpectedDbNamespace = null,
+            ExpectedInstanceName = null,
+        },
+        new SqlClientTestCase
+        {
+            ConnectionString = @"Data Source=SomeServer,1434",
+            ExpectedActivityName = "SomeServer:1434",
+            ExpectedServerAddress = "SomeServer",
+            ExpectedPort = 1434,
+            ExpectedDbNamespace = null,
+            ExpectedInstanceName = null,
+        },
+    ];
 
     public IEnumerator<object[]> GetEnumerator()
     {

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTestCase.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTestCase.cs
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections;
+
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+public class SqlClientTestCase : IEnumerable<object[]>
+{
+    public string ConnectionString { get; set; } = string.Empty;
+
+    public string ExpectedActivityName { get; set; } = string.Empty;
+
+    public string? ExpectedServerAddress { get; set; }
+
+    public int? ExpectedPort { get; set; }
+
+    public string? ExpectedDbNamespace { get; set; }
+
+    public string? ExpectedInstanceName { get; set; }
+
+    private static SqlClientTestCase[] TestCases =>
+    [
+        new SqlClientTestCase
+            {
+                ConnectionString = @"Data Source=SomeServer",
+                ExpectedActivityName = "SomeServer",
+                ExpectedServerAddress = "SomeServer",
+                ExpectedPort = null,
+                ExpectedDbNamespace = null,
+                ExpectedInstanceName = null,
+            },
+            new SqlClientTestCase
+            {
+                ConnectionString = @"Data Source=SomeServer,1434",
+                ExpectedActivityName = "SomeServer:1434",
+                ExpectedServerAddress = "SomeServer",
+                ExpectedPort = 1434,
+                ExpectedDbNamespace = null,
+                ExpectedInstanceName = null,
+            },
+        ];
+
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        foreach (var testCase in TestCases)
+        {
+            yield return new object[] { testCase };
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+}

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -200,27 +200,27 @@ public class SqlClientTests : IDisposable
         bool emitOldAttributes = true,
         bool emitNewAttributes = false)
     {
-        var activity = new Activity("Test Sql Activity");
         var options = new SqlClientTraceInstrumentationOptions()
         {
             EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
             EmitOldAttributes = emitOldAttributes,
             EmitNewAttributes = emitNewAttributes,
         };
-        SqlActivitySourceHelper.AddConnectionLevelDetailsToActivity(dataSource, activity, options);
 
-        Assert.Equal(expectedServerHostName ?? expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
+        var tags = SqlActivitySourceHelper.GetTagListFromConnectionInfo(dataSource, databaseName: null, options, out var _);
+
+        Assert.Equal(expectedServerHostName ?? expectedServerIpAddress, tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeServerAddress).Value);
 
         if (emitOldAttributes)
         {
-            Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+            Assert.Equal(expectedInstanceName, tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeDbMsSqlInstanceName).Value);
         }
         else
         {
-            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+            Assert.Null(tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeDbMsSqlInstanceName).Value);
         }
 
-        Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeServerPort));
+        Assert.Equal(expectedPort, tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeServerPort).Value);
     }
 
     [Theory]
@@ -291,27 +291,17 @@ public class SqlClientTests : IDisposable
     }
 
     [Theory]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand)]
-    public void SqlClientCreatesActivityWithDbSystem(
-        string beforeCommand)
+    [ClassData(typeof(SqlClientTestCase))]
+    public void SqlDataStartsActivityWithExpectedAttributes(SqlClientTestCase testCase)
     {
-        using var sqlConnection = new SqlConnection(TestConnectionString);
-        using var sqlCommand = sqlConnection.CreateCommand();
+        this.RunSqlClientTestCase(testCase, SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand);
+    }
 
-        var sampler = new TestSampler
-        {
-            SamplingAction = _ => new SamplingResult(SamplingDecision.Drop),
-        };
-        using (Sdk.CreateTracerProviderBuilder()
-            .AddSqlClientInstrumentation()
-            .SetSampler(sampler)
-            .Build())
-        {
-            this.fakeSqlClientDiagnosticSource.Write(beforeCommand, new { });
-        }
-
-        VerifySamplingParameters(sampler.LatestSamplingParameters);
+    [Theory]
+    [ClassData(typeof(SqlClientTestCase))]
+    public void MicrosoftDataStartsActivityWithExpectedAttributes(SqlClientTestCase testCase)
+    {
+        this.RunSqlClientTestCase(testCase, SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand);
     }
 
     [Fact]
@@ -384,7 +374,15 @@ public class SqlClientTests : IDisposable
         bool emitOldAttributes = true,
         bool emitNewAttributes = false)
     {
-        Assert.Equal("master", activity.DisplayName);
+        if (emitNewAttributes)
+        {
+            Assert.Equal("MSSQLLocalDB.master", activity.DisplayName);
+        }
+        else
+        {
+            Assert.Equal("master", activity.DisplayName);
+        }
+
         Assert.Equal(ActivityKind.Client, activity.Kind);
 
         if (!isFailure)
@@ -429,7 +427,7 @@ public class SqlClientTests : IDisposable
 
         if (emitNewAttributes)
         {
-            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
+            Assert.Equal("MSSQLLocalDB.master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
         }
 
         switch (commandType)
@@ -488,6 +486,60 @@ public class SqlClientTests : IDisposable
                    && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName);
     }
 
+    internal static void VerifySamplingParameters(SqlClientTestCase testCase, Activity activity, SamplingParameters samplingParameters)
+    {
+        Assert.NotNull(samplingParameters.Tags);
+
+        Assert.Equal(testCase.ExpectedActivityName, activity.DisplayName);
+        Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagItem(SemanticConventions.AttributeDbSystem));
+        Assert.Equal(testCase.ExpectedDbNamespace, activity.GetTagItem(SemanticConventions.AttributeDbName));
+        Assert.Equal(testCase.ExpectedServerAddress, activity.GetTagItem(SemanticConventions.AttributeServerAddress));
+        Assert.Equal(testCase.ExpectedPort, activity.GetTagItem(SemanticConventions.AttributeServerPort));
+        Assert.Equal(testCase.ExpectedInstanceName, activity.GetTagItem(SemanticConventions.AttributeDbMsSqlInstanceName));
+
+        Assert.Contains(
+            samplingParameters.Tags,
+            kvp => kvp.Key == SemanticConventions.AttributeDbSystem
+                   && kvp.Value is string
+                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName);
+
+        if (testCase.ExpectedDbNamespace != null)
+        {
+            Assert.Contains(
+                samplingParameters.Tags,
+                kvp => kvp.Key == SemanticConventions.AttributeDbName
+                       && kvp.Value is string
+                       && (string)kvp.Value == testCase.ExpectedDbNamespace);
+        }
+
+        if (testCase.ExpectedServerAddress != null)
+        {
+            Assert.Contains(
+            samplingParameters.Tags,
+            kvp => kvp.Key == SemanticConventions.AttributeServerAddress
+                   && kvp.Value is string
+                   && (string)kvp.Value == testCase.ExpectedServerAddress);
+        }
+
+        if (testCase.ExpectedPort.HasValue)
+        {
+            Assert.Contains(
+                samplingParameters.Tags,
+                kvp => kvp.Key == SemanticConventions.AttributeServerPort
+                       && kvp.Value is int
+                       && (int)kvp.Value == testCase.ExpectedPort);
+        }
+
+        if (testCase.ExpectedInstanceName != null)
+        {
+            Assert.Contains(
+                samplingParameters.Tags,
+                kvp => kvp.Key == SemanticConventions.AttributeDbMsSqlInstanceName
+                       && kvp.Value is string
+                       && (string)kvp.Value == testCase.ExpectedInstanceName);
+        }
+    }
+
     internal static void ActivityEnrichment(Activity activity, string method, object obj)
     {
         activity.SetTag("enriched", "yes");
@@ -504,6 +556,32 @@ public class SqlClientTests : IDisposable
     }
 
 #if !NETFRAMEWORK
+    private void RunSqlClientTestCase(SqlClientTestCase testCase, string beforeCommand, string afterCommand)
+    {
+        using var sqlConnection = new SqlConnection(testCase.ConnectionString);
+        using var sqlCommand = sqlConnection.CreateCommand();
+
+        var exportedItems = new List<Activity>();
+
+        var sampler = new TestSampler
+        {
+            SamplingAction = _ => new SamplingResult(SamplingDecision.RecordAndSample),
+        };
+
+        using (Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation()
+            .SetSampler(sampler)
+            .AddInMemoryExporter(exportedItems)
+            .Build())
+        {
+            this.fakeSqlClientDiagnosticSource.Write(beforeCommand, new { Command = sqlCommand });
+            this.fakeSqlClientDiagnosticSource.Write(afterCommand, new { Command = sqlCommand });
+        }
+
+        Assert.Single(exportedItems);
+        VerifySamplingParameters(testCase, exportedItems.First(), sampler.LatestSamplingParameters);
+    }
+
     private Activity[] RunCommandWithFilter(
         Action<SqlCommand> sqlCommandSetup,
         Func<object, bool> filter)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -243,7 +243,15 @@ public class SqlEventSourceTests
         bool emitOldAttributes = true,
         bool emitNewAttributes = false)
     {
-        Assert.Equal("master", activity.DisplayName);
+        if (emitNewAttributes && enableConnectionLevelAttributes)
+        {
+            Assert.Equal("instanceName.master", activity.DisplayName);
+        }
+        else
+        {
+            Assert.Equal("master", activity.DisplayName);
+        }
+
         Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
 
@@ -282,7 +290,7 @@ public class SqlEventSourceTests
 
         if (emitNewAttributes)
         {
-            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
+            Assert.Equal(!enableConnectionLevelAttributes ? "master" : "instanceName.master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
         }
 
         if (captureText)


### PR DESCRIPTION
Fixes #2236 
Towards #2224 
Towards #2237 

Per the [MSSQL conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/mssql.md):

> [3]: When connected to a default instance, db.namespace SHOULD be set to the name of the database. When connected to a [named instance](https://learn.microsoft.com/sql/connect/jdbc/building-the-connection-url#named-and-multiple-sql-server-instances), db.namespace SHOULD be set to the combination of instance and database name following the {instance_name}.{database_name} pattern.

In addition to including the instance name in the `db.namespace` attribute, this PR begins to address conforming the activity name to the conventions and starting the activity with required tags.

1. It includes `db.namespace` and `server.address`/`server.port` in the activity name [when appropriate](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#name).
2. It adds the following attributes when starting the activity
    * `db.system`
    * `db.namespace`
    * `server.address`
    * `server.port`