### PR TITLE
Use Environment.WorkingSet to improve performance of Process.Metrics

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -18,14 +18,15 @@ internal sealed class ProcessMetrics
 
     private static readonly Meter MeterInstance = new(MeterName, Assembly.GetPackageVersion());
 
+    private static readonly Diagnostics.Process Process = Diagnostics.Process.GetCurrentProcess();
+
     static ProcessMetrics()
     {
         MeterInstance.CreateObservableUpDownCounter(
             "process.memory.usage",
             () =>
             {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return process.WorkingSet64;
+                return Process.WorkingSet64;
             },
             unit: "By",
             description: "The amount of physical memory in use.");
@@ -34,8 +35,7 @@ internal sealed class ProcessMetrics
             "process.memory.virtual",
             () =>
             {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return process.VirtualMemorySize64;
+                return Process.VirtualMemorySize64;
             },
             unit: "By",
             description: "The amount of committed virtual memory.");
@@ -44,11 +44,10 @@ internal sealed class ProcessMetrics
             "process.cpu.time",
             () =>
             {
-                using var process = Diagnostics.Process.GetCurrentProcess();
                 return new[]
                 {
-                    new Measurement<double>(process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "user")),
-                    new Measurement<double>(process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "system")),
+                    new Measurement<double>(Process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "user")),
+                    new Measurement<double>(Process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "system")),
                 };
             },
             unit: "s",
@@ -67,8 +66,7 @@ internal sealed class ProcessMetrics
             "process.thread.count",
             () =>
             {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return process.Threads.Count;
+                return Process.Threads.Count;
             },
             unit: "{thread}",
             description: "Process threads count.");

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -18,15 +18,14 @@ internal sealed class ProcessMetrics
 
     private static readonly Meter MeterInstance = new(MeterName, Assembly.GetPackageVersion());
 
-    private static readonly Diagnostics.Process Process = Diagnostics.Process.GetCurrentProcess();
-
     static ProcessMetrics()
     {
         MeterInstance.CreateObservableUpDownCounter(
             "process.memory.usage",
             () =>
             {
-                return Process.WorkingSet64;
+                using var process = Diagnostics.Process.GetCurrentProcess();
+                return process.WorkingSet64;
             },
             unit: "By",
             description: "The amount of physical memory in use.");
@@ -35,7 +34,8 @@ internal sealed class ProcessMetrics
             "process.memory.virtual",
             () =>
             {
-                return Process.VirtualMemorySize64;
+                using var process = Diagnostics.Process.GetCurrentProcess();
+                return process.VirtualMemorySize64;
             },
             unit: "By",
             description: "The amount of committed virtual memory.");
@@ -44,10 +44,11 @@ internal sealed class ProcessMetrics
             "process.cpu.time",
             () =>
             {
+                using var process = Diagnostics.Process.GetCurrentProcess();
                 return new[]
                 {
-                    new Measurement<double>(Process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "user")),
-                    new Measurement<double>(Process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "system")),
+                    new Measurement<double>(process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "user")),
+                    new Measurement<double>(process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("process.cpu.state", "system")),
                 };
             },
             unit: "s",
@@ -66,7 +67,8 @@ internal sealed class ProcessMetrics
             "process.thread.count",
             () =>
             {
-                return Process.Threads.Count;
+                using var process = Diagnostics.Process.GetCurrentProcess();
+                return process.Threads.Count;
             },
             unit: "{thread}",
             description: "Process threads count.");

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -24,8 +24,7 @@ internal sealed class ProcessMetrics
             "process.memory.usage",
             () =>
             {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return process.WorkingSet64;
+                return Environment.WorkingSet;
             },
             unit: "By",
             description: "The amount of physical memory in use.");


### PR DESCRIPTION


Fixes #
Design discussion issue #

Based on traces GetProcessInfos which is called by DiagnosticsGetProcess has a big perf hit. Proposing using Environment.WorkingSet to improve the performance of this API.
## Changes

Please provide a brief description of the changes here.
This PR replaces the usage of a new Process to get its working set in favor of using Environment.WorkingSet instead. See benchmark below.
<img width="1755" alt="image" src="https://github.com/user-attachments/assets/a9b8558c-995b-460c-af63-60db7aabfe16">


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
