### PR TITLE
[Persistent Storage] Amend change log to include the deterministic flag enablement

### DIFF
--- a/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Enabled deterministic flag.
+  * This change was bundled with other changes in a previous PR merged on
+    2023-Oct-13. Thus the last release was built without the deterministic.
+    Relevant PR: [repo] Add dedicated CI for persistent storage projects
+    ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
+
 ## 1.0.0
 
 Released 2023-Aug-28

--- a/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Enabled deterministic flag.
   * This change was bundled with other changes in a previous PR merged on
     2023-Oct-13. Thus the last release was built without the deterministic.
-    Relevant PR: [repo] Add dedicated CI for persistent storage projects
     ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
 
 ## 1.0.0

--- a/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## Unreleased
 
-* Enabled deterministic flag.
-  * This change was bundled with other changes in a previous PR merged on
-    2023-Oct-13. Thus the last release was built without the deterministic.
-    ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
+* Switch to deterministic builds.
+  ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
 
 ## 1.0.0
 

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Fix `System.FormatException` thrown by `PersistentStorageEventSource`.
   [#1613](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1613)
 
+* Enabled deterministic flag.
+  * This change was bundled with other changes in a previous PR merged on
+    2023-Oct-13. Thus the last release was built without the deterministic.
+    Relevant PR: [repo] Add dedicated CI for persistent storage projects
+    ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
+
 ## 1.0.0
 
 Released 2023-Aug-28

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
@@ -5,9 +5,7 @@
 * Fix `System.FormatException` thrown by `PersistentStorageEventSource`.
   [#1613](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1613)
 
-* Enabled deterministic flag.
-  * This change was bundled with other changes in a previous PR merged on
-    2023-Oct-13. Thus the last release was built without the deterministic.
+* Switch to deterministic builds.
     ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
 
 ## 1.0.0

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
@@ -8,7 +8,6 @@
 * Enabled deterministic flag.
   * This change was bundled with other changes in a previous PR merged on
     2023-Oct-13. Thus the last release was built without the deterministic.
-    Relevant PR: [repo] Add dedicated CI for persistent storage projects
     ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
 
 ## 1.0.0

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
@@ -6,7 +6,7 @@
   [#1613](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1613)
 
 * Switch to deterministic builds.
-    ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
+  ([#1397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1397))
 
 ## 1.0.0
 


### PR DESCRIPTION
Preparing for a release which will be built with the [deterministic flag](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation#deterministic).

## Changes

Amended CHANGELOG to call out a previous change.

### Last release: 

When the packages were released last time, the `dotnet pack` command ignored the existing build with `Deterministic` flag due to the `--no-build` being commented out.

Release tag for OpenTelemetry.PersistentStorage.Abstractions 1.0.0 is [PersistentStorage.Abstractions-1.0.0](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/releases/tag/PersistentStorage.Abstractions-1.0.0).
  * Relevant code for building is at https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/PersistentStorage.Abstractions-1.0.0/.github/workflows/package-PersistentStorage.Abstractions.yml#L41

```
    - name: dotnet build ${{env.PROJECT}}
      run: dotnet build src/${{env.PROJECT}} --configuration Release --no-restore -p:Deterministic=true

    - name: dotnet pack ${{env.PROJECT}}
      run: dotnet pack src/${{env.PROJECT}} --configuration Release #--no-build <- OpenTelemetry.PersistentStorage.Abstractions has a conditional net6.0 target which causes dotnet pack to break when -no-build is used (for some reason)
```

Release tag for OpenTelemetry.PersistentStorage.FileSystem 1.0.0 is [PersistentStorage.FileSystem-1.0.0](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/releases/tag/PersistentStorage.FileSystem-1.0.0).
  * Relevant code for building is at https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/PersistentStorage.FileSystem-1.0.0/.github/workflows/package-PersistentStorage.FileSystem.yml#L44

### Current

Currently the packaging process is unified with other packages and built with `Deterministic` flag in `publish-packages.yml`.

https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/e68f51225bd616c062a3541dc9ca89166b2519a4/.github/workflows/publish-packages.yml#L76

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
