### PR TITLE
[Instrumentation.AWS]: always add context propagation data to requests

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Context propagation data is always added to SQS and SNS requests regardless of sampling decision.
+  This enables downstream services to make consistent sampling decisions and prevents incomplete traces.
+  ([#2447](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2447))
+
 ## 1.10.0-beta.3
 
 Released 2024-Dec-20

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* Context propagation data is always added to SQS and SNS requests regardless of sampling decision.
-  This enables downstream services to make consistent sampling decisions and prevents incomplete traces.
+* Context propagation data is always added to SQS and SNS requests regardless of
+  sampling decision. This enables downstream services to make consistent sampling
+  decisions and prevents incomplete traces.
   ([#2447](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2447))
 
 ## 1.10.0-beta.3


### PR DESCRIPTION
Fixes #2345

## Changes

Move code that adds context propagation data to requests into a dedicated method `AddPropagationDataToRequest`, and always run that regardless of sampling decision.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
