### PR TITLE
[Grpc] Fix flaky test

### DIFF
--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
@@ -176,11 +176,15 @@ internal class FoobarService : Foobar.FoobarBase
     }
 
     /// <inheritdoc/>
-    public override Task<FoobarResponse> Unary(FoobarRequest request, ServerCallContext context)
+    public async override Task<FoobarResponse> Unary(FoobarRequest request, ServerCallContext context)
     {
         this.CheckForFailure(context);
 
-        return Task.FromResult(DefaultResponseMessage);
+        // Yield to avoid race-condition where tests for disposal before the
+        // request completes fail as the call is completed before Dispose() completes.
+        await Task.Yield();
+
+        return DefaultResponseMessage;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Changes

Attempt to fix [test failure](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/15895059614/job/44824744896?pr=2866#step:8:35) if an async unary call completes before the call can be disposed.

```text
[xUnit.net 00:00:00.95]     OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.AsyncUnaryDisposed [FAIL]
[xUnit.net 00:00:00.95]       Assert.Contains() Failure: Filter not matched in collection
[xUnit.net 00:00:00.95]       Collection: [["activityidentifier"] = a9f98[36](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/15895059614/job/44824744896?pr=2866#step:8:37)5-03c2-4222-a7fe-591c6a85ac06, ["rpc.system"] = "grpc", ["rpc.service"] = "OpenTelemetry.Instrumentation.GrpcCore.Tests.Fooba"···, ["rpc.method"] = "Unary", ["rpc.grpc.status_code"] = 0]
[xUnit.net 00:00:00.95]       Stack Trace:
[xUnit.net 00:00:00.95]         /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs(327,0): at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(Activity activity, StatusCode expectedStatusCode, Boolean recordedMessages, Boolean recordedExceptions)
[xUnit.net 00:00:00.95]         /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs(530,0): at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.TestActivityIsCancelledWhenHandlerDisposed(Action`1 clientRequestAction)
[xUnit.net 00:00:00.95]         /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs(75,0): at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.AsyncUnaryDisposed()
[xUnit.net 00:00:00.95]            at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
[xUnit.net 00:00:00.95]            at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
[xUnit.net 00:00:01.05]   Finished:    OpenTelemetry.Instrumentation.GrpcCore.Tests
  Failed OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.AsyncUnaryDisposed [22 ms]
  Error Message:
   Assert.Contains() Failure: Filter not matched in collection
Collection: [["activityidentifier"] = a9f98365-03c2-[42](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/15895059614/job/44824744896?pr=2866#step:8:43)22-a7fe-591c6a85ac06, ["rpc.system"] = "grpc", ["rpc.service"] = "OpenTelemetry.Instrumentation.GrpcCore.Tests.Fooba"···, ["rpc.method"] = "Unary", ["rpc.grpc.status_code"] = 0]
  Stack Trace:
     at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(Activity activity, StatusCode expectedStatusCode, Boolean recordedMessages, Boolean recordedExceptions) in /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs:line 327
   at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.TestActivityIsCancelledWhenHandlerDisposed(Action`1 clientRequestAction) in /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs:line 530
   at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.AsyncUnaryDisposed() in /home/runner/work/opentelemetry-dotnet-contrib/opentelemetry-dotnet-contrib/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs:line 75
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
