### PR TITLE
[WCF] Add development note to README

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
@@ -17,7 +17,7 @@ and collects traces about outgoing gRPC requests.
 > This component is based on the OpenTelemetry semantic conventions for
 [traces](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md).
 These conventions are
-[Experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md),
+[in Development](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md),
 and hence, this package is a [pre-release](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/VERSIONING.md#pre-releases).
 Until a [stable
 version](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/telemetry-stability.md)

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -26,7 +26,7 @@ and later.
 > This component is based on the OpenTelemetry semantic conventions for
 [traces](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md).
 These conventions are
-[Experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md),
+[in Development](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md),
 and hence, this package is a [pre-release](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#pre-releases).
 Until a [stable
 version](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/telemetry-stability.md)

--- a/src/OpenTelemetry.Instrumentation.Wcf/README.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/README.md
@@ -20,6 +20,16 @@ Other configurations may work as well but have not been tested.
   * Streamed and buffered transfer modes
   * Signed and unsigned messages
 
+> [!CAUTION]
+> This component is based on the OpenTelemetry semantic conventions for
+[traces](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md).
+> These conventions are
+> [in Development](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md),
+> and hence, this package is a [pre-release](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#pre-releases).
+> Until a [stable
+> version](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/telemetry-stability.md)
+> is released, there can be breaking changes.
+
 ## Installation
 
 Add the OpenTelemetry.Instrumentation.Wcf package via NuGet.


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/2986#issuecomment-3164209206.

## Changes

- Add a note to the WCF readme that the RPC conventions are in development.
- Update gRPC and SqlClient notes to use "in Development" not "Experimental".

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
