### PR TITLE
[Instrumentation.ConfluentKafka] rethrow exception on consume and process

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -20,6 +20,9 @@
 * Updated OpenTelemetry core component version(s) to `1.12.0`.
   ([#2725](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2725))
 
+* Rethrow exception on consume and process.
+  ([#2847](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2847))
+
 ## 0.1.0-alpha.2
 
 Released 2024-Sep-18

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -115,6 +115,7 @@ public static class OpenTelemetryConsumeResultExtensions
         {
             processActivity?.SetStatus(ActivityStatusCode.Error);
             processActivity?.SetTag(SemanticConventions.AttributeErrorType, ex.GetType().FullName);
+            throw;
         }
         finally
         {


### PR DESCRIPTION
Fixes #2843 

## Changes

Rethrow exception on ConsumeAndProcessMessageAsync extension message

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
