### PR TITLE
[repo] Bump internal packages

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -32,7 +32,7 @@
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <SupportedNetTargets>net9.0;net8.0</SupportedNetTargets>
     <XUnitRunnerVisualStudioPkgVer>[2.8.2,3.0)</XUnitRunnerVisualStudioPkgVer>
-    <XUnitPkgVer>[2.9.0,3.0)</XUnitPkgVer>
+    <XUnitPkgVer>[2.9.2,3.0)</XUnitPkgVer>
     <WiremockNetPkgVer>[1.6.3,2.0)</WiremockNetPkgVer>
   </PropertyGroup>
 

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -27,7 +27,7 @@
     <BenchmarkDotNetPkgVer>[0.13.12,0.14)</BenchmarkDotNetPkgVer>
     <MicrosoftExtensionsConfigurationJsonPkgVer>8.0.1</MicrosoftExtensionsConfigurationJsonPkgVer>
     <MicrosoftExtensionsHostingPkgVer>8.0.1</MicrosoftExtensionsHostingPkgVer>
-    <MicrosoftNETTestSdkPkgVer>[17.11.1,18.0)</MicrosoftNETTestSdkPkgVer>
+    <MicrosoftNETTestSdkPkgVer>[17.12.0,18.0)</MicrosoftNETTestSdkPkgVer>
     <OpenTelemetryExporterInMemoryPkgVer>$(OpenTelemetryCoreLatestVersion)</OpenTelemetryExporterInMemoryPkgVer>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <SupportedNetTargets>net9.0;net8.0</SupportedNetTargets>

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -33,7 +33,7 @@
     <SupportedNetTargets>net9.0;net8.0</SupportedNetTargets>
     <XUnitRunnerVisualStudioPkgVer>[2.8.2,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.9.2,3.0)</XUnitPkgVer>
-    <WiremockNetPkgVer>[1.6.3,2.0)</WiremockNetPkgVer>
+    <WiremockNetPkgVer>[1.6.8,2.0)</WiremockNetPkgVer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">

--- a/build/Common.props
+++ b/build/Common.props
@@ -33,7 +33,7 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
     -->
-    <MinVerPkgVer>[5.0.0,6.0)</MinVerPkgVer>
+    <MinVerPkgVer>[6.0.0,7.0)</MinVerPkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,5.0)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsConfigurationPkgVer>[9.0.0,)</MicrosoftExtensionsConfigurationPkgVer>
     <MicrosoftExtensionsOptionsPkgVer>[9.0.0,)</MicrosoftExtensionsOptionsPkgVer>

--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="[5.3.0,6.0)" />
     <PackageReference Include="Microsoft.AspNet.WebPages" Version="[3.3.0,4.0)" />
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryCoreLatestVersion)" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryCoreLatestVersion)" />

--- a/examples/grpc.core/Examples.GrpcCore.AspNetCore/Examples.GrpcCore.AspNetCore.csproj
+++ b/examples/grpc.core/Examples.GrpcCore.AspNetCore/Examples.GrpcCore.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.66.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.67.0" />
     <PackageReference Include="Grpc" Version="[2.46.6,3.0)" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OpenTelemetry.Exporter.Geneva.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.25.3" />
-    <PackageReference Include="Grpc.Tools" Version="2.62.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.67.0" PrivateAssets="All" />
     <PackageReference Include="Grpc" Version="2.46.6" />
     <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -156,7 +156,7 @@ public class HttpInListenerTests
 
                 if (filter == "{ThrowException}")
                 {
-                    Assert.Single(inMemoryEventListener.Events.Where((e) => e.EventId == 2));
+                    Assert.Single(inMemoryEventListener.Events, e => e.EventId == 2);
                 }
 
                 Assert.Equal(TelemetryHttpModule.AspNetActivityName, Activity.Current!.OperationName);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -129,8 +129,8 @@ public sealed class BasicTests
 
         if (shouldEnrich)
         {
-            Assert.NotEmpty(activity.Tags.Where(tag => tag.Key == "enrichedOnStart" && tag.Value == "yes"));
-            Assert.NotEmpty(activity.Tags.Where(tag => tag.Key == "enrichedOnStop" && tag.Value == "yes"));
+            Assert.Contains(activity.Tags, tag => tag.Key == "enrichedOnStart" && tag.Value == "yes");
+            Assert.Contains(activity.Tags, tag => tag.Key == "enrichedOnStop" && tag.Value == "yes");
         }
 
         ValidateAspNetCoreActivity(activity, "/api/values");
@@ -321,7 +321,7 @@ public sealed class BasicTests
 
                 response1.EnsureSuccessStatusCode(); // Status Code 200-299
                 response2.EnsureSuccessStatusCode(); // Status Code 200-299
-                Assert.Single(inMemoryEventListener.Events.Where((e) => e.EventId == 3));
+                Assert.Single(inMemoryEventListener.Events, e => e.EventId == 3);
             }
 
             WaitForActivityExport(exportedItems, 1);

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Tools" Version="2.66.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.67.0" />
     <PackageReference Include="Grpc" Version="[2.46.6,3.0)" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
     <Description>Unit test project for OpenTelemetry Grpc for .NET instrumentation.</Description>
-    <NoWarn>$(NoWarn);CS8981</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +14,7 @@
     <PackageReference Include="Google.Protobuf" Version="[3.22.5,4.0)" />
     <PackageReference Include="Grpc.AspNetCore.Server" Version="[2.59.0, 3.0)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <PackageReference Include="Grpc.Net.Client" Version="[2.52.0,3.0)" />
-    <PackageReference Include="Grpc.Tools" Version="[2.59.0,3.0)" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="[2.67.0,3.0)" PrivateAssets="All" />
     <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="$(OpenTelemetryCoreLatestVersion)" />

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
@@ -592,7 +592,7 @@ public partial class HttpClientTests : IDisposable
             using var c = new HttpClient();
             using var inMemoryEventListener = new InMemoryEventListener(HttpInstrumentationEventSource.Log);
             await c.GetAsync(new Uri(this.url));
-            Assert.Single(inMemoryEventListener.Events.Where(e => e.EventId == 4));
+            Assert.Single(inMemoryEventListener.Events, e => e.EventId == 4);
         }
 
         Assert.Empty(exportedItems);
@@ -621,7 +621,7 @@ public partial class HttpClientTests : IDisposable
 
         // Exception is thrown and collected as event
         Assert.True(exceptionThrown);
-        Assert.Single(exportedItems[0].Events.Where(evt => evt.Name.Equals("exception")));
+        Assert.Single(exportedItems[0].Events, evt => evt.Name.Equals("exception"));
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -387,7 +387,7 @@ public partial class HttpClientTests
 
             if (tc.RecordException.HasValue && tc.RecordException.Value)
             {
-                Assert.Single(activity.Events.Where(evt => evt.Name.Equals("exception")));
+                Assert.Single(activity.Events, evt => evt.Name.Equals("exception"));
                 Assert.True(enrichWithExceptionCalled);
             }
         }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.cs
@@ -150,7 +150,7 @@ public partial class HttpWebRequestTests : IDisposable
 
             using var response = await request.GetResponseAsync();
 
-            Assert.Single(inMemoryEventListener.Events.Where(e => e.EventId == 4));
+            Assert.Single(inMemoryEventListener.Events, e => e.EventId == 4);
         }
 
         Assert.Empty(exportedItems);
@@ -327,7 +327,7 @@ public partial class HttpWebRequestTests : IDisposable
 
         // Exception is thrown and collected as event
         Assert.True(exceptionThrown);
-        Assert.Single(exportedItems[0].Events.Where(evt => evt.Name.Equals("exception")));
+        Assert.Single(exportedItems[0].Events, evt => evt.Name.Equals("exception"));
     }
 
     [Fact]
@@ -357,7 +357,7 @@ public partial class HttpWebRequestTests : IDisposable
 #if NETFRAMEWORK
         // Exception is thrown and collected as event
         Assert.True(exceptionThrown);
-        Assert.Single(exportedItems[0].Events.Where(evt => evt.Name.Equals("exception")));
+        Assert.Single(exportedItems[0].Events, evt => evt.Name.Equals("exception"));
 #else
         // Note: On .NET Core exceptions through HttpWebRequest do not
         // trigger exception events they just throw:

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
@@ -155,7 +155,7 @@ public partial class HttpWebRequestTests
 
         if (tc.RecordException.HasValue && tc.RecordException.Value)
         {
-            Assert.Single(activity.Events.Where(evt => evt.Name.Equals("exception")));
+            Assert.Single(activity.Events, evt => evt.Name.Equals("exception"));
             Assert.True(enrichWithExceptionCalled);
         }
     }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -457,7 +457,7 @@ public class SqlClientTests : IDisposable
 
         if (shouldEnrich)
         {
-            Assert.NotEmpty(activity.Tags.Where(tag => tag.Key == "enriched"));
+            Assert.Contains(activity.Tags, tag => tag.Key == "enriched");
             Assert.Equal("yes", activity.Tags.FirstOrDefault(tag => tag.Key == "enriched").Value);
         }
         else


### PR DESCRIPTION
## Changes

Bump internal packages.
Fixes: [xUnit2030](https://xunit.net/xunit.analyzers/rules/xUnit2030) and [xUnit2031](https://xunit.net/xunit.analyzers/rules/xUnit2031)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
