### PR TITLE
Add network info for hosts #2894

### DIFF
--- a/src/OpenTelemetry.Resources.Host/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Resources.Host/.publicApi/PublicAPI.Unshipped.txt
@@ -4,6 +4,9 @@ OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeIP.get -> bool
 OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeIP.set -> void
 OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeMac.get -> bool
 OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeMac.set -> void
+OpenTelemetry.Resources.Host.HostDetectorOptions.Name.get -> string?
+OpenTelemetry.Resources.Host.HostDetectorOptions.Name.set -> void
 OpenTelemetry.Resources.HostResourceBuilderExtensions
 static OpenTelemetry.Resources.HostResourceBuilderExtensions.AddHostDetector(this OpenTelemetry.Resources.ResourceBuilder! builder) -> OpenTelemetry.Resources.ResourceBuilder!
 static OpenTelemetry.Resources.HostResourceBuilderExtensions.AddHostDetector(this OpenTelemetry.Resources.ResourceBuilder! builder, OpenTelemetry.Resources.Host.HostDetectorOptions! options) -> OpenTelemetry.Resources.ResourceBuilder!
+static OpenTelemetry.Resources.HostResourceBuilderExtensions.AddHostDetector(this OpenTelemetry.Resources.ResourceBuilder! builder, System.Action<OpenTelemetry.Resources.Host.HostDetectorOptions!>? configure) -> OpenTelemetry.Resources.ResourceBuilder!

--- a/src/OpenTelemetry.Resources.Host/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Resources.Host/.publicApi/PublicAPI.Unshipped.txt
@@ -1,2 +1,9 @@
+OpenTelemetry.Resources.Host.HostDetectorOptions
+OpenTelemetry.Resources.Host.HostDetectorOptions.HostDetectorOptions() -> void
+OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeIP.get -> bool
+OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeIP.set -> void
+OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeMac.get -> bool
+OpenTelemetry.Resources.Host.HostDetectorOptions.IncludeMac.set -> void
 OpenTelemetry.Resources.HostResourceBuilderExtensions
 static OpenTelemetry.Resources.HostResourceBuilderExtensions.AddHostDetector(this OpenTelemetry.Resources.ResourceBuilder! builder) -> OpenTelemetry.Resources.ResourceBuilder!
+static OpenTelemetry.Resources.HostResourceBuilderExtensions.AddHostDetector(this OpenTelemetry.Resources.ResourceBuilder! builder, OpenTelemetry.Resources.Host.HostDetectorOptions! options) -> OpenTelemetry.Resources.ResourceBuilder!

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-* Added support for `host.ip` and `host.mac` attributes within the resource detector
+* Added ability for `host.ip` and `host.mac` attributes to be enabled
+which results in them being determined by the resource detector
+  ([#2895](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2895))
+
+* Added the ability to explicitly set the `host.name` rather than having it
+looked up from the system.
   ([#2895](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2895))
 
 ## 1.12.0-beta.1

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added support for `host.ip` and `host.mac` attributes within the resource detector
+  ([#2895](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2895))
 
 ## 1.12.0-beta.1
 

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added support for `host.ip` and `host.mac` attributes within the resource detector
+
 ## 1.12.0-beta.1
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Resources.Host/HostDetector.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetector.cs
@@ -257,6 +257,11 @@ internal sealed class HostDetector : IResourceDetector
 
     private string? GetMachineName()
     {
+        if (!string.IsNullOrEmpty(this.options.Name))
+        {
+            return this.options.Name;
+        }
+
         try
         {
             return Environment.MachineName;

--- a/src/OpenTelemetry.Resources.Host/HostDetectorOptions.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetectorOptions.cs
@@ -17,4 +17,9 @@ public class HostDetectorOptions
     /// Gets or sets a value indicating whether the IP addresses of the host are to be included as a resource attributes.
     /// </summary>
     public bool IncludeIP { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the host resource.
+    /// </summary>
+    public string? Name { get; set; }
 }

--- a/src/OpenTelemetry.Resources.Host/HostDetectorOptions.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetectorOptions.cs
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Resources.Host;
+
+/// <summary>
+/// Provides options for configuring the host resource detector.
+/// </summary>
+public class HostDetectorOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the MAC addresses of the host are to be included as a resource attributes.
+    /// </summary>
+    public bool IncludeMac { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the IP addresses of the host are to be included as a resource attributes.
+    /// </summary>
+    public bool IncludeIP { get; set; }
+}

--- a/src/OpenTelemetry.Resources.Host/HostResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry.Resources.Host/HostResourceBuilderExtensions.cs
@@ -25,11 +25,24 @@ public static class HostResourceBuilderExtensions
     /// Enables host resource detector.
     /// </summary>
     /// <param name="builder">The <see cref="ResourceBuilder"/> being configured.</param>
-    /// <param name="options">The <see cref="HostDetectorOptions"/> used to control the behavior of the resource detector.</param>
+    /// <param name="options">The <see cref="HostDetectorOptions"/> which controls the behavior of the resource detector.</param>
     /// <returns>The instance of <see cref="ResourceBuilder"/> being configured.</returns>
     public static ResourceBuilder AddHostDetector(this ResourceBuilder builder, HostDetectorOptions options)
     {
         Guard.ThrowIfNull(builder);
         return builder.AddDetector(new HostDetector(options));
+    }
+
+    /// <summary>
+    /// Enables host resource detector.
+    /// </summary>
+    /// <param name="builder">The <see cref="ResourceBuilder"/> being configured.</param>
+    /// <param name="configure">Optional callback action for configuring <see cref="HostDetectorOptions"/> which controls the behavior of the resource detector.</param>
+    /// <returns>The instance of <see cref="ResourceBuilder"/> being configured.</returns>
+    public static ResourceBuilder AddHostDetector(this ResourceBuilder builder, Action<HostDetectorOptions>? configure)
+    {
+        var options = new HostDetectorOptions();
+        configure?.Invoke(options);
+        return builder.AddHostDetector(options);
     }
 }

--- a/src/OpenTelemetry.Resources.Host/HostResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry.Resources.Host/HostResourceBuilderExtensions.cs
@@ -18,7 +18,18 @@ public static class HostResourceBuilderExtensions
     /// <returns>The instance of <see cref="ResourceBuilder"/> being configured.</returns>
     public static ResourceBuilder AddHostDetector(this ResourceBuilder builder)
     {
+        return builder.AddHostDetector(new HostDetectorOptions());
+    }
+
+    /// <summary>
+    /// Enables host resource detector.
+    /// </summary>
+    /// <param name="builder">The <see cref="ResourceBuilder"/> being configured.</param>
+    /// <param name="options">The <see cref="HostDetectorOptions"/> used to control the behavior of the resource detector.</param>
+    /// <returns>The instance of <see cref="ResourceBuilder"/> being configured.</returns>
+    public static ResourceBuilder AddHostDetector(this ResourceBuilder builder, HostDetectorOptions options)
+    {
         Guard.ThrowIfNull(builder);
-        return builder.AddDetector(new HostDetector());
+        return builder.AddDetector(new HostDetector(options));
     }
 }

--- a/src/OpenTelemetry.Resources.Host/HostSemanticConventions.cs
+++ b/src/OpenTelemetry.Resources.Host/HostSemanticConventions.cs
@@ -7,4 +7,6 @@ internal static class HostSemanticConventions
 {
     public const string AttributeHostName = "host.name";
     public const string AttributeHostId = "host.id";
+    public const string AttributeHostIp = "host.ip";
+    public const string AttributeHostMac = "host.mac";
 }

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -38,7 +38,12 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 
 using var meterProvider = Sdk.CreateMeterProviderBuilder()
-    .ConfigureResource(resource => resource.AddHostDetector())
+    .ConfigureResource(resource => resource.AddHostDetector(new HostDetectorOptions()
+        {
+            IncludeIP = true, // Optional, default is false
+            IncludeMac = false, // Optional, default is false
+            Name = "MyCustomHostName", // Optional custom host name which is used instead of the looked up name for the host.
+        }))
     // other configurations
     .Build();
 
@@ -46,7 +51,12 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 {
     builder.AddOpenTelemetry(options =>
     {
-        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddHostDetector());
+        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddHostDetector(x =>
+        {
+            x.IncludeIP = false; // Optional, default is false
+            x.IncludeMac = true; // Optional, default is false
+            x.Name = "MyCustomHostName"; // Optional custom host name which is used instead of the looked up name for the host.
+        }));
     });
 });
 ```

--- a/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
@@ -49,12 +49,18 @@ public class HostDetectorTests
     {
         var resource = ResourceBuilder.CreateEmpty().AddHostDetector().Build();
 
-        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
-        Assert.Equal(2, resourceAttributes.Count);
+        Assert.Equal(4, resourceAttributes.Count);
 
-        Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostName]);
-        Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostName]);
+        Assert.NotEmpty((string)resourceAttributes[HostSemanticConventions.AttributeHostName]);
+        Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.NotEmpty((string)resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostMac]);
+        Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostMac]).Length > 0);
+        Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostIp]);
+        Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostIp]).Length > 0);
     }
 
 #if NET
@@ -77,14 +83,21 @@ public class HostDetectorTests
                 () => throw new Exception("should not be called"),
                 () => throw new Exception("should not be called"));
             var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
-            var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
+            var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
+
+            Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostName]);
+            Assert.NotEmpty((string)resourceAttributes[HostSemanticConventions.AttributeHostName]);
+            Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostMac]);
+            Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostMac]).Length > 0);
+            Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostIp]);
+            Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostIp]).Length > 0);
             if (string.IsNullOrEmpty(expected))
             {
                 Assert.False(resourceAttributes.ContainsKey(HostSemanticConventions.AttributeHostId));
             }
             else
             {
-                Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+                Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostId]);
                 Assert.Equal(expected, resourceAttributes[HostSemanticConventions.AttributeHostId]);
             }
         }
@@ -99,8 +112,15 @@ public class HostDetectorTests
             () => MacOSMachineIdOutput,
             () => throw new Exception("should not be called"));
         var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
-        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
-        Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
+        Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostName]);
+        Assert.NotEmpty((string)resourceAttributes[HostSemanticConventions.AttributeHostName]);
+        Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.NotEmpty((string)resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostMac]);
+        Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostMac]).Length > 0);
+        Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostIp]);
+        Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostIp]).Length > 0);
         Assert.Equal("1AB2345C-03E4-57D4-A375-1234D48DE123", resourceAttributes[HostSemanticConventions.AttributeHostId]);
     }
 #endif
@@ -122,8 +142,15 @@ public class HostDetectorTests
 #endif
 
         var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
-        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
-        Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
+        Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostName]);
+        Assert.NotEmpty((string)resourceAttributes[HostSemanticConventions.AttributeHostName]);
+        Assert.IsType<string>(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.NotEmpty((string)resourceAttributes[HostSemanticConventions.AttributeHostId]);
+        Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostMac]);
+        Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostMac]).Length > 0);
+        Assert.IsType<string[]>(resourceAttributes[HostSemanticConventions.AttributeHostIp]);
+        Assert.True(((string[])resourceAttributes[HostSemanticConventions.AttributeHostIp]).Length > 0);
         Assert.Equal("windows-machine-id", resourceAttributes[HostSemanticConventions.AttributeHostId]);
     }
 


### PR DESCRIPTION
Fixes #2894 
Design discussion issue #

## Changes

Allows both the ip addresses as well as the mac addresses of the host to be set if the applicable setting is set to true (false by default). It also enables the host name to be explicitly set rather than looked up.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
