### PR TITLE
[SqlClient] Stop Activity.Current if present

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -29,8 +29,9 @@ Released 2025-Jul-15
   the `SetDbQueryParameters` option. Not supported on .NET Framework.
   ([#3015](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3015))
 
-* Fix activities not being stopped on .NET Framework when using a global activity listener.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+* Fix activities not being stopped on .NET Framework when using a global activity
+  listener.
+  ([#3041](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3041))
 
 ## 1.12.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -29,6 +29,9 @@ Released 2025-Jul-15
   the `SetDbQueryParameters` option. Not supported on .NET Framework.
   ([#3015](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3015))
 
+* Fix activities not being stopped on .NET Framework when using a global activity listener.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.12.0-beta.1
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Add `db.query.parameter.<key>` attribute(s) to query spans if opted into using
+  the `SetDbQueryParameters` option. Not supported on .NET Framework.
+  ([#3015](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3015))
+
+* Fix activities not being stopped on .NET Framework when using a global activity
+  listener.
+  ([#3041](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3041))
+
 ## 1.12.0-beta.2
 
 Released 2025-Jul-15
@@ -24,14 +32,6 @@ Released 2025-Jul-15
   > Propagate `traceparent` information to SQL Server databases
     (see [SET CONTEXT_INFO](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-context-info-transact-sql?view=sql-server-ver16)).
     Note that this option incurs an additional round-trip to the database.
-
-* Add `db.query.parameter.<key>` attribute(s) to query spans if opted into using
-  the `SetDbQueryParameters` option. Not supported on .NET Framework.
-  ([#3015](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3015))
-
-* Fix activities not being stopped on .NET Framework when using a global activity
-  listener.
-  ([#3041](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3041))
 
 ## 1.12.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -205,7 +205,10 @@ internal sealed class SqlEventSourceListener : EventListener
         {
             // Ensure any activity that may exist due to ActivitySource.AddActivityListener() is stopped.
             // See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/3033.
-            activity?.Stop();
+            if (activity?.Source == SqlActivitySourceHelper.ActivitySource)
+            {
+                activity.Stop();
+            }
 
             this.RecordDuration(null, eventData);
             return;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -187,8 +187,9 @@ internal sealed class SqlEventSourceListener : EventListener
             [2] -> SqlExceptionNumber
          */
 
-        if (SqlClientInstrumentation.Instance.HandleManager.TracingHandles == 0
-            && SqlClientInstrumentation.Instance.HandleManager.MetricHandles == 0)
+        var handleManager = SqlClientInstrumentation.Instance.HandleManager;
+
+        if (handleManager.TracingHandles == 0 && handleManager.MetricHandles == 0)
         {
             return;
         }
@@ -208,7 +209,7 @@ internal sealed class SqlEventSourceListener : EventListener
 
         // If we're only collecting metrics, then we don't want to modify the activity
         var traceActivity =
-            SqlClientInstrumentation.TracingHandles == 0 && SqlClientInstrumentation.MetricHandles != 0 ?
+            handleManager.TracingHandles == 0 && handleManager.MetricHandles != 0 ?
             null :
             sqlActivity;
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -199,14 +199,18 @@ internal sealed class SqlEventSourceListener : EventListener
             return;
         }
 
-        if (SqlClientInstrumentation.Instance.HandleManager.TracingHandles == 0
-            && SqlClientInstrumentation.Instance.HandleManager.MetricHandles != 0)
+        var activity = Activity.Current;
+
+        if (SqlClientInstrumentation.TracingHandles == 0 && SqlClientInstrumentation.MetricHandles != 0)
         {
+            // Ensure any activity that may exist due to ActivitySource.AddActivityListener() is stopped.
+            // See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/3033.
+            activity?.Stop();
+
             this.RecordDuration(null, eventData);
             return;
         }
 
-        var activity = Activity.Current;
         if (activity?.Source != SqlActivitySourceHelper.ActivitySource)
         {
             return;

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Text;
 using Microsoft.Data.SqlClient;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Testcontainers.MsSql;
@@ -159,12 +160,56 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
         var result = await sqlCommand.ExecuteScalarAsync();
 
         // Assert
+        Assert.Equal(79, result);
+
         var activity = Assert.Single(activities);
 
         Assert.Equal(42, activity.GetTagValue("db.query.parameter.@x"));
         Assert.Equal(37, activity.GetTagValue("db.query.parameter.@y"));
     }
 #endif
+
+    [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
+    public async Task ActivityIsStoppedWhenOnlyUsingMetrics()
+    {
+        // Arrange
+        var activities = new List<Activity>();
+        var metrics = new List<MetricSnapshot>();
+
+        using var listener = new ActivityListener()
+        {
+            ActivityStarted = activities.Add,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ShouldListenTo = _ => true,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddInMemoryExporter(metrics)
+            .AddSqlClientInstrumentation()
+            .Build();
+
+        using var sqlConnection = new SqlConnection(this.GetConnectionString());
+
+        await sqlConnection.OpenAsync();
+
+        var dataSource = sqlConnection.DataSource;
+
+        sqlConnection.ChangeDatabase("master");
+
+        using var sqlCommand = new SqlCommand("select 1/1", sqlConnection);
+
+        // Act
+        var result = await sqlCommand.ExecuteScalarAsync();
+
+        // Assert
+        Assert.Equal(1, result);
+
+        var activity = Assert.Single(activities);
+
+        Assert.True(activity.IsStopped);
+    }
 
     private static void VerifyContextInfo(
         string? commandText,
@@ -292,15 +337,12 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
                    && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDbSystem);
     }
 
-    private string GetConnectionString()
+    private string GetConnectionString() => this.fixture.DatabaseContainer switch
     {
-        return this.fixture.DatabaseContainer switch
-        {
-            SqlEdgeContainer container => container.GetConnectionString(),
-            MsSqlContainer container => container.GetConnectionString(),
-            _ => throw new InvalidOperationException($"Container type '${this.fixture.DatabaseContainer.GetType().Name}' is not supported."),
-        };
-    }
+        SqlEdgeContainer container => container.GetConnectionString(),
+        MsSqlContainer container => container.GetConnectionString(),
+        _ => throw new InvalidOperationException($"Container type '${this.fixture.DatabaseContainer.GetType().Name}' is not supported."),
+    };
 
     private sealed class SemanticConventionScope(string? previous) : IDisposable
     {


### PR DESCRIPTION
Fixes #3033

## Changes

Ensure any current activity is stopped if only metrics is enabled but a global activity listener is registered.

I've manually verified the original issue is resolved and that .NET isn't affected by the same issue.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
