### PR TITLE
[OpenTelemetry.Instrumentation.AWSLambda] Do not crash on empty LambdaContext

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Trace instrumentation will not fail with an exception if empty `LambdaContext` instance is passed.
+* Trace instrumentation will not fail with an exception
+  if empty `LambdaContext` instance is passed.
   ([#2457](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2457))
 
 ## 1.10.0-rc.1

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Trace instrumentation will not fail with an exception if empty `LambdaContext` instance is passed.
+  ([#2457](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2457))
+
 ## 1.10.0-rc.1
 
 Released 2025-Jan-06

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
@@ -170,14 +170,19 @@ internal class AWSLambdaUtils
         return items.Length >= 5 ? items[4] : null;
     }
 
-    private static string GetFaasId(string functionArn)
+    private static string? GetFaasId(string? functionArn)
     {
+        if (string.IsNullOrEmpty(functionArn))
+        {
+            return null;
+        }
+
         var faasId = functionArn;
 
         // According to faas.id description https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#all-triggers
         // the 8th part of arn (function version or alias, see https://docs.aws.amazon.com/lambda/latest/dg/lambda-api-permissions-ref.html)
         // should not be included into faas.id
-        var items = functionArn.Split(':');
+        var items = functionArn!.Split(':');
         if (items.Length >= 8)
         {
             faasId = string.Join(":", items.Take(7));

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleLambdaContext.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleLambdaContext.cs
@@ -7,25 +7,25 @@ namespace OpenTelemetry.Instrumentation.AWSLambda.Tests;
 
 internal class SampleLambdaContext : ILambdaContext
 {
-    public string AwsRequestId { get; } = "testrequestid";
+    public string AwsRequestId { get; set; } = "testrequestid";
 
-    public IClientContext? ClientContext { get; }
+    public IClientContext? ClientContext { get; set; }
 
-    public string FunctionName { get; } = "testfunction";
+    public string FunctionName { get; set; } = "testfunction";
 
-    public string FunctionVersion { get; } = "latest";
+    public string FunctionVersion { get; set; } = "latest";
 
-    public ICognitoIdentity? Identity { get; }
+    public ICognitoIdentity? Identity { get; set; }
 
-    public string InvokedFunctionArn { get; } = "arn:aws:lambda:us-east-1:111111111111:function:testfunction";
+    public string InvokedFunctionArn { get; set; } = "arn:aws:lambda:us-east-1:111111111111:function:testfunction";
 
-    public ILambdaLogger? Logger { get; }
+    public ILambdaLogger? Logger { get; set; }
 
-    public string? LogGroupName { get; }
+    public string? LogGroupName { get; set; }
 
-    public string? LogStreamName { get; }
+    public string? LogStreamName { get; set; }
 
-    public int MemoryLimitInMB { get; }
+    public int MemoryLimitInMB { get; set; }
 
-    public TimeSpan RemainingTime { get; }
+    public TimeSpan RemainingTime { get; set; }
 }


### PR DESCRIPTION
Fixes #2445

## Changes

Handle the case is InvokedFunctionArn is null in LambdaContext.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
