### PR TITLE
[Infra] Remove version from compose files

### DIFF
--- a/build/docker-compose.net8.0.yml
+++ b/build/docker-compose.net8.0.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   tests:
     build:

--- a/build/docker-compose.net9.0.yml
+++ b/build/docker-compose.net9.0.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   tests:
     build:

--- a/test/OpenTelemetry.Instrumentation.Cassandra.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Instrumentation.Cassandra.Tests/docker-compose.yml
@@ -1,4 +1,4 @@
-# Start a redis container and then run OpenTelemetry redis integration tests.
+# Start a Cassandra container and then run OpenTelemetry Cassandra integration tests.
 # This should be run from the root of the repo:
 #  opentelemetry>docker-compose --file=test/OpenTelemetry.Instrumentation.Cassandra.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
 services:

--- a/test/OpenTelemetry.Instrumentation.Cassandra.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Instrumentation.Cassandra.Tests/docker-compose.yml
@@ -1,8 +1,6 @@
 # Start a redis container and then run OpenTelemetry redis integration tests.
 # This should be run from the root of the repo:
 #  opentelemetry>docker-compose --file=test/OpenTelemetry.Instrumentation.Cassandra.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
-version: '3.7'
-
 services:
   cassandra:
     image: cassandra

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/docker-compose.yml
@@ -1,8 +1,6 @@
 # Start a kafka container and then run OpenTelemetry ConfluentKafka integration tests.
 # This should be run from the root of the repo:
 #  opentelemetry>docker-compose --file=test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
-version: '3.7'
-
 services:
   kafka:
     image: confluentinc/confluent-local

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/docker-compose.yml
@@ -1,8 +1,6 @@
 # Start a redis container and then run OpenTelemetry redis integration tests.
 # This should be run from the root of the repo:
 #  opentelemetry>docker-compose --file=test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
-version: '3.7'
-
 services:
   redis:
     image: redis


### PR DESCRIPTION
## Changes

Avoid obsolete warning from Docker Compose by removing the `version` properties.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
