### PR TITLE
[Instrumentation.SqlClient] CHANGELOG entry for `db.client.operation.duration`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -48,7 +48,7 @@
 * **Breaking change**: The `SetDbStatementForStoredProcedure` option has been removed.
   ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
 * Add support for metric `db.client.operation.duration`
-  from [new database semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientoperationduration).
+  from [new database semantic conventions] on .NET 8+.(https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientoperationduration).
   ([#2309](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2309))
 
 ## 1.9.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -48,7 +48,8 @@
 * **Breaking change**: The `SetDbStatementForStoredProcedure` option has been removed.
   ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
 * Add support for metric `db.client.operation.duration`
-  from [new database semantic conventions] on .NET 8+.(https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientoperationduration).
+  from [new database semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientoperationduration)
+  on .NET 8+.
   ([#2309](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2309))
 
 ## 1.9.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -47,6 +47,9 @@
   ([#2277](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2277))
 * **Breaking change**: The `SetDbStatementForStoredProcedure` option has been removed.
   ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+* Add support for metric `db.client.operation.duration`
+  from [new database semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientoperationduration).
+  ([#2309](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2309))
 
 ## 1.9.0-beta.1
 


### PR DESCRIPTION
## Changes

Adds CHANGELOG entry for https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2309

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
