### PR TITLE
[SqlClient] Refactor tests validating RecordException

### DIFF
--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlTestData.cs
@@ -27,18 +27,5 @@ internal class SqlTestData
                     emitNewAttributes,
                };
     }
-
-    public static IEnumerable<object[]> SqlClientErrorsAreCollectedSuccessfullyCases()
-    {
-        var bools = new[] { true, false };
-        return from beforeCommand in new[] { SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand }
-               from shouldEnrich in bools
-               from recordException in bools
-               select new object[]
-               {
-                    beforeCommand,
-                    recordException,
-               };
-    }
 #endif
 }


### PR DESCRIPTION
Similar to #2714 simplifying SqlClient tests

This PR refactors the `RecordException` test removing the `MemberData`. The primary purpose of the test is to validate the recording of exception span events, so I also removed the metric validation.