### PR TITLE
Add Timothy as Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ component's `Readme.md` file.
 [@open-telemetry/dotnet-contrib-triagers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-triagers):
 
 * [Martin Thwaites](https://github.com/martinjt), Honeycomb
-* [Timothy "Mothra" Lee](https://github.com/TimothyMothra), Microsoft
 
 *Find more about the triager role in [community
 repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).*
@@ -81,6 +80,7 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 [@open-telemetry/dotnet-contrib-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-approvers):
 
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
+* [Timothy "Mothra" Lee](https://github.com/TimothyMothra), Microsoft
 
 *Find more about the approver role in [community
 repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).*


### PR DESCRIPTION
@TimothyMothra is actively contributing to this repository, He is already triager in this repository but also in the main sdk repo.

His contribution is extremely valuable, especially if we speaking about countless of reviews.

I would like to nominate Timothy to work as an Approver in this repository.