### PR TITLE
[SqlClient] Delete redundant unused SqlClient integration test

### DIFF
--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -3,12 +3,10 @@
 
 #if NETFRAMEWORK
 using System.Data;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
 


### PR DESCRIPTION
No CI was configured to run this .NET Framework integration test. We already have another integration test that runs on both .NET and .NET Framework.