### PR TITLE
Allow custom string size limit to increase ETW buffer space efficiency

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaLogExporter.cs
@@ -90,6 +90,7 @@ public class GenevaLogExporter : GenevaBaseExporter<LogRecord>
 
         if (useMsgPackExporter)
         {
+            MessagePackSerializer.StringSizeLimitCharCount = connectionStringBuilder.PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount;
             var msgPackLogExporter = new MsgPackLogExporter(options);
             this.IsUsingUnixDomainSocket = msgPackLogExporter.IsUsingUnixDomainSocket;
             this.exportLogRecord = msgPackLogExporter.Export;

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
@@ -68,6 +68,7 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
 
         if (useMsgPackExporter)
         {
+            MessagePackSerializer.StringSizeLimitCharCount = connectionStringBuilder.PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount;
             var msgPackTraceExporter = new MsgPackTraceExporter(options);
             this.IsUsingUnixDomainSocket = msgPackTraceExporter.IsUsingUnixDomainSocket;
             this.exportActivity = msgPackTraceExporter.Export;

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Exporter.Geneva.Transports;
 using OpenTelemetry.Internal;
 
@@ -80,6 +81,9 @@ internal sealed class ConnectionStringBuilder
 
     public bool PrivatePreviewEnableAFDCorrelationIdEnrichment => this.parts.TryGetValue(nameof(this.PrivatePreviewEnableAFDCorrelationIdEnrichment), out var value)
                 && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+
+    public int PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount => this.parts.TryGetValue(nameof(this.PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount), out var value)
+                && int.TryParse(value, out var intValue) ? intValue : MessagePackSerializer.DEFAULT_STRING_SIZE_LIMIT_CHAR_COUNT;
 
     public string Endpoint
     {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/ConnectionStringBuilderTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/ConnectionStringBuilderTests.cs
@@ -240,4 +240,15 @@ public class ConnectionStringBuilderTests
         builder = new ConnectionStringBuilder("PrivatePreviewEnableAFDCorrelationIdEnrichment=false");
         Assert.False(builder.PrivatePreviewEnableAFDCorrelationIdEnrichment);
     }
+
+    [Fact]
+    public void ConnectionStringBuilder_PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount_No_Default_Value()
+    {
+        var builder = new ConnectionStringBuilder("key1=value1");
+        Assert.Equal(16383, builder.PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount);
+        builder = new ConnectionStringBuilder("PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount=1024");
+        Assert.Equal(1024, builder.PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount);
+        builder = new ConnectionStringBuilder("PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount=32767");
+        Assert.Equal(32767, builder.PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount);
+    }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -129,6 +129,33 @@ public class GenevaLogExporterTests
         Assert.Equal("ETW cannot be used on non-Windows operating systems.", exception.Message);
     }
 
+    [Fact]
+    public void ConnectionString_CustomStringSizeLimit()
+    {
+        var exporterOptions = new GenevaExporterOptions() { ConnectionString = "EtwSession=OpenTelemetry" };
+        using var exporter1 = new GenevaLogExporter(exporterOptions);
+        var defaultStringSizeLimit = (1 << 14) - 1;
+        Assert.Equal(defaultStringSizeLimit, MessagePackSerializer.StringSizeLimitCharCount);
+
+        var exporterOptions2 = new GenevaExporterOptions() { ConnectionString = "EtwSession=OpenTelemetry;PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount=65360" };
+        using var exporter2 = new GenevaLogExporter(exporterOptions2);
+        Assert.Equal(65360, MessagePackSerializer.StringSizeLimitCharCount);
+
+        var exporterOptions3 = new GenevaExporterOptions() { ConnectionString = "EtwSession=OpenTelemetry;PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount=-1" };
+        var exception3 = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            using var exporter3 = new GenevaLogExporter(exporterOptions3);
+        });
+        Assert.StartsWith("String size limit must be between 0 and 65360 characters.", exception3.Message);
+
+        var exporterOptions4 = new GenevaExporterOptions() { ConnectionString = "EtwSession=OpenTelemetry;PrivatePreviewCustomMessagePackStringSizeLimitCharacterCount=65365" };
+        var exception4 = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            using var exporter4 = new GenevaLogExporter(exporterOptions4);
+        });
+        Assert.StartsWith("String size limit must be between 0 and 65360 characters.", exception4.Message);
+    }
+
     [Theory]
     [InlineData("categoryA", "TableA")]
     [InlineData("categoryB", "TableB")]


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
