### PR TITLE
[SqlClient] Refactor tests enabling trace/metric instrumentation

### DIFF
--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
@@ -19,8 +19,6 @@ internal class SqlTestData
                from captureTextCommandContent in bools
                from emitOldAttributes in bools
                from emitNewAttributes in bools
-               from tracingEnabled in bools
-               from metricsEnabled in bools
                where emitOldAttributes && emitNewAttributes
                let commandText = commandType == CommandType.Text
                    ? "select * from sys.databases"
@@ -33,8 +31,6 @@ internal class SqlTestData
                     captureTextCommandContent,
                     emitOldAttributes,
                     emitNewAttributes,
-                    tracingEnabled,
-                    metricsEnabled,
                };
     }
 
@@ -44,14 +40,10 @@ internal class SqlTestData
         return from beforeCommand in new[] { SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand }
                from shouldEnrich in bools
                from recordException in bools
-               from tracingEnabled in bools
-               from metricsEnabled in bools
                select new object[]
                {
                     beforeCommand,
                     recordException,
-                    tracingEnabled,
-                    metricsEnabled,
                };
     }
 #endif


### PR DESCRIPTION
Similar to #2714 simplifying SqlClient tests

This PR extracts the testing of enabling trace vs. metric instrumentation into its own test.