### PR TITLE
[Sampler.AWS] Tests - Bump WireMock.Net to 1.7.0

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -33,7 +33,7 @@
     <SupportedNetTargets>net9.0;net8.0</SupportedNetTargets>
     <XUnitRunnerVisualStudioPkgVer>[2.8.2,3.0)</XUnitRunnerVisualStudioPkgVer>
     <XUnitPkgVer>[2.9.2,3.0)</XUnitPkgVer>
-    <WiremockNetPkgVer>[1.6.8,2.0)</WiremockNetPkgVer>
+    <WiremockNetPkgVer>[1.7.0,2.0)</WiremockNetPkgVer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -32,7 +32,7 @@
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <SupportedNetTargets>net9.0;net8.0</SupportedNetTargets>
     <XUnitRunnerVisualStudioPkgVer>[2.8.2,3.0)</XUnitRunnerVisualStudioPkgVer>
-    <XUnitPkgVer>[2.9.2,3.0)</XUnitPkgVer>
+    <XUnitPkgVer>[2.9.3,3.0)</XUnitPkgVer>
     <WiremockNetPkgVer>[1.7.0,2.0)</WiremockNetPkgVer>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/OpenTelemetry.Sampler.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/OpenTelemetry.Sampler.AWS.Tests.csproj
@@ -7,8 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Wiremock.Net" Version="$(WiremockNetPkgVer)" />
-    <!-- System.Text.RegularExpressions is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-4cv2-4hjh-77rx
It was transitive dependency to WireMock.NET < 1.7.0

## Changes

[[Sampler.AWS] Bump WireMock.Net to 1.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/commit/7d16e789cdc2c74cbafc57b0ee739d99abea7c6d)
[Bump xunit to 2.9.3](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/commit/34a6ffc61b5226da1291ef65dcf3be51f7b19f31)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
