### PR TITLE
[fix] #3049 Support AWS SDK v3 in AWS SDK instrumentation library

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add support for AWS SDK v3 to address this issue.
+  ([#3049](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/3049))
+
 ## 1.12.0
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="AWSSDK.Core" Version="[3.7.400, 5.0.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.400, 5.0.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.400, 5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/OpenTelemetry.Instrumentation.AWS.Tests.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="AWSSDK.BedrockAgentRuntime" Version="4.0.0" />
     <PackageReference Include="AWSSDK.BedrockRuntime" Version="4.0.0" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryCoreLatestVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR addresses issue #3049:
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/3049

The AWS SDK instrumentation library should support both v3 and v4 SDKs. While tests may primarily focus on v4, SDK v3 is not deprecated, and the instrumentation library code is compatible with both versions.

Validation / Testing:
dotnet build
dotnet test (all test failures were investigated and are not caused by this PR) 
Manual testing with instrumentation enabled on apps using AWS SDK v3
Manual testing with instrumentation enabled on apps using AWS SDK v4

