### PR TITLE
[SqlClient] Refactor Enrich test

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -12,7 +12,7 @@
     <!-- Tweak style rules for Geneva: Allow underscores in constant names and allow regions inside code blocks -->
     <NoWarn>$(NoWarn);SA1123;SA1310</NoWarn>
     <MinVerTagPrefix>Exporter.Geneva-</MinVerTagPrefix>
-    <PackageValidationBaselineVersion>1.11.2</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.11.3</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -315,8 +315,8 @@ public class SqlClientTests : IDisposable
         Assert.Equal(2, activities.Count);
         if (shouldEnrich)
         {
-            Assert.Contains(activities[0].Tags, tag => tag.Key == "enriched");
-            Assert.Contains(activities[1].Tags, tag => tag.Key == "enriched");
+            Assert.Contains("enriched", activities[0].Tags.Select(x => x.Key));
+            Assert.Contains("enriched", activities[1].Tags.Select(x => x.Key));
             Assert.Equal("yes", activities[0].Tags.FirstOrDefault(tag => tag.Key == "enriched").Value);
             Assert.Equal("yes", activities[1].Tags.FirstOrDefault(tag => tag.Key == "enriched").Value);
         }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
@@ -17,26 +17,20 @@ internal class SqlTestData
         return from beforeCommand in new[] { SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand }
                from commandType in new[] { CommandType.StoredProcedure, CommandType.Text }
                from captureTextCommandContent in bools
-               from shouldEnrich in bools
                from emitOldAttributes in bools
                from emitNewAttributes in bools
                from tracingEnabled in bools
                from metricsEnabled in bools
                where emitOldAttributes && emitNewAttributes
-               let endCommand = beforeCommand == SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand
-                   ? SqlClientDiagnosticListener.SqlDataAfterExecuteCommand
-                   : SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand
                let commandText = commandType == CommandType.Text
                    ? "select * from sys.databases"
                    : "SP_GetOrders"
                select new object[]
                {
                     beforeCommand,
-                    endCommand,
                     commandType,
                     commandText,
                     captureTextCommandContent,
-                    shouldEnrich,
                     emitOldAttributes,
                     emitNewAttributes,
                     tracingEnabled,
@@ -52,14 +46,9 @@ internal class SqlTestData
                from recordException in bools
                from tracingEnabled in bools
                from metricsEnabled in bools
-               let errorCommand = beforeCommand == SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand
-                   ? SqlClientDiagnosticListener.SqlDataWriteCommandError
-                   : SqlClientDiagnosticListener.SqlMicrosoftWriteCommandError
                select new object[]
                {
                     beforeCommand,
-                    errorCommand,
-                    shouldEnrich,
                     recordException,
                     tracingEnabled,
                     metricsEnabled,


### PR DESCRIPTION
The SqlClient unit tests need to be improved. There's a lot of holes in coverage and the existing tests make it difficult to surmise what we do and do not cover.

This is the first PR of a few more to come which simply aims to refactor the existing tests making them more readable and making coverage more apparent.

Currently, we have this mega test. It's like a one test to rule them all kind of test which, in my opinion, needlessly tests a bazillion config combinations. This test has become exceedingly difficult to debug.

In this first PR, I'm extracting the testing of the `Enrich` configuration into its own test. I'll do the same for the .NET Framework tests in a different PR.