### PR TITLE
[Instrumentation.Cassandra] Bump min Cassandra package to 3.17.0

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -47,7 +47,7 @@
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.11.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.6.122,3.0)</StackExchangeRedisPkgVer>
     <ConfluentKafkaPkgVer>[2.4.0,3.0)</ConfluentKafkaPkgVer>
-    <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>
+    <CassandraCSharpDriverPkgVer>[3.17.0,4.0)</CassandraCSharpDriverPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.556,2.0)</StyleCopAnalyzersPkgVer>
     <SystemNetHttp>[4.3.4,)</SystemNetHttp>
     <SystemReflectionEmitLightweightPkgVer>[4.7.0,)</SystemReflectionEmitLightweightPkgVer>

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Updated OpenTelemetry core component version(s) to `1.12.0`.
   ([#2725](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2725))
-* bumped min version of Cassandra to 3.17.0 ([#2836)(https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2836))
+* Updated CassandraCSharpDriver to `3.17.0`.
+  ([#2836](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2836))
 
 ## 1.0.0-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Updated OpenTelemetry core component version(s) to `1.12.0`.
   ([#2725](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2725))
+* bumped min version of Cassandra to 3.17.0 ([#2836)(https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2836))
 
 ## 1.0.0-beta.2
 


### PR DESCRIPTION
## Changes

In the 3.1.16 version of Cassandra the upper bound limit on [System.Threading.Tasks.Dataflow](https://www.nuget.org/packages/System.Threading.Tasks.Dataflow/) has been known to cause conflicts on newer TFM so package has been bumped 1 minor to address that

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
