### PR TITLE
[Instrumentation.StackExchangeRedis] Adopt v1.23 database span network attributes

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updated OpenTelemetry core component version(s) to `1.11.0`.
   ([#2470](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2470))
 * Rename span network attributes to comply with
-[v1.23.0 of Semantic Conventions for Database Client Calls](https://github.com/open-telemetry/semantic-conventions/blob/release/v1.23.x/docs/database/database-spans.md)
+  [v1.23.0 of Semantic Conventions for Database Client Calls](https://github.com/open-telemetry/semantic-conventions/blob/release/v1.23.x/docs/database/database-spans.md)
   ([#2468](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2468))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Rename span network attributes to comply with
+[v1.23.0 of Semantic Conventions for Database Client Calls](https://github.com/open-telemetry/semantic-conventions/blob/release/v1.23.x/docs/database/database-spans.md)
+  ([#2468](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2468))
+
 ## 1.10.0-beta.1
 
 Released 2024-Dec-09

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -3,7 +3,9 @@
 
 using System.Diagnostics;
 using System.Net;
+#if NET8_0_OR_GREATER
 using System.Net.Sockets;
+#endif
 using System.Reflection;
 using System.Reflection.Emit;
 using OpenTelemetry.Trace;

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -25,8 +25,6 @@ internal static class SemanticConventions
     public const string AttributeEnduserRole = "enduser.role";
     public const string AttributeEnduserScope = "enduser.scope";
 
-    public const string AttributePeerService = "peer.service";
-
     public const string AttributeHttpMethod = "http.method";
     public const string AttributeHttpUrl = "http.url";
     public const string AttributeHttpTarget = "http.target";
@@ -115,6 +113,11 @@ internal static class SemanticConventions
     public const string AttributeServerAddress = "server.address"; // replaces: "net.host.name" (AttributeNetHostName)
     public const string AttributeServerPort = "server.port"; // replaces: "net.host.port" (AttributeNetHostPort)
     public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: http.user_agent (AttributeHttpUserAgent)
+
+    // v1.23.0 Database spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/release/v1.23.x/docs/database/database-spans.md
+    public const string AttributeNetworkPeerAddress = "network.peer.address"; // replaces: "net.peer.ip" (AttributeNetPeerIp)
+    public const string AttributeNetworkPeerPort = "network.peer.port"; // replaces: "net.peer.port" (AttributeNetPeerPort)
 
     // v1.24.0 Messaging spans
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-spans.md

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -116,6 +116,7 @@ public class RedisProfilerEntryToActivityConverterTests : IDisposable
     {
         long address = 1;
         var port = 2;
+        var ip = $"{address}.0.0.0";
 
         var activity = new Activity("redis-profiler");
         var ipLocalEndPoint = new IPEndPoint(address, port);
@@ -124,10 +125,14 @@ public class RedisProfilerEntryToActivityConverterTests : IDisposable
         var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand, new StackExchangeRedisInstrumentationOptions());
 
         Assert.NotNull(result);
-        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeNetPeerIp));
-        Assert.Equal($"{address}.0.0.0", result.GetTagValue(SemanticConventions.AttributeNetPeerIp));
-        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeNetPeerPort));
-        Assert.Equal(port, result.GetTagValue(SemanticConventions.AttributeNetPeerPort));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeServerAddress));
+        Assert.Equal(ip, result.GetTagValue(SemanticConventions.AttributeServerAddress));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeServerPort));
+        Assert.Equal(port, result.GetTagValue(SemanticConventions.AttributeServerPort));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeNetworkPeerAddress));
+        Assert.Equal(ip, result.GetTagValue(SemanticConventions.AttributeNetworkPeerAddress));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeNetworkPeerPort));
+        Assert.Equal(port, result.GetTagValue(SemanticConventions.AttributeNetworkPeerPort));
     }
 
     [Fact]
@@ -141,10 +146,10 @@ public class RedisProfilerEntryToActivityConverterTests : IDisposable
         var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand, new StackExchangeRedisInstrumentationOptions());
 
         Assert.NotNull(result);
-        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeNetPeerName));
-        Assert.Equal(dnsEndPoint.Host, result.GetTagValue(SemanticConventions.AttributeNetPeerName));
-        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeNetPeerPort));
-        Assert.Equal(dnsEndPoint.Port, result.GetTagValue(SemanticConventions.AttributeNetPeerPort));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeServerAddress));
+        Assert.Equal(dnsEndPoint.Host, result.GetTagValue(SemanticConventions.AttributeServerAddress));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeServerPort));
+        Assert.Equal(dnsEndPoint.Port, result.GetTagValue(SemanticConventions.AttributeServerPort));
     }
 
 #if !NETFRAMEWORK
@@ -158,8 +163,10 @@ public class RedisProfilerEntryToActivityConverterTests : IDisposable
         var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand, new StackExchangeRedisInstrumentationOptions());
 
         Assert.NotNull(result);
-        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributePeerService));
-        Assert.Equal(unixEndPoint.ToString(), result.GetTagValue(SemanticConventions.AttributePeerService));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeServerAddress));
+        Assert.Equal(unixEndPoint.ToString(), result.GetTagValue(SemanticConventions.AttributeServerAddress));
+        Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeNetworkPeerAddress));
+        Assert.Equal(unixEndPoint.ToString(), result.GetTagValue(SemanticConventions.AttributeNetworkPeerAddress));
     }
 #endif
 }

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -417,17 +417,19 @@ public class StackExchangeRedisCallsInstrumentationTests
 
         if (endPoint is IPEndPoint ipEndPoint)
         {
-            Assert.Equal(ipEndPoint.Address.ToString(), activity.GetTagValue(SemanticConventions.AttributeNetPeerIp));
-            Assert.Equal(ipEndPoint.Port, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
+            Assert.Equal(ipEndPoint.Address.ToString(), activity.GetTagValue(SemanticConventions.AttributeServerAddress));
+            Assert.Equal(ipEndPoint.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
         }
         else if (endPoint is DnsEndPoint dnsEndPoint)
         {
-            Assert.Equal(dnsEndPoint.Host, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
-            Assert.Equal(dnsEndPoint.Port, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
+            Assert.Equal(dnsEndPoint.Host, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
+            Assert.Equal(dnsEndPoint.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
         }
         else
         {
-            Assert.Equal(endPoint.ToString(), activity.GetTagValue(SemanticConventions.AttributePeerService));
+            var tags = activity.Tags.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.DoesNotContain(SemanticConventions.AttributeServerAddress, tags.Keys);
+            Assert.DoesNotContain(SemanticConventions.AttributeServerPort, tags.Keys);
         }
     }
 


### PR DESCRIPTION
## Changes

Adopt v1.23 database span network attributes. This does not update any other attributes that may be out of date.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
