### PR TITLE
[aws] default to use Semantic Convention 1.28 and remove option Legacy

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWS/.publicApi/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion
-OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion.Legacy = -1 -> OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion
 OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion.Latest = 0 -> OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion
 OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion.V1_29_0 = 2 -> OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion
 OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion.V1_28_0 = 1 -> OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* BREAKING: Change default Semantic Convention to 1.28
+
 ## 1.10.0-beta.3
 
 Released 2024-Dec-20

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * BREAKING: Change default Semantic Convention to 1.28
+* BREAKING: Remove option to use Legacy semantic conventions (the old default)
 
 ## 1.10.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 #nullable enable
-OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion.Legacy = -1 -> OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion
 OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion
 OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion.Latest = 0 -> OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion
 OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion.V1_29_0 = 2 -> OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* BREAKING: Change default Semantic Convention to 1.28
+
 ## 1.10.0-beta.3
 
 Released 2024-Dec-20

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * BREAKING: Change default Semantic Convention to 1.28
+* BREAKING: Remove option to use Legacy semantic conventions (the old default)
 
 ## 1.10.0-beta.3
 

--- a/src/OpenTelemetry.Resources.AWS/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Resources.AWS/.publicApi/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 OpenTelemetry.Resources.AWS.SemanticConventionVersion
-OpenTelemetry.Resources.AWS.SemanticConventionVersion.Legacy = -1 -> OpenTelemetry.Resources.AWS.SemanticConventionVersion
 OpenTelemetry.Resources.AWS.SemanticConventionVersion.Latest = 0 -> OpenTelemetry.Resources.AWS.SemanticConventionVersion
 OpenTelemetry.Resources.AWS.SemanticConventionVersion.V1_29_0 = 2 -> OpenTelemetry.Resources.AWS.SemanticConventionVersion
 OpenTelemetry.Resources.AWS.SemanticConventionVersion.V1_28_0 = 1 -> OpenTelemetry.Resources.AWS.SemanticConventionVersion

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* BREAKING: Change default Semantic Convention to 1.28
+
 ## 1.10.0-beta.1
 
 Released 2024-Dec-20

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * BREAKING: Change default Semantic Convention to 1.28
+* BREAKING: Remove option to use Legacy semantic conventions (the old default)
 
 ## 1.10.0-beta.1
 

--- a/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
@@ -20,7 +20,7 @@ internal partial class AWSSemanticConventions
     /// <remarks>
     /// Future version specific convention classes will only need to define new or changed attributes.
     /// </remarks>
-    private class AWSSemanticConventionsLegacy : AWSSemanticConventionsBase
+    private abstract class AWSSemanticConventionsLegacy : AWSSemanticConventionsBase
     {
         // CLOUD Attributes
         public override string AttributeCloudAccountID => "cloud.account.id";

--- a/src/Shared/AWS/AWSSemanticConventions.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.cs
@@ -19,9 +19,6 @@ using OpenTelemetry.Resources.AWS;
 #pragma warning disable SA1201
 #pragma warning disable SA1623
 
-// disable obsolete warning - remove in RC
-#pragma warning disable CS0618
-
 namespace OpenTelemetry.AWS;
 
 /// <summary>
@@ -69,10 +66,7 @@ internal partial class AWSSemanticConventions
     /// Per SemanticConventionVersion, default should stay as
     /// <see cref="SemanticConventionVersion.V1_28_0"/> until next major version bump.
     /// </remarks>
-    internal const SemanticConventionVersion DefaultSemanticConventionVersion = SemanticConventionVersion.Legacy;
-
-    // RC Release: change to
-    //SemanticConventionVersion.V1_28_0;
+    internal const SemanticConventionVersion DefaultSemanticConventionVersion = SemanticConventionVersion.V1_28_0;
 
     private readonly SemanticConventionVersion semanticConventionVersion;
 
@@ -493,9 +487,6 @@ internal partial class AWSSemanticConventions
 
             case SemanticConventionVersion.V1_28_0:
                 return new AWSSemanticConventions_V1_28_0();
-
-            case SemanticConventionVersion.Legacy:
-                return new AWSSemanticConventionsLegacy();
 
             default:
                 throw new InvalidEnumArgumentException(

--- a/src/Shared/AWS/SemanticConventionVersion.cs
+++ b/src/Shared/AWS/SemanticConventionVersion.cs
@@ -74,18 +74,6 @@ public enum SemanticConventionVersion
     Latest = 0,
 
     /// <summary>
-    /// Represents the mixture of Semantic Conventions used in OpenTelemetry.*.AWS libraries
-    /// in 1.10.0-beta.x.
-    /// <para />
-    /// This allows users to upgrade to the latest beta nuget package without experiencing a change in
-    /// Semantic Convention output.  Then there is an opportunity for users to trial <see cref="V1_28_0"/>.
-    /// <para />
-    /// This option will be REMOVED in the next Release Candidate.
-    /// </summary>
-    [Obsolete("This will be removed in the 1.10.0-RC", error: false)]
-    Legacy = -1,
-
-    /// <summary>
     /// Pin to the specific state of all Semantic Conventions as of the 1.28.0
     /// release. See:
     /// https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.28.0.


### PR DESCRIPTION
Fixes #
Design discussion issue #  Continuation of #2367

## Changes

Update the OpenTelemetry.*.AWS libraries to to use Semantic Convention 1.28 and remove the option `SemanticConventionVerisons.Legacy`

## Background

We determined that #2367, should not change Semantic Conventions by default, allowing users a non-breaking way to test opting in-to 1.28.

This is a fast follow up PR that removes `SemanticConventionVersions.Legacy` and changes the default to SemanticConventionVersions.V1_28_0. This PR is to be released as a Release Candidate.

This follows the release strategy for other contrib packages that have made similar breaking changes around Semantic Convention stabilization.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
