### PR TITLE
[Instrumentation.EntityFrameworkCore] Add case for providerName when Devart Oracle is used

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -5,8 +5,8 @@
 * Updated OpenTelemetry core component version(s) to `1.11.0`.
   ([#2470](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2470))
 
-* Added case when `providerName` has
-  value `Devart.Data.Oracle.Entity.EFCore`.
+*  Attribute `db.system` reports `oracle` when
+  `Devart.Data.Oracle.Entity.EFCore` is used a provider.
   ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Added case when `providerName` has 
-value `"Devart.Data.Oracle.Entity.EFCore"` ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
+  value `Devart.Data.Oracle.Entity.EFCore`.
+  ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updated OpenTelemetry core component version(s) to `1.11.0`.
   ([#2470](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2470))
 
-*  Attribute `db.system` reports `oracle` when
+* Attribute `db.system` reports `oracle` when
   `Devart.Data.Oracle.Entity.EFCore` is used a provider.
   ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added case when `providerName` has 
+value `"Devart.Data.Oracle.Entity.EFCore"` ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
+
 ## 1.10.0-beta.1
 
 Released 2024-Dec-09

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added case when `providerName` has 
+* Added case when `providerName` has
   value `Devart.Data.Oracle.Entity.EFCore`.
   ([#2465](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2465))
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
@@ -107,6 +107,7 @@ internal sealed class EntityFrameworkDiagnosticListener : ListenerHandler
                                 break;
                             case "Oracle.EntityFrameworkCore":
                             case "Devart.Data.Oracle.EFCore":
+                            case "Devart.Data.Oracle.Entity.EFCore":
                                 activity.AddTag(AttributeDbSystem, "oracle");
                                 break;
                             case "Microsoft.EntityFrameworkCore.InMemory":

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -200,6 +200,7 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
     [InlineData("Devart.Data.PostgreSql.EFCore")]
     [InlineData("Oracle.EntityFrameworkCore")]
     [InlineData("Devart.Data.Oracle.EFCore")]
+    [InlineData("Devart.Data.Oracle.Entity.EFCore")]
     [InlineData("Microsoft.EntityFrameworkCore.InMemory")]
     [InlineData("FirebirdSql.EntityFrameworkCore.Firebird")]
     [InlineData("FileContextCore")]


### PR DESCRIPTION
Fixes #2462

## Changes

Added case when `providerName` has value `"Devart.Data.Oracle.Entity.EFCore"`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
