### PR TITLE
Include `ParentActivity` in `Filter` and `Enrich` of `StackExchangeRe…

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/.publicApi/PublicAPI.Unshipped.txt
@@ -1,13 +1,15 @@
+OpenTelemetry.Instrumentation.StackExchangeRedis.RedisInstrumentationContext
+OpenTelemetry.Instrumentation.StackExchangeRedis.RedisInstrumentationContext.ProfiledCommand.get -> StackExchange.Redis.Profiling.IProfiledCommand!
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation.AddConnection(StackExchange.Redis.IConnectionMultiplexer! connection) -> System.IDisposable!
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation.AddConnection(string! name, StackExchange.Redis.IConnectionMultiplexer! connection) -> System.IDisposable!
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation.Dispose() -> void
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions
-OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity!, StackExchange.Redis.Profiling.IProfiledCommand!>?
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity!, OpenTelemetry.Instrumentation.StackExchangeRedis.RedisInstrumentationContext!>?
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Enrich.set -> void
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.EnrichActivityWithTimingEvents.get -> bool
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.EnrichActivityWithTimingEvents.set -> void
-OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Filter.get -> System.Func<StackExchange.Redis.Profiling.IProfiledCommand!, bool>?
+OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Filter.get -> System.Func<OpenTelemetry.Instrumentation.StackExchangeRedis.RedisInstrumentationContext!, bool>?
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.FlushInterval.get -> System.TimeSpan
 OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions.FlushInterval.set -> void
@@ -23,4 +25,5 @@ static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentati
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, string? name, StackExchange.Redis.IConnectionMultiplexer? connection, object? serviceKey, System.Action<OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.ConfigureRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.ConfigureRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<System.IServiceProvider!, OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.ConfigureRedisInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<System.IServiceProvider!, OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentation!>! configure) -> OpenTelemetry.Trace.TracerProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -75,7 +75,7 @@ internal static class RedisProfilerEntryToActivityConverter
     {
         try
         {
-            if (options.Filter != null && !options.Filter(command))
+            if (options.Filter != null && !options.Filter(new(parentActivity, command)))
             {
                 return null;
             }
@@ -186,7 +186,7 @@ internal static class RedisProfilerEntryToActivityConverter
                 activity.AddEvent(new ActivityEvent("ResponseReceived", response));
             }
 
-            options.Enrich?.Invoke(activity, command);
+            options.Enrich?.Invoke(activity, new(parentActivity, command));
         }
 
         activity.Stop();

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/RedisInstrumentationContext.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/RedisInstrumentationContext.cs
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using StackExchange.Redis.Profiling;
+
+namespace OpenTelemetry.Instrumentation.StackExchangeRedis;
+
+/// <summary>
+/// Represents contextual information about a profiled Redis command off of which an <see cref="Activity"/> can be created.
+/// </summary>
+/// <param name="ParentActivity">
+/// The parent activity associated with the profiled command.
+/// <see cref="Activity.Current"/> is not guaranteed to be the parent activity since commands are profiled asynchronously.
+/// </param>
+/// <param name="ProfiledCommand">
+/// The profiled Redis command.
+/// </param>
+public readonly record struct RedisInstrumentationContext(
+    Activity? ParentActivity,
+    IProfiledCommand ProfiledCommand);

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using StackExchange.Redis.Profiling;
 
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis;
 
@@ -23,26 +22,26 @@ public class StackExchangeRedisInstrumentationOptions
     public bool SetVerboseDatabaseStatements { get; set; }
 
     /// <summary>
-    /// Gets or sets a callback method allowing to filter out particular <see cref="IProfiledCommand"/> instances.
+    /// Gets or sets a callback method allowing to filter out particular <see cref="RedisInstrumentationContext"/> instances.
     /// </summary>
     /// <remarks>
-    /// The filter callback receives the <see cref="IProfiledCommand"/> for the
+    /// The filter callback receives the <see cref="RedisInstrumentationContext"/> for the
     /// processed profiled command and returns a boolean indicating whether it should be filtered out.
     /// <list type="bullet">
     /// <item>If filter returns <see langword="true"/> the event is collected.</item>
     /// <item>If filter returns <see langword="false"/> or throws an exception the event is filtered out (NOT collected).</item>
     /// </list>
     /// </remarks>
-    public Func<IProfiledCommand, bool>? Filter { get; set; }
+    public Func<RedisInstrumentationContext, bool>? Filter { get; set; }
 
     /// <summary>
     /// Gets or sets an action to enrich an Activity.
     /// </summary>
     /// <remarks>
     /// <para><see cref="Activity"/>: the activity being enriched.</para>
-    /// <para><see cref="IProfiledCommand"/>: the profiled redis command from which additional information can be extracted to enrich the activity.</para>
+    /// <para><see cref="RedisInstrumentationContext"/>: the profiled redis command from which additional information can be extracted to enrich the activity.</para>
     /// </remarks>
-    public Action<Activity, IProfiledCommand>? Enrich { get; set; }
+    public Action<Activity, RedisInstrumentationContext>? Enrich { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the <see cref="StackExchangeRedisConnectionInstrumentation"/> should enrich Activity with <see cref="ActivityEvent"/> entries about the Redis command processing/lifetime. Defaults to <see langword="true"/>.


### PR DESCRIPTION
I'm the contributor creating this earlier PR: #2804
I did not know that activities are created for profiled commands in an asynchronous fashion, which means that doing the following wouldn't work as expected:
```cs
.AddRedisInstrumentation(b =>
{
	b.Filter = e =>
	{
		return Activity.Current is not null; // PROBLEM: This is always `false`
	};
})
```
This is arguably the most common reason for adding a `Filter`, and it was certainly my motivation for #2804 — this is so that "orphan" Redis commands, that is, Redis commands that are not performed in the context of some larger unit of work, are discarded and don't make it to the OTEL back-end, hammering it with not-so-useful spans.

What I did is that instead of passing only the `IProfiledCommand` which is currently being passed to `Filter` in v1.12.0-beta.2, a so-called `RedisInstrumentationContext` is being passed which additionally includes the `ParentActivity` — this construct is very similar to [NATS's `NatsInstrumentationContext`](https://github.com/nats-io/nats.net/blob/c7756475acc4f1c148817662971dc4e3ce8651cd/src/NATS.Client.Core/NatsInstrumentationContext.cs).

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
