### PR TITLE
[sqlclient] Remove SetDbStatementForStoredProcedure option

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
@@ -8,8 +8,6 @@ OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Fil
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.RecordException.get -> bool
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.RecordException.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForStoredProcedure.get -> bool
-OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForStoredProcedure.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForText.get -> bool
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForText.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SqlClientTraceInstrumentationOptions() -> void

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -45,6 +45,8 @@
   `server.address`, and `server.port`. These attributes are now available for sampling
   decisions.
   ([#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
+* **Breaking change**: The `SetDbStatementForStoredProcedure` option has been removed.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
 
 ## 1.9.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -103,19 +103,16 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                             switch (commandType)
                             {
                                 case CommandType.StoredProcedure:
-                                    if (this.options.SetDbStatementForStoredProcedure)
+                                    if (this.options.EmitOldAttributes)
                                     {
-                                        if (this.options.EmitOldAttributes)
-                                        {
-                                            activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
-                                        }
+                                        activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
+                                    }
 
-                                        if (this.options.EmitNewAttributes)
-                                        {
-                                            activity.SetTag(SemanticConventions.AttributeDbOperationName, "EXECUTE");
-                                            activity.SetTag(SemanticConventions.AttributeDbCollectionName, commandText);
-                                            activity.SetTag(SemanticConventions.AttributeDbQueryText, commandText);
-                                        }
+                                    if (this.options.EmitNewAttributes)
+                                    {
+                                        activity.SetTag(SemanticConventions.AttributeDbOperationName, "EXECUTE");
+                                        activity.SetTag(SemanticConventions.AttributeDbCollectionName, commandText);
+                                        activity.SetTag(SemanticConventions.AttributeDbQueryText, commandText);
                                     }
 
                                     break;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -88,8 +88,9 @@ This instrumentation can be configured to change the default behavior by using
 Capturing the text of a database query may run the risk of capturing sensitive data.
 `SetDbStatementForText` controls whether the
 [`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
-attribute is captured in scenarios where there could be a risk of exposing sensitive data.
-The behavior of `SetDbStatementForText` depends on the runtime used.
+attribute is captured in scenarios where there could be a risk of exposing
+sensitive data. The behavior of `SetDbStatementForText` depends on the runtime
+used.
 
 #### .NET
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -83,42 +83,31 @@ For an ASP.NET application, adding instrumentation is typically done in the
 This instrumentation can be configured to change the default behavior by using
 `SqlClientTraceInstrumentationOptions`.
 
-### Capturing database statements
+### SetDbStatementForText
 
-The `SqlClientTraceInstrumentationOptions` class exposes two properties that can
-be used to configure how the
+Capturing the text of a database query may run the risk of capturing sensitive data.
+`SetDbStatementForText` controls whether the
 [`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
-attribute is captured upon execution of a query but the behavior depends on the
-runtime used.
+attribute is captured in scenarios where there could be a risk of exposing sensitive data.
+The behavior of `SetDbStatementForText` depends on the runtime used.
 
-#### .NET and .NET Core
+#### .NET
 
-On .NET and .NET Core, two properties are available:
-`SetDbStatementForStoredProcedure` and `SetDbStatementForText`. These properties
-control capturing of `CommandType.StoredProcedure` and `CommandType.Text`
-respectively.
-
-`SetDbStatementForStoredProcedure` is _true_ by default and will set
+On .NET, `SetDbStatementForText` controls whether or not
+this instrumentation will set the
 [`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
-attribute to the stored procedure command name.
+attribute to the `CommandText` of the `SqlCommand` being executed when the `CommandType`
+is `CommandType.Text`. The
+[`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
+attribute is always captured for `CommandType.StoredProcedure` because the `SqlCommand.CommandText`
+only contains the stored procedure name.
 
-`SetDbStatementForText` is _false_ by default (to prevent accidental capture of
-sensitive data that might be part of the SQL statement text). When set to
-`true`, the instrumentation will set
+`SetDbStatementForText` is _false_ by default. When set to `true`, the
+instrumentation will set
 [`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
 attribute to the text of the SQL command being executed.
 
-To disable capturing stored procedure commands use configuration like below.
-
-```csharp
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddSqlClientInstrumentation(
-        options => options.SetDbStatementForStoredProcedure = false)
-    .AddConsoleExporter()
-    .Build();
-```
-
-To enable capturing of `sqlCommand.CommandText` for `CommandType.Text` use the
+To enable capturing of `SqlCommand.CommandText` for `CommandType.Text` use the
 following configuration.
 
 ```csharp
@@ -131,20 +120,22 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 #### .NET Framework
 
-On .NET Framework, the `SetDbStatementForText` property controls whether or not
-this instrumentation will set the
+On .NET Framework, there is no way to determine the type of command being
+executed, so the `SetDbStatementForText` property always controls whether
+or not this instrumentation will set the
 [`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
-attribute to the text of the `SqlCommand` being executed. This could either be
-the name of a stored procedure (when `CommandType.StoredProcedure` is used) or
-the full text of a `CommandType.Text` query. `SetDbStatementForStoredProcedure`
-is ignored because on .NET Framework there is no way to determine the type of
-command being executed.
+attribute to the `CommandText` of the `SqlCommand` being executed. The
+`CommandText` could be the name of a stored procedure (when
+`CommandType.StoredProcedure` is used) or the full text of a `CommandType.Text`
+query.
 
-Since `CommandType.Text` might contain sensitive data, all SQL capturing is
-_disabled_ by default to protect against accidentally sending full query text to
-a telemetry backend. If you are only using stored procedures or have no
-sensitive data in your `sqlCommand.CommandText`, you can enable SQL capturing
-using the options like below:
+`SetDbStatementForText` is _false_ by default. When set to `true`, the
+instrumentation will set
+[`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
+attribute to the text of the SQL command being executed.
+
+To enable capturing of `SqlCommand.CommandText` for `CommandType.Text` use the
+following configuration.
 
 ```csharp
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
@@ -34,19 +34,6 @@ public class SqlClientTraceInstrumentationOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether or not the <see
-    /// cref="SqlClientInstrumentation"/> should add the names of <see
-    /// cref="CommandType.StoredProcedure"/> commands as the <see
-    /// cref="SemanticConventions.AttributeDbStatement"/> tag. Default
-    /// value: <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>SetDbStatementForStoredProcedure is only supported on .NET
-    /// and .NET Core runtimes.</b></para>
-    /// </remarks>
-    public bool SetDbStatementForStoredProcedure { get; set; } = true;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether or not the <see
     /// cref="SqlClientInstrumentation"/> should add the text of commands as
     /// the <see cref="SemanticConventions.AttributeDbStatement"/> tag.
     /// Default value: <see langword="false"/>.

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -23,17 +23,15 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
     }
 
     [EnabledOnDockerPlatformTheory(EnabledOnDockerPlatformTheoryAttribute.DockerPlatform.Linux)]
-    [InlineData(CommandType.Text, "select 1/1", false)]
-    [InlineData(CommandType.Text, "select 1/1", false, true)]
-    [InlineData(CommandType.Text, "select 1/0", false, false, true)]
-    [InlineData(CommandType.Text, "select 1/0", false, false, true, false, false)]
-    [InlineData(CommandType.Text, "select 1/0", false, false, true, true, false)]
-    [InlineData(CommandType.StoredProcedure, "sp_who", false)]
-    [InlineData(CommandType.StoredProcedure, "sp_who", true)]
+    [InlineData(CommandType.Text, "select 1/1")]
+    [InlineData(CommandType.Text, "select 1/1", true)]
+    [InlineData(CommandType.Text, "select 1/0", false, true)]
+    [InlineData(CommandType.Text, "select 1/0", false, true, false, false)]
+    [InlineData(CommandType.Text, "select 1/0", false, true, true, false)]
+    [InlineData(CommandType.StoredProcedure, "sp_who")]
     public void SuccessfulCommandTest(
         CommandType commandType,
         string commandText,
-        bool captureStoredProcedureCommandName,
         bool captureTextCommandContent = false,
         bool isFailure = false,
         bool recordException = false,
@@ -52,12 +50,7 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
             .AddInMemoryExporter(activities)
             .AddSqlClientInstrumentation(options =>
             {
-#if !NETFRAMEWORK
-                options.SetDbStatementForStoredProcedure = captureStoredProcedureCommandName;
                 options.SetDbStatementForText = captureTextCommandContent;
-#else
-                options.SetDbStatementForText = captureStoredProcedureCommandName || captureTextCommandContent;
-#endif
                 options.RecordException = recordException;
                 if (shouldEnrich)
                 {
@@ -91,7 +84,7 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
         Assert.Single(activities);
         var activity = activities[0];
 
-        SqlClientTests.VerifyActivityData(commandType, commandText, captureStoredProcedureCommandName, captureTextCommandContent, isFailure, recordException, shouldEnrich, activity);
+        SqlClientTests.VerifyActivityData(commandType, commandText, captureTextCommandContent, isFailure, recordException, shouldEnrich, activity);
         SqlClientTests.VerifySamplingParameters(sampler.LatestSamplingParameters);
 
         if (isFailure)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -65,40 +65,39 @@ public class SqlClientTests : IDisposable
     // DiagnosticListener-based instrumentation is only available on .NET Core
 #if !NETFRAMEWORK
     [Theory]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false)]
 
     // Test cases when EmitOldAttributes = false and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database)
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, true, false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false, false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, true, false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false, false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, true, false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false, false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, true, false, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, false, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, false, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, true, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false, true)]
 
     // Test cases when EmitOldAttributes = true and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database/dup)
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, true, true, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false, true, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, true, true, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false, true, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, true, true, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false, true, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, true, true, true)]
-    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, false, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, false, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, true, true, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, true, true)]
     public void SqlClientCallsAreCollectedSuccessfully(
         string beforeCommand,
         string afterCommand,
         CommandType commandType,
         string commandText,
-        bool captureStoredProcedureCommandName,
         bool captureTextCommandContent,
         bool shouldEnrich = true,
         bool emitOldAttributes = true,
@@ -113,7 +112,6 @@ public class SqlClientTests : IDisposable
                     (opt) =>
                     {
                         opt.SetDbStatementForText = captureTextCommandContent;
-                        opt.SetDbStatementForStoredProcedure = captureStoredProcedureCommandName;
                         if (shouldEnrich)
                         {
                             opt.Enrich = ActivityEnrichment;
@@ -160,7 +158,6 @@ public class SqlClientTests : IDisposable
         VerifyActivityData(
             sqlCommand.CommandType,
             sqlCommand.CommandText,
-            captureStoredProcedureCommandName,
             captureTextCommandContent,
             false,
             false,
@@ -282,7 +279,6 @@ public class SqlClientTests : IDisposable
         VerifyActivityData(
             sqlCommand.CommandType,
             sqlCommand.CommandText,
-            true,
             false,
             true,
             recordException,
@@ -365,7 +361,6 @@ public class SqlClientTests : IDisposable
     internal static void VerifyActivityData(
         CommandType commandType,
         string commandText,
-        bool captureStoredProcedureCommandName,
         bool captureTextCommandContent,
         bool isFailure,
         bool recordException,
@@ -433,24 +428,16 @@ public class SqlClientTests : IDisposable
         switch (commandType)
         {
             case CommandType.StoredProcedure:
-                if (captureStoredProcedureCommandName)
+                if (emitOldAttributes)
                 {
-                    if (emitOldAttributes)
-                    {
-                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-                    }
-
-                    if (emitNewAttributes)
-                    {
-                        Assert.Equal("EXECUTE", activity.GetTagValue(SemanticConventions.AttributeDbOperationName));
-                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbCollectionName));
-                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
-                    }
+                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
                 }
-                else
+
+                if (emitNewAttributes)
                 {
-                    Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-                    Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
+                    Assert.Equal("EXECUTE", activity.GetTagValue(SemanticConventions.AttributeDbOperationName));
+                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbCollectionName));
+                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
                 }
 
                 break;


### PR DESCRIPTION
Removes the `SetDbStatementForStoredProcedure` configuration option.

The [database semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md) are nearing stability, there are number of attributes which are required when they are readily available (i.e. no complex parsing or sanitization of query text is necessary). This includes `db.query.text`, `db.operation.name`, and `db.collection.name`.

In the case of stored procedures, no parsing or sanitization is necessary, so the instrumentation needs to capture these attributes.

Note that the readme has not yet been updated with documentation of the new conventions, so it currently only refers to the old `db.statement` attribute.