### PR TITLE
[SqlClient] Sanitize SQL query text

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Enabling `SetDbStatementForText` will no longer capture the raw query text.
   The query is now sanitized. Literal values in the query text are replaced
   by a `?` character.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+  ([#2446](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2446))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -10,6 +10,11 @@
   to set default explicit buckets following the [OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/database/database-metrics.md).
   ([#2430](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2430))
 
+* Enabling `SetDbStatementForText` will no longer capture the raw query text.
+  The query is now sanitized. Literal values in the query text are replaced
+  by a `?` character.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+
 ## 1.10.0-beta.1
 
 Released 2024-Dec-09

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -26,6 +26,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.AOT.cs" Link="Includes\PropertyFetcher.AOT.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SqlProcessor.cs" Link="Includes\SqlProcessor.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -123,12 +123,13 @@ This instrumentation can be configured to change the default behavior by using
 
 ### SetDbStatementForText
 
-Capturing the text of a database query may run the risk of capturing sensitive data.
-`SetDbStatementForText` controls whether the
+The text of a database query may include sensitive data. `SetDbStatementForText`
+controls whether the
 [`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
-attribute is captured in scenarios where there could be a risk of exposing
-sensitive data. The behavior of `SetDbStatementForText` depends on the runtime
-used.
+attribute is captured in scenarios where the query text requires sanitization to
+prevent the capture of sensitive data. When enabled, literal values in the query
+text are replaced by a `?` character. The behavior of `SetDbStatementForText`
+depends on the runtime used.
 
 #### .NET
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -123,13 +123,13 @@ This instrumentation can be configured to change the default behavior by using
 
 ### SetDbStatementForText
 
-The text of a database query may include sensitive data. `SetDbStatementForText`
-controls whether the
-[`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
-attribute is captured in scenarios where the query text requires sanitization to
-prevent the capture of sensitive data. When enabled, literal values in the query
-text are replaced by a `?` character. The behavior of `SetDbStatementForText`
-depends on the runtime used.
+`SetDbStatementForText` controls whether the `db.statement` attribute is
+emitted. The behavior of `SetDbStatementForText` depends on the runtime used,
+see below for more details.
+
+Query text may contain sensitive data, so when `SetDbStatementForText` is
+enabled the raw query text is sanitized by automatically replacing literal
+values with a `?` character.
 
 #### .NET
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -24,15 +24,16 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
 
     [EnabledOnDockerPlatformTheory(EnabledOnDockerPlatformTheoryAttribute.DockerPlatform.Linux)]
     [InlineData(CommandType.Text, "select 1/1")]
-    [InlineData(CommandType.Text, "select 1/1", true)]
-    [InlineData(CommandType.Text, "select 1/0", false, true)]
-    [InlineData(CommandType.Text, "select 1/0", false, true, false, false)]
-    [InlineData(CommandType.Text, "select 1/0", false, true, true, false)]
-    [InlineData(CommandType.StoredProcedure, "sp_who")]
+    [InlineData(CommandType.Text, "select 1/1", true, "select ?/?")]
+    [InlineData(CommandType.Text, "select 1/0", false, null, true)]
+    [InlineData(CommandType.Text, "select 1/0", false, null, true, false, false)]
+    [InlineData(CommandType.Text, "select 1/0", false, null, true, true, false)]
+    [InlineData(CommandType.StoredProcedure, "sp_who", false, "sp_who")]
     public void SuccessfulCommandTest(
         CommandType commandType,
         string commandText,
         bool captureTextCommandContent = false,
+        string? sanitizedCommandText = null,
         bool isFailure = false,
         bool recordException = false,
         bool shouldEnrich = true)
@@ -84,7 +85,7 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
         Assert.Single(activities);
         var activity = activities[0];
 
-        SqlClientTests.VerifyActivityData(commandType, commandText, captureTextCommandContent, isFailure, recordException, shouldEnrich, activity);
+        SqlClientTests.VerifyActivityData(commandType, sanitizedCommandText, captureTextCommandContent, isFailure, recordException, shouldEnrich, activity);
         SqlClientTests.VerifySamplingParameters(sampler.LatestSamplingParameters);
 
         if (isFailure)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -408,7 +408,7 @@ public class SqlClientTests : IDisposable
 
     internal static void VerifyActivityData(
         CommandType commandType,
-        string commandText,
+        string? commandText,
         bool captureTextCommandContent,
         bool isFailure,
         bool recordException,


### PR DESCRIPTION
Fixes #2221 

Performs [sanitization of SQL text](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#sanitization-of-dbquerytext). First 1000 results are cached. This number is arbitrary. I do not wish to make it configurable yet in this PR though I'm open to choosing a different arbitrary number.