### PR TITLE
[Resources.ProcessRuntime] Allow preview versions

### DIFF
--- a/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
@@ -21,7 +21,7 @@ public class ProcessRuntimeDetectorTests
         Assert.Equal(".NET Framework", resourceAttributes[ProcessRuntimeSemanticConventions.AttributeProcessRuntimeName]);
         Assert.Matches(@"^4.[1-9](.[1-2])?$", resourceAttributes[ProcessRuntimeSemanticConventions.AttributeProcessRuntimeVersion]);
 #else
-        Assert.Matches(@"^\.NET \d+\.\d+\.\d+$", resourceAttributes[ProcessRuntimeSemanticConventions.AttributeProcessRuntimeDescription]);
+        Assert.Matches(@"^\.NET \d+\.\d+\.\d+(\-(preview|rc)\.\d+\.\d+\.\d+)?$", resourceAttributes[ProcessRuntimeSemanticConventions.AttributeProcessRuntimeDescription]);
         Assert.Equal(".NET", resourceAttributes[ProcessRuntimeSemanticConventions.AttributeProcessRuntimeName]);
         Assert.Matches(@"^\d+\.\d+\.\d+$", resourceAttributes[ProcessRuntimeSemanticConventions.AttributeProcessRuntimeVersion]);
 #endif


### PR DESCRIPTION
## Changes

Update assertion to not fail if a preview or release candidate version of .NET is being used.

See #2822.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
