### PR TITLE
Fix user_event test cases

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -100,7 +100,7 @@ jobs:
     - name: dotnet test ${{ steps.resolve-project.outputs.title }}
       if: ${{ inputs.run-tests }}
       run: >
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'dotnet --info && echo $PATH && sudo -E' || '' }}
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'dotnet --info && echo $PATH && sudo -E echo $PATH && sudo -E' || '' }}
         dotnet test ${{ steps.resolve-project.outputs.project }}
         --collect:"Code Coverage"
         --results-directory:TestResults

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -100,7 +100,7 @@ jobs:
     - name: dotnet test ${{ steps.resolve-project.outputs.title }}
       if: ${{ inputs.run-tests }}
       run: >
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'sudo -E' || '' }}
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'dotnet --info && ' || '' }}
         dotnet test ${{ steps.resolve-project.outputs.project }}
         --collect:"Code Coverage"
         --results-directory:TestResults

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -100,7 +100,7 @@ jobs:
     - name: dotnet test ${{ steps.resolve-project.outputs.title }}
       if: ${{ inputs.run-tests }}
       run: >
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'dotnet --info && echo $PATH && sudo -E echo $PATH && sudo -E' || '' }}
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'dotnet --info && echo $PATH && sudo echo $PATH && sudo -E echo $PATH && export PATH=/usr/share/dotnet:$PATH && echo $PATH && sudo -E' || '' }}
         dotnet test ${{ steps.resolve-project.outputs.project }}
         --collect:"Code Coverage"
         --results-directory:TestResults

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -100,7 +100,7 @@ jobs:
     - name: dotnet test ${{ steps.resolve-project.outputs.title }}
       if: ${{ inputs.run-tests }}
       run: >
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'dotnet --info && ' || '' }}
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'dotnet --info && echo $PATH && sudo -E' || '' }}
         dotnet test ${{ steps.resolve-project.outputs.project }}
         --collect:"Code Coverage"
         --results-directory:TestResults

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Exporter.Geneva]
       code-cov-name: Exporter.Geneva
+      os-list: '[ "ubuntu-24.04" ]' # Note: This may be switched to latest once ubuntu-latest has a kernel version >= 6.8.0-1014-azure
+      tfm-list: '[ "net8.0", "net9.0" ]' # Note: Should be able to remove this once the above is using ubuntu-latest
       test-case-filter: CategoryName=Geneva:user_events:metrics
       test-require-elevated: true
       pack: false

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "9.0.100"
+    "version": "9.0.101"
   }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixUserEventsDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixUserEventsDataTransportTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.LinuxTracepoints.Provider;
+using OpenTelemetry.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -49,7 +50,7 @@ public class UnixUserEventsDataTransportTests
         this.testOutputHelper = testOutputHelper;
     }
 
-    [Fact(Skip = "This would fail on Ubuntu. Skipping for now.")]
+    [SkipUnlessPlatformMatchesFact(TestPlatform.Linux, requireElevatedProcess: true)]
     public void UserEvents_Enabled_Success_Linux()
     {
         EnsureUserEventsEnabled();
@@ -113,7 +114,7 @@ public class UnixUserEventsDataTransportTests
         }
     }
 
-    [Fact(Skip = "This would fail on Ubuntu. Skipping for now.")]
+    [SkipUnlessPlatformMatchesFact(TestPlatform.Linux, requireElevatedProcess: true)]
     public void UserEvents_Disabled_Success_Linux()
     {
         EnsureUserEventsEnabled();


### PR DESCRIPTION
Fixes #2326.

Added back tests which were failing on Linux after bumping .NET SDK to 9.0.100. I'm not able to reproduce the failures locally. Not sure why they were failing before.

Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
