### PR TITLE
[Instrumentation.AspNet] Rename extensions methods

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/PublicAPI.Unshipped.txt
@@ -15,10 +15,10 @@ OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.Filter.ge
 OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.RecordException.get -> bool
 OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.RecordException.set -> void
-OpenTelemetry.Metrics.MeterProviderBuilderExtensions
-OpenTelemetry.Trace.TracerProviderBuilderExtensions
-static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
-static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+OpenTelemetry.Metrics.AspNetInstrumentationMeterProviderBuilderExtensions
+OpenTelemetry.Trace.AspNetInstrumentationTracerProviderBuilderExtensions
+static OpenTelemetry.Metrics.AspNetInstrumentationMeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
+static OpenTelemetry.Metrics.AspNetInstrumentationMeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!
+static OpenTelemetry.Trace.AspNetInstrumentationTracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.AspNetInstrumentationTracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
 virtual OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichFunc.Invoke(System.Web.HttpContext! context, ref System.Diagnostics.TagList tags) -> void

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationMeterProviderBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace OpenTelemetry.Metrics;
 /// <summary>
 /// Extension methods to simplify registering of ASP.NET request instrumentation.
 /// </summary>
-public static class MeterProviderBuilderExtensions
+public static class AspNetInstrumentationMeterProviderBuilderExtensions
 {
     /// <summary>
     /// Enables the incoming requests automatic data collection for ASP.NET.

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationTracerProviderBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace OpenTelemetry.Trace;
 /// <summary>
 /// Extension methods to simplify registering of ASP.NET request instrumentation.
 /// </summary>
-public static class TracerProviderBuilderExtensions
+public static class AspNetInstrumentationTracerProviderBuilderExtensions
 {
     /// <summary>
     /// Enables the incoming requests automatic data collection for ASP.NET.

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* **Breaking Change**: Renamed `MeterProviderBuilderExtensions` and
+  `TracerProviderBuilderExtensions` to
+  `AspNetInstrumentationMeterProviderBuilderExtensions`
+  and `AspNetInstrumentationTracerProviderBuilderExtensions` respectively.
+  ([#2910](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2910))
+
 ## 1.12.0-beta.1
 
 Released 2025-May-05


### PR DESCRIPTION
Towards #2909 

## Changes

[Instrumentation.AspNet] Rename extensions methods to avoid name collisions if more instrumentation packages is referenced

It is breaking change on binary level, for most cases no changes required on the code level.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
