### PR TITLE
Add db.operation.name attribute

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Add the `db.operation.name` attribute when `CommandType` is
+  `StoredProcedure` to conform to the new semantic conventions.
+  This affects you if you have opted into the new conventions.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+
 ## 1.12.0-beta.1
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add the `db.operation.name` attribute when `CommandType` is
   `StoredProcedure` to conform to the new semantic conventions.
   This affects you if you have opted into the new conventions.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TBD))
+  ([#2800](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2800))
 
 ## 1.12.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -37,6 +37,7 @@ internal sealed class SqlActivitySourceHelper
         SemanticConventions.AttributeDbSystem,
         SemanticConventions.AttributeDbSystemName,
         SemanticConventions.AttributeDbNamespace,
+        SemanticConventions.AttributeDbOperationName,
         SemanticConventions.AttributeDbStoredProcedureName,
         SemanticConventions.AttributeDbResponseStatusCode,
         SemanticConventions.AttributeErrorType,

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -115,6 +115,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
 
                                     if (options.EmitNewAttributes)
                                     {
+                                        activity.SetTag(SemanticConventions.AttributeDbOperationName, "EXECUTE");
                                         activity.SetTag(SemanticConventions.AttributeDbStoredProcedureName, commandText);
                                     }
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTestCases.json
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTestCases.json
@@ -38,7 +38,7 @@
       "db.collection.name": null,
       "db.namespace": "MSSQLLocalDB.master",
       "db.operation.batch.size": null,
-      "db.operation.name": null,
+      "db.operation.name": "EXECUTE",
       "db.query.summary": null,
       "db.query.text": null,
       "db.response.status_code": null,


### PR DESCRIPTION
I originally removed the `db.operation.name` attribute in #2693, but forgot to add it back after the final result of this discussion https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2693#discussion_r2069225825.