### PR TITLE
[Instrumentation.Owin] fix incorrect url.query attribute

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed `url.query` value that was incorrectly always set to `Microsoft.Owin.ReadableStringCollection`.
+  ([#2732](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2732))
+
 ## 1.11.0-beta.1
 
 Released 2025-Mar-05

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
@@ -94,13 +94,17 @@ internal sealed class DiagnosticsMiddleware : OwinMiddleware
 
             if (activity.IsAllDataRequested)
             {
+                var queryString = OwinInstrumentationActivitySource.Options.DisableUrlQueryRedaction
+                    ? request.QueryString.Value
+                    : RedactionHelper.GetRedactedQueryString(request.QueryString.Value);
+
                 RequestDataHelper.SetHttpMethodTag(activity, request.Method);
                 activity.SetTag(SemanticConventions.AttributeServerAddress, request.Uri.Host);
                 activity.SetTag(SemanticConventions.AttributeServerPort, request.Uri.Port);
                 activity.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, request.Protocol);
 
                 activity.SetTag(SemanticConventions.AttributeUrlPath, request.Uri.AbsolutePath);
-                activity.SetTag(SemanticConventions.AttributeUrlQuery, request.Query);
+                activity.SetTag(SemanticConventions.AttributeUrlQuery, queryString);
                 activity.SetTag(SemanticConventions.AttributeUrlScheme, owinContext.Request.Scheme);
 
                 if (request.Headers.TryGetValue("User-Agent", out var userAgent) && userAgent.Length > 0)

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
@@ -345,7 +345,8 @@ public class DiagnosticsMiddlewareTests : IDisposable
             Assert.Equal(requestUri.Host, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeServerAddress).Value);
             Assert.Equal(requestUri.Port, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeServerPort).Value);
             Assert.Equal("GET", activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeHttpRequestMethod).Value);
-            Assert.Equal(requestUri.AbsolutePath, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeUrlPath).Value);
+            Assert.Equal(expectedRequestUri.AbsolutePath, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeUrlPath).Value);
+            Assert.Equal(expectedRequestUri.Query.TrimStart('?'), activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeUrlQuery).Value);
         }
         finally
         {


### PR DESCRIPTION
Fixes #2731

## Changes

Fixes incorrect `url.query` attribute due to usage of IOwinRequest Query property which returns a collection. 
This was introduced with https://github.com/open-telemetry/opentelemetry-dotnet-contrib/commit/d5a630fe62c72be42f49309709f6a77c2058df22.
In addition this fixes the query string redaction.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
