### PR TITLE
Initialize SNS/SQS MessageAttributes if needed to inject trace context

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/SnsRequestContextHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/SnsRequestContextHelper.cs
@@ -16,22 +16,29 @@ internal class SnsRequestContextHelper
     internal static void AddAttributes(IRequestContext context, IReadOnlyDictionary<string, string> attributes)
     {
         var originalRequest = context.OriginalRequest as PublishRequest;
-        if (originalRequest?.MessageAttributes == null)
+        if (originalRequest == null)
         {
             return;
         }
 
-        if (attributes.Keys.Any(originalRequest.MessageAttributes.ContainsKey))
+        if (originalRequest.MessageAttributes == null)
         {
-            // If at least one attribute is already present in the request then we skip the injection.
-            return;
+            originalRequest.MessageAttributes = new Dictionary<string, MessageAttributeValue>(attributes.Count);
         }
-
-        var attributesCount = originalRequest.MessageAttributes.Count;
-        if (attributes.Count + attributesCount > MaxMessageAttributes)
+        else
         {
-            // TODO: add logging (event source).
-            return;
+            if (attributes.Keys.Any(originalRequest.MessageAttributes.ContainsKey))
+            {
+                // If at least one attribute is already present in the request then we skip the injection.
+                return;
+            }
+
+            var attributesCount = originalRequest.MessageAttributes.Count;
+            if (attributes.Count + attributesCount > MaxMessageAttributes)
+            {
+                // TODO: add logging (event source).
+                return;
+            }
         }
 
         foreach (var param in attributes)

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
@@ -16,22 +16,29 @@ internal class SqsRequestContextHelper
     internal static void AddAttributes(IRequestContext context, IReadOnlyDictionary<string, string> attributes)
     {
         var originalRequest = context.OriginalRequest as SendMessageRequest;
-        if (originalRequest?.MessageAttributes == null)
+        if (originalRequest == null)
         {
             return;
         }
 
-        if (attributes.Keys.Any(originalRequest.MessageAttributes.ContainsKey))
+        if (originalRequest.MessageAttributes == null)
         {
-            // If at least one attribute is already present in the request then we skip the injection.
-            return;
+            originalRequest.MessageAttributes = new Dictionary<string, MessageAttributeValue>(attributes.Count);
         }
-
-        var attributesCount = originalRequest.MessageAttributes.Count;
-        if (attributes.Count + attributesCount > MaxMessageAttributes)
+        else
         {
-            // TODO: add logging (event source).
-            return;
+            if (attributes.Keys.Any(originalRequest.MessageAttributes.ContainsKey))
+            {
+                // If at least one attribute is already present in the request then we skip the injection.
+                return;
+            }
+
+            var attributesCount = originalRequest.MessageAttributes.Count;
+            if (attributes.Count + attributesCount > MaxMessageAttributes)
+            {
+                // TODO: add logging (event source).
+                return;
+            }
         }
 
         foreach (var param in attributes)

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Amazon;
 using Amazon.Runtime.Internal;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AWS.Implementation;
@@ -43,8 +44,10 @@ public class RequestContextHelperTests
         Assert.Equal(30, parameters.Count);
     }
 
-    [Fact]
-    public void SQS_AddAttributes_MessageAttributes_TraceDataInjected()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SQS_AddAttributes_MessageAttributes_TraceDataInjected(bool initializeMessageAttributes)
     {
         var expectedParameters = new List<KeyValuePair<string, string>>
         {
@@ -54,7 +57,8 @@ public class RequestContextHelperTests
 
         var originalRequest = new SQS.SendMessageRequest()
         {
-            MessageAttributes = [],
+            // The test parameter is used to simulate the AWS SDK's AWSConfigs.InitializeCollections setting.
+            MessageAttributes = initializeMessageAttributes ? [] : null,
         };
 
         var context = new TestRequestContext(originalRequest, new TestRequest());
@@ -64,8 +68,10 @@ public class RequestContextHelperTests
         TestsHelper.AssertMessageParameters(expectedParameters, originalRequest);
     }
 
-    [Fact]
-    public void SNS_AddAttributes_MessageAttributes_TraceDataInjected()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SNS_AddAttributes_MessageAttributes_TraceDataInjected(bool initializeMessageAttributes)
     {
         var expectedParameters = new List<KeyValuePair<string, string>>
         {
@@ -75,7 +81,8 @@ public class RequestContextHelperTests
 
         var originalRequest = new SNS.PublishRequest()
         {
-            MessageAttributes = [],
+            // The test parameter is used to simulate the AWS SDK's AWSConfigs.InitializeCollections setting.
+            MessageAttributes = initializeMessageAttributes ? [] : null,
         };
 
         var context = new TestRequestContext(originalRequest, new TestRequest());

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Amazon;
 using Amazon.Runtime.Internal;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AWS.Implementation;


### PR DESCRIPTION
Fixes #2808 

## Changes

Check if SNS/SQS `MessageAttributes` is null and initialize as needed so that trace context can be injected.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
