### PR TITLE
Publish NuGet packages to Artifacts

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -140,3 +140,9 @@ jobs:
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Code Coverage for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
         codecov_yml_path: .github/codecov.yml
+
+    - name: Publish NuGet packages to Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.project-name }}-packages
+        path: 'src\**\*.*nupkg'


### PR DESCRIPTION
See discussion from here: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2653#issuecomment-2713844502

## Changes

Publish NuGet packages from CI builds as workflow run artifacts.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
