### PR TITLE
[sqlclient] Make SqlClientInstrumentation a singleton

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -11,6 +11,9 @@ namespace OpenTelemetry.Instrumentation.SqlClient;
 /// <summary>
 /// SqlClient instrumentation.
 /// </summary>
+#if NET
+[RequiresUnreferencedCode(SqlClientTrimmingUnsupportedMessage)]
+#endif
 internal sealed class SqlClientInstrumentation : IDisposable
 {
     public static readonly SqlClientInstrumentation Instance = new SqlClientInstrumentation();
@@ -42,9 +45,6 @@ internal sealed class SqlClientInstrumentation : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlClientInstrumentation"/> class.
     /// </summary>
-#if NET
-    [RequiresUnreferencedCode(SqlClientTrimmingUnsupportedMessage)]
-#endif
     private SqlClientInstrumentation()
     {
 #if NETFRAMEWORK
@@ -61,6 +61,8 @@ internal sealed class SqlClientInstrumentation : IDisposable
 
     public static SqlClientTraceInstrumentationOptions TracingOptions { get; set; } = new SqlClientTraceInstrumentationOptions();
 
+    public static IDisposable AddTracingHandle() => new TracingHandle();
+
     /// <inheritdoc/>
     public void Dispose()
     {
@@ -71,7 +73,10 @@ internal sealed class SqlClientInstrumentation : IDisposable
 #endif
     }
 
-    internal class TracingHandle : IDisposable
+#if NET
+    [RequiresUnreferencedCode(SqlClientTrimmingUnsupportedMessage)]
+#endif
+    private sealed class TracingHandle : IDisposable
     {
         private bool disposed;
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -70,8 +70,8 @@ public static class TracerProviderBuilderExtensions
         builder.AddInstrumentation(sp =>
         {
             var sqlOptions = sp.GetRequiredService<IOptionsMonitor<SqlClientTraceInstrumentationOptions>>().Get(name);
-
-            return new SqlClientInstrumentation(sqlOptions);
+            SqlClientInstrumentation.TracingOptions = sqlOptions;
+            return new SqlClientInstrumentation.TracingHandle();
         });
 
         builder.AddSource(SqlActivitySourceHelper.ActivitySourceName);

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -52,7 +52,6 @@ public static class TracerProviderBuilderExtensions
 #if NET
     [RequiresUnreferencedCode(SqlClientInstrumentation.SqlClientTrimmingUnsupportedMessage)]
 #endif
-
     public static TracerProviderBuilder AddSqlClientInstrumentation(
         this TracerProviderBuilder builder,
         string? name,
@@ -71,7 +70,7 @@ public static class TracerProviderBuilderExtensions
         {
             var sqlOptions = sp.GetRequiredService<IOptionsMonitor<SqlClientTraceInstrumentationOptions>>().Get(name);
             SqlClientInstrumentation.TracingOptions = sqlOptions;
-            return new SqlClientInstrumentation.TracingHandle();
+            return SqlClientInstrumentation.AddTracingHandle();
         });
 
         builder.AddSource(SqlActivitySourceHelper.ActivitySourceName);


### PR DESCRIPTION
In an upcoming PR we will be adding metric instrumentation. That instrumentation will need to leverage the same `DiagnosticSourceListener` that is used for traces. This PR makes `SqlClientInstrumentation` a singleton because multiple instances of the instrumentation would create duplicate activities.