### PR TITLE
[Instrumentation.AspNetCore] Listen to SignalR server activities

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -34,6 +34,7 @@
       Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
     -->
     <MinVerPkgVer>[6.0.0,7.0)</MinVerPkgVer>
+    <MicrosoftAspNetCoreSignalRClientPkgVer>[9.0.0,)</MicrosoftAspNetCoreSignalRClientPkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,5.0)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsConfigurationPkgVer>[9.0.0,)</MicrosoftExtensionsConfigurationPkgVer>
     <MicrosoftExtensionsOptionsPkgVer>[9.0.0,)</MicrosoftExtensionsOptionsPkgVer>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.DisableAspNetCoreSignalRSupport.get -> bool
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.DisableAspNetCoreSignalRSupport.set -> void

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.DisableAspNetCoreSignalRSupport.get -> bool
-OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.DisableAspNetCoreSignalRSupport.set -> void
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreSignalRSupport.get -> bool
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreSignalRSupport.set -> void

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
@@ -121,5 +121,12 @@ public static class AspNetCoreInstrumentationTracerProviderBuilderExtensions
             builder.AddSource(HttpInListener.ActivitySourceName);
             builder.AddLegacySource(HttpInListener.ActivityOperationName); // for the activities created by AspNetCore
         }
+
+        // SignalR activities first added in .NET 9.0
+        if (Environment.Version.Major >= 9)
+        {
+            // https://github.com/dotnet/aspnetcore/blob/6ae3ea387b20f6497b82897d613e9b8a6e31d69c/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs#L13C35-L13C70
+            builder.AddSource("Microsoft.AspNetCore.SignalR.Server");
+        }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
@@ -130,7 +130,7 @@ public static class AspNetCoreInstrumentationTracerProviderBuilderExtensions
         if (Environment.Version.Major >= 9)
         {
             var options = serviceProvider?.GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>().Get(optionsName);
-            if (options is null || !options.DisableAspNetCoreSignalRSupport)
+            if (options is null || options.EnableAspNetCoreSignalRSupport)
             {
                 // https://github.com/dotnet/aspnetcore/blob/6ae3ea387b20f6497b82897d613e9b8a6e31d69c/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs#L13C35-L13C70
                 builder.AddSource("Microsoft.AspNetCore.SignalR.Server");

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
@@ -96,7 +96,10 @@ public class AspNetCoreTraceInstrumentationOptions
     /// <summary>
     /// Gets or sets a value indicating whether SignalR activities are recorded.
     /// </summary>
-    public bool DisableAspNetCoreSignalRSupport { get; set; }
+    /// <remarks>
+    /// Defaults to true.
+    /// </remarks>
+    public bool EnableAspNetCoreSignalRSupport { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether RPC attributes are added to an Activity when using Grpc.AspNetCore.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
@@ -94,6 +94,11 @@ public class AspNetCoreTraceInstrumentationOptions
     public bool RecordException { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether SignalR activities are recorded.
+    /// </summary>
+    public bool DisableAspNetCoreSignalRSupport { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether RPC attributes are added to an Activity when using Grpc.AspNetCore.
     /// </summary>
     /// <remarks>

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -1178,7 +1178,7 @@ public sealed class BasicTests
         void ConfigureTestServices(IServiceCollection services)
         {
             this.tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddAspNetCoreInstrumentation(o => o.DisableAspNetCoreSignalRSupport = true)
+                .AddAspNetCoreInstrumentation(o => o.EnableAspNetCoreSignalRSupport = false)
                 .AddInMemoryExporter(exportedItems)
                 .Build();
         }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryCoreLatestVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreSignalRClientPkgVer)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestApp.AspNetCore/Program.cs
+++ b/test/TestApp.AspNetCore/Program.cs
@@ -20,6 +20,8 @@ public class Program
 
         builder.Services.AddMvc();
 
+        builder.Services.AddSignalR();
+
         builder.Services.AddSingleton<HttpClient>();
 
         builder.Services.AddSingleton(
@@ -42,6 +44,8 @@ public class Program
         app.UseAuthorization();
 
         app.MapControllers();
+
+        app.MapHub<TestHub>("/testHub");
 
         app.UseMiddleware<CallbackMiddleware>();
 

--- a/test/TestApp.AspNetCore/TestHub.cs
+++ b/test/TestApp.AspNetCore/TestHub.cs
@@ -9,5 +9,7 @@ public class TestHub : Hub
 {
     public override Task OnConnectedAsync() => base.OnConnectedAsync();
 
-    public void Send(string message) { }
+    public void Send(string message)
+    {
+    }
 }

--- a/test/TestApp.AspNetCore/TestHub.cs
+++ b/test/TestApp.AspNetCore/TestHub.cs
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace TestApp.AspNetCore;
+
+public class TestHub : Hub
+{
+    public override Task OnConnectedAsync() => base.OnConnectedAsync();
+
+    public void Send(string message) { }
+}


### PR DESCRIPTION
Fixes #1998
Design discussion issue #1998

## Changes

Adds activity source "Microsoft.AspNetCore.SignalR.Server" when calling `AddAspNetCoreInstrumentation`.
This activity source is new in .NET 9.0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
