### PR TITLE
[Infra] Improve CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,32 +1,32 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
 name: "CodeQL"
 
 on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
   schedule:
     - cron: '0 0 * * *' # once in a day at 00:00
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze:
-    name: Analyze
     permissions:
-      security-events: write # for github/codeql-action/analyze to upload SARIF results
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     runs-on: windows-latest
 
     strategy:
       fail-fast: false
       matrix:
-        language: ['csharp']
+        language: ['actions', 'csharp']
 
     steps:
       - name: configure Pagefile
+        if: matrix.language == 'csharp'
         uses: al-cheb/configure-pagefile-action@a3b6ebd6b634da88790d9c58d4b37a7f4a7b8708 # v1.4
         with:
           minimum-size: 8GB
@@ -35,17 +35,37 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         with:
+          build-mode: none
           languages: ${{ matrix.language }}
-
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-
-      - name: dotnet pack opentelemetry-dotnet-contrib.proj
-        run: dotnet pack opentelemetry-dotnet-contrib.proj --configuration Release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        with:
+          category: '/language:${{ matrix.language }}'
+
+  codeql:
+    if: ${{ !cancelled() }}
+    needs: [ analyze ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report status
+        shell: bash
+        env:
+          SCAN_SUCCESS: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [ "${SCAN_SUCCESS}" == "true" ]
+          then
+            echo 'CodeQL analysis successful'
+          else
+            echo 'CodeQL analysis failed'
+            exit 1
+          fi


### PR DESCRIPTION
Mirror of https://github.com/open-telemetry/opentelemetry-dotnet/pull/6415.

## Changes

- Scan pushes to main to resolve https://github.com/open-telemetry/opentelemetry-dotnet-contrib/security/code-scanning/40.
- Scan PRs to avoid introducing new issues.
- Use `build-mode: none` to avoid need to compile the code for C#.
- Enable analysis for GitHub Actions.
- Add job that allows only one status to be required for PRs so new languages can be added without reconfiguration.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
