### PR TITLE
[Instrumentation.EntityFrameworkCore] Add component owners

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -35,6 +35,9 @@ components:
     - g7ed6e
   src/OpenTelemetry.Instrumentation.ElasticsearchClient/:
     - ejsmith
+  src/OpenTelemetry.Instrumentation.EntityFrameworkCore/:
+    - martincostello
+    - matt-hensley
   src/OpenTelemetry.Instrumentation.EventCounters/:
     - hananiel
     - mic-max

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -125,6 +125,9 @@ components:
     - g7ed6e
   test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/:
     - ejsmith
+  test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/:
+    - martincostello
+    - matt-hensley
   test/OpenTelemetry.Instrumentation.EventCounters.Tests/:
     - hananiel
     - mic-max

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/README.md
@@ -2,8 +2,8 @@
 
 | Status        |           |
 | ------------- |-----------|
-| Stability     |  [Beta](../../README.md#beta)|
-| Code Owners   ||
+| Stability     | [Beta](../../README.md#beta) |
+| Code Owners   | [@martincostello](https://github.com/martincostello), [@matt-hensley](https://github.com/matt-hensley) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.EntityFrameworkCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EntityFrameworkCore)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.EntityFrameworkCore)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.EntityFrameworkCore)


### PR DESCRIPTION
Fixes #888.

@matt-hensley and I are happy to take on the component ownership for the OpenTelemetry.Instrumentation.EntityFrameworkCore as part of our OpenTelemetry work at Grafana.

## Changes

Add component owners for OpenTelemetry.Instrumentation.EntityFrameworkCore.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
