### PR TITLE
Remove EnableConnectionLevelAttributes option

### DIFF
--- a/src/OpenTelemetry.Instrumentation.MySqlData/README.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/README.md
@@ -101,26 +101,6 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-## EnableConnectionLevelAttributes
-
-By default, `EnabledConnectionLevelAttributes` is disabled and this
-instrumentation sets the `peer.service` attribute to the
-[`DataSource`](https://docs.microsoft.com/dotnet/api/system.data.common.dbconnection.datasource)
-property of the connection. If `EnabledConnectionLevelAttributes` is enabled,
-the `DataSource` will be parsed and the server name will be sent as the
-`net.peer.name` or `net.peer.ip` attribute, and the port will be sent as the
-`net.peer.port` attribute.
-
-The following example shows how to use `EnableConnectionLevelAttributes`.
-
-```csharp
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddMySqlDataInstrumentation(
-        options => options.EnableConnectionLevelAttributes = true)
-    .AddConsoleExporter()
-    .Build();
-```
-
 ### RecordException
 
 This option can be set to instruct the instrumentation to record Exceptions

--- a/src/OpenTelemetry.Instrumentation.MySqlData/README.md
+++ b/src/OpenTelemetry.Instrumentation.MySqlData/README.md
@@ -101,6 +101,26 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
+## EnableConnectionLevelAttributes
+
+By default, `EnabledConnectionLevelAttributes` is disabled and this
+instrumentation sets the `peer.service` attribute to the
+[`DataSource`](https://docs.microsoft.com/dotnet/api/system.data.common.dbconnection.datasource)
+property of the connection. If `EnabledConnectionLevelAttributes` is enabled,
+the `DataSource` will be parsed and the server name will be sent as the
+`net.peer.name` or `net.peer.ip` attribute, and the port will be sent as the
+`net.peer.port` attribute.
+
+The following example shows how to use `EnableConnectionLevelAttributes`.
+
+```csharp
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddMySqlDataInstrumentation(
+        options => options.EnableConnectionLevelAttributes = true)
+    .AddConsoleExporter()
+    .Build();
+```
+
 ### RecordException
 
 This option can be set to instruct the instrumentation to record Exceptions

--- a/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
@@ -1,7 +1,5 @@
 #nullable enable
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions
-OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.EnableConnectionLevelAttributes.get -> bool
-OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.EnableConnectionLevelAttributes.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity!, string!, object!>?
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Enrich.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Filter.get -> System.Func<object!, bool>?

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * **Breaking change** The `EnableConnectionLevelAttributes` option has been removed.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+  ([#2414](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2414))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* **Breaking change** The `EnableConnectionLevelAttributes` option has been removed.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+
 ## 1.10.0-beta.1
 
 Released 2024-Dec-09

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -51,7 +51,7 @@ internal sealed class SqlActivitySourceHelper
             { SemanticConventions.AttributeDbSystem, MicrosoftSqlServerDatabaseSystemName },
         };
 
-        if (options.EnableConnectionLevelAttributes && dataSource != null)
+        if (dataSource != null)
         {
             var connectionDetails = SqlConnectionDetails.ParseFromDataSource(dataSource);
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -152,29 +152,6 @@ command names will ever be captured. When using the `Microsoft.Data.SqlClient`
 NuGet package (v1.1+) stored procedure command names, full query text, and other
 command text will be captured.
 
-### EnableConnectionLevelAttributes
-
-> [!NOTE]
-> EnableConnectionLevelAttributes is supported on all runtimes.
-
-By default, `EnabledConnectionLevelAttributes` is enabled.
-When `EnabledConnectionLevelAttributes` is enabled,
-the [`DataSource`](https://docs.microsoft.com/dotnet/api/system.data.common.dbconnection.datasource)
-will be parsed and the server name or IP address will be sent as
-the `server.address` attribute, the instance name will be sent as
-the `db.mssql.instance_name` attribute, and the port will be sent as the
-`server.port` attribute if it is not 1433 (the default port).
-
-The following example shows how to use `EnableConnectionLevelAttributes`.
-
-```csharp
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddSqlClientInstrumentation(
-        options => options.EnableConnectionLevelAttributes = true)
-    .AddConsoleExporter()
-    .Build();
-```
-
 ### Enrich
 
 > [!NOTE]

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
@@ -64,26 +64,6 @@ public class SqlClientTraceInstrumentationOptions
     public bool SetDbStatementForText { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether or not the <see
-    /// cref="SqlClientInstrumentation"/> should parse the DataSource on a
-    /// SqlConnection into server name, instance name, and/or port
-    /// connection-level attribute tags. Default value: <see
-    /// langword="true"/>.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <b>EnableConnectionLevelAttributes is supported on all runtimes.</b>
-    /// </para>
-    /// <para>
-    /// If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the
-    /// <see cref="SemanticConventions.AttributeServerAddress"/> tag,
-    /// the instance name will be sent as the <see cref="SemanticConventions.AttributeDbMsSqlInstanceName"/> tag,
-    /// and the port will be sent as the <see cref="SemanticConventions.AttributeServerPort"/> tag if it is not 1433 (the default port).
-    /// </para>
-    /// </remarks>
-    public bool EnableConnectionLevelAttributes { get; set; } = true;
-
-    /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with the
     /// raw <c>SqlCommand</c> object.
     /// </summary>

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -189,21 +189,18 @@ public class SqlClientTests : IDisposable
     [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null)]
     [InlineData("127.0.0.1,1434", null, "127.0.0.1", null, 1434)]
     [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", 1818)]
-    [InlineData("localhost", null, null, null, null)]
 
     // Test cases when EmitOldAttributes = false and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database)
     [InlineData("localhost", "localhost", null, null, null, false, true)]
     [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null, false, true)]
     [InlineData("127.0.0.1,1434", null, "127.0.0.1", null, 1434, false, true)]
     [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", null, 1818, false, true)]
-    [InlineData("localhost", null, null, null, null, false, true)]
 
     // Test cases when EmitOldAttributes = true and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database/dup)
     [InlineData("localhost", "localhost", null, null, null, true, true)]
     [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null, true, true)]
     [InlineData("127.0.0.1,1434", null, "127.0.0.1", null, 1434, true, true)]
     [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", 1818, true, true)]
-    [InlineData("localhost", null, null, null, null, true, true)]
     public void SqlClientAddsConnectionLevelAttributes(
         string dataSource,
         string? expectedServerHostName,

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -185,27 +185,26 @@ public class SqlClientTests : IDisposable
     }
 
     [Theory]
-    [InlineData(true, "localhost", "localhost", null, null, null)]
-    [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null)]
-    [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, 1434)]
-    [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", 1818)]
-    [InlineData(false, "localhost", null, null, null, null)]
+    [InlineData("localhost", "localhost", null, null, null)]
+    [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null)]
+    [InlineData("127.0.0.1,1434", null, "127.0.0.1", null, 1434)]
+    [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", 1818)]
+    [InlineData("localhost", null, null, null, null)]
 
     // Test cases when EmitOldAttributes = false and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database)
-    [InlineData(true, "localhost", "localhost", null, null, null, false, true)]
-    [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null, false, true)]
-    [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, 1434, false, true)]
-    [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", null, 1818, false, true)]
-    [InlineData(false, "localhost", null, null, null, null, false, true)]
+    [InlineData("localhost", "localhost", null, null, null, false, true)]
+    [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null, false, true)]
+    [InlineData("127.0.0.1,1434", null, "127.0.0.1", null, 1434, false, true)]
+    [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", null, 1818, false, true)]
+    [InlineData("localhost", null, null, null, null, false, true)]
 
     // Test cases when EmitOldAttributes = true and EmitNewAttributes = true (i.e., OTEL_SEMCONV_STABILITY_OPT_IN=database/dup)
-    [InlineData(true, "localhost", "localhost", null, null, null, true, true)]
-    [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null, true, true)]
-    [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, 1434, true, true)]
-    [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", 1818, true, true)]
-    [InlineData(false, "localhost", null, null, null, null, true, true)]
+    [InlineData("localhost", "localhost", null, null, null, true, true)]
+    [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null, true, true)]
+    [InlineData("127.0.0.1,1434", null, "127.0.0.1", null, 1434, true, true)]
+    [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", 1818, true, true)]
+    [InlineData("localhost", null, null, null, null, true, true)]
     public void SqlClientAddsConnectionLevelAttributes(
-        bool enableConnectionLevelAttributes,
         string dataSource,
         string? expectedServerHostName,
         string? expectedServerIpAddress,
@@ -216,7 +215,6 @@ public class SqlClientTests : IDisposable
     {
         var options = new SqlClientTraceInstrumentationOptions()
         {
-            EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
             EmitOldAttributes = emitOldAttributes,
             EmitNewAttributes = emitNewAttributes,
         };

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -37,7 +37,6 @@ public class SqlEventSourceTests
                from commandType in new[] { CommandType.StoredProcedure, CommandType.Text }
                from isFailure in bools
                from captureText in bools
-               from enableConnectionLevelAttributes in bools
                from emitOldAttributes in bools
                from emitNewAttributes in bools
                from tracingEnabled in bools
@@ -56,7 +55,6 @@ public class SqlEventSourceTests
                    captureText,
                    isFailure,
                    sqlExceptionNumber,
-                   enableConnectionLevelAttributes,
                    emitOldAttributes,
                    emitNewAttributes,
                    tracingEnabled,
@@ -120,7 +118,6 @@ public class SqlEventSourceTests
         bool captureText,
         bool isFailure = false,
         int sqlExceptionNumber = 0,
-        bool enableConnectionLevelAttributes = false,
         bool emitOldAttributes = true,
         bool emitNewAttributes = false,
         bool tracingEnabled = true,
@@ -139,7 +136,6 @@ public class SqlEventSourceTests
                 .AddSqlClientInstrumentation(options =>
                 {
                     options.SetDbStatementForText = captureText;
-                    options.EnableConnectionLevelAttributes = enableConnectionLevelAttributes;
                     options.EmitOldAttributes = emitOldAttributes;
                     options.EmitNewAttributes = emitNewAttributes;
                 });
@@ -187,7 +183,7 @@ public class SqlEventSourceTests
         if (tracingEnabled)
         {
             activity = Assert.Single(activities);
-            VerifyActivityData(commandText, captureText, isFailure, dataSource, activity, enableConnectionLevelAttributes, emitOldAttributes, emitNewAttributes);
+            VerifyActivityData(commandText, captureText, isFailure, dataSource, activity, emitOldAttributes, emitNewAttributes);
         }
 
         var dbClientOperationDurationMetrics = metrics
@@ -308,11 +304,10 @@ public class SqlEventSourceTests
         bool isFailure,
         string dataSource,
         Activity activity,
-        bool enableConnectionLevelAttributes = false,
         bool emitOldAttributes = true,
         bool emitNewAttributes = false)
     {
-        if (emitNewAttributes && enableConnectionLevelAttributes)
+        if (emitNewAttributes)
         {
             Assert.Equal("instanceName.master", activity.DisplayName);
         }
@@ -324,32 +319,29 @@ public class SqlEventSourceTests
         Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
 
-        if (enableConnectionLevelAttributes)
+        var connectionDetails = SqlConnectionDetails.ParseFromDataSource(dataSource);
+
+        if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
         {
-            var connectionDetails = SqlConnectionDetails.ParseFromDataSource(dataSource);
+            Assert.Equal(connectionDetails.ServerHostName, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
+        }
+        else
+        {
+            Assert.Equal(connectionDetails.ServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
+        }
 
-            if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
-            {
-                Assert.Equal(connectionDetails.ServerHostName, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-            }
-            else
-            {
-                Assert.Equal(connectionDetails.ServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-            }
+        if (emitOldAttributes && !string.IsNullOrEmpty(connectionDetails.InstanceName))
+        {
+            Assert.Equal(connectionDetails.InstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+        }
+        else
+        {
+            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+        }
 
-            if (emitOldAttributes && !string.IsNullOrEmpty(connectionDetails.InstanceName))
-            {
-                Assert.Equal(connectionDetails.InstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
-            }
-            else
-            {
-                Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
-            }
-
-            if (connectionDetails.Port.HasValue)
-            {
-                Assert.Equal(connectionDetails.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
-            }
+        if (connectionDetails.Port.HasValue)
+        {
+            Assert.Equal(connectionDetails.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
         }
 
         if (emitOldAttributes)
@@ -359,7 +351,7 @@ public class SqlEventSourceTests
 
         if (emitNewAttributes)
         {
-            Assert.Equal(!enableConnectionLevelAttributes ? "master" : "instanceName.master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
+            Assert.Equal("instanceName.master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
         }
 
         if (captureText)


### PR DESCRIPTION
The attributes gated by `EnableConnectionLevelAttributes` are required. No other language has offered an option to disable these attributes. Removing `EnableConnectionLevelAttributes` to simplify things.