### PR TITLE
[Resources.AWS] Execute tests against .NET9

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -31,7 +31,6 @@
     <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryCoreLatestVersion)</OpenTelemetryExporterInMemoryPkgVer>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <SupportedNetTargets>net9.0;net8.0</SupportedNetTargets>
-    <SupportedNetTargetsWithoutNet9>net8.0</SupportedNetTargetsWithoutNet9>
     <XUnitRunnerVisualStudioPkgVer>[2.8.2,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.9.0,3.0)</XUnitPkgVer>
     <WiremockNetPkgVer>[1.6.3,2.0)</WiremockNetPkgVer>

--- a/test/OpenTelemetry.Resources.AWS.Tests/Http/ServerCertificateValidationProviderTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/Http/ServerCertificateValidationProviderTests.cs
@@ -23,7 +23,11 @@ public class ServerCertificateValidationProviderTests
 
         Assert.NotNull(serverCertificateValidationProvider);
 
+#if NET9_0_OR_GREATER
+        var certificate = X509CertificateLoader.LoadCertificateFromFile(certificateUploader.FilePath);
+#else
         var certificate = new X509Certificate2(certificateUploader.FilePath);
+#endif
         X509Chain chain = new X509Chain();
         chain.Build(certificate);
 
@@ -65,7 +69,12 @@ public class ServerCertificateValidationProviderTests
             ServerCertificateValidationProvider.FromCertificateFile(certificateUploader.FilePath, NoopServerCertificateValidationEventSource.Instance);
 
         Assert.NotNull(serverCertificateValidationProvider);
-        Assert.False(serverCertificateValidationProvider.ValidationCallback(this, new X509Certificate2(certificateUploader.FilePath), null, default));
+#if NET9_0_OR_GREATER
+        var certificate = X509CertificateLoader.LoadCertificateFromFile(certificateUploader.FilePath);
+#else
+        var certificate = new X509Certificate2(certificateUploader.FilePath);
+#endif
+        Assert.False(serverCertificateValidationProvider.ValidationCallback(this, certificate, null, default));
     }
 }
 

--- a/test/OpenTelemetry.Resources.AWS.Tests/OpenTelemetry.Resources.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Resources.AWS.Tests/OpenTelemetry.Resources.AWS.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>$(SupportedNetTargetsWithoutNet9)</TargetFrameworks>
+    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>Unit test project for AWS Detector for OpenTelemetry.</Description>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #2323
Design discussion issue #

## Changes

[Resources.AWS] Execute tests against .NET9
Drops unused `SupportedNetTargetsWithoutNet9`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
