### PR TITLE
[Infra] Remove leftover AssemblyInfo files

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("OpenTelemetry.Instrumentation.AWS.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("OpenTelemetry.Instrumentation.AWSLambda.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]


### PR DESCRIPTION
## Changes

Remove two AssemblyInfo.cs files that get missed in #2918.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
