### PR TITLE
[Instrumentation.SqlClient] Metrics documentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -127,7 +127,7 @@ public class WebApiApplication : HttpApplication
 #### List of metrics produced
 
 The instrumentation is implemented based on [metrics semantic
-conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpserverduration).
+conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/http/http-metrics.md#metric-httpserverrequestduration).
 Currently, the instrumentation supports the following metric.
 
 | Name  | Instrument Type | Unit | Description |

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -49,10 +49,12 @@ dotnet add package --prerelease OpenTelemetry.Instrumentation.SqlClient
 
 SqlClient instrumentation must be enabled at application startup.
 
-The following example demonstrates adding SqlClient instrumentation to a console
-application. This example also sets up the OpenTelemetry Console exporter, which
-requires adding the package
-[`OpenTelemetry.Exporter.Console`](../OpenTelemetry.Exporter.Console/README.md)
+#### Traces
+
+The following example demonstrates adding SqlClient traces instrumentation
+to a console application. This example also sets up the OpenTelemetry Console
+exporter, which requires adding the package
+[`OpenTelemetry.Exporter.Console`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Console/README.md)
 to the application.
 
 ```csharp
@@ -70,13 +72,50 @@ public class Program
 }
 ```
 
+#### Metrics
+
+The following example demonstrates adding SqlClient metrics instrumentation
+to a console application. This example also sets up the OpenTelemetry Console
+exporter, which requires adding the package
+[`OpenTelemetry.Exporter.Console`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Console/README.md)
+to the application.
+
+```csharp
+using OpenTelemetry.Metrics;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        using var tracerProvider = Sdk.CreateMeterProviderBuilder()
+            .AddSqlClientInstrumentation()
+            .AddConsoleExporter()
+            .Build();
+    }
+}
+```
+
+##### List of metrics produced
+
+The instrumentation is implemented based on [metrics semantic
+conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/database/database-metrics.md#database-operation).
+Currently, the instrumentation supports the following metric.
+
+| Name  | Instrument Type | Unit | Description |
+|-------|-----------------|------|-------------|
+| `db.client.operation.duration` | Histogram | `s` | Duration of database client operations. |
+
+#### ASP.NET Core
+
 For an ASP.NET Core application, adding instrumentation is typically done in the
 `ConfigureServices` of your `Startup` class. Refer to documentation for
 [OpenTelemetry.Instrumentation.AspNetCore](../OpenTelemetry.Instrumentation.AspNetCore/README.md).
 
+#### ASP.NET
+
 For an ASP.NET application, adding instrumentation is typically done in the
 `Global.asax.cs`. Refer to the documentation for
-[OpenTelemetry.Instrumentation.AspNet](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.AspNet/README.md).
+[OpenTelemetry.Instrumentation.AspNet](../OpenTelemetry.Instrumentation.AspNet/README.md).
 
 ## Advanced configuration
 


### PR DESCRIPTION
Follow up #2309 and @#2311
I need a link to put in AutoInstrumentation doc with available list of metrics.

## Changes

[Instrumentation.SqlClient] Metrics documentation
Some minor fix in AspNet documentation (I think that we are lack of url check in CI)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
