### PR TITLE
Fix AWS SQS/SNS TraceStateNotInjected unit tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
@@ -92,14 +92,25 @@ public class RequestContextHelperTests
         // if at least one attribute is already present the whole injection is skipped.
         // We just use default trace propagator as an example which injects only traceparent and tracestate.
 
+        string traceParentValue = $"00-{TraceId}-{ParentId}-00";
         var expectedParameters = new List<KeyValuePair<string, string>>
         {
-            new("traceparent", $"00-{TraceId}-{ParentId}-00"),
+            new("traceparent", traceParentValue),
         };
 
         var originalRequest = new SQS.SendMessageRequest()
         {
-            MessageAttributes = [],
+            MessageAttributes = new Dictionary<string, SQS.MessageAttributeValue>
+            {
+                {
+                    "traceparent",
+                    new SQS.MessageAttributeValue
+                    {
+                        DataType = "String",
+                        StringValue = traceParentValue,
+                    }
+                },
+            },
         };
 
         var context = new TestRequestContext(originalRequest, new TestRequest());
@@ -107,6 +118,7 @@ public class RequestContextHelperTests
         SqsRequestContextHelper.AddAttributes(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
 
         TestsHelper.AssertMessageParameters(expectedParameters, originalRequest);
+        Assert.DoesNotContain("tracestate", originalRequest.MessageAttributes);
     }
 
     [Fact]
@@ -116,14 +128,25 @@ public class RequestContextHelperTests
         // if at least one attribute is already present the whole injection is skipped.
         // We just use default trace propagator as an example which injects only traceparent and tracestate.
 
+        string traceParentValue = $"00-{TraceId}-{ParentId}-00";
         var expectedParameters = new List<KeyValuePair<string, string>>
         {
-            new("traceparent", $"00-{TraceId}-{ParentId}-00"),
+            new("traceparent", traceParentValue),
         };
 
         var originalRequest = new SNS.PublishRequest()
         {
-            MessageAttributes = [],
+            MessageAttributes = new Dictionary<string, SNS.MessageAttributeValue>
+            {
+                {
+                    "traceparent",
+                    new SNS.MessageAttributeValue
+                    {
+                        DataType = "String",
+                        StringValue = traceParentValue,
+                    }
+                },
+            },
         };
 
         var context = new TestRequestContext(originalRequest, new TestRequest());
@@ -131,6 +154,7 @@ public class RequestContextHelperTests
         SnsRequestContextHelper.AddAttributes(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
 
         TestsHelper.AssertMessageParameters(expectedParameters, originalRequest);
+        Assert.DoesNotContain("tracestate", originalRequest.MessageAttributes);
     }
 
     private static PropagationContext CreatePropagationContext()


### PR DESCRIPTION
## Changes

The following two unit tests looked like they were missing assertions based on my understanding (which could be wrong, please let me know) of the intent of the tests:

- `SQS_AddAttributes_MessageAttributesWithTraceParent_TraceStateNotInjected`
- `SNS_AddAttributes_MessageAttributesWithTraceParent_TraceStateNotInjected`

> `public void ..._MessageAttributesWithTraceParent_...()`
> // if at least one attribute is already present...

My understand of the above is that `originalRequest.MessageAttributes` should have the `traceparent` attribute rather than be empty.

> `public void ..._TraceStateNotInjected()`
> // ... the whole injection is skipped.

My understanding of the above is that the `originalRequest.MessageAttributes` after `AddAttributes` is called should not have the `tracestate` attribute.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
