### PR TITLE
[SqlClient] For `CommandType.StoredProcedure` set `db.operation.name` and `db.collection.name`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -25,7 +25,8 @@
   semantic conventions for
   [spans](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md).
   ([#2229](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2229),
-   [#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
+   [#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277),
+   [#2279](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2279))
 * **Breaking change**: The `peer.service` and `server.socket.address` attributes
   are no longer emitted. Users should rely on the `server.address` attribute
   for the same information. Note that `server.address` is only included when

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -110,6 +110,8 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
 
                                         if (this.options.EmitNewAttributes)
                                         {
+                                            activity.SetTag(SemanticConventions.AttributeDbOperationName, "EXECUTE");
+                                            activity.SetTag(SemanticConventions.AttributeDbCollectionName, commandText);
                                             activity.SetTag(SemanticConventions.AttributeDbQueryText, commandText);
                                         }
                                     }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -442,6 +442,8 @@ public class SqlClientTests : IDisposable
 
                     if (emitNewAttributes)
                     {
+                        Assert.Equal("EXECUTE", activity.GetTagValue(SemanticConventions.AttributeDbOperationName));
+                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbCollectionName));
                         Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
                     }
                 }


### PR DESCRIPTION
Towards #2222

`db.operation.name` and `db.collection.name` are required attributes when readily available. For stored procedures, they are readily available.

There is some unsettled conversation about whether the attribute name `db.collection.name` makes sense in the context of stored procedure, so the attribute name may change. For now let's just use `db.collection.name`.

In a follow on PR, I plan to propose removing the `SetDbStatementForStoredProcedure` option.