### PR TITLE
Support for Blazor diagnostics in Net10

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Shipped.txt
@@ -3,6 +3,8 @@ OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.AspNetCoreTraceInstrumentationOptions() -> void
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreSignalRSupport.get -> bool
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreSignalRSupport.set -> void
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreBlazorSupport.get -> bool
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreBlazorSupport.set -> void
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnrichWithException.get -> System.Action<System.Diagnostics.Activity!, System.Exception!>?
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnrichWithException.set -> void
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnrichWithHttpRequest.get -> System.Action<System.Diagnostics.Activity!, Microsoft.AspNetCore.Http.HttpRequest!>?

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
@@ -49,6 +49,8 @@ public static class AspNetCoreInstrumentationMeterProviderBuilderExtensions
              .AddMeter("Microsoft.AspNetCore.Http.Connections")
              .AddMeter("Microsoft.AspNetCore.Routing")
              .AddMeter("Microsoft.AspNetCore.Diagnostics")
-             .AddMeter("Microsoft.AspNetCore.RateLimiting");
+             .AddMeter("Microsoft.AspNetCore.RateLimiting")
+             .AddMeter("Microsoft.AspNetCore.Components")
+             .AddMeter("Microsoft.AspNetCore.Components.Server.Circuits");
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
@@ -136,5 +136,19 @@ public static class AspNetCoreInstrumentationTracerProviderBuilderExtensions
                 builder.AddSource("Microsoft.AspNetCore.SignalR.Server");
             }
         }
+
+        // Blazor activities first added in .NET 10.0
+        if (Environment.Version.Major >= 10)
+        {
+            var options = serviceProvider?.GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>().Get(optionsName);
+            if (options is null || options.EnableAspNetCoreBlazorSupport)
+            {
+                // https://github.com/dotnet/aspnetcore/blob/182e86a5943c4e0fea5fc006a88ff257bcc0fa73/src/Components/Components/src/ComponentsActivitySource.cs#L14
+                builder.AddSource("Microsoft.AspNetCore.Components");
+
+                // https://github.com/dotnet/aspnetcore/blob/182e86a5943c4e0fea5fc006a88ff257bcc0fa73/src/Components/Server/src/Circuits/CircuitActivitySource.cs#L11
+                builder.AddSource("Microsoft.AspNetCore.Components.Server.Circuits");
+            }
+        }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
@@ -119,4 +119,13 @@ public class AspNetCoreTraceInstrumentationOptions
     /// The redaction can be disabled by setting this property to <see langword="true" />.
     /// </remarks>
     internal bool DisableUrlQueryRedaction { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Blazor activities are recorded.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to true.
+    /// Only applies to .NET 10.0 or greater.
+    /// </remarks>
+    public bool EnableAspNetCoreBlazorSupport { get; set; } = true;
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Added support for listening to ASP.NET Core Blazor activities.
+  Configurable with the
+  `AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreBlazorSupport`
+  option which defaults to `true`. Only applies to .NET 10.0 or greater.
+
 ## 1.12.0
 
 Released 2025-May-05


### PR DESCRIPTION
## Changes

- adds `Microsoft.AspNetCore.Components` and `Microsoft.AspNetCore.Components.Server.Circuits` tracing sources into `AspNetCoreInstrumentationTracerProviderBuilderExtensions.AddAspNetCoreInstrumentation`
    - can be disabled by new `AspNetCoreTraceInstrumentationOptions.EnableAspNetCoreBlazorSupport` = false
- adds `Microsoft.AspNetCore.Components` and `Microsoft.AspNetCore.Components.Server.Circuits` into `AspNetCoreInstrumentationMeterProviderBuilderExtensions.AddAspNetCoreInstrumentation`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
