### PR TITLE
[Instrumentation.Wcf] Restore aspnet headers read-only state

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.12.0`.
   ([#2725](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2725))
 
+* Preservers `IsReadOnly` state of instrumented HTTP Headers.
+  ([#2716](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2716))
+
 ## 1.11.0-beta.2
 
 Released 2025-Mar-05


### PR DESCRIPTION
Fixes

- AspNetParentSpanCorrector always sets the request headers to read-only, even if it was originally writable. This breaks any existing application code that makes further changes to the request headers.

## Changes

AspNetParentSpanCorrector.OnRequestStarted now records the original state of `HttpContext.Request.Headers.IsReadOnly`, and always restores the original value to the property when done writing the headers.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
