### PR TITLE
[Infra] Fix labelling for blank issues

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -24,18 +24,19 @@ jobs:
       - name: Add labels for component found in bug issue descriptions
         shell: pwsh
         run: |
-          Import-Module .\build\scripts\add-labels.psm1
+          if (-Not [string]::IsNullOrEmpty($env:ISSUE_LABELS)) {
+            Import-Module .\build\scripts\add-labels.psm1
 
-          AddLabelsOnIssuesForComponentFoundInBody `
-            -issueNumber ${env:ISSUE_NUMBER} `
-            -issueLabels ${env:ISSUE_LABELS} `
-            -issueBody ${env:ISSUE_BODY}
+            AddLabelsOnIssuesForComponentFoundInBody `
+              -issueNumber ${env:ISSUE_NUMBER} `
+              -issueLabels ${env:ISSUE_LABELS} `
+              -issueBody ${env:ISSUE_BODY}
+          }
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-        if: ${{ env.ISSUE_LABELS != '' }}
 
   add-labels-on-pull-requests:
     permissions:

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -27,12 +27,15 @@ jobs:
           Import-Module .\build\scripts\add-labels.psm1
 
           AddLabelsOnIssuesForComponentFoundInBody `
-            -issueNumber ${{ github.event.issue.number }} `
-            -issueLabels '${{ join(github.event.issue.labels.*.name, ', ') }}' `
-            -issueBody $env:ISSUE_BODY
+            -issueNumber ${env:ISSUE_NUMBER} `
+            -issueLabels ${env:ISSUE_LABELS} `
+            -issueBody ${env:ISSUE_BODY}
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        if: ${{ env.ISSUE_LABELS != '' }}
 
   add-labels-on-pull-requests:
     permissions:
@@ -53,7 +56,8 @@ jobs:
           Import-Module .\build\scripts\add-labels.psm1
 
           AddLabelsOnPullRequestsBasedOnFilesChanged `
-            -pullRequestNumber ${{ github.event.pull_request.number }} `
+            -pullRequestNumber ${env:PR_NUMBER} `
             -labelPackagePrefix 'comp:'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -24,18 +24,16 @@ jobs:
       - name: Add labels for component found in bug issue descriptions
         shell: pwsh
         run: |
-          if (-Not [string]::IsNullOrEmpty($env:ISSUE_LABELS)) {
-            Import-Module .\build\scripts\add-labels.psm1
+          Import-Module .\build\scripts\add-labels.psm1
 
-            AddLabelsOnIssuesForComponentFoundInBody `
-              -issueNumber ${env:ISSUE_NUMBER} `
-              -issueLabels ${env:ISSUE_LABELS} `
-              -issueBody ${env:ISSUE_BODY}
-          }
+          AddLabelsOnIssuesForComponentFoundInBody `
+            -issueNumber ${env:ISSUE_NUMBER} `
+            -issueLabels ${env:ISSUE_LABELS} `
+            -issueBody ${env:ISSUE_BODY}
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
   add-labels-on-pull-requests:

--- a/build/scripts/add-labels.psm1
+++ b/build/scripts/add-labels.psm1
@@ -3,7 +3,7 @@ Import-Module $PSScriptRoot\build.psm1
 function AddLabelsOnIssuesForComponentFoundInBody {
   param(
     [Parameter(Mandatory=$true)][int]$issueNumber,
-    [Parameter(Mandatory=$true)][string]$issueLabels,
+    [Parameter(Mandatory=$true)][AllowEmptyString][string]$issueLabels,
     [Parameter(Mandatory=$true)][string]$issueBody
   )
 
@@ -17,7 +17,9 @@ function AddLabelsOnIssuesForComponentFoundInBody {
 
   gh issue edit $issueNumber --add-label $("comp:" + $component.ToLower())
 
-  if ($issueLabels.Contains('bug') -or $issueLabels.Contains('enhancement'))
+  $labels = ($issueLabels ?? "").Split(",", [System.StringSplitOptions]::RemoveEmptyEntries)
+
+  if ($labels.Contains('bug') -or $labels.Contains('enhancement'))
   {
      $componentOwners = $null
 


### PR DESCRIPTION
## Changes

- If a blank issue is opened (which has no tags) (e.g. #2960), avoid the labelling workflow [failing](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/16629013955).
- Use environment variables instead of interpolation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
