### PR TITLE
[repo] Remove #nullable enable

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using OpenTelemetry.Internal;

--- a/src/Shared/ActivityHelperExtensions.cs
+++ b/src/Shared/ActivityHelperExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/src/Shared/ActivityInstrumentationHelper.cs
+++ b/src/Shared/ActivityInstrumentationHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 
 namespace OpenTelemetry.Instrumentation;

--- a/src/Shared/AssemblyVersionExtensions.cs
+++ b/src/Shared/AssemblyVersionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Reflection;
 

--- a/src/Shared/Configuration/IConfigurationExtensionsLogger.cs
+++ b/src/Shared/Configuration/IConfigurationExtensionsLogger.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace Microsoft.Extensions.Configuration;
 
 internal interface IConfigurationExtensionsLogger

--- a/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
+++ b/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 #if NET || NETSTANDARD2_1
 using System.Diagnostics.CodeAnalysis;

--- a/src/Shared/DatabaseSemanticConventionHelper.cs
+++ b/src/Shared/DatabaseSemanticConventionHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 

--- a/src/Shared/DiagnosticSourceListener.cs
+++ b/src/Shared/DiagnosticSourceListener.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 

--- a/src/Shared/DiagnosticSourceSubscriber.cs
+++ b/src/Shared/DiagnosticSourceSubscriber.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 

--- a/src/Shared/ExceptionExtensions.cs
+++ b/src/Shared/ExceptionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Globalization;
 
 namespace OpenTelemetry.Internal;

--- a/src/Shared/GrpcStatusCanonicalCode.cs
+++ b/src/Shared/GrpcStatusCanonicalCode.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Instrumentation;
 
 /// <summary>

--- a/src/Shared/GrpcTagHelper.cs
+++ b/src/Shared/GrpcTagHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using OpenTelemetry.Trace;

--- a/src/Shared/Guard.cs
+++ b/src/Shared/Guard.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 // Note: For some targets this file will contain more than one type/namespace.
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
 

--- a/src/Shared/ListenerHandler.cs
+++ b/src/Shared/ListenerHandler.cs
@@ -3,8 +3,6 @@
 
 using System.Diagnostics;
 
-#nullable enable
-
 namespace OpenTelemetry.Instrumentation;
 
 /// <summary>

--- a/src/Shared/MultiTypePropertyFetcher.cs
+++ b/src/Shared/MultiTypePropertyFetcher.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Collections.Concurrent;
 using System.Reflection;
 

--- a/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
+++ b/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 #if NET
 using System.Diagnostics.CodeAnalysis;

--- a/src/Shared/Options/SingletonOptionsManager.cs
+++ b/src/Shared/Options/SingletonOptionsManager.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif

--- a/src/Shared/PropertyFetcher.AOT.cs
+++ b/src/Shared/PropertyFetcher.AOT.cs
@@ -5,8 +5,6 @@
 // Usages of the non-AOT-compatible version can be moved over to this one when they need to support AOT/trimming.
 // Copied from https://github.com/open-telemetry/opentelemetry-dotnet/blob/86a6ba0b7f7ed1f5e84e5a6610e640989cd3ae9f/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs#L30
 
-#nullable enable
-
 #if NETSTANDARD2_1_0_OR_GREATER || NET
 using System.Diagnostics.CodeAnalysis;
 #endif

--- a/src/Shared/RedactionHelper.cs
+++ b/src/Shared/RedactionHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Text;
 
 namespace OpenTelemetry.Internal;

--- a/src/Shared/RequestDataHelper.cs
+++ b/src/Shared/RequestDataHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 #if NET
 using System.Collections.Frozen;
 #endif

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Globalization;
 using System.Net.Sockets;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Globalization;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Reflection;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Text;
 using OpenTelemetry.Exporter.Geneva.Tld;
 using Xunit;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Globalization;
 using System.Text;
 using OpenTelemetry.Exporter.Geneva.MsgPack;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
@@ -8,7 +8,6 @@
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net48;net472;net471;net47;net462</TargetFrameworks>
     <Description>Unit test project for Geneva Exporters for OpenTelemetry.</Description>
     <NoWarn>$(NoWarn);SA1311;SA1312;SA1313;SA1123;SA1202;OTEL1002</NoWarn>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Google.Protobuf;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/TableNameSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/TableNameSerializerTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Text;
 using Xunit;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable disable
+
 using System.Net.Sockets;
 using System.Reflection;
 using OpenTelemetry.Exporter.Geneva.Transports;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketEndPointTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketEndPointTests.cs
@@ -3,6 +3,8 @@
 
 #if !NET
 
+#nullable disable
+
 using System.Net;
 using System.Net.Sockets;
 using System.Text;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixUserEventsDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixUserEventsDataTransportTests.cs
@@ -3,8 +3,6 @@
 
 #if NET6_0_OR_GREATER
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;

--- a/test/OpenTelemetry.Exporter.Instana.Tests/Processors/EventsActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Exporter.Instana.Tests/Processors/EventsActivityProcessorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using OpenTelemetry.Exporter.Instana.Implementation;
 using OpenTelemetry.Exporter.Instana.Implementation.Processors;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestFixture.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestFixture.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Globalization;
 using System.Text;
 using Microsoft.AspNetCore.Builder;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestResult.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestResult.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using RouteTests.TestApplication;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/ActionDescriptorInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/ActionDescriptorInfo.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/ControllerActionDescriptorInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/ControllerActionDescriptorInfo.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
 using System.Text.Json.Serialization;
 
 namespace RouteTests.TestApplication;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/PageActionDescriptorInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/PageActionDescriptorInfo.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
 using System.Text.Json.Serialization;
 
 namespace RouteTests.TestApplication;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/RouteInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/RouteInfo.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 #if NET

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/RouteInfoDiagnosticObserver.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/RouteInfoDiagnosticObserver.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Diagnostics;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestCase.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestCase.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
 using RouteTests.TestApplication;
 
 namespace RouteTests;

--- a/test/Shared/CustomTextMapPropagator.cs
+++ b/test/Shared/CustomTextMapPropagator.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 

--- a/test/Shared/EventSourceTestHelper.cs
+++ b/test/Shared/EventSourceTestHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Reflection;

--- a/test/Shared/InMemoryEventListener.cs
+++ b/test/Shared/InMemoryEventListener.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Collections.Concurrent;
 using System.Diagnostics.Tracing;
 

--- a/test/Shared/PlatformHelpers.cs
+++ b/test/Shared/PlatformHelpers.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 #pragma warning disable SA1649 // File name should match first type name
 #pragma warning disable SA1402 // File may only contain a single type
 

--- a/test/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
+++ b/test/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Tests;

--- a/test/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
+++ b/test/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Tests;

--- a/test/Shared/TestActivityExportProcessor.cs
+++ b/test/Shared/TestActivityExportProcessor.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 
 namespace OpenTelemetry.Tests;

--- a/test/Shared/TestActivityProcessor.cs
+++ b/test/Shared/TestActivityProcessor.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 
 namespace OpenTelemetry.Tests;

--- a/test/Shared/TestEventListener.cs
+++ b/test/Shared/TestEventListener.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.Tracing;
 
 namespace OpenTelemetry.Tests;

--- a/test/Shared/TestHttpServer.cs
+++ b/test/Shared/TestHttpServer.cs
@@ -4,8 +4,6 @@
 // Note: When implicit usings are enabled in a project this file will generate
 // warnings/errors without this suppression.
 
-#nullable enable
-
 using System.Net;
 #if !NETFRAMEWORK
 using System.Security.Cryptography;

--- a/test/Shared/TestSampler.cs
+++ b/test/Shared/TestSampler.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Tests;

--- a/test/Shared/TestTextMapPropagator.cs
+++ b/test/Shared/TestTextMapPropagator.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using OpenTelemetry.Context.Propagation;
 
 namespace OpenTelemetry.Tests;


### PR DESCRIPTION
Follow up: #2251
Towards #894

## Changes

Remove #nullable enable
in addition, it disables nullable per-file in Geneva.tests.

It is done to avoid [IDE0240](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0240) while migrating to .NET9

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
