### PR TITLE
[EFCore] Use db.system.name values

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -139,8 +139,8 @@ internal static class SemanticConventions
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
     public const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
 
-    // New database conventions:
-    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database
+    // v1.36.0 database conventions:
+    // https://github.com/open-telemetry/semantic-conventions/tree/v1.36.0/docs/database
     public const string AttributeDbCollectionName = "db.collection.name";
     public const string AttributeDbOperationName = "db.operation.name";
     public const string AttributeDbSystemName = "db.system.name";

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using OpenTelemetry.Instrumentation.EntityFrameworkCore.Implementation;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -26,6 +27,158 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         this.connection = RelationalOptionsExtension.Extract(this.contextOptions).Connection!;
 
         this.Seed();
+    }
+
+    public static TheoryData<string, string, string> DbSystemTestCases()
+    {
+        var testCases = new TheoryData<string, string, string>()
+        {
+            { "EntityFrameworkCore.OpenEdge", "openedge", "openedge" },
+            { "FileContextCore", "filecontextcore", "filecontextcore" },
+            { "Microsoft.EntityFrameworkCore.Cosmos", "cosmosdb", "azure.cosmosdb" },
+            { "Microsoft.EntityFrameworkCore.InMemory", "efcoreinmemory", "efcoreinmemory" },
+        };
+
+        // Firebird
+        string[] names =
+        [
+            "FirebirdSql.Data.FirebirdClient.FbCommand",
+            "FirebirdSql.EntityFrameworkCore.Firebird",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "firebird", "firebirdsql");
+        }
+
+        // JET
+        names =
+        [
+            "EntityFrameworkCore.Jet",
+            "EntityFrameworkCore.Jet.Data.JetCommand",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "jet", "jet");
+        }
+
+        // Microsoft SQL Server
+        names =
+        [
+            "Microsoft.Data.SqlClient.SqlCommand",
+            "Microsoft.EntityFrameworkCore.SqlServer",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "mssql", "microsoft.sql_server");
+        }
+
+        // MySQL
+        names =
+        [
+            "Devart.Data.MySql.Entity.EFCore",
+            "Devart.Data.MySql.MySqlCommand",
+            "MySql.Data.EntityFrameworkCore",
+            "MySql.Data.MySqlClient.MySqlCommand",
+            "Pomelo.EntityFrameworkCore.MySql",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "mysql", "mysql");
+        }
+
+        // Oracle Database
+        names =
+        [
+            "Devart.Data.Oracle.Entity.EFCore",
+            "Devart.Data.Oracle.OracleCommand",
+            "Oracle.EntityFrameworkCore",
+            "Oracle.ManagedDataAccess.Client.OracleCommand",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "oracle", "oracle.db");
+        }
+
+        // PostgreSQL
+        names =
+        [
+            "Devart.Data.PostgreSql.Entity.EFCore",
+            "Devart.Data.PostgreSql.PgSqlCommand",
+            "Npgsql.EntityFrameworkCore.PostgreSQL",
+            "Npgsql.NpgsqlCommand",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "postgresql", "postgresql");
+        }
+
+        // SQLite
+        names =
+        [
+            "Devart.Data.SQLite.Entity.EFCore",
+            "Microsoft.Data.Sqlite.SqliteCommand",
+            "Microsoft.EntityFrameworkCore.Sqlite",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "sqlite", "sqlite");
+        }
+
+        // SQL Server Compact
+        names =
+        [
+            "EntityFrameworkCore.SqlServerCompact35",
+            "EntityFrameworkCore.SqlServerCompact40",
+            "System.Data.SqlServerCe.SqlCeCommand",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "mssqlcompact", "mssqlcompact");
+        }
+
+        // Spanner
+        names =
+        [
+            "Google.Cloud.EntityFrameworkCore.Spanner",
+            "Google.Cloud.Spanner.Data.SpannerCommand",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "spanner", "gcp.spanner");
+        }
+
+        // Teradata
+        names =
+        [
+            "Teradata.Client.Provider.TdCommand",
+            "Teradata.EntityFrameworkCore",
+        ];
+
+        foreach (string name in names)
+        {
+            testCases.Add(name, "teradata", "teradata");
+        }
+
+        return testCases;
+    }
+
+    [Theory]
+    [MemberData(nameof(DbSystemTestCases))]
+    public void ShouldReturnCorrectAttributeValuesProviderOrCommandName(string name, string expectedDbSystem, string expectedDbSystemName)
+    {
+        var actual = EntityFrameworkDiagnosticListener.GetDbSystemNames(name);
+
+        Assert.Equal(expectedDbSystem, actual.Old);
+        Assert.Equal(expectedDbSystemName, actual.New);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using OpenTelemetry.Instrumentation.EntityFrameworkCore.Implementation;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -266,19 +265,19 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         Assert.Equal(altDisplayName ?? "main", activity.DisplayName);
 
         Assert.Equal(ActivityKind.Client, activity.Kind);
-        Assert.Equal("sqlite", activity.Tags.FirstOrDefault(t => t.Key == EntityFrameworkDiagnosticListener.AttributeDbSystem).Value);
+        Assert.Equal("sqlite", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbSystem).Value);
 
         // TBD: SqlLite not setting the DataSource so it doesn't get set.
-        Assert.DoesNotContain(activity.Tags, t => t.Key == EntityFrameworkDiagnosticListener.AttributePeerService);
+        Assert.DoesNotContain(activity.Tags, t => t.Key == "peer.service");
 
         if (!emitNewAttributes)
         {
-            Assert.Equal(altDisplayName ?? "main", activity.Tags.FirstOrDefault(t => t.Key == EntityFrameworkDiagnosticListener.AttributeDbName).Value);
+            Assert.Equal(altDisplayName ?? "main", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbName).Value);
         }
 
         if (emitNewAttributes)
         {
-            Assert.Equal(altDisplayName ?? "main", activity.Tags.FirstOrDefault(t => t.Key == EntityFrameworkDiagnosticListener.AttributeDbNamespace).Value);
+            Assert.Equal(altDisplayName ?? "main", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbNamespace).Value);
         }
 
         if (!isError)

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.SqlClient.Tests\SqlClientIntegrationTestsFixture.cs" Link="SqlClientIntegrationTestsFixture.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\EnabledOnDockerPlatformTheoryAttribute.cs" Link="Includes\EnabledOnDockerPlatformTheoryAttribute.cs" />
   </ItemGroup>


### PR DESCRIPTION
Contributes to #2973.

## Changes

- Emit the correct names for `db.system.name` as per the [v1.36.0 semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/db/#general-database-attributes).
- Refactor code that sets old and/or new attribute names to reduce branching.
- Consume the `SemantiConventions` shared code, rather than re-define constants.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
