### PR TITLE
[WCF] Skip ServiceHost tests if non-elevated

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/RunAsAdminTheoryAttribute.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/RunAsAdminTheoryAttribute.cs
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Security.Principal;
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Tests;
+
+/// <summary>
+/// Attribute that is applied to a method to indicate that it is a fact that should be run by the test runner
+/// if the user account running the test has administrative privileges. This class cannot be inherited.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class RunAsAdminTheoryAttribute : TheoryAttribute
+{
+    public RunAsAdminTheoryAttribute()
+        : base()
+    {
+        this.Skip = IsCurrentUserAdmin(out string name) ? null : $"The current user '{name}' does not have administrative privileges.";
+    }
+
+    internal static bool IsCurrentUserAdmin() => IsCurrentUserAdmin(out string _);
+
+    private static bool IsCurrentUserAdmin(out string name)
+    {
+#if NET
+        if (!OperatingSystem.IsWindows())
+        {
+            name = Environment.UserName;
+            return false;
+        }
+#endif
+
+        using var identity = WindowsIdentity.GetCurrent();
+        name = identity.Name;
+
+        return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+    }
+}


### PR DESCRIPTION
## Changes

- Skip `TelemetryContextPropagatesTest` if the tests are run as a non-elevated user.
- Move `ServiceHost` setup to its own class and use per-test so that the operation is deferred until after the skip check has determined that the test should run.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
