### PR TITLE
[SqlClient] Use Stopwatch.GetElapsedTime()

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -133,11 +133,17 @@ internal sealed class SqlActivitySourceHelper
 
     internal static double CalculateDurationFromTimestamp(long begin, long? end = null)
     {
-        end ??= Stopwatch.GetTimestamp();
+        var endingTimestamp = end ?? Stopwatch.GetTimestamp();
+
+#if NET8_0_OR_GREATER
+        var duration = Stopwatch.GetElapsedTime(begin, endingTimestamp);
+#else
         var timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
-        var delta = end - begin;
+        var delta = endingTimestamp - begin;
         var ticks = (long)(timestampToTicks * delta);
         var duration = new TimeSpan(ticks);
+#endif
+
         return duration.TotalSeconds;
     }
 }


### PR DESCRIPTION
## Changes

Use the `Stopwatch.GetElapsedTime()` method where available.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
