### PR TITLE
Remove Cijo Thomas from GenevaExporter codeowners

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -4,7 +4,6 @@
 # Please add the entries in alphabetically sorted order
 components:
   src/OpenTelemetry.Exporter.Geneva/:
-    - cijothomas
     - codeblanch
     - rajkumar-rangaraj
   src/OpenTelemetry.Exporter.InfluxDB/:
@@ -91,15 +90,12 @@ components:
     - srprash
     - ppittle
   test/OpenTelemetry.Exporter.Geneva.Benchmarks/:
-    - cijothomas
     - codeblanch
     - rajkumar-rangaraj
   test/OpenTelemetry.Exporter.Geneva.Stress/:
-    - cijothomas
     - codeblanch
     - rajkumar-rangaraj
   test/OpenTelemetry.Exporter.Geneva.Tests/:
-    - cijothomas
     - codeblanch
     - rajkumar-rangaraj
   test/OpenTelemetry.Exporter.InfluxDB.Tests/:

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Stable](../../README.md#stable)|
-| Code Owners   |  [@cijothomas](https://github.com/cijothomas), [@codeblanch](https://github.com/codeblanch), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/)|
+| Code Owners   |  [@codeblanch](https://github.com/codeblanch), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)


### PR DESCRIPTION
Moving on from owning this component, to focus on other languages.