### PR TITLE
Add NuGet Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![NuGet Version](https://img.shields.io/nuget/vpre/OpenTelemetry.Extensions.AWS)](https://www.nuget.org/packages/OpenTelemetry.Extensions.AWS)[![NuGet Downloads](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions.AWS)](https://www.nuget.org/packages/OpenTelemetry.Extensions.AWS)
+
 # OpenTelemetry .NET Contrib
 
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/dotnet-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01N3BC2W7Q)


### PR DESCRIPTION
## Changes

This PR adds a NuGet Badge to the top of the README.

This helps developers find the NuGet Package as they can now click the badge to navigate directly to the package on NuGet. It also highlights the AMAZING number of downloads!

<img width="463" alt="image" src="https://github.com/user-attachments/assets/f3916463-97ad-4123-a67e-5c513237d321" />


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
