### PR TITLE
[repo] Disable pack for Shared.Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,7 @@ jobs:
     with:
       project-name: OpenTelemetry.SemanticConventions
       code-cov-name: SemanticConventions
+      pack: false # No packages produced
       run-tests: false # Note: No test project
 
   build-test-contrib-shared-tests:
@@ -560,6 +561,7 @@ jobs:
     with:
       project-name: OpenTelemetry.Contrib.Shared.Tests
       code-cov-name: Contrib.Shared.Tests
+      pack: false # No packages produced
 
   verify-aot-compat:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,7 +548,6 @@ jobs:
     with:
       project-name: OpenTelemetry.SemanticConventions
       code-cov-name: SemanticConventions
-      pack: false # No packages produced
       run-tests: false # Note: No test project
 
   build-test-contrib-shared-tests:


### PR DESCRIPTION
## Changes

Disable pack for project that do not produce any NuGet packages.

Relates to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2658#issuecomment-2742476285.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
