### PR TITLE
Refactor tests validating configuration for capture of db.query.text

### DIFF
--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
@@ -16,19 +16,13 @@ internal class SqlTestData
         var bools = new[] { true, false };
         return from beforeCommand in new[] { SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand }
                from commandType in new[] { CommandType.StoredProcedure, CommandType.Text }
-               from captureTextCommandContent in bools
                from emitOldAttributes in bools
                from emitNewAttributes in bools
                where emitOldAttributes && emitNewAttributes
-               let commandText = commandType == CommandType.Text
-                   ? "select * from sys.databases"
-                   : "SP_GetOrders"
                select new object[]
                {
                     beforeCommand,
                     commandType,
-                    commandText,
-                    captureTextCommandContent,
                     emitOldAttributes,
                     emitNewAttributes,
                };


### PR DESCRIPTION
Similar to #2714 simplifying SqlClient tests

This PR extracts the testing of the configuration enabling capture of `db.query.text` and `db.statement` (old conventions).