### PR TITLE
Add ASP.NET Core telemetry metrics and traces for .NET 10

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableBlazorSupport.get -> bool
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableBlazorSupport.set -> void

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableBlazorSupport.get -> bool
-OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableBlazorSupport.set -> void
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableRazorComponentsSupport.get -> bool
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnableRazorComponentsSupport.set -> void

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
@@ -43,7 +43,8 @@ public static class AspNetCoreInstrumentationMeterProviderBuilderExtensions
 
     internal static MeterProviderBuilder ConfigureMeters(this MeterProviderBuilder builder)
     {
-        // There is no cost to listen for meters so listen for all built-in ASP.NET Core meters.
+        // There is no cost to listen for meters that aren't used. For example, listening for Kestrel meter in an app that doesn't use Kestrel is fine.
+        // Listen for all built-in ASP.NET Core meters so metrics automatically light up depending on what an app does.
         var builtInAspNetCoreMeters = new[]
         {
             "Microsoft.AspNetCore.Hosting",

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
@@ -49,6 +49,13 @@ public static class AspNetCoreInstrumentationMeterProviderBuilderExtensions
              .AddMeter("Microsoft.AspNetCore.Http.Connections")
              .AddMeter("Microsoft.AspNetCore.Routing")
              .AddMeter("Microsoft.AspNetCore.Diagnostics")
-             .AddMeter("Microsoft.AspNetCore.RateLimiting");
+             .AddMeter("Microsoft.AspNetCore.RateLimiting")
+             .AddMeter("Microsoft.AspNetCore.Components")
+             .AddMeter("Microsoft.AspNetCore.Components.Server.Circuits")
+             .AddMeter("Microsoft.AspNetCore.Components.Lifecycle")
+             .AddMeter("Microsoft.AspNetCore.Authorization")
+             .AddMeter("Microsoft.AspNetCore.Authentication")
+             .AddMeter("Microsoft.AspNetCore.Identity")
+             .AddMeter("Microsoft.AspNetCore.MemoryPool");
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationMeterProviderBuilderExtensions.cs
@@ -43,19 +43,24 @@ public static class AspNetCoreInstrumentationMeterProviderBuilderExtensions
 
     internal static MeterProviderBuilder ConfigureMeters(this MeterProviderBuilder builder)
     {
-        return builder
-             .AddMeter("Microsoft.AspNetCore.Hosting")
-             .AddMeter("Microsoft.AspNetCore.Server.Kestrel")
-             .AddMeter("Microsoft.AspNetCore.Http.Connections")
-             .AddMeter("Microsoft.AspNetCore.Routing")
-             .AddMeter("Microsoft.AspNetCore.Diagnostics")
-             .AddMeter("Microsoft.AspNetCore.RateLimiting")
-             .AddMeter("Microsoft.AspNetCore.Components")
-             .AddMeter("Microsoft.AspNetCore.Components.Server.Circuits")
-             .AddMeter("Microsoft.AspNetCore.Components.Lifecycle")
-             .AddMeter("Microsoft.AspNetCore.Authorization")
-             .AddMeter("Microsoft.AspNetCore.Authentication")
-             .AddMeter("Microsoft.AspNetCore.Identity")
-             .AddMeter("Microsoft.AspNetCore.MemoryPool");
+        // There is no cost to listen for meters so listen for all built-in ASP.NET Core meters.
+        var builtInAspNetCoreMeters = new[]
+        {
+            "Microsoft.AspNetCore.Hosting",
+            "Microsoft.AspNetCore.Server.Kestrel",
+            "Microsoft.AspNetCore.Http.Connections",
+            "Microsoft.AspNetCore.Routing",
+            "Microsoft.AspNetCore.Diagnostics",
+            "Microsoft.AspNetCore.RateLimiting",
+            "Microsoft.AspNetCore.Components",
+            "Microsoft.AspNetCore.Components.Server.Circuits",
+            "Microsoft.AspNetCore.Components.Lifecycle",
+            "Microsoft.AspNetCore.Authorization",
+            "Microsoft.AspNetCore.Authentication",
+            "Microsoft.AspNetCore.Identity",
+            "Microsoft.AspNetCore.MemoryPool",
+        };
+
+        return builder.AddMeter(builtInAspNetCoreMeters);
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
@@ -126,14 +126,25 @@ public static class AspNetCoreInstrumentationTracerProviderBuilderExtensions
             builder.AddLegacySource(HttpInListener.ActivityOperationName); // for the activities created by AspNetCore
         }
 
+        var options = serviceProvider?.GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>().Get(optionsName);
+
         // SignalR activities first added in .NET 9.0
         if (Environment.Version.Major >= 9)
         {
-            var options = serviceProvider?.GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>().Get(optionsName);
             if (options is null || options.EnableAspNetCoreSignalRSupport)
             {
                 // https://github.com/dotnet/aspnetcore/blob/6ae3ea387b20f6497b82897d613e9b8a6e31d69c/src/SignalR/server/Core/src/Internal/SignalRServerActivitySource.cs#L13C35-L13C70
                 builder.AddSource("Microsoft.AspNetCore.SignalR.Server");
+            }
+        }
+
+        // Blazor activities first added in .NET 10.0
+        if (Environment.Version.Major >= 10)
+        {
+            if (options is null || options.EnableBlazorSupport)
+            {
+                builder.AddSource("Microsoft.AspNetCore.Components");
+                builder.AddSource("Microsoft.AspNetCore.Components.Server.Circuits");
             }
         }
     }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
@@ -141,9 +141,12 @@ public static class AspNetCoreInstrumentationTracerProviderBuilderExtensions
         // Blazor activities first added in .NET 10.0
         if (Environment.Version.Major >= 10)
         {
-            if (options is null || options.EnableBlazorSupport)
+            if (options is null || options.EnableRazorComponentsSupport)
             {
+                // https://github.com/dotnet/aspnetcore/blob/182e86a5943c4e0fea5fc006a88ff257bcc0fa73/src/Components/Components/src/ComponentsActivitySource.cs#L14
                 builder.AddSource("Microsoft.AspNetCore.Components");
+
+                // https://github.com/dotnet/aspnetcore/blob/182e86a5943c4e0fea5fc006a88ff257bcc0fa73/src/Components/Server/src/Circuits/CircuitActivitySource.cs#L11
                 builder.AddSource("Microsoft.AspNetCore.Components.Server.Circuits");
             }
         }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
@@ -103,7 +103,7 @@ public class AspNetCoreTraceInstrumentationOptions
     public bool EnableAspNetCoreSignalRSupport { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether Razor Componenets (Blazor) activities are recorded.
+    /// Gets or sets a value indicating whether Razor Components (Blazor) activities are recorded.
     /// </summary>
     /// <remarks>
     /// Defaults to true.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
@@ -103,13 +103,13 @@ public class AspNetCoreTraceInstrumentationOptions
     public bool EnableAspNetCoreSignalRSupport { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether Blazor activities are recorded.
+    /// Gets or sets a value indicating whether Razor Componenets (Blazor) activities are recorded.
     /// </summary>
     /// <remarks>
     /// Defaults to true.
     /// Only applies to .NET 10.0 or greater.
     /// </remarks>
-    public bool EnableBlazorSupport { get; set; } = true;
+    public bool EnableRazorComponentsSupport { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether RPC attributes are added to an Activity when using Grpc.AspNetCore.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
@@ -103,6 +103,15 @@ public class AspNetCoreTraceInstrumentationOptions
     public bool EnableAspNetCoreSignalRSupport { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether Blazor activities are recorded.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to true.
+    /// Only applies to .NET 10.0 or greater.
+    /// </remarks>
+    public bool EnableBlazorSupport { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether RPC attributes are added to an Activity when using Grpc.AspNetCore.
     /// </summary>
     /// <remarks>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## Unreleased
 
+* Added support for listening to ASP.NET Core Blazor activities.
+  Configurable with the
+  `AspNetCoreTraceInstrumentationOptions.EnableBlazorSupport`
+  option which defaults to `true`. Only applies to .NET 10.0 or greater.
+  ([#3012](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3012))
+
+* Following metrics will now be enabled by default when targeting `.NET10.0` or
+  newer framework:
+
+  * **Meter** : `Microsoft.AspNetCore.MemoryPool`
+    * `aspnetcore.memory_pool.pooled`
+    * `aspnetcore.memory_pool.evicted`
+    * `aspnetcore.memory_pool.allocated`
+    * `aspnetcore.memory_pool.rented`
+  * **Meter** : `Microsoft.AspNetCore.Authentication`
+    * `aspnetcore.authentication.authenticate.duration`
+    * `aspnetcore.authentication.challenges`
+    * `aspnetcore.authentication.forbids`
+    * `aspnetcore.authentication.sign_ins`
+    * `aspnetcore.authentication.sign_outs`
+  * **Meter** : `Microsoft.AspNetCore.Authorization`
+    * `aspnetcore.authorization.attempts`
+  * **Meter** : `Microsoft.AspNetCore.Identity`
+    * `aspnetcore.identity.user.create.duration`
+    * `aspnetcore.identity.user.update.duration`
+    * `aspnetcore.identity.user.delete.duration`
+    * `aspnetcore.identity.user.check_password_attempts`
+    * `aspnetcore.identity.user.generated_tokens`
+    * `aspnetcore.identity.user.verify_token_attempts`
+    * `aspnetcore.identity.sign_in.authenticate.duration`
+    * `aspnetcore.identity.sign_in.check_password_attempts`
+    * `aspnetcore.identity.sign_in.sign_ins`
+    * `aspnetcore.identity.sign_in.sign_outs`
+    * `aspnetcore.identity.sign_in.two_factor_clients_remembered`
+    * `aspnetcore.identity.sign_in.two_factor_clients_forgotten`
+  * **Meter** : `Microsoft.AspNetCore.Components`
+    * `aspnetcore.components.navigate`
+    * `aspnetcore.components.handle_event.duration`
+  * **Meter** : `Microsoft.AspNetCore.Components.Lifecycle`
+    * `aspnetcore.components.update_parameters.duration`
+    * `aspnetcore.components.render_diff.duration`
+    * `aspnetcore.components.render_diff.size`
+  * **Meter** : `Microsoft.AspNetCore.Components.Server.Circuits`
+    * `aspnetcore.components.circuit.active`
+    * `aspnetcore.components.circuit.connected`
+    * `aspnetcore.components.circuit.duration`
+
+  For details about each individual metric check [ASP.NET Core
+  docs
+  page](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-aspnetcore).
+
 ## 1.12.0
 
 Released 2025-May-05

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -52,6 +52,7 @@
   For details about each individual metric check [ASP.NET Core
   docs
   page](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-aspnetcore).
+  ([#3012](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3012))
 
 ## 1.12.0
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added support for listening to ASP.NET Core Blazor activities.
   Configurable with the
-  `AspNetCoreTraceInstrumentationOptions.EnableBlazorSupport`
+  `AspNetCoreTraceInstrumentationOptions.EnableRazorComponentsSupport`
   option which defaults to `true`. Only applies to .NET 10.0 or greater.
   ([#3012](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3012))
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -1211,6 +1211,55 @@ public sealed class BasicTests
 
         Assert.Empty(hubActivity);
     }
+
+    // note: this is always passing on Net9 or lower, because AddAspNetCoreInstrumentation only adds the subscription in Net10 or higher.
+    [Fact]
+    public async Task RazorComponentsActivitesCanBeDisabled()
+    {
+        var exportedItems = new List<Activity>();
+        void ConfigureTestServices(IServiceCollection services)
+        {
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddAspNetCoreInstrumentation(o => o.EnableRazorComponentsSupport = false)
+                .AddInMemoryExporter(exportedItems)
+                .Build();
+        }
+
+        using (var client = this.factory
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(ConfigureTestServices);
+                builder.ConfigureLogging(loggingBuilder => loggingBuilder.ClearProviders());
+            })
+            .CreateClient())
+        {
+            var fakeActivitySource = new ActivitySource("Microsoft.AspNetCore.Components");
+            var activity = fakeActivitySource.CreateActivity("Microsoft.AspNetCore.Components.HandleEvent", ActivityKind.Internal, parentId: null, null, null);
+            if (activity != null)
+            {
+                activity.Start();
+                activity.SetTag("aspnetcore.components.type", "BasicTests");
+                activity.SetTag("aspnetcore.components.method", "BlazorActivitesCanBeDisabled");
+                activity.Stop();
+            }
+
+            try
+            {
+                using var response = await client.GetAsync(new Uri("/api/values", UriKind.Relative));
+            }
+            catch (Exception)
+            {
+                // ignore errors
+            }
+
+            WaitForActivityExport(exportedItems, 1);
+        }
+
+        var blazorActivity = exportedItems
+            .Where(a => a.DisplayName.StartsWith("Microsoft.AspNetCore.Components", StringComparison.InvariantCulture));
+
+        Assert.Empty(blazorActivity);
+    }
 #endif
 
     public void Dispose()


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/3014

## Changes

Add ASP.NET Core telemetry metrics and traces for .NET 10

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
