### PR TITLE
[Extensions] Improve assertions

### DIFF
--- a/test/OpenTelemetry.Extensions.Tests/Trace/RateLimitingSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/RateLimitingSamplerTests.cs
@@ -102,7 +102,7 @@ public class RateLimitingSamplerTests
 
         // Assert - We should have sampled in 5 traces per second over duration
         // Adding in a fudge factor
-        Assert.True(sampleIn > (approxSamples * 0.9) && sampleIn < (approxSamples * 1.1));
-        Assert.True(sampleOut == (CYCLES - sampleIn));
+        Assert.InRange(sampleIn, approxSamples * 0.9, approxSamples * 1.1);
+        Assert.Equal(sampleOut, CYCLES - sampleIn);
     }
 }


### PR DESCRIPTION
## Changes

Improve assertions so that failures report useful information about why the assertion failed.

[Example before](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/15534139464/job/43729300711?pr=2827#step:7:67):

```text
  Failed OpenTelemetry.Extensions.Tests.Trace.RateLimitingSamplerTests.ShouldFilter_WhenAboveRateLimit [9 s]
  Error Message:
   Assert.True() Failure
Expected: True
Actual:   False
  Stack Trace:
     at OpenTelemetry.Extensions.Tests.Trace.RateLimitingSamplerTests.<ShouldFilter_WhenAboveRateLimit>d__1.MoveNext() in D:\a\opentelemetry-dotnet-contrib\opentelemetry-dotnet-contrib\test\OpenTelemetry.Extensions.Tests\Trace\RateLimitingSamplerTests.cs:line 106
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
