### PR TITLE
[Infra] Update Dockerfiles with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       day: "wednesday"
     labels:
       - "infra"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
   - package-ecosystem: "docker"
     directory: "test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests"
     schedule:
@@ -20,6 +25,11 @@ updates:
       day: "wednesday"
     labels:
       - "infra"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
   - package-ecosystem: "docker"
     directory: "test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests"
     schedule:
@@ -27,6 +37,11 @@ updates:
       day: "wednesday"
     labels:
       - "infra"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
   - package-ecosystem: "dotnet-sdk"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,27 @@ updates:
       interval: "daily"
     labels:
       - "infra"
+  - package-ecosystem: "docker"
+    directory: "test/OpenTelemetry.Instrumentation.Cassandra.Tests"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
+  - package-ecosystem: "docker"
+    directory: "test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
+  - package-ecosystem: "docker"
+    directory: "test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
   - package-ecosystem: "dotnet-sdk"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,31 +7,7 @@ updates:
     labels:
       - "infra"
   - package-ecosystem: "docker"
-    directory: "test/OpenTelemetry.Instrumentation.Cassandra.Tests"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    labels:
-      - "infra"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-  - package-ecosystem: "docker"
-    directory: "test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    labels:
-      - "infra"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-  - package-ecosystem: "docker"
-    directory: "test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests"
+    directories: ["**/*"]
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
## Changes

Update dependabot configuration to keep the SDK versions in the Dockerfiles up-to-date on a weekly basis to match the .NET SDK in `global.json`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
