### PR TITLE
[Exporter.Geneva] Add httpUrl for HTTP server spans

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -7,6 +7,7 @@
   set using the `PrivatePreviewLogMessagePackStringSizeLimit=<CharCount>`
   connection string parameter.
   ([#2813](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2813))
+* Add httpUrl for HTTP server spans mapped from multiple attributes.
 
 ## 1.12.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -8,6 +8,7 @@
   connection string parameter.
   ([#2813](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2813))
 * Add httpUrl for HTTP server spans mapped from multiple attributes.
+  ([#2818](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2818))
 
 ## 1.12.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -296,8 +296,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             var host = httpUrlParts[1]?.ToString() ?? string.Empty;  // 1 => CS40_PART_B_HTTPURL_MAPPING_LIST["net.host.name"]
             var port = httpUrlParts[2]?.ToString();  // 2 => CS40_PART_B_HTTPURL_MAPPING_LIST["net.host.port"]
             port = port != null ? $":{port}" : string.Empty;
-            var target = httpUrlParts[3]?.ToString();  // 3 => CS40_PART_B_HTTPURL_MAPPING_LIST["http.target"]
-            target = target != null ? $"?{target}" : string.Empty;
+            var target = httpUrlParts[3]?.ToString() ?? string.Empty;  // 3 => CS40_PART_B_HTTPURL_MAPPING_LIST["http.target"]
 
             var length = scheme.Length + Uri.SchemeDelimiter.Length + host.Length + port.Length + target.Length;
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -296,7 +296,8 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
         var length = scheme.Length + Uri.SchemeDelimiter.Length + address.Length + port.Length + path.Length + query.Length;
 
-        if (length == Uri.SchemeDelimiter.Length) // No URL elements found, i.e. no address, no port, no path, no query
+        // No URL elements found, i.e. no scheme, no address, no port, no path, no query
+        if (length == Uri.SchemeDelimiter.Length)
         {
             return null;
         }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -336,6 +336,110 @@ public class GenevaTraceExporterTests
         }
     }
 
+    [Fact]
+    public void GenevaTraceExporter_ServerSpan_HttpUrl_Success()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var invocationCount = 0;
+            var exporterOptions = new GenevaExporterOptions();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GetRandomFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            using var exporter = new MsgPackTraceExporter(exporterOptions);
+
+            var m_buffer = exporter.Buffer;
+
+            // Add an ActivityListener to serialize the activity and assert that it was valid on ActivityStopped event
+
+            // Set the ActivitySourceName to the unique value of the test method name to avoid interference with
+            // the ActivitySource used by other unit tests.
+            var sourceName = GetTestMethodName();
+
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = (activitySource) => activitySource.Name == sourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded;
+            listener.ActivityStopped = (activity) =>
+            {
+                _ = exporter.SerializeActivity(activity);
+                var fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Options);
+                this.AssertHttpUrlForActivity(exporterOptions, fluentdData, activity);
+                invocationCount++;
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var source = new ActivitySource(sourceName);
+
+            // Unstable HTTP semconv: Combination of http.scheme, net.host.name, net.host.port, and http.target
+            // attributes for HTTP server spans.
+            using (var parent = source.StartActivity("HttpIn", ActivityKind.Server))
+            {
+                // https://localhost:443/wiki/Rabbit
+                parent.SetTag("http.method", "GET");
+                parent.SetTag("http.scheme", "https");
+                parent.SetTag("net.host.name", "localhost");
+                parent.SetTag("net.host.port", 443);
+                parent.SetTag("http.target", "/wiki/Rabbit");
+                using (var child = source.StartActivity("HttpOut", ActivityKind.Client))
+                {
+                    // Unstable HTTP semconv: http.url attribute for HTTP client spans.
+                    child.SetTag("http.method", "GET");
+                    child.SetTag("http.url", "https://www.wikipedia.org/wiki/Rabbit?semver=unstable");
+                    child.SetTag("http.status_code", 404);
+                }
+
+                parent?.SetTag("http.status_code", 200);
+            }
+
+            // Stable HTTP semconv: Combination of url.scheme, server.address, server.port, url.path and url.query
+            // attributes for HTTP server spans.
+            using (var parent = source.StartActivity("HttpIn", ActivityKind.Server))
+            {
+                parent.SetTag("http.request.method", "GET");
+                parent.SetTag("url.scheme", "https");
+                parent.SetTag("server.address", "localhost");
+                parent.SetTag("server.port", 443);
+                parent.SetTag("url.path", "/wiki/Rabbit");
+
+                // Stable HTTP semconv: url.full attribute for HTTP client spans.
+                using (var child = source.StartActivity("HttpOut", ActivityKind.Client))
+                {
+                    child.SetTag("http.request.method", "GET");
+                    child.SetTag("url.full", "https://www.wikipedia.org/wiki/Rabbit?semver=stable");
+                    child.SetTag("http.status_code", 404);
+                }
+
+                parent?.SetTag("http.response.status_code", 200);
+            }
+
+            Assert.Equal(4, invocationCount);
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
     [SkipUnlessPlatformMatchesFact(TestPlatform.Linux)]
     public void GenevaTraceExporter_Constructor_Missing_Agent_Linux()
     {
@@ -777,5 +881,83 @@ public class GenevaTraceExporterTests
         Assert.Equal("DateTime", timeFormat["TimeFormat"]);
 
         customChecksForActivity?.Invoke(mapping);
+    }
+
+    private void AssertHttpUrlForActivity(GenevaExporterOptions exporterOptions, object fluentdData, Activity activity)
+    {
+        /* Fluentd Forward Mode:
+        [
+            "Span",
+            [
+                [ <timestamp>, { "env_ver": "4.0", ... } ]
+            ],
+            { "TimeFormat": "DateTime" }
+        ]
+        */
+
+        var signal = (fluentdData as object[])[0] as string;
+        var TimeStampAndMappings = ((fluentdData as object[])[1] as object[])[0];
+        var timeStamp = (DateTime)(TimeStampAndMappings as object[])[0];
+        var mapping = (TimeStampAndMappings as object[])[1] as Dictionary<object, object>;
+
+        Assert.Equal((byte)activity.Kind, mapping["kind"]);
+        var tags = activity.TagObjects.ToDictionary(tag => tag.Key, tag => tag.Value);
+
+        if (activity.Kind == ActivityKind.Server)
+        {
+            // For HTTP server spans, they might contain these attributes for URL:
+            // Unstable HTTP semconv: Combination of http.scheme, net.host.name, net.host.port, and http.target attributes.
+            // Stable HTTP semconv: Combination of url.scheme, server.address, server.port, url.path and url.query attributes.
+            // They will be mapped to httpUrl by Geneva exporter in MsgPackTraceExporter.
+            Assert.DoesNotContain("http.scheme", mapping.Keys);
+            Assert.DoesNotContain("net.host.name", mapping.Keys);
+            Assert.DoesNotContain("net.host.port", mapping.Keys);
+            Assert.DoesNotContain("http.target", mapping.Keys);
+            Assert.DoesNotContain("url.scheme", mapping.Keys);
+            Assert.DoesNotContain("server.address", mapping.Keys);
+            Assert.DoesNotContain("server.port", mapping.Keys);
+            Assert.DoesNotContain("url.path", mapping.Keys);
+            Assert.DoesNotContain("url.query", mapping.Keys);
+
+            Assert.Contains("httpUrl", mapping.Keys);
+
+            Assert.Equal("GET", mapping["httpMethod"]);
+            Assert.Contains("httpUrl", mapping.Keys);
+            Assert.Equal("https://localhost:443/wiki/Rabbit", mapping["httpUrl"]);
+
+            Assert.DoesNotContain("http.status_code", mapping.Keys);
+            Assert.DoesNotContain("http.response.status_code", mapping.Keys);
+            Assert.Equal(200, Convert.ToInt32(mapping["httpStatusCode"]));
+        }
+        else if (activity.Kind == ActivityKind.Client)
+        {
+            // For HTTP client spans, they might contain this attribute for URL:
+            // Unstable HTTP semconv: http.url attribute.
+            // Stable HTTP semconv: url.full attribute.
+            // They will be mapped to httpUrl by Geneva exporter in MsgPackTraceExporter.
+            Assert.DoesNotContain("http.url", mapping.Keys);
+            Assert.DoesNotContain("url.full", mapping.Keys);
+
+            Assert.Contains("httpUrl", mapping.Keys);
+
+            Assert.Equal("GET", mapping["httpMethod"]);
+
+            if (tags.ContainsKey(MsgPackTraceExporter.HTTP_METHOD_V1))
+            {
+                Assert.Equal(tags["http.url"], mapping["httpUrl"]);
+            }
+            else if (tags.ContainsKey(MsgPackTraceExporter.HTTP_METHOD_V2))
+            {
+                Assert.Equal(tags["url.full"], mapping["httpUrl"]);
+            }
+
+            Assert.DoesNotContain("http.status_code", mapping.Keys);
+            Assert.DoesNotContain("http.response.status_code", mapping.Keys);
+            Assert.Equal(404, Convert.ToInt32(mapping["httpStatusCode"]));
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unexpected ActivityKind: {activity.Kind}. Expected either Server or Client.");
+        }
     }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
@@ -12,7 +12,7 @@ public class MsgPackTraceExporterTests
     public void CacheIfPartOfHttpUrl_KeyPresent_IndexInRange_SetsValueAndReturnsTrue()
     {
         var entry = new KeyValuePair<string, object?>("http.scheme", "https");
-        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.True(result);
         Assert.Equal("https", arr[0]);
@@ -31,7 +31,7 @@ public class MsgPackTraceExporterTests
     public void CacheIfPartOfHttpUrl_KeyNotPresent_ReturnsFalse()
     {
         var entry = new KeyValuePair<string, object?>("not.a.key", "value");
-        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.False(result);
     }
@@ -40,7 +40,7 @@ public class MsgPackTraceExporterTests
     public void CacheIfPartOfHttpUrl_NullValue_SetsNull()
     {
         var entry = new KeyValuePair<string, object?>("http.scheme", null);
-        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.True(result);
         Assert.Null(arr[0]);
@@ -60,7 +60,7 @@ public class MsgPackTraceExporterTests
     [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "http", "host", "", "/x?y=1", "http://host/x?y=1")]
     public void GetHttpUrl_ReturnsExpectedUrl(string method, string scheme, string hostOrAddress, string port, string pathOrTarget, string expected)
     {
-        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_MAPPING_DICTIONARY.Count];
         if (method == MsgPackTraceExporter.HTTP_METHOD_V1)
         {
             arr[0] = scheme;
@@ -92,7 +92,7 @@ public class MsgPackTraceExporterTests
     [Fact]
     public void GetHttpUrl_UnknownMethod_ReturnsNull()
     {
-        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var url = MsgPackTraceExporter.GetHttpUrl("not.a.method", arr);
         Assert.Null(url);
     }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
@@ -15,7 +15,7 @@ public class MsgPackTraceExporterTests
         var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.True(result);
-        Assert.Equal("https", arr[1]);
+        Assert.Equal("https", arr[0]);
     }
 
     [Fact]
@@ -43,31 +43,30 @@ public class MsgPackTraceExporterTests
         var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.True(result);
-        Assert.Null(arr[1]);
+        Assert.Null(arr[0]);
     }
 
     [Theory]
-    [InlineData("http.request.method", "", "", "", "", "://")]
-    [InlineData("http.request.method", "http", "host", "", "", "http://host")]
-    [InlineData("http.request.method", "http", "host", "8080", "/x", "http://host:8080/x")]
-    [InlineData("http.request.method", "https", "server", "443", "/api", "https://server:443/api")]
-    [InlineData("http.request.method", "http", "host", "", "/x?y=1", "http://host/x?y=1")]
-    public void GetHttpUrl_ReturnsExpectedUrl(string method, string scheme, string hostOrAddress, string port, string pathAndQuery, string expected)
+    [InlineData("", "", "", "", null)]
+    [InlineData("http", "host", "", "", "http://host")]
+    [InlineData("http", "host", "8080", "/x", "http://host:8080/x")]
+    [InlineData("https", "server", "443", "/api", "https://server:443/api")]
+    [InlineData("http", "host", "", "/x?y=1", "http://host/x?y=1")]
+    public void GetHttpUrl_ReturnsExpectedUrl(string scheme, string hostOrAddress, string port, string pathAndQuery, string? expected)
     {
         var arr = new object?[MsgPackTraceExporter.CS40_PART_B_MAPPING_DICTIONARY.Count];
-        arr[0] = method;
-        arr[1] = scheme;
-        arr[2] = hostOrAddress;
-        arr[3] = string.IsNullOrEmpty(port) ? null : port;
+        arr[0] = scheme;
+        arr[1] = hostOrAddress;
+        arr[2] = string.IsNullOrEmpty(port) ? null : port;
         if (!string.IsNullOrEmpty(pathAndQuery) && pathAndQuery.Contains('?'))
         {
             var split = pathAndQuery.Split(['?'], 2);
-            arr[4] = split[0];
-            arr[5] = split.Length > 1 ? split[1] : null;
+            arr[3] = split[0];
+            arr[4] = split.Length > 1 ? split[1] : null;
         }
         else
         {
-            arr[4] = string.IsNullOrEmpty(pathAndQuery) ? null : pathAndQuery;
+            arr[3] = string.IsNullOrEmpty(pathAndQuery) ? null : pathAndQuery;
         }
 
         var url = MsgPackTraceExporter.GetHttpUrl(arr);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Exporter.Geneva.MsgPack;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Geneva.Tests;
+
+public class MsgPackTraceExporterTests
+{
+    [Fact]
+    public void CacheIfPartOfHttpUrl_KeyPresent_IndexInRange_SetsValueAndReturnsTrue()
+    {
+        var entry = new KeyValuePair<string, object?>("http.scheme", "https");
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
+        Assert.True(result);
+        Assert.Equal("https", arr[0]);
+    }
+
+    [Fact]
+    public void CacheIfPartOfHttpUrl_KeyPresent_IndexOutOfRange_ReturnsFalse()
+    {
+        var entry = new KeyValuePair<string, object?>("http.scheme", "https");
+        var arr = Array.Empty<object?>(); // zero-length array
+        var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CacheIfPartOfHttpUrl_KeyNotPresent_ReturnsFalse()
+    {
+        var entry = new KeyValuePair<string, object?>("not.a.key", "value");
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CacheIfPartOfHttpUrl_NullValue_SetsNull()
+    {
+        var entry = new KeyValuePair<string, object?>("http.scheme", null);
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
+        Assert.True(result);
+        Assert.Null(arr[0]);
+    }
+
+    [Theory]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "", "", "", "", "://")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "", "", "http://host")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "8080", "", "http://host:8080")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "", "/path", "http://host/path")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "https", "example.com", "443", "/foo/bar", "https://example.com:443/foo/bar")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "80", "/x?y=1", "http://host:80/x?y=1")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "", "", "", "", "://")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "http", "host", "", "", "http://host")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "http", "host", "8080", "/x", "http://host:8080/x")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "https", "server", "443", "/api", "https://server:443/api")]
+    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "http", "host", "", "/x?y=1", "http://host/x?y=1")]
+    public void GetHttpUrl_ReturnsExpectedUrl(string method, string scheme, string hostOrAddress, string port, string pathOrTarget, string expected)
+    {
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        if (method == MsgPackTraceExporter.HTTP_METHOD_V1)
+        {
+            arr[0] = scheme;
+            arr[1] = hostOrAddress;
+            arr[2] = string.IsNullOrEmpty(port) ? null : port;
+            arr[3] = string.IsNullOrEmpty(pathOrTarget) ? null : pathOrTarget;
+        }
+        else if (method == MsgPackTraceExporter.HTTP_METHOD_V2)
+        {
+            arr[4] = scheme;
+            arr[5] = hostOrAddress;
+            arr[6] = string.IsNullOrEmpty(port) ? null : port;
+            if (!string.IsNullOrEmpty(pathOrTarget) && pathOrTarget.Contains('?'))
+            {
+                var split = pathOrTarget.Split(['?'], 2);
+                arr[7] = split[0];
+                arr[8] = split.Length > 1 ? split[1] : null;
+            }
+            else
+            {
+                arr[7] = string.IsNullOrEmpty(pathOrTarget) ? null : pathOrTarget;
+            }
+        }
+
+        var url = MsgPackTraceExporter.GetHttpUrl(method, arr);
+        Assert.Equal(expected, url);
+    }
+
+    [Fact]
+    public void GetHttpUrl_UnknownMethod_ReturnsNull()
+    {
+        var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING_LIST.Count];
+        var url = MsgPackTraceExporter.GetHttpUrl("not.a.method", arr);
+        Assert.Null(url);
+    }
+}

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
@@ -11,17 +11,17 @@ public class MsgPackTraceExporterTests
     [Fact]
     public void CacheIfPartOfHttpUrl_KeyPresent_IndexInRange_SetsValueAndReturnsTrue()
     {
-        var entry = new KeyValuePair<string, object?>("http.scheme", "https");
+        var entry = new KeyValuePair<string, object?>("url.scheme", "https");
         var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.True(result);
-        Assert.Equal("https", arr[0]);
+        Assert.Equal("https", arr[1]);
     }
 
     [Fact]
     public void CacheIfPartOfHttpUrl_KeyPresent_IndexOutOfRange_ReturnsFalse()
     {
-        var entry = new KeyValuePair<string, object?>("http.scheme", "https");
+        var entry = new KeyValuePair<string, object?>("url.scheme", "https");
         var arr = Array.Empty<object?>(); // zero-length array
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.False(result);
@@ -39,53 +39,38 @@ public class MsgPackTraceExporterTests
     [Fact]
     public void CacheIfPartOfHttpUrl_NullValue_SetsNull()
     {
-        var entry = new KeyValuePair<string, object?>("http.scheme", null);
+        var entry = new KeyValuePair<string, object?>("url.scheme", null);
         var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
         var result = MsgPackTraceExporter.CacheIfPartOfHttpUrl(entry, arr);
         Assert.True(result);
-        Assert.Null(arr[0]);
+        Assert.Null(arr[1]);
     }
 
     [Theory]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "", "", "", "", "://")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "", "", "http://host")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "8080", "", "http://host:8080")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "", "/path", "http://host/path")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "https", "example.com", "443", "/foo/bar", "https://example.com:443/foo/bar")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V1, "http", "host", "80", "/x?y=1", "http://host:80/x?y=1")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "", "", "", "", "://")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "http", "host", "", "", "http://host")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "http", "host", "8080", "/x", "http://host:8080/x")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "https", "server", "443", "/api", "https://server:443/api")]
-    [InlineData(MsgPackTraceExporter.HTTP_METHOD_V2, "http", "host", "", "/x?y=1", "http://host/x?y=1")]
-    public void GetHttpUrl_ReturnsExpectedUrl(string method, string scheme, string hostOrAddress, string port, string pathOrTarget, string expected)
+    [InlineData("http.request.method", "", "", "", "", "://")]
+    [InlineData("http.request.method", "http", "host", "", "", "http://host")]
+    [InlineData("http.request.method", "http", "host", "8080", "/x", "http://host:8080/x")]
+    [InlineData("http.request.method", "https", "server", "443", "/api", "https://server:443/api")]
+    [InlineData("http.request.method", "http", "host", "", "/x?y=1", "http://host/x?y=1")]
+    public void GetHttpUrl_ReturnsExpectedUrl(string method, string scheme, string hostOrAddress, string port, string pathAndQuery, string expected)
     {
         var arr = new object?[MsgPackTraceExporter.CS40_PART_B_MAPPING_DICTIONARY.Count];
-        if (method == MsgPackTraceExporter.HTTP_METHOD_V1)
+        arr[0] = method;
+        arr[1] = scheme;
+        arr[2] = hostOrAddress;
+        arr[3] = string.IsNullOrEmpty(port) ? null : port;
+        if (!string.IsNullOrEmpty(pathAndQuery) && pathAndQuery.Contains('?'))
         {
-            arr[0] = scheme;
-            arr[1] = hostOrAddress;
-            arr[2] = string.IsNullOrEmpty(port) ? null : port;
-            arr[3] = string.IsNullOrEmpty(pathOrTarget) ? null : pathOrTarget;
+            var split = pathAndQuery.Split(['?'], 2);
+            arr[4] = split[0];
+            arr[5] = split.Length > 1 ? split[1] : null;
         }
-        else if (method == MsgPackTraceExporter.HTTP_METHOD_V2)
+        else
         {
-            arr[4] = scheme;
-            arr[5] = hostOrAddress;
-            arr[6] = string.IsNullOrEmpty(port) ? null : port;
-            if (!string.IsNullOrEmpty(pathOrTarget) && pathOrTarget.Contains('?'))
-            {
-                var split = pathOrTarget.Split(['?'], 2);
-                arr[7] = split[0];
-                arr[8] = split.Length > 1 ? split[1] : null;
-            }
-            else
-            {
-                arr[7] = string.IsNullOrEmpty(pathOrTarget) ? null : pathOrTarget;
-            }
+            arr[4] = string.IsNullOrEmpty(pathAndQuery) ? null : pathAndQuery;
         }
 
-        var url = MsgPackTraceExporter.GetHttpUrl(method, arr);
+        var url = MsgPackTraceExporter.GetHttpUrl(arr);
         Assert.Equal(expected, url);
     }
 
@@ -93,7 +78,7 @@ public class MsgPackTraceExporterTests
     public void GetHttpUrl_UnknownMethod_ReturnsNull()
     {
         var arr = new object?[MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count];
-        var url = MsgPackTraceExporter.GetHttpUrl("not.a.method", arr);
+        var url = MsgPackTraceExporter.GetHttpUrl(arr);
         Assert.Null(url);
     }
 }


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

[HTTP semconv](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/http/http-spans.md#http-server-semantic-conventions): Combination of `url.scheme`, `server.address`, `server.port`, `url.path` and `url.query` attributes for HTTP server spans.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
