### PR TITLE
List OpenTelemetry.Resources.AWS as Stable

### DIFF
--- a/src/OpenTelemetry.Resources.AWS/README.md
+++ b/src/OpenTelemetry.Resources.AWS/README.md
@@ -2,7 +2,7 @@
 
 | Status        |           |
 | ------------- |-----------|
-| Stability     |  [Beta](../../README.md#beta)|
+| Stability     |  [Stable](../../README.md#stable)|
 | Code Owners   |  [@srprash](https://github.com/srprash), [@ppittle](https://github.com/ppittle)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.AWS)](https://www.nuget.org/packages/OpenTelemetry.Resources.AWS)


### PR DESCRIPTION
List OpenTelemetry.Resources.AWS as Stable in the README.md

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
