### PR TITLE
Allow WCF services to record exceptions if `RecordException` is set

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added server instrumentation support for `RecordException` option.
+
 ## 1.12.0-beta.1
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
@@ -104,6 +104,11 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
                 }
             }
 
+            if (WcfInstrumentationActivitySource.Options.RecordException)
+            {
+                OperationContext.Current?.Extensions.Add(new WcfOperationContext(activity));
+            }
+
             if (textMapPropagator is not TraceContextPropagator)
             {
                 Baggage.Current = ctx.Baggage;

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TracingErrorHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TracingErrorHandler.cs
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NETFRAMEWORK
+using System.Diagnostics;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Dispatcher;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
+
+internal class TracingErrorHandler : IErrorHandler
+{
+    public bool HandleError(Exception error)
+    {
+        return false;
+    }
+
+    public void ProvideFault(Exception error, MessageVersion version, ref Message fault)
+    {
+        // By rights this should be in `HandleError` instead, which would keep it from
+        // interfering with the response to the client.
+        // However, by the time `HandleError` fires, the Activity has already been stopped
+        // so the error appears after the Activity has completed.  Additionally, sometimes
+        // the context has already been disposed or otherwise lost, preventing association
+        // at all.
+        // Also it becomes very difficult to unit-test, because there is no easy `ErrorsHandled`
+        // event to listen for before checking to see whether the error was logged.
+
+        if (!WcfInstrumentationActivitySource.Options?.RecordException ?? false)
+        {
+            return;
+        }
+
+        // OperationContext.Current *should* be reliable even in async calls at .NET 4.6.2+.
+        // In older versions it may not be.
+        var context = OperationContext.Current?.Extensions.FirstOrDefault(item => item is WcfOperationContext) as WcfOperationContext;
+        var activity = context?.Activity ?? WcfInstrumentationActivitySource.ActivitySource.StartActivity(WcfInstrumentationActivitySource.UnassociatedExceptionActivityName, ActivityKind.Internal);
+
+        activity?.AddException(error);
+
+        if (activity != context?.Activity)
+        {
+            activity?.Stop();
+        }
+    }
+}
+#endif

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfInstrumentationActivitySource.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfInstrumentationActivitySource.cs
@@ -19,6 +19,7 @@ internal static class WcfInstrumentationActivitySource
     internal static readonly string ActivitySourceName = AssemblyName.Name!;
     internal static readonly string IncomingRequestActivityName = ActivitySourceName + ".IncomingRequest";
     internal static readonly string OutgoingRequestActivityName = ActivitySourceName + ".OutgoingRequest";
+    internal static readonly string UnassociatedExceptionActivityName = ActivitySourceName + ".Exception";
 
     public static ActivitySource ActivitySource { get; } = new(ActivitySourceName, Assembly.GetPackageVersion());
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfOperationContext.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfOperationContext.cs
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.ServiceModel;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
+
+internal class WcfOperationContext : IExtension<OperationContext>
+{
+    public WcfOperationContext(Activity activity)
+    {
+        this.Activity = activity;
+    }
+
+    public Activity Activity { get; }
+
+    public void Attach(OperationContext owner)
+    {
+    }
+
+    public void Detach(OperationContext owner)
+    {
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryContractBehaviorAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryContractBehaviorAttribute.cs
@@ -45,6 +45,7 @@ public sealed class TelemetryContractBehaviorAttribute : Attribute, IContractBeh
     {
 #if NETFRAMEWORK
         Guard.ThrowIfNull(dispatchRuntime);
+        dispatchRuntime.ChannelDispatcher.ErrorHandlers.Add(new TracingErrorHandler());
         TelemetryEndpointBehavior.ApplyDispatchBehaviorToEndpoint(dispatchRuntime.EndpointDispatcher);
 #endif
     }

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryEndpointBehavior.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryEndpointBehavior.cs
@@ -41,6 +41,7 @@ public class TelemetryEndpointBehavior : IEndpointBehavior
     {
 #if NETFRAMEWORK
         Guard.ThrowIfNull(endpointDispatcher);
+        endpointDispatcher.ChannelDispatcher.ErrorHandlers.Add(new TracingErrorHandler());
         ApplyDispatchBehaviorToEndpoint(endpointDispatcher);
 #endif
     }

--- a/src/OpenTelemetry.Instrumentation.Wcf/TelemetryServiceBehavior.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TelemetryServiceBehavior.cs
@@ -5,6 +5,7 @@
 using System.ServiceModel;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+using OpenTelemetry.Instrumentation.Wcf.Implementation;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Wcf;
@@ -27,6 +28,9 @@ public class TelemetryServiceBehavior : IServiceBehavior
         foreach (var channelDispatcherBase in serviceHostBase.ChannelDispatchers)
         {
             var channelDispatcher = (ChannelDispatcher)channelDispatcherBase;
+
+            channelDispatcher.ErrorHandlers.Add(new TracingErrorHandler());
+
             foreach (var endpointDispatcher in channelDispatcher.Endpoints)
             {
                 TelemetryEndpointBehavior.ApplyDispatchBehaviorToEndpoint(endpointDispatcher);


### PR DESCRIPTION
Implements #2878 

## Changes

Adds an `IErrorHandler` implementation (`TracingErrorHandler`) that gets added to the `ChannelDispatcher` instances for any instrumented services.  If the `RecordExceptions` option is set, it associates the current `Activity` with `OperationContext.Current` during the initial message inspection.  When an exception is triggered, the `TracingErrorHandler` loads the `Activity` and adds the exception to it.

Although the documentation [specifically notes](https://learn.microsoft.com/en-us/dotnet/api/system.servicemodel.dispatcher.ierrorhandler?view=netframework-4.8.1#remarks) that the `HandleError` method should be used to perform activities such as logging, I'm performing the logging in the `ProvideFault` method.  This is being done for reasons of timing--`ProvideFault` is called before the message is returned to the client and therefore before the `Activity` is stopped in `TelemetryDispatchMessageInspector.BeforeSendReply`.  This allows the exception to be properly placed inside the recorded span, prevents it from being attached to an already completed `Activity`, and ensures the `OperationContext` with the relevant information still exists.

It also simplifies the testing considerably, because I have not been able to find an event that only fires after all `HandleError` implementations have been called, so I'm forced to simply rely on predefined waits to see if the error is recorded.

As far as I am aware, the biggest potential issue with using `ProvideFault` is it will block completing the request and sending the response to the client.  I don't expect that to be an issue here, but it will rely on the good behavior of the `ActivityListener.ExceptionRecorder` implementations.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
