### PR TITLE
[sql] Implement updates to new semantic conventions for stored procedures

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -11,7 +11,7 @@
   When `CommandType` is `StoredProcedure`, the `db.stored_procedure.name` has
   been added and the `db.query.text`, `db.operation.name`, and
   `db.collection.name` attributes have been removed.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+  ([#2693](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2693))
 
 ## 1.11.0-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -6,6 +6,12 @@
   connection's `DataSource` when used to populate the `server.address`
   attribute.
   ([#2674](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2674))
+* Updates have been made to adhere to recent changes in the new semantic
+  conventions. These affect you if you have opted in to the new conventions.
+  When `CommandType` is `StoredProcedure`, the `db.stored_procedure.name` has
+  been added and the `db.query.text`, `db.operation.name`, and
+  `db.collection.name` attributes have been removed.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
 
 ## 1.11.0-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -34,10 +34,9 @@ internal sealed class SqlActivitySourceHelper
     internal static readonly string[] SharedTagNames =
     [
         SemanticConventions.AttributeDbSystem,
-        SemanticConventions.AttributeDbCollectionName,
         SemanticConventions.AttributeDbNamespace,
+        SemanticConventions.AttributeDbStoredProcedureName,
         SemanticConventions.AttributeDbResponseStatusCode,
-        SemanticConventions.AttributeDbOperationName,
         SemanticConventions.AttributeErrorType,
         SemanticConventions.AttributeServerPort,
         SemanticConventions.AttributeServerAddress,

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -115,9 +115,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
 
                                     if (options.EmitNewAttributes)
                                     {
-                                        activity.SetTag(SemanticConventions.AttributeDbOperationName, "EXECUTE");
-                                        activity.SetTag(SemanticConventions.AttributeDbCollectionName, commandText);
-                                        activity.SetTag(SemanticConventions.AttributeDbQueryText, commandText);
+                                        activity.SetTag(SemanticConventions.AttributeDbStoredProcedureName, commandText);
                                     }
 
                                     break;
@@ -278,8 +276,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                 {
                     if (this.commandTextFetcher.TryFetch(command, out var commandText))
                     {
-                        tags.Add(SemanticConventions.AttributeDbOperationName, "EXECUTE");
-                        tags.Add(SemanticConventions.AttributeDbCollectionName, commandText);
+                        tags.Add(SemanticConventions.AttributeDbStoredProcedureName, commandText);
                     }
                 }
             }

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -141,13 +141,12 @@ internal static class SemanticConventions
     // New database conventions as of commit:
     // https://github.com/open-telemetry/semantic-conventions/blob/25f74191d749645fdd5ec42ae661438cf2c1cf51/docs/database/database-spans.md#common-attributes
     public const string AttributeDbSystem = "db.system";
-    public const string AttributeDbCollectionName = "db.collection.name";
     public const string AttributeDbNamespace = "db.namespace";
-    public const string AttributeDbOperationName = "db.operation.name";
     public const string AttributeDbResponseStatusCode = "db.response.status_code";
     public const string AttributeDbOperationBatchSize = "db.operation.batch.size";
     public const string AttributeDbQuerySummary = "db.query.summary";
     public const string AttributeDbQueryText = "db.query.text";
+    public const string AttributeDbStoredProcedureName = "db.stored_procedure.name";
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -482,9 +482,7 @@ public class SqlClientTests : IDisposable
 
                 if (emitNewAttributes)
                 {
-                    Assert.Equal("EXECUTE", activity.GetTagValue(SemanticConventions.AttributeDbOperationName));
-                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbCollectionName));
-                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
+                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStoredProcedureName));
                 }
 
                 break;


### PR DESCRIPTION
Implementing the new [`db.stored_procedure.name` attribute](https://github.com/open-telemetry/semantic-conventions/pull/2037).

The `db.operation.name`, `db.collection.name`, and `db.query.text` attributes have been removed when `CommandType` = `StoredProcedure` because they are no longer applicable.

Side note, we have an odd scenario for .NET Framework users. `CommandType` is not known, so `db.query.text` will still be used even for stored procedures. This requires documentation, but is beyond the scope of this PR.