### PR TITLE
Update code ownership for OpenTelemetry.Extensions.Enrichment

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -22,7 +22,7 @@ components:
     - srprash
     - ppittle
   src/OpenTelemetry.Extensions.Enrichment/:
-    - xakep139
+    - evgenyfedorov2
   src/OpenTelemetry.Instrumentation.AWS/:
     - srprash
     - ppittle

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -119,7 +119,7 @@ components:
     - srprash
     - ppittle
   test/OpenTelemetry.Extensions.Enrichment.Tests/:
-    - xakep139
+    - evgenyfedorov2
   test/OpenTelemetry.Instrumentation.AWS.Tests/:
     - srprash
     - ppittle

--- a/src/OpenTelemetry.Extensions.Enrichment/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Development](../../README.md#development)|
-| Code Owners   |  [@xakep139](https://github.com/xakep139)|
+| Code Owners   |  [@evgenyfedorov2](https://github.com/evgenyfedorov2)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions.Enrichment)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Enrichment)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions.Enrichment)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Enrichment)


### PR DESCRIPTION
Fixes # n/a
Design discussion issue # n/a

## Changes

Updates ownership of the OpenTelemetry.Extensions.Enrichment component. @xakep139 left Microsoft last year and I am supposed to work on this component from now on.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
