### PR TITLE
[Infra] Fix flaky test

### DIFF
--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/AWSClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/AWSClientInstrumentationOptionsTests.cs
@@ -12,9 +12,6 @@ using OpenTelemetry.Instrumentation.AWS.Tests.Tools;
 using OpenTelemetry.Trace;
 using Xunit;
 
-// Avoid mutations to RuntimePipelineCustomizerRegistry.Instance causing flaky tests
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
-
 namespace OpenTelemetry.Instrumentation.AWS.Tests;
 
 /// <summary>

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+// Avoid mutations to RuntimePipelineCustomizerRegistry.Instance causing flaky tests
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Changes

Fix flaky AWS instrumentation tests ([example](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/15870949396/job/44747162596)).

```text
[xUnit.net 00:00:00.73]       Assert.Equal() Failure: Values differ
[xUnit.net 00:00:00.73]     OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientInstrumentation.TestBedrockRuntimeInvokeModelSuccessful [FAIL]
[xUnit.net 00:00:00.73]       Expected: amazon.titan-text-express-v1
[xUnit.net 00:00:00.73]       Actual:   null
[xUnit.net 00:00:00.73]       Stack Trace:
[xUnit.net 00:00:00.73]         /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs([64](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/15870949396/job/44747162596#step:8:65)9,0): at OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientInstrumentation.ValidateBedrockRuntimeActivityTags(Activity bedrock_activity)
[xUnit.net 00:00:00.73]         /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs(380,0): at OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientInstrumentation.TestBedrockRuntimeInvokeModelSuccessful()
[xUnit.net 00:00:00.73]         --- End of stack trace from previous location ---
  Passed OpenTelemetry.Instrumentation.AWS.Tests.Implementation.RequestContextHelperTests.AddAttributes_ParametersCollectionSizeReachesLimit_TraceDataNotInjected(serviceType: "SNS") [< 1 ms]
  Passed OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientMetricsInstrumentation.TestS3PutObjectSuccessful [297 ms]
  Passed OpenTelemetry.Instrumentation.AWS.Tests.AWSClientInstrumentationOptionsTests.CanUseSemanticConvention_V1_29_0 [430 ms]
  Passed OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientInstrumentation.TestBedrockGetGuardrailSuccessful [447 ms]
  Passed OpenTelemetry.Instrumentation.AWS.Tests.AWSClientInstrumentationOptionsTests.CanUseSemanticConvention_V1_28_0 [13 ms]
  Failed OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientInstrumentation.TestBedrockRuntimeInvokeModelSuccessful [8 ms]
  Error Message:
   Assert.Equal() Failure: Values differ
Expected: amazon.titan-text-express-v1
Actual:   null
  Stack Trace:
     at OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientInstrumentation.ValidateBedrockRuntimeActivityTags(Activity bedrock_activity) in /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs:line 649
   at OpenTelemetry.Instrumentation.AWS.Tests.TestAWSClientInstrumentation.TestBedrockRuntimeInvokeModelSuccessful() in /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs:line 3[80](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/15870949396/job/44747162596#step:8:81)
--- End of stack trace from previous location ---
```

Tested by running the following for 25 minutes on my laptop with no errors:

```powershell
while ($LASTEXITCODE -eq 0) { dotnet test }
```

Before the change, it failed within 2 minutes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
