### PR TITLE
[EFCore] Set server.port attribute 

### DIFF
--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -257,6 +257,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{1FCC8E
 		src\Shared\ServerCertificateValidationProvider.cs = src\Shared\ServerCertificateValidationProvider.cs
 		src\Shared\SpanAttributeConstants.cs = src\Shared\SpanAttributeConstants.cs
 		src\Shared\SpanHelper.cs = src\Shared\SpanHelper.cs
+		src\Shared\SqlConnectionDetails.cs = src\Shared\SqlConnectionDetails.cs
 		src\Shared\SqlProcessor.cs = src\Shared\SqlProcessor.cs
 		src\Shared\UriHelper.cs = src\Shared\UriHelper.cs
 	EndProjectSection

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Fix `db.system.name` values to follow new database semantic conventions when opted
   into using the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable.
   ([#3004](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3004))
+* Add the `server.port` resource attribute when following the new database semantic
+  conventions when opted into using the `OTEL_SEMCONV_STABILITY_OPT_IN` environment
+  variable.
+  ([#3011](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3011))
 
 ## 1.12.0-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
@@ -31,6 +31,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SqlConnectionDetails.cs" Link="Includes\SqlConnectionDetails.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -90,16 +90,21 @@ internal sealed class SqlActivitySourceHelper
             if (!string.IsNullOrEmpty(serverAddress))
             {
                 tags.Add(SemanticConventions.AttributeServerAddress, serverAddress);
-                if (connectionDetails.Port.HasValue)
+                if (connectionDetails.Port is { } port)
                 {
-                    tags.Add(SemanticConventions.AttributeServerPort, connectionDetails.Port);
+                    tags.Add(SemanticConventions.AttributeServerPort, port);
                 }
 
                 if (activityName == MicrosoftSqlServerDbSystem || activityName == MicrosoftSqlServerDbSystemName)
                 {
-                    activityName = connectionDetails.Port.HasValue
-                        ? $"{serverAddress}:{connectionDetails.Port}" // TODO: Another opportunity to refactor SqlConnectionDetails
-                        : serverAddress!;
+                    if (connectionDetails.Port is { } portNumber)
+                    {
+                        activityName = $"{serverAddress}:{portNumber}"; // TODO: Another opportunity to refactor SqlConnectionDetails
+                    }
+                    else
+                    {
+                        activityName = serverAddress!;
+                    }
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SqlConnectionDetails.cs" Link="Includes\SqlConnectionDetails.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlProcessor.cs" Link="Includes\SqlProcessor.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlStatementInfo.cs" Link="Includes\SqlStatementInfo.cs" />
   </ItemGroup>

--- a/src/Shared/SqlConnectionDetails.cs
+++ b/src/Shared/SqlConnectionDetails.cs
@@ -4,7 +4,7 @@
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
+namespace OpenTelemetry.Instrumentation;
 
 internal sealed partial class SqlConnectionDetails
 {

--- a/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SqlConnectionDetails.cs" Link="Includes\SqlConnectionDetails.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlProcessor.cs" Link="Includes\SqlProcessor.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlStatementInfo.cs" Link="Includes\SqlStatementInfo.cs" />
   </ItemGroup>

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
@@ -1,10 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using Xunit;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+namespace OpenTelemetry.Instrumentation.Tests;
 
 public class SqlConnectionDetailsTests
 {

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -423,6 +423,7 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         // TBD: SqlLite not setting the DataSource so it doesn't get set.
         Assert.DoesNotContain(activity.Tags, t => t.Key == "peer.service");
         Assert.DoesNotContain(activity.Tags, t => t.Key == "server.address");
+        Assert.DoesNotContain(activity.Tags, t => t.Key == "server.port");
 
         if (!emitNewAttributes)
         {

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -180,6 +180,13 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
             Assert.Contains(
                 activities,
                 activity => activity.Tags.Any(t => t.Key == conventions.Database));
+
+            if (conventions.ServerPort is not null)
+            {
+                Assert.Contains(
+                    activities,
+                    activity => activity.TagObjects.Any(t => t.Key == conventions.ServerPort));
+            }
         }
     }
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -30,33 +30,37 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         this.fixture = fixture;
     }
 
-    public static TheoryData<string, string, bool, bool, Type, string, string> RawSqlTestCases()
+    public static TheoryData<string, string, bool, bool, bool, Type, string, string> RawSqlTestCases()
     {
-        (string, Type, string, string)[] providers =
+        (string, Type, bool, string, string)[] providers =
         [
-            (SqliteProvider, typeof(SqliteCommand), "sqlite", "main"),
-            (SqlServerProvider, typeof(SqlCommand), "mssql", "master"),
+            (SqliteProvider, typeof(SqliteCommand), false, "sqlite", "main"),
+            (SqliteProvider, typeof(SqliteCommand), true, "sqlite", "main"),
+            (SqlServerProvider, typeof(SqlCommand), false, "mssql", "master"),
+            (SqlServerProvider, typeof(SqlCommand), true, "microsoft.sql_server", "master"),
         ];
 
-        var testCases = new TheoryData<string, string, bool, bool, Type, string, string>();
+        var testCases = new TheoryData<string, string, bool, bool, bool, Type, string, string>();
 
-        foreach ((var provider, var commandType, var system, var database) in providers)
+        foreach ((var provider, var commandType, var useNewConventions, var system, var database) in providers)
         {
-            testCases.Add(provider, "select 1/1", false, false, commandType, system, database);
-            testCases.Add(provider, "select 1/1", true, false, commandType, system, database);
+            testCases.Add(provider, "select 1/1", false, false, useNewConventions, commandType, system, database);
+            testCases.Add(provider, "select 1/1", true, false, useNewConventions, commandType, system, database);
 
             // For some reason, SQLite does not throw an exception for division by zero
-            if (provider != SqliteProvider)
+            // TODO Remove the second part of the condition when EFCore sets SemanticConventions.AttributeDbQuerySummary
+            // so that there isn't a drive between the expected span names used between SQL Server and EFCore
+            if (provider != SqliteProvider && !useNewConventions)
             {
-                testCases.Add(provider, "select 1/0", false, true, commandType, system, database);
-                testCases.Add(provider, "select 1/0", true, true, commandType, system, database);
+                testCases.Add(provider, "select 1/0", false, true, useNewConventions, commandType, system, database);
+                testCases.Add(provider, "select 1/0", true, true, useNewConventions, commandType, system, database);
             }
         }
 
         return testCases;
     }
 
-    public static TheoryData<string, bool, bool, Type, string, string> DataContextTestCases()
+    public static TheoryData<string, bool, bool, bool, Type, string, string> DataContextTestCases()
     {
         (string, Type, string, string)[] providers =
         [
@@ -66,7 +70,7 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
 
         bool[] trueFalse = [true, false];
 
-        var testCases = new TheoryData<string, bool, bool, Type, string, string>();
+        var testCases = new TheoryData<string, bool, bool, bool, Type, string, string>();
 
         foreach ((var provider, var commandType, var system, var database) in providers)
         {
@@ -74,7 +78,7 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
             {
                 foreach (var shouldEnrich in trueFalse)
                 {
-                    testCases.Add(provider, captureTextCommandContent, shouldEnrich, commandType, system, database);
+                    testCases.Add(provider, captureTextCommandContent, shouldEnrich, false, commandType, system, database);
                 }
             }
         }
@@ -89,10 +93,13 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         string commandText,
         bool captureTextCommandContent,
         bool isFailure,
+        bool useNewConventions,
         Type expectedCommandType,
         string expectedSystemName,
         string expectedDatabaseName)
     {
+        var conventions = useNewConventions ? SemanticConvention.New : SemanticConvention.Old;
+
         // In the case of SQL Server, the activity we're interested in is the one
         // created by the SqlClient instrumentation which is a child of EFCore.
         var expectedSourceName = isFailure && provider is SqlServerProvider
@@ -111,8 +118,11 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
             return true;
         }
 
+        using var scope = SemanticConventionScope.Get(useNewConventions);
+
         var activities = new List<Activity>();
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+
+        using var traceProvider = Sdk.CreateTracerProviderBuilder()
             .AddInMemoryExporter(activities)
             .AddSqlClientInstrumentation(options =>
             {
@@ -152,6 +162,7 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         VerifyActivityData(
             captureTextCommandContent,
             isFailure,
+            conventions,
             expectedSystemName,
             expectedDatabaseName,
             activity);
@@ -163,6 +174,13 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         }
 
         Assert.True(filtered);
+
+        if (!isFailure && provider is SqlServerProvider)
+        {
+            Assert.Contains(
+                activities,
+                activity => activity.Tags.Any(t => t.Key == conventions.Database));
+        }
     }
 
     [EnabledOnDockerPlatformTheory(EnabledOnDockerPlatformTheoryAttribute.DockerPlatform.Linux)]
@@ -171,10 +189,12 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         string provider,
         bool captureTextCommandContent,
         bool shouldEnrich,
+        bool useNewConventions,
         Type expectedCommandType,
         string expectedSystemName,
         string expectedDatabaseName)
     {
+        var conventions = useNewConventions ? SemanticConvention.New : SemanticConvention.Old;
         var enriched = false;
 
         void ActivityEnrichment(Activity activity, IDbCommand command)
@@ -196,6 +216,8 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
 
             return true;
         }
+
+        using var scope = SemanticConventionScope.Get(useNewConventions);
 
         var activities = new List<Activity>();
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -240,8 +262,8 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         Assert.Equal(ActivitySourceName, activity.Source.Name);
         Assert.Null(activity.Parent);
 
-        Assert.Equal(expectedSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
-        Assert.Equal(expectedDatabaseName, activity.GetTagValue(SemanticConventions.AttributeDbName));
+        Assert.Equal(expectedSystemName, activity.GetTagValue(conventions.System));
+        Assert.Equal(expectedDatabaseName, activity.GetTagValue(conventions.Database));
 
         Assert.Equal(shouldEnrich, enriched);
         Assert.True(filtered);
@@ -250,6 +272,7 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
     private static void VerifyActivityData(
         bool captureTextCommandContent,
         bool isFailure,
+        SemanticConvention conventions,
         string expectedSystemName,
         string expectedDatabaseName,
         Activity activity)
@@ -269,17 +292,16 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
             Assert.Empty(activity.Events);
         }
 
-        Assert.Equal(expectedSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
-        Assert.Equal(expectedDatabaseName, activity.GetTagValue(SemanticConventions.AttributeDbName));
+        Assert.Equal(expectedSystemName, activity.GetTagValue(conventions.System));
+        Assert.Equal(expectedDatabaseName, activity.GetTagValue(conventions.Database));
 
         if (captureTextCommandContent)
         {
-            Assert.NotNull(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+            Assert.NotNull(activity.GetTagValue(conventions.QueryText));
         }
         else
         {
-            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbQueryText));
+            Assert.Null(activity.GetTagValue(conventions.QueryText));
         }
     }
 
@@ -306,5 +328,58 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
             default:
                 throw new NotSupportedException($"Unsupported provider: {provider}");
         }
+    }
+
+    private sealed class SemanticConvention
+    {
+        public static SemanticConvention Old { get; } = new SemanticConvention
+        {
+            EmitsNewAttributes = false,
+            Database = SemanticConventions.AttributeDbName,
+            QueryText = SemanticConventions.AttributeDbStatement,
+            ServerAddress = "peer.service",
+            ServerPort = null,
+            System = SemanticConventions.AttributeDbSystem,
+        };
+
+        public static SemanticConvention New { get; } = new SemanticConvention
+        {
+            EmitsNewAttributes = true,
+            Database = SemanticConventions.AttributeDbNamespace,
+            QueryText = SemanticConventions.AttributeDbQueryText,
+            ServerAddress = SemanticConventions.AttributeServerAddress,
+            ServerPort = SemanticConventions.AttributeServerPort,
+            System = SemanticConventions.AttributeDbSystemName,
+        };
+
+        public bool EmitsNewAttributes { get; private init; }
+
+        public required string Database { get; init; }
+
+        public required string QueryText { get; init; }
+
+        public required string ServerAddress { get; init; }
+
+        public required string? ServerPort { get; init; }
+
+        public required string System { get; init; }
+    }
+
+    private sealed class SemanticConventionScope(string? previous) : IDisposable
+    {
+        private const string ConventionsOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN";
+
+        public static IDisposable Get(bool useNewConventions)
+        {
+            var previous = Environment.GetEnvironmentVariable(ConventionsOptIn);
+
+            Environment.SetEnvironmentVariable(
+                    ConventionsOptIn,
+                    useNewConventions ? "database" : string.Empty);
+
+            return new SemanticConventionScope(previous);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(ConventionsOptIn, previous);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -49,7 +49,7 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
 
             // For some reason, SQLite does not throw an exception for division by zero
             // TODO Remove the second part of the condition when EFCore sets SemanticConventions.AttributeDbQuerySummary
-            // so that there isn't a drive between the expected span names used between SQL Server and EFCore
+            // so that there isn't a drift between the expected span names used between SQL Server and EFCore
             if (provider != SqliteProvider && !useNewConventions)
             {
                 testCases.Add(provider, "select 1/0", false, true, useNewConventions, commandType, system, database);

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -121,7 +121,7 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         using var scope = SemanticConventionScope.Get(useNewConventions);
 
         var activities = new List<Activity>();
-        using var traceProvider = Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddInMemoryExporter(activities)
             .AddSqlClientInstrumentation(options =>
             {

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -375,7 +375,7 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
     {
         private const string ConventionsOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN";
 
-        public static IDisposable Get(bool useNewConventions)
+        public static SemanticConventionScope Get(bool useNewConventions)
         {
             var previous = Environment.GetEnvironmentVariable(ConventionsOptIn);
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -121,7 +121,6 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
         using var scope = SemanticConventionScope.Get(useNewConventions);
 
         var activities = new List<Activity>();
-
         using var traceProvider = Sdk.CreateTracerProviderBuilder()
             .AddInMemoryExporter(activities)
             .AddSqlClientInstrumentation(options =>
@@ -381,8 +380,8 @@ public sealed class EntityFrameworkIntegrationTests : IClassFixture<SqlClientInt
             var previous = Environment.GetEnvironmentVariable(ConventionsOptIn);
 
             Environment.SetEnvironmentVariable(
-                    ConventionsOptIn,
-                    useNewConventions ? "database" : string.Empty);
+                ConventionsOptIn,
+                useNewConventions ? "database" : string.Empty);
 
             return new SemanticConventionScope(previous);
         }


### PR DESCRIPTION
Fixes #3010

## Changes

- Make `SqlConnectionDetails` shared for reuse for EFCore.
- Use pattern matching to avoid call through `Nullable<T>.Value`.
- Use `SqlConnectionDetails` to set the `server.port` resource attribute for EFCore.
- Extend the EFCore integration tests to cover old and new database semantic conventions.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
