### PR TITLE
Replace ActivityExtensions.SetStatus by Activity.SetStatus

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Following tags will be not added to spans when the exception is recorder:
+  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+  ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+
 ## 1.10.0-beta.1
 
 Released 2024-Nov-23

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* The following tags are no longer added to spans when an exception is recorded:
-  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+* Trace instrumentation will now call the [Activity.SetStatus](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.setstatus)
+  API instead of the deprecated OpenTelemetry API package extension when setting
+  span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Following tags will be not added to spans when the exception is recorder:
+* The following tags are no longer added to spans when an exception is recorded:
   `otel.status_code` and `otel.status_description`. Both values are handled natively.
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Tracing/AWSTraceSpan.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Tracing/AWSTraceSpan.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using Amazon.Runtime.Telemetry;
 using Amazon.Runtime.Telemetry.Tracing;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AWS.Implementation.Tracing;
 
@@ -60,9 +59,7 @@ internal sealed class AWSTraceSpan : TraceSpan
         var tags = attributes != null ? new TagList(attributes.AllAttributes.ToArray()) : default;
 
         this.activity.AddException(exception, tags);
-#pragma warning disable CS0618 // Type or member is obsolete
-        this.activity.SetStatus(Status.Error.WithDescription(exception.Message));
-#pragma warning restore CS0618 // Type or member is obsolete
+        this.activity.SetStatus(ActivityStatusCode.Error, exception.Message);
     }
 
     public override void End()

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
@@ -192,9 +192,7 @@ public static class AWSLambdaWrapper
             if (activity.IsAllDataRequested)
             {
                 activity.AddException(exception);
-#pragma warning disable CS0618 // Type or member is obsolete
-                activity.SetStatus(Status.Error.WithDescription(exception.Message));
-#pragma warning restore CS0618 // Type or member is obsolete
+                activity.SetStatus(ActivityStatusCode.Error, exception.Message);
             }
         }
     }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Following tags will be not added to spans when the exception is recorder:
+  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+  ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+
 ## 1.10.0-beta.1
 
 Released 2024-Nov-23

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* The following tags are no longer added to spans when an exception is recorded:
-  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+* Trace instrumentation will now call the [Activity.SetStatus](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.setstatus)
+  API instead of the deprecated OpenTelemetry API package extension when setting
+  span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Following tags will be not added to spans when the exception is recorder:
+* The following tags are no longer added to spans when an exception is recorded:
   `otel.status_code` and `otel.status_description`. Both values are handled natively.
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* Following tags will be not added to spans when the exception is handled:
+* FThe following tags are no longer added to spans when an exception is handled:
   `otel.status_code` and `otel.status_description`. Both values are handled natively.
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -9,8 +9,9 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* FThe following tags are no longer added to spans when an exception is handled:
-  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+* Trace instrumentation will now call the [Activity.SetStatus](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.setstatus)
+  API instead of the deprecated OpenTelemetry API package extension when setting
+  span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
 ## 0.1.0-alpha.2

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
+* Following tags will be not added to spans when the exception is handled:
+  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+  ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+
 ## 0.1.0-alpha.2
 
 Released 2024-Sep-18

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -113,9 +113,7 @@ public static class OpenTelemetryConsumeResultExtensions
         }
         catch (Exception ex)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            processActivity?.SetStatus(Status.Error);
-#pragma warning restore CS0618 // Type or member is obsolete
+            processActivity?.SetStatus(ActivityStatusCode.Error);
             processActivity?.SetTag(SemanticConventions.AttributeErrorType, ex.GetType().FullName);
         }
         finally

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -27,8 +27,9 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* The following tags are no longer added to spans when an exception is handled:
-  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+* Trace instrumentation will now call the [Activity.SetStatus](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.setstatus)
+  API instead of the deprecated OpenTelemetry API package extension when setting
+  span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
 ## 1.0.0-beta.12

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* Following tags will be not added to spans when the exception is handled:
+* The following tags are no longer added to spans when an exception is handled:
   `otel.status_code` and `otel.status_description`. Both values are handled natively.
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -27,6 +27,10 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
+* Following tags will be not added to spans when the exception is handled:
+  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+  ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+
 ## 1.0.0-beta.12
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
@@ -5,7 +5,6 @@ using System.Data;
 using System.Diagnostics;
 using System.Reflection;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Implementation;
 
@@ -297,9 +296,7 @@ internal sealed class EntityFrameworkDiagnosticListener : ListenerHandler
                         {
                             if (this.exceptionFetcher.Fetch(payload) is Exception exception)
                             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                                activity.SetStatus(Status.Error.WithDescription(exception.Message));
-#pragma warning restore CS0618 // Type or member is obsolete
+                                activity.SetStatus(ActivityStatusCode.Error, exception.Message);
                             }
                             else
                             {

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
+* Following tags will be not added to spans when the exception is handled:
+  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+  ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+
 ## 1.0.0-rc.6
 
 Released 2024-Apr-19

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -19,7 +19,7 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* Following tags will be not added to spans when the exception is handled:
+* The following tags are no longer added to spans when an exception is handled:
   `otel.status_code` and `otel.status_description`. Both values are handled natively.
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -19,8 +19,9 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* The following tags are no longer added to spans when an exception is handled:
-  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+* Trace instrumentation will now call the [Activity.SetStatus](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.setstatus)
+  API instead of the deprecated OpenTelemetry API package extension when setting
+  span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
 ## 1.0.0-rc.6

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
@@ -150,9 +150,7 @@ internal sealed class DiagnosticsMiddleware : OwinMiddleware
 
                 if (exception != null)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    activity.SetStatus(Status.Error);
-#pragma warning restore CS0618 // Type or member is obsolete
+                    activity.SetStatus(ActivityStatusCode.Error);
 
                     if (OwinInstrumentationActivitySource.Options?.RecordException == true)
                     {

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* Following tags will be not added to spans when the exception is recorder:
+* The following tags are no longer added to spans when an exception is recorded:
   `otel.status_code` and `otel.status_description`. Both values are handled natively.
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -5,8 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
-* The following tags are no longer added to spans when an exception is recorded:
-  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+* Trace instrumentation will now call the [Activity.SetStatus](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.setstatus)
+  API instead of the deprecated OpenTelemetry API package extension when setting
+  span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
 ## 1.0.0-beta.3

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Updated OpenTelemetry core component version(s) to `1.10.0`.
   ([#2317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2317))
 
+* Following tags will be not added to spans when the exception is recorder:
+  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+  ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+
 ## 1.0.0-beta.3
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.Quartz/Implementation/QuartzDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Quartz/Implementation/QuartzDiagnosticListener.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Reflection;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Quartz.Implementation;
 
@@ -140,9 +139,7 @@ internal sealed class QuartzDiagnosticListener : ListenerHandler
                 activity.AddException(exc);
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            activity.SetStatus(Status.Error.WithDescription(exc.Message));
-#pragma warning restore CS0618 // Type or member is obsolete
+            activity.SetStatus(ActivityStatusCode.Error, exc.Message);
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -12,8 +12,9 @@
   recorded (defaults to `false`). This is only supported by client instrumentation.
   ([#2271](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2271))
 
-* The following tags are no longer added to spans when a request is faulted:
-  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+* Trace instrumentation will now call the [Activity.SetStatus](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.setstatus)
+  API instead of the deprecated OpenTelemetry API package extension when setting
+  span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
 ## 1.0.0-rc.18

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -12,7 +12,7 @@
   recorded (defaults to `false`). This is only supported by client instrumentation.
   ([#2271](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2271))
 
-* Following tags will be not added to spans when the request is faulted:
+* The following tags are no longer added to spans when a request is faulted:
   `otel.status_code` and `otel.status_description`. Both values are handled natively.
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -12,6 +12,10 @@
   recorded (defaults to `false`). This is only supported by client instrumentation.
   ([#2271](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2271))
 
+* Following tags will be not added to spans when the request is faulted:
+  `otel.status_code` and `otel.status_description`. Both values are handled natively.
+  ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
+
 ## 1.0.0-rc.18
 
 Released 2024-Oct-28

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.ServiceModel.Channels;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
 
@@ -92,9 +91,7 @@ internal static class ClientChannelInstrumentation
             {
                 if (reply == null || reply.IsFault)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    activity.SetStatus(Status.Error);
-#pragma warning restore CS0618 // Type or member is obsolete
+                    activity.SetStatus(ActivityStatusCode.Error);
 
                     if (WcfInstrumentationActivitySource.Options!.RecordException && exception != null)
                     {

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
@@ -8,7 +8,6 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Dispatcher;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
 
@@ -123,9 +122,7 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
             {
                 if (reply.IsFault)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    activity.SetStatus(Status.Error);
-#pragma warning restore CS0618 // Type or member is obsolete
+                    activity.SetStatus(ActivityStatusCode.Error);
                 }
 
                 activity.SetTag(WcfInstrumentationConstants.SoapReplyActionTag, reply.Headers.Action);

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -279,7 +279,10 @@ public class AWSLambdaWrapperTests
 
     private void AssertSpanException(Activity activity)
     {
-        Assert.Equal("ERROR", activity.GetTagValue(SpanAttributeConstants.StatusCodeKey));
-        Assert.NotNull(activity.GetTagValue(SpanAttributeConstants.StatusDescriptionKey));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("TestException", activity.StatusDescription);
+        var exception = Assert.Single(activity.Events);
+        Assert.Equal("exception", exception.Name);
+        Assert.Equal("TestException", exception.Tags.SingleOrDefault(t => t.Key.Equals("exception.message")).Value);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -289,7 +289,6 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         {
             Assert.Equal(ActivityStatusCode.Error, activity.Status);
             Assert.Equal("SQLite Error 1: 'no such table: no_table'.", activity.StatusDescription);
-            Assert.Contains(activity.Tags, t => t.Key == SpanAttributeConstants.StatusDescriptionKey);
         }
     }
 

--- a/test/OpenTelemetry.Instrumentation.Quartz.Tests/QuartzDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Quartz.Tests/QuartzDiagnosticListenerTests.cs
@@ -186,9 +186,10 @@ public class QuartzDiagnosticListenerTests
         Assert.Single(exportedItems);
         var activity = exportedItems[0];
 
-        Assert.Equal("exception", activity.Events.First().Name);
-        Assert.Equal("ERROR", activity.Tags.SingleOrDefault(t => t.Key.Equals(SpanAttributeConstants.StatusCodeKey)).Value);
-        Assert.Equal("Catch me if you can!", activity.Tags.SingleOrDefault(t => t.Key.Equals(SpanAttributeConstants.StatusDescriptionKey)).Value);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        var exception = Assert.Single(activity.Events);
+        Assert.Equal("exception", exception.Name);
+        Assert.Equal("Catch me if you can!", exception.Tags.SingleOrDefault(t => t.Key.Equals("exception.message")).Value);
     }
 
     [Fact]
@@ -253,8 +254,10 @@ public class QuartzDiagnosticListenerTests
         Assert.Single(exportedItems);
         var activity = exportedItems[0];
 
-        Assert.Equal("ERROR", activity.Tags.SingleOrDefault(t => t.Key.Equals(SpanAttributeConstants.StatusCodeKey)).Value);
-        Assert.Equal("Catch me if you can!", activity.Tags.SingleOrDefault(t => t.Key.Equals(SpanAttributeConstants.StatusDescriptionKey)).Value);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        var exception = Assert.Single(activity.Events);
+        Assert.Equal("exception", exception.Name);
+        Assert.Equal("Catch me if you can!", exception.Tags.SingleOrDefault(t => t.Key.Equals("exception.message")).Value);
         Assert.Equal(testId, activity.Tags.SingleOrDefault(t => t.Key.Equals("test.id")).Value);
     }
 


### PR DESCRIPTION
Fixes #2321

## Changes

Replace ActivityExtensions.SetStatus by Activity.SetStatus
 Following tags will be not added to spans when the exception is recorder:
  `otel.status_code` and `otel.status_description`. Both values are handled natively.

Changes affects only pre-released instrumentation packages. It should be safe to merge as is.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
