### PR TITLE
[repo] Move Blanch to approver

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -4,7 +4,6 @@
 # Please add the entries in alphabetically sorted order
 components:
   src/OpenTelemetry.Exporter.Geneva/:
-    - codeblanch
     - rajkumar-rangaraj
     - TimothyMothra
     - xiang17
@@ -14,10 +13,10 @@ components:
     - zivaninstana
   src/OpenTelemetry.Exporter.OneCollector/:
     - codeblanch
+    - rajkumar-rangaraj
   src/OpenTelemetry.Exporter.Stackdriver/:
     - SergeyKanzhelev
   src/OpenTelemetry.Extensions/:
-    - codeblanch
     - mikegoldsmith
   src/OpenTelemetry.Extensions.AWS/:
     - srprash
@@ -46,8 +45,6 @@ components:
     - pcwiese
   src/OpenTelemetry.Instrumentation.Hangfire/:
     - fred2u
-  src/OpenTelemetry.Instrumentation.Owin/:
-    - codeblanch
   src/OpenTelemetry.Instrumentation.Process/:
     - Yun-Ting
   src/OpenTelemetry.Instrumentation.Quartz/:
@@ -59,8 +56,6 @@ components:
     - xiang17
   src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/:
     - sablancoleis
-  src/OpenTelemetry.Instrumentation.Wcf/:
-    - codeblanch
   src/OpenTelemetry.PersistentStorage.Abstractions/:
     - rajkumar-rangaraj
   src/OpenTelemetry.PersistentStorage.FileSystem/:
@@ -92,17 +87,14 @@ components:
     - srprash
     - ppittle
   test/OpenTelemetry.Exporter.Geneva.Benchmarks/:
-    - codeblanch
     - rajkumar-rangaraj
     - TimothyMothra
     - xiang17
   test/OpenTelemetry.Exporter.Geneva.Stress/:
-    - codeblanch
     - rajkumar-rangaraj
     - TimothyMothra
     - xiang17
   test/OpenTelemetry.Exporter.Geneva.Tests/:
-    - codeblanch
     - rajkumar-rangaraj
     - TimothyMothra
     - xiang17
@@ -112,12 +104,13 @@ components:
     - zivaninstana
   test/OpenTelemetry.Exporter.OneCollector.Benchmarks/:
     - codeblanch
+    - rajkumar-rangaraj
   test/OpenTelemetry.Exporter.OneCollector.Tests/:
     - codeblanch
+    - rajkumar-rangaraj
   test/OpenTelemetry.Exporter.Stackdriver.Tests/:
     - SergeyKanzhelev
   test/OpenTelemetry.Extensions.Tests/:
-    - codeblanch
     - mikegoldsmith
   test/OpenTelemetry.Extensions.AWS.Tests/:
     - srprash
@@ -146,8 +139,6 @@ components:
     - pcwiese
   test/OpenTelemetry.Instrumentation.Hangfire.Tests/:
     - fred2u
-  test/OpenTelemetry.Instrumentation.Owin.Tests/:
-    - codeblanch
   test/OpenTelemetry.Instrumentation.Quartz.Tests/:
     - maldago
   test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/:
@@ -157,8 +148,6 @@ components:
     - xiang17
   test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/:
     - sablancoleis
-  test/OpenTelemetry.Instrumentation.Wcf.Tests/:
-    - codeblanch
   test/OpenTelemetry.PersistentStorage.FileSystem.Tests/:
     - rajkumar-rangaraj
   test/OpenTelemetry.Resources.AWS.Tests/:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 
 [@open-telemetry/dotnet-contrib-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-approvers):
 
-There are no approvers today.
+* [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
 
 *Find more about the approver role in [community
 repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).*
@@ -90,7 +90,6 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers):
 
 * [Alan West](https://github.com/alanwest), New Relic
-* [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
 * [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
 * [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Stable](../../README.md#stable)|
-| Code Owners   |  [@codeblanch](https://github.com/codeblanch), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/), [@TimothyMothra](https://github.com/TimothyMothra), [@xiang17](https://github.com/xiang17) |
+| Code Owners   |  [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/), [@TimothyMothra](https://github.com/TimothyMothra), [@xiang17](https://github.com/xiang17) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Geneva)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva)

--- a/src/OpenTelemetry.Exporter.OneCollector/README.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Stable](../../README.md#stable)|
-| Code Owners   |  [@codeblanch](https://github.com/codeblanch)|
+| Code Owners   |  [@codeblanch](https://github.com/codeblanch), [@rajkumar-rangaraj](https://github.com/rajkumar-rangaraj/)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.OneCollector)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OneCollector)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.OneCollector)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OneCollector)

--- a/src/OpenTelemetry.Extensions/README.md
+++ b/src/OpenTelemetry.Extensions/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Beta](../../README.md#beta)|
-| Code Owners   |  [@codeblanch](https://github.com/codeblanch), [@mikegoldsmith](https://github.com/mikegoldsmith)|
+| Code Owners   |  [@mikegoldsmith](https://github.com/mikegoldsmith)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions)](https://www.nuget.org/packages/OpenTelemetry.Extensions)

--- a/src/OpenTelemetry.Instrumentation.Owin/README.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [RC](../../README.md#rc)|
-| Code Owners   |  [@codeblanch](https://github.com/codeblanch)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Owin)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Owin)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Owin)

--- a/src/OpenTelemetry.Instrumentation.Wcf/README.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [RC](../../README.md#rc)|
-| Code Owners   |  [@codeblanch](https://github.com/codeblanch)|
+| Code Owners   |  [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Wcf)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Wcf/)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Wcf)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Wcf/)


### PR DESCRIPTION
Stepping down as a maintainer to free up time to work on new things. We're in good hands with @alanwest, 
@Kielek, and @rajkumar-rangaraj!

For components where I was the owner I gave them to maintainers. The exception being OneCollectorExporter where I added @rajkumar-rangaraj (we will co-own that for now).