### PR TITLE
[Instrumentation.AspNetCore] Missing PR link in CHANGELOG

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -6,6 +6,7 @@
   Configurable with the
   `AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreSignalRSupport`
   option which defaults to `true`. Only applies to .NET 9.0 or greater.
+  ([#2539](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2539))
 
 ## 1.11.0
 


### PR DESCRIPTION
Follow up #2539

## Changes

[Instrumentation.AspNetCore] Missing PR link in CHANGELOG

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
