### PR TITLE
Add Martin Costello as Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 
 [@open-telemetry/dotnet-contrib-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-approvers):
 
+* [Martin Costello](https://github.com/martincostello), Grafana Labs
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
 * [Timothy "Mothra" Lee](https://github.com/TimothyMothra)
 


### PR DESCRIPTION
Martin has been actively contributing in [not only the main repo](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6383), but also the contrib repo. I wish to propose Martin as an approver in this repo as well.

Thank you, Martin, for your contributions in improving this project, reviewing PRs, and responding to issues. Your expertise is valued, and as such, I ask that you join us as an approver.