### PR TITLE
[repo] Fix FindComponentOwners for latest project in component_owners

### DIFF
--- a/build/scripts/build.psm1
+++ b/build/scripts/build.psm1
@@ -125,7 +125,7 @@ function FindComponentOwners {
   {
     $projectName = [System.IO.Path]::GetFileName($projectDir)
 
-    $match = [regex]::Match($componentOwnersContent, "src\/$projectName\/:([\w\W\s]*?)src")
+    $match = [regex]::Match($componentOwnersContent, "src\/$projectName\/:([\w\W\s]*?)(src|test)")
     if ($match.Success -eq $true)
     {
       $matches = [regex]::Matches($match.Groups[1].Value, "-\s*(.*)")


### PR DESCRIPTION
Related to #2410

## Changes

[repo] Fix FindComponentOwners for latest project in component_owners
Before changes it was not able to detect component owners for the latest record in `component_owners.yml`.
Changes tested locally.

```yml
  src/OpenTelemetry.Resources.Gcp/:
    - matt-hensley
    - pyohannes
  src/OpenTelemetry.Sampler.AWS/:
    - srprash
    - ppittle
  test/OpenTelemetry.Exporter.Geneva.Benchmarks/:
    - cijothomas
    - codeblanch
    - rajkumar-rangaraj
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
