### PR TITLE
[geneva] Updates for 1.10.0-rc.1

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -19,6 +19,9 @@
   For configuration details see:
   [OtlpProtobufEncoding](./README.md#otlpprotobufencoding).
 
+* Update OpenTelemetry SDK version to `1.10.0-rc.1`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.9.0
 
 Released 2024-Jun-21

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -20,7 +20,7 @@
   [OtlpProtobufEncoding](./README.md#otlpprotobufencoding).
 
 * Update OpenTelemetry SDK version to `1.10.0-rc.1`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#2294](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2294))
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
+++ b/src/OpenTelemetry.Exporter.Geneva/Common.GenevaExporter.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <OTelSdkVersion>$(OpenTelemetryCoreLatestVersion)</OTelSdkVersion>
+    <OTelSdkVersion>$(OpenTelemetryCoreLatestPrereleaseVersion)</OTelSdkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(OTelSdkVersion.Contains('alpha')) OR $(OTelSdkVersion.Contains('beta')) OR $(OTelSdkVersion.Contains('rc'))">

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantExportProcessor.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ReentrantExportProcessor.cs
@@ -1,21 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Linq.Expressions;
-using System.Reflection;
-
 namespace OpenTelemetry.Exporter.Geneva;
 
-// This export processor exports without synchronization.
-// Once OpenTelemetry .NET officially support this,
-// we can get rid of this class.
-// This is currently only used in ETW export, where we know
-// that the underlying system is safe under concurrent calls.
 internal class ReentrantExportProcessor<T> : BaseExportProcessor<T>
     where T : class
 {
-    private static readonly Func<T, Batch<T>> CreateBatch = BuildCreateBatchDelegate();
-
     public ReentrantExportProcessor(BaseExporter<T> exporter)
         : base(exporter)
     {
@@ -23,16 +13,6 @@ internal class ReentrantExportProcessor<T> : BaseExportProcessor<T>
 
     protected override void OnExport(T data)
     {
-        this.exporter.Export(CreateBatch(data));
-    }
-
-    private static Func<T, Batch<T>> BuildCreateBatchDelegate()
-    {
-        var flags = BindingFlags.Instance | BindingFlags.NonPublic;
-        var ctor = typeof(Batch<T>).GetConstructor(flags, null, new Type[] { typeof(T) }, null)
-            ?? throw new InvalidOperationException("Batch ctor accepting a single item could not be found reflectively");
-        var value = Expression.Parameter(typeof(T), null);
-        var lambda = Expression.Lambda<Func<T, Batch<T>>>(Expression.New(ctor, value), value);
-        return lambda.Compile();
+        this.exporter.Export(new(data));
     }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDTraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDTraceExporterBenchmarks.cs
@@ -55,7 +55,7 @@ public class TLDTraceExporterBenchmarks
             this.activity = testActivity!;
             this.activity.SetTag("tagString", "value");
             this.activity.SetTag("tagInt", 100);
-            this.activity.SetStatus(Status.Error);
+            this.activity.SetStatus(ActivityStatusCode.Error);
         }
 
         this.msgPackExporter = new MsgPackTraceExporter(new GenevaExporterOptions
@@ -128,7 +128,7 @@ public class TLDTraceExporterBenchmarks
         {
             activity.SetTag("tagString", "value");
             activity.SetTag("tagInt", 100);
-            activity.SetStatus(Status.Error);
+            activity.SetStatus(ActivityStatusCode.Error);
         }
 
         return batchGeneratorExporter.Batch;

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TraceExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TraceExporterBenchmarks.cs
@@ -54,7 +54,7 @@ public class TraceExporterBenchmarks
             this.activity = testActivity!;
             this.activity.SetTag("tagString", "value");
             this.activity.SetTag("tagInt", 100);
-            this.activity.SetStatus(Status.Error);
+            this.activity.SetStatus(ActivityStatusCode.Error);
         }
 
         activityListener.Dispose();
@@ -129,7 +129,7 @@ public class TraceExporterBenchmarks
         {
             activity.SetTag("tagString", "value");
             activity.SetTag("tagInt", 100);
-            activity.SetStatus(Status.Error);
+            activity.SetStatus(ActivityStatusCode.Error);
         }
 
         return batchGeneratorExporter.Batch;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -173,12 +173,12 @@ public class GenevaTraceExporterTests
 
         using (var activity = source.StartActivity("Bar"))
         {
-            activity.SetStatus(Status.Error);
+            activity.SetStatus(ActivityStatusCode.Error);
         }
 
         using (var activity = source.StartActivity("Baz"))
         {
-            activity.SetStatus(Status.Ok);
+            activity.SetStatus(ActivityStatusCode.Ok);
         }
     }
 
@@ -296,21 +296,25 @@ public class GenevaTraceExporterTests
                     activity?.SetTag("clientRequestId", "58a37988-2c05-427a-891f-5e0e1266fcc5");
                     activity?.SetTag("foo", 1);
                     activity?.SetTag("bar", 2);
+#pragma warning disable CS0618 // Type or member is obsolete
                     activity?.SetStatus(Status.Error.WithDescription("Error description from OTel API"));
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
 
             using (var activity = source.StartActivity("TestActivityForSetStatusAPI"))
             {
-                activity?.SetStatus(ActivityStatusCode.Error, "Error description from .NET API");
+                activity?.SetStatus(ActivityStatusCode.Error, description: "Error description from .NET API");
             }
 
             // If the activity Status is set using both the OTel API and the .NET API, the `Status` and `StatusDescription` set by
             // the .NET API is chosen
             using (var activity = source.StartActivity("PreferStatusFromDotnetAPI"))
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 activity?.SetStatus(Status.Error.WithDescription("Error description from OTel API"));
-                activity?.SetStatus(ActivityStatusCode.Error, "Error description from .NET API");
+#pragma warning restore CS0618 // Type or member is obsolete
+                activity?.SetStatus(ActivityStatusCode.Error, description: "Error description from .NET API");
                 customChecksForActivity = mapping =>
                 {
                     Assert.Equal("Error description from .NET API", mapping["statusMessage"]);
@@ -678,17 +682,19 @@ public class GenevaTraceExporterTests
         Assert.Equal((byte)activity.Kind, mapping["kind"]);
         Assert.Equal(activity.StartTimeUtc, mapping["startTime"]);
 
-        var activityStatusCode = activity.GetStatus().StatusCode;
+#pragma warning disable CS0618 // Type or member is obsolete
+        var otelApiStatusCode = activity.GetStatus();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (activity.Status == ActivityStatusCode.Error)
         {
             Assert.False((bool)mapping["success"]);
             Assert.Equal(activity.StatusDescription, mapping["statusMessage"]);
         }
-        else if (activityStatusCode == StatusCode.Error)
+        else if (otelApiStatusCode.StatusCode == StatusCode.Error)
         {
             Assert.False((bool)mapping["success"]);
-            var activityStatusDesc = activity.GetStatus().Description;
+            var activityStatusDesc = otelApiStatusCode.Description;
             Assert.Equal(activityStatusDesc, mapping["statusMessage"]);
         }
         else


### PR DESCRIPTION
Fixes #1814

## Changes

* Bump GenevaExporter to `1.10.0-rc.1` SDK
* Utilize the new `Batch(T item)` ctor to remove the need for reflection/dynamic code in `ReentrantExportProcessor`
* Update tests for new obsoletions

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
