### PR TITLE
[chore] Update Resources.Gcp component owners

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -85,7 +85,6 @@ components:
     - lachmatt
   src/OpenTelemetry.Resources.Gcp/:
     - matt-hensley
-    - pyohannes
   src/OpenTelemetry.Sampler.AWS/:
     - srprash
     - ppittle
@@ -174,7 +173,6 @@ components:
     - lachmatt
   test/OpenTelemetry.Resources.Gcp.Tests/:
     - matt-hensley
-    - pyohannes
   test/OpenTelemetry.Sampler.AWS.Tests/:
     - srprash
     - ppittle

--- a/src/OpenTelemetry.Resources.Gcp/README.md
+++ b/src/OpenTelemetry.Resources.Gcp/README.md
@@ -3,7 +3,7 @@
 | Status        |           |
 | ------------- |-----------|
 | Stability     |  [Development](../../README.md#development)|
-| Code Owners   |  [@matt-hensley](https://github.com/matt-hensley), [@pyohannes](https://github.com/pyohannes)|
+| Code Owners   |  [@matt-hensley](https://github.com/matt-hensley)|
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Gcp)](https://www.nuget.org/packages/OpenTelemetry.Resources.Gcp)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Resources.Gcp)](https://www.nuget.org/packages/OpenTelemetry.Resources.Gcp)


### PR DESCRIPTION
## Changes

Remove Johannes Tax (pyohannes) from Resources.Gcp component owners. Johannes is no longer available to maintain this package.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
