### PR TITLE
[repo] Metrics instrumentations - utilize advice API for histogram boundaries

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+  ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+
 ## 1.10.0-beta.1
 
 Released 2024-Dec-09

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+* The `http.server.request.duration` histogram (measured in seconds) produced by
+  the metrics instrumentation in this package now uses the [Advice API](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.10.0/docs/metrics/customizing-the-sdk/README.md#explicit-bucket-histogram-aggregation)
+  to set default explicit buckets following the [OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/http/http-metrics.md).
   ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
@@ -18,10 +18,11 @@ internal sealed class HttpInMetricsListener : IDisposable
 
     public HttpInMetricsListener(Meter meter, AspNetMetricsInstrumentationOptions options)
     {
-        this.httpServerDuration = meter.CreateHistogram<double>(
+        this.httpServerDuration = meter.CreateHistogram(
             "http.server.request.duration",
             unit: "s",
-            description: "Duration of HTTP server requests.");
+            description: "Duration of HTTP server requests.",
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
         TelemetryHttpModule.Options.OnRequestStoppedCallback += this.OnStopActivity;
         this.options = options;
     }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+* The `http.server.request.duration` histogram (measured in seconds) produced by
+  the metrics instrumentation in this package now uses the [Advice API](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.10.0/docs/metrics/customizing-the-sdk/README.md#explicit-bucket-histogram-aggregation)
+  to set default explicit buckets following the [OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/http/http-metrics.md).
   ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
 
 ## 1.10.1

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+  ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+
 ## 1.10.1
 
 Released 2024-Dec-10

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -33,7 +33,11 @@ internal sealed class HttpInMetricsListener : ListenerHandler
     private static readonly PropertyFetcher<HttpContext> HttpContextPropertyFetcher = new("HttpContext");
     private static readonly object ErrorTypeHttpContextItemsKey = new();
 
-    private static readonly Histogram<double> HttpServerRequestDuration = Meter.CreateHistogram<double>(HttpServerRequestDurationMetricName, "s", "Duration of HTTP server requests.");
+    private static readonly Histogram<double> HttpServerRequestDuration = Meter.CreateHistogram(
+        HttpServerRequestDurationMetricName,
+        unit: "s",
+        description: " Duration of HTTP server requests.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
 
     internal HttpInMetricsListener(string name)
         : base(name)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -14,6 +14,9 @@
   span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
+* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+  ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+
 ## 0.1.0-alpha.2
 
 Released 2024-Sep-18

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -14,7 +14,10 @@
   span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
-* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+* The `messaging.receive.duration` and `messaging.publish.duration` histograms
+  (measured in seconds) produced by the metrics instrumentation in this package
+  now uses the [Advice API](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.10.0/docs/metrics/customizing-the-sdk/README.md#explicit-bucket-histogram-aggregation)
+  to set default explicit buckets following the [OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-metrics.md).
   ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
 
 ## 0.1.0-alpha.2

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -19,8 +19,23 @@ internal static class ConfluentKafkaCommon
     internal static readonly string InstrumentationVersion = typeof(ConfluentKafkaCommon).Assembly.GetPackageVersion();
     internal static readonly ActivitySource ActivitySource = new(InstrumentationName, InstrumentationVersion);
     internal static readonly Meter Meter = new(InstrumentationName, InstrumentationVersion);
-    internal static readonly Counter<long> ReceiveMessagesCounter = Meter.CreateCounter<long>(SemanticConventions.MetricMessagingReceiveMessages);
-    internal static readonly Histogram<double> ReceiveDurationHistogram = Meter.CreateHistogram<double>(SemanticConventions.MetricMessagingReceiveDuration);
-    internal static readonly Counter<long> PublishMessagesCounter = Meter.CreateCounter<long>(SemanticConventions.MetricMessagingPublishMessages);
-    internal static readonly Histogram<double> PublishDurationHistogram = Meter.CreateHistogram<double>(SemanticConventions.MetricMessagingPublishDuration);
+    internal static readonly Counter<long> ReceiveMessagesCounter = Meter.CreateCounter<long>(
+        SemanticConventions.MetricMessagingReceiveMessages,
+        description: "Measures the number of received messages.");
+
+    internal static readonly Histogram<double> ReceiveDurationHistogram = Meter.CreateHistogram(
+        SemanticConventions.MetricMessagingReceiveDuration,
+        unit: "s",
+        description: "Measures the duration of receive operation.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
+
+    internal static readonly Counter<long> PublishMessagesCounter = Meter.CreateCounter<long>(
+        SemanticConventions.MetricMessagingPublishMessages,
+        description: "Measures the number of published messages.");
+
+    internal static readonly Histogram<double> PublishDurationHistogram = Meter.CreateHistogram(
+        SemanticConventions.MetricMessagingPublishDuration,
+        unit: "s",
+        description: "Measures the duration of publish operation.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
 }

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+* The `http.client.request.duration` histogram (measured in seconds) produced by
+  the metrics instrumentation in this package now uses the [Advice API](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.10.0/docs/metrics/customizing-the-sdk/README.md#explicit-bucket-histogram-aggregation)
+  to set default explicit buckets following the [OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/http/http-metrics.md).
   ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
 
 ## 1.10.0

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+  ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+
 ## 1.10.0
 
 Released 2024-Nov-27

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -22,7 +22,11 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     internal static readonly string MeterVersion = AssemblyName.Version!.ToString();
     internal static readonly Meter Meter = new(MeterName, MeterVersion);
     private const string OnUnhandledExceptionEvent = "System.Net.Http.Exception";
-    private static readonly Histogram<double> HttpClientRequestDuration = Meter.CreateHistogram<double>("http.client.request.duration", "s", "Duration of HTTP client requests.");
+    private static readonly Histogram<double> HttpClientRequestDuration = Meter.CreateHistogram(
+        "http.client.request.duration",
+        unit: "s",
+        description: "Duration of HTTP client requests.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
 
     private static readonly PropertyFetcher<HttpRequestMessage> StopRequestFetcher = new("Request");
     private static readonly PropertyFetcher<HttpResponseMessage> StopResponseFetcher = new("Response");

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -38,7 +38,11 @@ internal static class HttpWebRequestActivitySource
     private static readonly string Version = AssemblyName.Version.ToString();
     private static readonly ActivitySource WebRequestActivitySource = new(ActivitySourceName, Version);
     private static readonly Meter WebRequestMeter = new(MeterName, Version);
-    private static readonly Histogram<double> HttpClientRequestDuration = WebRequestMeter.CreateHistogram<double>("http.client.request.duration", "s", "Duration of HTTP client requests.");
+    private static readonly Histogram<double> HttpClientRequestDuration = WebRequestMeter.CreateHistogram(
+        "http.client.request.duration",
+        unit: "s",
+        description: "Duration of HTTP client requests.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
 
     // Fields for reflection
     private static FieldInfo connectionGroupListField;

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -24,6 +24,9 @@
   span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
+* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+  ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+
 ## 1.0.0-rc.6
 
 Released 2024-Apr-19

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -24,7 +24,9 @@
   span status. For details see: [Setting Status](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md#setting-status).
   ([#2358](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2358))
 
-* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+* The `http.server.request.duration` histogram (measured in seconds) produced by
+  the metrics instrumentation in this package now uses the [Advice API](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.10.0/docs/metrics/customizing-the-sdk/README.md#explicit-bucket-histogram-aggregation)
+  to set default explicit buckets following the [OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/http/http-metrics.md).
   ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
 
 ## 1.0.0-rc.6

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/OwinInstrumentationMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/OwinInstrumentationMetrics.cs
@@ -13,5 +13,9 @@ internal static class OwinInstrumentationMetrics
     internal static readonly AssemblyName AssemblyName = Assembly.GetName();
     internal static readonly string MeterName = AssemblyName.Name;
     internal static readonly Meter Instance = new(MeterName, Assembly.GetPackageVersion());
-    internal static readonly Histogram<double> HttpServerDuration = Instance.CreateHistogram<double>("http.server.request.duration", "s", "Duration of HTTP server requests.");
+    internal static readonly Histogram<double> HttpServerDuration = Instance.CreateHistogram(
+        "http.server.request.duration",
+        unit: "s",
+        description: "Duration of HTTP server requests.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -5,6 +5,9 @@
 * **Breaking change** The `EnableConnectionLevelAttributes` option has been removed.
   ([#2414](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2414))
 
+* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+  ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
+
 ## 1.10.0-beta.1
 
 Released 2024-Dec-09

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -5,7 +5,9 @@
 * **Breaking change** The `EnableConnectionLevelAttributes` option has been removed.
   ([#2414](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2414))
 
-* Histograms produced by this instrumentation package specify explicit bucket boundaries.
+* The `db.client.operation.duration` histogram (measured in seconds) produced by
+  the metrics instrumentation in this package now uses the [Advice API](https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.10.0/docs/metrics/customizing-the-sdk/README.md#explicit-bucket-histogram-aggregation)
+  to set default explicit buckets following the [OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/database/database-metrics.md).
   ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -25,10 +25,11 @@ internal sealed class SqlActivitySourceHelper
     public static readonly string MeterName = AssemblyName.Name!;
     public static readonly Meter Meter = new(MeterName, Assembly.GetPackageVersion());
 
-    public static readonly Histogram<double> DbClientOperationDuration = Meter.CreateHistogram<double>(
+    public static readonly Histogram<double> DbClientOperationDuration = Meter.CreateHistogram(
         "db.client.operation.duration",
-        "s",
-        "Duration of database client operations.");
+        unit: "s",
+        description: "Duration of database client operations.",
+        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10] });
 
     internal static readonly string[] SharedTagNames =
     [


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

[repo] Metrics instrumentations - utilize advice API for histogram boundaries
Values taken from semantic conventions.
Kafka also adds units and descriptions.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
