### PR TITLE
[repo] Add Rajkumar Rangaraj as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 * [Alan West](https://github.com/alanwest), New Relic
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
 * [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
+* [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 
 *Find more about the maintainer role in [community
 repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).*


### PR DESCRIPTION
## Changes

* Add Rajkumar Rangaraj as maintainer.

Raj is working as a component owner of couple of the packages. What is more, he is the maintainer and main author of the latest SDK and the maintainer of the auto-instrumentation package. New responsibilities should streamline releasing process whole of the ecosystem.

@rajkumar-rangaraj, thanks for what you are doing now. Looking for more :- )

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
