### PR TITLE
[Resources.AWS] Move string literals to AWS Semantic Conventions class

### DIFF
--- a/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
@@ -56,9 +56,9 @@ internal sealed class AWSEBSDetector : IResourceDetector
     {
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {
-            new(AWSSemanticConventions.AttributeCloudProvider, "aws"),
-            new(AWSSemanticConventions.AttributeCloudPlatform, "aws_elastic_beanstalk"),
-            new(AWSSemanticConventions.AttributeServiceName, "aws_elastic_beanstalk"),
+            new(AWSSemanticConventions.AttributeCloudProvider, AWSSemanticConventions.CloudProviderValuesAws),
+            new(AWSSemanticConventions.AttributeCloudPlatform, AWSSemanticConventions.CloudPlatformValuesAwsElasticBeanstalk),
+            new(AWSSemanticConventions.AttributeServiceName, AWSSemanticConventions.ServiceNameValuesAwsElasticBeanstalk),
         };
 
         if (metadata != null)

--- a/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
@@ -45,8 +45,8 @@ internal sealed class AWSEC2Detector : IResourceDetector
     {
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {
-            new(AWSSemanticConventions.AttributeCloudProvider, "aws"),
-            new(AWSSemanticConventions.AttributeCloudPlatform, "aws_ec2"),
+            new(AWSSemanticConventions.AttributeCloudProvider, AWSSemanticConventions.CloudProviderValuesAws),
+            new(AWSSemanticConventions.AttributeCloudPlatform, AWSSemanticConventions.CloudPlatformValuesAwsEc2),
             new(AWSSemanticConventions.AttributeHostName, hostName),
         };
 

--- a/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
@@ -29,8 +29,8 @@ internal sealed class AWSECSDetector : IResourceDetector
 
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {
-            new(AWSSemanticConventions.AttributeCloudProvider, "aws"),
-            new(AWSSemanticConventions.AttributeCloudPlatform, "aws_ecs"),
+            new(AWSSemanticConventions.AttributeCloudProvider, AWSSemanticConventions.CloudProviderValuesAws),
+            new(AWSSemanticConventions.AttributeCloudPlatform, AWSSemanticConventions.CloudPlatformValuesAwsEcs),
         };
 
         try

--- a/src/OpenTelemetry.Resources.AWS/AWSEKSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEKSDetector.cs
@@ -38,8 +38,8 @@ internal sealed class AWSEKSDetector : IResourceDetector
     {
         var resourceAttributes = new List<KeyValuePair<string, object>>()
         {
-            new(AWSSemanticConventions.AttributeCloudProvider, "aws"),
-            new(AWSSemanticConventions.AttributeCloudPlatform, "aws_eks"),
+            new(AWSSemanticConventions.AttributeCloudProvider, AWSSemanticConventions.CloudProviderValuesAws),
+            new(AWSSemanticConventions.AttributeCloudPlatform, AWSSemanticConventions.CloudPlatformValuesAwsEks),
         };
 
         if (!string.IsNullOrEmpty(clusterName))

--- a/src/OpenTelemetry.Resources.AWS/AWSSemanticConventions.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSSemanticConventions.cs
@@ -11,6 +11,11 @@ internal static class AWSSemanticConventions
     public const string AttributeCloudProvider = "cloud.provider";
     public const string AttributeCloudRegion = "cloud.region";
     public const string AttributeCloudResourceId = "cloud.resource_id";
+    public const string CloudPlatformValuesAwsEc2 = "aws_ec2";
+    public const string CloudPlatformValuesAwsEcs = "aws_ecs";
+    public const string CloudPlatformValuesAwsEks = "aws_eks";
+    public const string CloudPlatformValuesAwsElasticBeanstalk = "aws_elastic_beanstalk";
+    public const string CloudProviderValuesAws = "aws";
 
     public const string AttributeContainerID = "container.id";
 
@@ -43,4 +48,5 @@ internal static class AWSSemanticConventions
     public const string AttributeServiceNamespace = "service.namespace";
     public const string AttributeServiceInstanceID = "service.instance.id";
     public const string AttributeServiceVersion = "service.version";
+    public const string ServiceNameValuesAwsElasticBeanstalk = "aws_elastic_beanstalk";
 }


### PR DESCRIPTION
## Changes

Move string literals to be constants in the AWS Semantic Conventions class.  This is in preparation of a larger overhaul in how the AWS libraries will handle Semantic Conventions.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
