### PR TITLE
[AWSLambda] Add faas.instance and faas.max_memory

### DIFF
--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -407,6 +407,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.OpAmp.Client"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.OpAmp.Client.Tests", "test\OpenTelemetry.OpAmp.Client.Tests\OpenTelemetry.OpAmp.Client.Tests.csproj", "{044B896A-FDC6-422F-B349-483BDE19F685}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AWS", "AWS", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+	ProjectSection(SolutionItems) = preProject
+		src\Shared\AWS\AWSSemanticConventions.Base.cs = src\Shared\AWS\AWSSemanticConventions.Base.cs
+		src\Shared\AWS\AWSSemanticConventions.cs = src\Shared\AWS\AWSSemanticConventions.cs
+		src\Shared\AWS\AWSSemanticConventions.Legacy.cs = src\Shared\AWS\AWSSemanticConventions.Legacy.cs
+		src\Shared\AWS\AWSSemanticConventions.v1.28.0.cs = src\Shared\AWS\AWSSemanticConventions.v1.28.0.cs
+		src\Shared\AWS\AWSSemanticConventions.v1.29.0.cs = src\Shared\AWS\AWSSemanticConventions.v1.29.0.cs
+		src\Shared\AWS\SemanticConventionVersion.cs = src\Shared\AWS\SemanticConventionVersion.cs
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -965,6 +975,7 @@ Global
 		{00C9F0B8-3D51-483C-821A-5889B38A144C} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
 		{B5AF4876-3970-4686-A4A9-4EA369843F1F} = {22DF5DC0-1290-4E83-A9D8-6BB7DE3B3E63}
 		{044B896A-FDC6-422F-B349-483BDE19F685} = {2097345F-4DD3-477D-BC54-A922F9B2B402}
+		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {1FCC8EEC-9E75-4FEA-AFCF-363DD33FF0B9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0816796-CDB3-47D7-8C3C-946434DE3B66}

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add `faas.instance` and `faas.max_memory` resource/span attributes.
+  ([#2928](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2928))
+
 ## 1.12.0
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
@@ -21,18 +21,16 @@ internal sealed class AWSLambdaResourceDetector : IResourceDetector
     /// <returns>Detected resource.</returns>
     public Resource Detect()
     {
-        var builder = this.semanticConventionBuilder
-            .AttributeBuilder
-            .AddAttributeCloudProviderIsAWS()
-            .AddAttributeCloudRegion(AWSLambdaUtils.GetAWSRegion())
-            .AddAttributeFaasName(AWSLambdaUtils.GetFunctionName())
-            .AddAttributeFaasVersion(AWSLambdaUtils.GetFunctionVersion());
-
-        // TODO Update semantic conventions to include this
-        builder.Add("faas.instance", AWSLambdaUtils.GetFunctionInstance()!);
-        builder.Add("faas.max_memory", AWSLambdaUtils.GetFunctionMemorySize()!);
-
-        var resourceAttributes = builder.Build();
+        var resourceAttributes =
+            this.semanticConventionBuilder
+                .AttributeBuilder
+                .AddAttributeCloudProviderIsAWS()
+                .AddAttributeCloudRegion(AWSLambdaUtils.GetAWSRegion())
+                .AddAttributeFaasName(AWSLambdaUtils.GetFunctionName())
+                .AddAttributeFaasVersion(AWSLambdaUtils.GetFunctionVersion())
+                .AddAttributeFaasInstance(AWSLambdaUtils.GetFunctionInstance())
+                .AddAttributeFaasMaxMemory(AWSLambdaUtils.GetFunctionMemorySize())
+                .Build();
 
         return new Resource(resourceAttributes);
     }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
@@ -21,14 +21,18 @@ internal sealed class AWSLambdaResourceDetector : IResourceDetector
     /// <returns>Detected resource.</returns>
     public Resource Detect()
     {
-        var resourceAttributes =
-            this.semanticConventionBuilder
-                .AttributeBuilder
-                .AddAttributeCloudProviderIsAWS()
-                .AddAttributeCloudRegion(AWSLambdaUtils.GetAWSRegion())
-                .AddAttributeFaasName(AWSLambdaUtils.GetFunctionName())
-                .AddAttributeFaasVersion(AWSLambdaUtils.GetFunctionVersion())
-                .Build();
+        var builder = this.semanticConventionBuilder
+            .AttributeBuilder
+            .AddAttributeCloudProviderIsAWS()
+            .AddAttributeCloudRegion(AWSLambdaUtils.GetAWSRegion())
+            .AddAttributeFaasName(AWSLambdaUtils.GetFunctionName())
+            .AddAttributeFaasVersion(AWSLambdaUtils.GetFunctionVersion());
+
+        // TODO Update semantic conventions to include this
+        builder.Add("faas.instance", AWSLambdaUtils.GetFunctionInstance()!);
+        builder.Add("faas.max_memory", AWSLambdaUtils.GetFunctionMemorySize()!);
+
+        var resourceAttributes = builder.Build();
 
         return new Resource(resourceAttributes);
     }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
@@ -170,20 +170,18 @@ internal class AWSLambdaUtils
     {
         var functionArn = context.InvokedFunctionArn;
 
-        var builder = this.semanticConventionBuilder
-            .AttributeBuilder
-            .AddAttributeFaasTrigger(GetFaasTrigger(input))
-            .AddAttributeFaasColdStart(isColdStart)
-            .AddAttributeFaasName(GetFunctionName(context))
-            .AddAttributeFaasExecution(context.AwsRequestId)
-            .AddAttributeFaasID(GetFaasId(functionArn))
-            .AddAttributeCloudAccountID(GetAccountId(functionArn));
-
-        // TODO Update semantic conventions to include these
-        builder.Add("faas.instance", GetFunctionInstance(context)!);
-        builder.Add("faas.max_memory", GetFunctionMemorySize(context)!);
-
-        var tags = builder.Build();
+        var tags =
+            this.semanticConventionBuilder
+                .AttributeBuilder
+                .AddAttributeFaasTrigger(GetFaasTrigger(input))
+                .AddAttributeFaasColdStart(isColdStart)
+                .AddAttributeFaasName(GetFunctionName(context))
+                .AddAttributeFaasExecution(context.AwsRequestId)
+                .AddAttributeFaasID(GetFaasId(functionArn))
+                .AddAttributeFaasInstance(GetFunctionInstance(context))
+                .AddAttributeFaasMaxMemory(GetFunctionMemorySize(context))
+                .AddAttributeCloudAccountID(GetAccountId(functionArn))
+                .Build();
 
         return tags;
     }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using Amazon.Lambda.Core;
@@ -23,6 +24,8 @@ internal class AWSLambdaUtils
     private const string AWSXRayTraceHeaderKey = "X-Amzn-Trace-Id";
     private const string FunctionName = "AWS_LAMBDA_FUNCTION_NAME";
     private const string FunctionVersion = "AWS_LAMBDA_FUNCTION_VERSION";
+    private const string FunctionMaxMemory = "AWS_LAMBDA_FUNCTION_MEMORY_SIZE";
+    private const string FunctionLogStreamName = "AWS_LAMBDA_LOG_STREAM_NAME";
 
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
     {
@@ -101,6 +104,34 @@ internal class AWSLambdaUtils
         return Environment.GetEnvironmentVariable(FunctionVersion);
     }
 
+    internal static int? GetFunctionMemorySize(ILambdaContext? context = null)
+    {
+        int? memoryLimitInMB = context?.MemoryLimitInMB;
+
+        if (!memoryLimitInMB.HasValue)
+        {
+            var value = Environment.GetEnvironmentVariable(FunctionMaxMemory);
+
+            if (!string.IsNullOrWhiteSpace(value) && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int valueMB))
+            {
+                memoryLimitInMB = valueMB;
+            }
+        }
+
+        if (memoryLimitInMB.HasValue)
+        {
+            // Convert to bytes to match semantic conventions (e.g. 128 to 134217728)
+            return memoryLimitInMB.Value * 1024 * 1024;
+        }
+
+        return null;
+    }
+
+    internal static string? GetFunctionInstance(ILambdaContext? context = null)
+    {
+        return context?.LogStreamName ?? Environment.GetEnvironmentVariable(FunctionLogStreamName);
+    }
+
     internal static IEnumerable<string>? GetHeaderValues(APIGatewayProxyRequest request, string name)
     {
         var multiValueHeader = request.MultiValueHeaders?.GetValueByKeyIgnoringCase(name);
@@ -139,16 +170,20 @@ internal class AWSLambdaUtils
     {
         var functionArn = context.InvokedFunctionArn;
 
-        var tags =
-            this.semanticConventionBuilder
-                .AttributeBuilder
-                .AddAttributeFaasTrigger(GetFaasTrigger(input))
-                .AddAttributeFaasColdStart(isColdStart)
-                .AddAttributeFaasName(GetFunctionName(context))
-                .AddAttributeFaasExecution(context.AwsRequestId)
-                .AddAttributeFaasID(GetFaasId(functionArn))
-                .AddAttributeCloudAccountID(GetAccountId(functionArn))
-                .Build();
+        var builder = this.semanticConventionBuilder
+            .AttributeBuilder
+            .AddAttributeFaasTrigger(GetFaasTrigger(input))
+            .AddAttributeFaasColdStart(isColdStart)
+            .AddAttributeFaasName(GetFunctionName(context))
+            .AddAttributeFaasExecution(context.AwsRequestId)
+            .AddAttributeFaasID(GetFaasId(functionArn))
+            .AddAttributeCloudAccountID(GetAccountId(functionArn));
+
+        // TODO Update semantic conventions to include these
+        builder.Add("faas.instance", GetFunctionInstance(context)!);
+        builder.Add("faas.max_memory", GetFunctionMemorySize(context)!);
+
+        var tags = builder.Build();
 
         return tags;
     }

--- a/src/Shared/AWS/AWSSemanticConventions.Base.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.Base.cs
@@ -439,6 +439,22 @@ internal partial class AWSSemanticConventions
         /// FaasAttributes.AttributeFaasColdstart
         /// </remarks>
         public virtual string AttributeFaasColdStart => string.Empty;
+
+        /// <summary>
+        /// The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version.
+        /// </summary>
+        /// <remarks>
+        /// FaasAttributes.AttributeFaasInstance
+        /// </remarks>
+        public virtual string AttributeFaasInstance => string.Empty;
+
+        /// <summary>
+        /// The amount of memory available to the serverless function converted to Bytes.
+        /// </summary>
+        /// <remarks>
+        /// FaasAttributes.AttributeFaasMaxMemory
+        /// </remarks>
+        public virtual string AttributeFaasMaxMemory => string.Empty;
         #endregion
 
         #region GEN AI Attributes

--- a/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
@@ -70,6 +70,8 @@ internal partial class AWSSemanticConventions
         public override string AttributeFaasVersion => "faas.version";
         public override string AttributeFaasTrigger => "faas.trigger";
         public override string AttributeFaasColdStart => "faas.coldstart";
+        public override string AttributeFaasInstance => "faas.instance";
+        public override string AttributeFaasMaxMemory => "faas.max_memory";
 
         // GEN AI Attributes
         public override string AttributeGenAiModelId => "gen_ai.request.model";

--- a/src/Shared/AWS/AWSSemanticConventions.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.cs
@@ -290,6 +290,14 @@ internal partial class AWSSemanticConventions
         public AttributeBuilderImpl AddAttributeFaasColdStart(object? value, bool addIfEmpty = false) =>
             this.awsSemanticConventions.Add(this, x => x.AttributeFaasColdStart, value, addIfEmpty);
 
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeFaasInstance"/>
+        public AttributeBuilderImpl AddAttributeFaasInstance(object? value, bool addIfEmpty = false) =>
+            this.awsSemanticConventions.Add(this, x => x.AttributeFaasInstance, value, addIfEmpty);
+
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeFaasMaxMemory"/>
+        public AttributeBuilderImpl AddAttributeFaasMaxMemory(object? value, bool addIfEmpty = false) =>
+            this.awsSemanticConventions.Add(this, x => x.AttributeFaasMaxMemory, value, addIfEmpty);
+
         #endregion
 
         #region Host

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -26,6 +26,8 @@ public class AWSLambdaWrapperTests : IDisposable
         Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
         Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME", "testfunction");
         Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_VERSION", "latest");
+        Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128");
+        Environment.SetEnvironmentVariable("AWS_LAMBDA_LOG_STREAM_NAME", "2025/07/21/[$LATEST]7b176c212e954e62adfb9b5451cb5374");
     }
 
     public void Dispose()
@@ -322,6 +324,8 @@ public class AWSLambdaWrapperTests : IDisposable
         Assert.Equal("us-east-1", resourceAttributes[ExpectedSemanticConventions.AttributeCloudRegion]);
         Assert.Equal("testfunction", resourceAttributes[ExpectedSemanticConventions.AttributeFaasName]);
         Assert.Equal("latest", resourceAttributes[ExpectedSemanticConventions.AttributeFaasVersion]);
+        Assert.Equal("2025/07/21/[$LATEST]7b176c212e954e62adfb9b5451cb5374", resourceAttributes[ExpectedSemanticConventions.AttributeFaasInstance]);
+        Assert.Equal(134217728L, resourceAttributes[ExpectedSemanticConventions.AttributeFaasMaxMemory]);
     }
 
     private void AssertSpanAttributes(Activity activity)
@@ -331,6 +335,8 @@ public class AWSLambdaWrapperTests : IDisposable
         Assert.Equal(this.sampleLambdaContext.FunctionName, activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasName));
         Assert.Equal("other", activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
         Assert.Equal("111111111111", activity.GetTagValue(ExpectedSemanticConventions.AttributeCloudAccountID));
+        Assert.Equal(this.sampleLambdaContext.LogStreamName, activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasInstance));
+        Assert.Equal(this.sampleLambdaContext.MemoryLimitInMB * 1024 * 1024, activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasMaxMemory));
     }
 
     private void AssertSpanException(Activity activity)
@@ -353,5 +359,7 @@ public class AWSLambdaWrapperTests : IDisposable
         public const string AttributeFaasID = "cloud.resource_id";
         public const string AttributeFaasTrigger = "faas.trigger";
         public const string AttributeFaasVersion = "faas.version";
+        public const string AttributeFaasInstance = "faas.instance";
+        public const string AttributeFaasMaxMemory = "faas.max_memory";
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleLambdaContext.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleLambdaContext.cs
@@ -23,9 +23,9 @@ internal class SampleLambdaContext : ILambdaContext
 
     public string? LogGroupName { get; set; }
 
-    public string? LogStreamName { get; set; }
+    public string? LogStreamName { get; set; } = "2025/07/21/[$LATEST]c53dd774881747b29e48cc58a46720e5";
 
-    public int MemoryLimitInMB { get; set; }
+    public int MemoryLimitInMB { get; set; } = 256;
 
     public TimeSpan RemainingTime { get; set; }
 }


### PR DESCRIPTION
 ## Changes

Set the [`faas.instance`](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/faas/faas-spans.md) and [`faas.max_memory`](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/model/faas/registry.yaml#L54) attributes for AWS Lambda functions, which are both recommended.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
