### PR TITLE
[geneva] Update links to openmetrics to reference the v1.0.0 release in proto files

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.Tests/Proto/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/Proto/opentelemetry/proto/metrics/v1/metrics.proto
@@ -415,7 +415,7 @@ message HistogramDataPoint {
   // events, and is assumed to be monotonic over the values of these events.
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  // see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   optional double sum = 5;
 
   // bucket_counts is an optional field contains the count values of histogram
@@ -494,7 +494,7 @@ message ExponentialHistogramDataPoint {
   // events, and is assumed to be monotonic over the values of these events.
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  // see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   optional double sum = 5;
   
   // scale describes the resolution of the histogram.  Boundaries are
@@ -607,7 +607,7 @@ message SummaryDataPoint {
   // events, and is assumed to be monotonic over the values of these events.
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+  // see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
   double sum = 5;
 
   // Represents the value at a given quantile of a distribution.


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.