### PR TITLE
Add `Filter` option to `StackExchangeRedisInstrumentationOptions`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "rollForward": "latestFeature"
+    "rollForward": "latestFeature",
+    "version": "9.0.203"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "rollForward": "latestFeature",
-    "version": "9.0.203"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentati
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Enrich.set -> void
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.EnrichActivityWithTimingEvents.get -> bool
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.EnrichActivityWithTimingEvents.set -> void
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Filter.get -> System.Func<StackExchange.Redis.Profiling.IProfiledCommand!, bool>?
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.FlushInterval.get -> System.TimeSpan
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.FlushInterval.set -> void
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.SetVerboseDatabaseStatements.get -> bool

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add support for early filtering of telemetry collection via a `Filter` option
+  ([#2804](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2804))
+
 ## 1.12.0-beta.1
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -73,7 +73,14 @@ internal static class RedisProfilerEntryToActivityConverter
 
     public static Activity? ProfilerCommandToActivity(Activity? parentActivity, IProfiledCommand command, StackExchangeRedisInstrumentationOptions options)
     {
-        if (options.Filter != null && !options.Filter(command))
+        try
+        {
+            if (options.Filter != null && !options.Filter(command))
+            {
+                return null;
+            }
+        }
+        catch
         {
             return null;
         }

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -73,6 +73,11 @@ internal static class RedisProfilerEntryToActivityConverter
 
     public static Activity? ProfilerCommandToActivity(Activity? parentActivity, IProfiledCommand command, StackExchangeRedisInstrumentationOptions options)
     {
+        if (options.Filter != null && !options.Filter(command))
+        {
+            return null;
+        }
+
         var name = command.Command; // Example: SET;
         if (string.IsNullOrEmpty(name))
         {

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -23,7 +23,7 @@ public class StackExchangeRedisInstrumentationOptions
     public bool SetVerboseDatabaseStatements { get; set; }
 
     /// <summary>
-    /// Gets or sets the callback method allowing to filter out particular <see cref="IProfiledCommand"/>.
+    /// Gets or sets a callback method allowing to filter out particular <see cref="IProfiledCommand"/> instances.
     /// </summary>
     /// <remarks>
     /// The filter callback receives the <see cref="IProfiledCommand"/> for the

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -23,6 +23,16 @@ public class StackExchangeRedisInstrumentationOptions
     public bool SetVerboseDatabaseStatements { get; set; }
 
     /// <summary>
+    /// Gets or sets a filter function that determines whether or not to collect telemetry on a per command basis.
+    /// </summary>
+    /// <remarks>
+    /// The return value for the filter function is interpreted as follows:
+    /// - If filter returns `true`, the command is collected.
+    /// - If filter returns `false` or throws an exception the command is NOT collected.
+    /// </remarks>
+    public Func<IProfiledCommand, bool>? Filter { get; set; }
+
+    /// <summary>
     /// Gets or sets an action to enrich an Activity.
     /// </summary>
     /// <remarks>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -27,7 +27,7 @@ public class StackExchangeRedisInstrumentationOptions
     /// </summary>
     /// <remarks>
     /// The filter callback receives the <see cref="IProfiledCommand"/> for the
-    /// processed profiled command and should return a boolean.
+    /// processed profiled command and returns a boolean indicating whether it should be filtered out.
     /// <list type="bullet">
     /// <item>If filter returns <see langword="true"/> the event is collected.</item>
     /// <item>If filter returns <see langword="false"/> or throws an exception the event is filtered out (NOT collected).</item>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -23,12 +23,15 @@ public class StackExchangeRedisInstrumentationOptions
     public bool SetVerboseDatabaseStatements { get; set; }
 
     /// <summary>
-    /// Gets or sets a filter function that determines whether or not to collect telemetry on a per command basis.
+    /// Gets or sets the callback method allowing to filter out particular <see cref="IProfiledCommand"/>.
     /// </summary>
     /// <remarks>
-    /// The return value for the filter function is interpreted as follows:
-    /// - If filter returns `true`, the command is collected.
-    /// - If filter returns `false` or throws an exception the command is NOT collected.
+    /// The filter callback receives the <see cref="IProfiledCommand"/> for the
+    /// processed profiled command and should return a boolean.
+    /// <list type="bullet">
+    /// <item>If filter returns <see langword="true"/> the event is collected.</item>
+    /// <item>If filter returns <see langword="false"/> or throws an exception the event is filtered out (NOT collected).</item>
+    /// </list>
     /// </remarks>
     public Func<IProfiledCommand, bool>? Filter { get; set; }
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -384,14 +384,15 @@ public class StackExchangeRedisCallsInstrumentationTests
         Assert.Empty(instrumentation.InstrumentedConnections);
     }
 
-    [Fact]
-    public void FilterOption_FiltersOutSpecifiedCommands()
+    [InlineData("value1")]
+    [SkipUnlessEnvVarFoundTheory(RedisEndPointEnvVarName)]
+    public void FilterOption_FiltersOutSpecifiedCommands(string value)
     {
         var connectionOptions = new ConfigurationOptions
         {
             AbortOnConnectFail = false,
         };
-        connectionOptions.EndPoints.Add("localhost");
+        connectionOptions.EndPoints.Add(RedisEndPoint!);
 
         using var connection = ConnectionMultiplexer.Connect(connectionOptions);
         var db = connection.GetDatabase();
@@ -407,7 +408,7 @@ public class StackExchangeRedisCallsInstrumentationTests
             })
             .Build())
         {
-            db.StringSet("key1", "value1");
+            db.StringSet("key1", value);
             db.StringGet("key1");
         }
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -412,7 +412,7 @@ public class StackExchangeRedisCallsInstrumentationTests
         }
 
         Assert.Single(exportedItems);
-        Assert.Equal("SETEX", exportedItems[0].DisplayName);
+        Assert.Equal("SET", exportedItems[0].DisplayName);
     }
 
     private static void VerifyActivityData(Activity activity, bool isSet, EndPoint endPoint, bool setCommandKey = false)


### PR DESCRIPTION
Fixes #2803

## Changes
- Added a `Filter` option (in line with conventions that most libraries in this repo follow) to `StackExchangeRedisInstrumentationOptions`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
