### PR TITLE
Correct default MetricExporterIntervalMilliseconds from 20000 to 60000 in documentation

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -340,7 +340,7 @@ the `ConnectionString`.
 #### `MetricExportIntervalMilliseconds` (optional)
 
 Set the exporter's periodic time interval to export Metrics. The default value
-is 20000 milliseconds.
+is 60000 milliseconds.
 
 #### `PrepopulatedMetricDimensions` (optional)
 


### PR DESCRIPTION
The default interval, named metricExporterIntervalMilliseconds, is set to 60 seconds in the code, which contrasts with the documentation.

Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs#L15
![image](https://github.com/user-attachments/assets/98c04ec5-25a2-415e-a2a8-08a6de676569)

![image](https://github.com/user-attachments/assets/4d9a04d2-71eb-40fe-989d-3c5e689eefe9)

After PR:

![image](https://github.com/user-attachments/assets/301f57a5-01e4-4f10-a8cd-ef655af672cf)


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
