### PR TITLE
Set max support AWS SDK version to V3

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Update package references to AWS SDK to indicate that this library is not compatible with AWS SDK v4.
+* Update package references to AWS SDK to indicate that this library is not
+  compatible with AWS SDK v4.
    ([#2726](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2726))
 
 ## 1.11.2

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update package references to AWS SDK to indicate that this library is not compatible with AWS SDK v4.
+   ([#2726](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2726))
+
 ## 1.11.2
 
 Released 2025-Mar-18

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.400" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.Core" Version="[3.7.400, 4.0.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.400, 4.0.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.400, 4.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Set max support AWS SDK version to V3

Design discussion issue #
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/2719

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
