### PR TITLE
[SqlClient] Support new DB convention: `db.system.name`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -15,7 +15,8 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
 /// </summary>
 internal sealed class SqlActivitySourceHelper
 {
-    public const string MicrosoftSqlServerDatabaseSystemName = "mssql";
+    public const string MicrosoftSqlServerDbSystemName = "microsoft.sql_server";
+    public const string MicrosoftSqlServerDbSystem = "mssql";
 
     public static readonly Assembly Assembly = typeof(SqlActivitySourceHelper).Assembly;
     public static readonly AssemblyName AssemblyName = Assembly.GetName();
@@ -34,6 +35,7 @@ internal sealed class SqlActivitySourceHelper
     internal static readonly string[] SharedTagNames =
     [
         SemanticConventions.AttributeDbSystem,
+        SemanticConventions.AttributeDbSystemName,
         SemanticConventions.AttributeDbCollectionName,
         SemanticConventions.AttributeDbNamespace,
         SemanticConventions.AttributeDbResponseStatusCode,
@@ -45,12 +47,21 @@ internal sealed class SqlActivitySourceHelper
 
     public static TagList GetTagListFromConnectionInfo(string? dataSource, string? databaseName, SqlClientTraceInstrumentationOptions options, out string activityName)
     {
-        activityName = MicrosoftSqlServerDatabaseSystemName;
+        activityName = options.EmitNewAttributes
+            ? MicrosoftSqlServerDbSystemName
+            : MicrosoftSqlServerDbSystem;
 
-        var tags = new TagList
+        var tags = new TagList { };
+
+        if (options.EmitOldAttributes)
         {
-            { SemanticConventions.AttributeDbSystem, MicrosoftSqlServerDatabaseSystemName },
-        };
+            tags.Add(SemanticConventions.AttributeDbSystem, MicrosoftSqlServerDbSystem);
+        }
+
+        if (options.EmitNewAttributes)
+        {
+            tags.Add(SemanticConventions.AttributeDbSystemName, MicrosoftSqlServerDbSystemName);
+        }
 
         if (dataSource != null)
         {
@@ -80,7 +91,7 @@ internal sealed class SqlActivitySourceHelper
                     tags.Add(SemanticConventions.AttributeServerPort, connectionDetails.Port);
                 }
 
-                if (activityName == MicrosoftSqlServerDatabaseSystemName)
+                if (activityName == MicrosoftSqlServerDbSystem || activityName == MicrosoftSqlServerDbSystemName)
                 {
                     activityName = connectionDetails.Port.HasValue
                         ? $"{serverAddress}:{connectionDetails.Port}" // TODO: Another opportunity to refactor SqlConnectionDetails

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -253,7 +253,17 @@ internal sealed class SqlEventSourceListener : EventListener
         }
         else
         {
-            tags.Add(SemanticConventions.AttributeDbSystem, SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName);
+            var options = SqlClientInstrumentation.TracingOptions;
+
+            if (options.EmitOldAttributes)
+            {
+                tags.Add(SemanticConventions.AttributeDbSystem, SqlActivitySourceHelper.MicrosoftSqlServerDbSystem);
+            }
+
+            if (options.EmitNewAttributes)
+            {
+                tags.Add(SemanticConventions.AttributeDbSystemName, SqlActivitySourceHelper.MicrosoftSqlServerDbSystemName);
+            }
 
             var (hasError, errorNumber, exceptionType) = ExtractErrorFromEvent(eventData);
 

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -48,6 +48,7 @@ internal static class SemanticConventions
     public const string AttributeDbJdbcDriverClassName = "db.jdbc.driver_classname";
     public const string AttributeDbName = "db.name";
     public const string AttributeDbStatement = "db.statement";
+    public const string AttributeDbSystem = "db.system";
     public const string AttributeDbOperation = "db.operation";
     public const string AttributeDbInstance = "db.instance";
     public const string AttributeDbCassandraKeyspace = "db.cassandra.keyspace";
@@ -138,9 +139,9 @@ internal static class SemanticConventions
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
     public const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
 
-    // New database conventions as of commit:
-    // https://github.com/open-telemetry/semantic-conventions/blob/25f74191d749645fdd5ec42ae661438cf2c1cf51/docs/database/database-spans.md#common-attributes
-    public const string AttributeDbSystem = "db.system";
+    // New database conventions:
+    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database
+    public const string AttributeDbSystemName = "db.system.name";
     public const string AttributeDbCollectionName = "db.collection.name";
     public const string AttributeDbNamespace = "db.namespace";
     public const string AttributeDbOperationName = "db.operation.name";

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -556,7 +556,7 @@ public class SqlClientTests : IDisposable
             samplingParameters.Tags,
             kvp => kvp.Key == SemanticConventions.AttributeDbSystem
                    && kvp.Value != null
-                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDbSystemName);
+                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDbSystem);
     }
 
     internal static void VerifySamplingParameters(SqlClientTestCase testCase, Activity activity, SamplingParameters samplingParameters)

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -469,15 +469,15 @@ public class SqlClientTests : IDisposable
             Assert.DoesNotContain(activity.Tags, tag => tag.Key == "enriched");
         }
 
-        Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
-
         if (emitOldAttributes)
         {
+            Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDbSystem, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
             Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
         }
 
         if (emitNewAttributes)
         {
+            Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDbSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystemName));
             Assert.Equal("MSSQLLocalDB.master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
         }
 
@@ -556,7 +556,7 @@ public class SqlClientTests : IDisposable
             samplingParameters.Tags,
             kvp => kvp.Key == SemanticConventions.AttributeDbSystem
                    && kvp.Value != null
-                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName);
+                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDbSystemName);
     }
 
     internal static void VerifySamplingParameters(SqlClientTestCase testCase, Activity activity, SamplingParameters samplingParameters)
@@ -564,7 +564,7 @@ public class SqlClientTests : IDisposable
         Assert.NotNull(samplingParameters.Tags);
 
         Assert.Equal(testCase.ExpectedActivityName, activity.DisplayName);
-        Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagItem(SemanticConventions.AttributeDbSystem));
+        Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDbSystem, activity.GetTagItem(SemanticConventions.AttributeDbSystem));
         Assert.Equal(testCase.ExpectedDbNamespace, activity.GetTagItem(SemanticConventions.AttributeDbName));
         Assert.Equal(testCase.ExpectedServerAddress, activity.GetTagItem(SemanticConventions.AttributeServerAddress));
         Assert.Equal(testCase.ExpectedPort, activity.GetTagItem(SemanticConventions.AttributeServerPort));
@@ -574,7 +574,7 @@ public class SqlClientTests : IDisposable
             samplingParameters.Tags,
             kvp => kvp.Key == SemanticConventions.AttributeDbSystem
                    && kvp.Value is string
-                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName);
+                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDbSystem);
 
         if (testCase.ExpectedDbNamespace != null)
         {

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -317,7 +317,6 @@ public class SqlEventSourceTests
         }
 
         Assert.Equal(ActivityKind.Client, activity.Kind);
-        Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
 
         var connectionDetails = SqlConnectionDetails.ParseFromDataSource(dataSource);
 
@@ -346,11 +345,13 @@ public class SqlEventSourceTests
 
         if (emitOldAttributes)
         {
+            Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDbSystem, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
             Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
         }
 
         if (emitNewAttributes)
         {
+            Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDbSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystemName));
             Assert.Equal("instanceName.master", activity.GetTagValue(SemanticConventions.AttributeDbNamespace));
         }
 


### PR DESCRIPTION
Introduces the new `db.system.name` attribute when the new conventions are enabled.

We're still lacking great test coverage, and this PR does not seek to improve upon that. Coming soon, though!