### PR TITLE
[OneCollector] Bump SDK to 1.10.0-rc.1

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Update OpenTelemetry SDK version to `1.10.0-rc.1` and removed the direct
   reference to `Microsoft.Extensions.Configuration.Binder`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#2295](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2295))
 
 ## 1.9.3
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -15,6 +15,10 @@
   also be applied to subsequent `LogRecord`s in the same batch.
   ([#2205](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2205))
 
+* Update OpenTelemetry SDK version to `1.10.0-rc.1` and removed the direct
+  reference to `Microsoft.Extensions.Configuration.Binder`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 1.9.3
 
 Released 2024-Oct-11

--- a/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
+++ b/src/OpenTelemetry.Exporter.OneCollector/OpenTelemetry.Exporter.OneCollector.csproj
@@ -18,13 +18,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OTelSdkVersion>$(OpenTelemetryCoreLatestVersion)</OTelSdkVersion>
+    <OTelSdkVersion>$(OpenTelemetryCoreLatestPrereleaseVersion)</OTelSdkVersion>
     <DefineConstants Condition="$(OTelSdkVersion.Contains('alpha')) OR $(OTelSdkVersion.Contains('beta')) OR $(OTelSdkVersion.Contains('rc'))">$(DefineConstants);EXPOSE_EXPERIMENTAL_FEATURES</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OTelSdkVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPkgVer)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Bump OneCollectorExporter to `1.10.0-rc.1` SDK

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
