### PR TITLE
[infra] Fix Use Artifacts Output layout

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -102,7 +102,7 @@ jobs:
           SOURCE: https://www.myget.org/F/opentelemetry/api/v2/package
         if: env.MYGET_TOKEN_EXISTS == 'true' # Skip MyGet publish if run on a fork without the secret
         shell: pwsh
-        run: dotnet nuget push "./artifacts/package/release/*.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
+        run: dotnet nuget push "artifacts/package/release/*.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
 
       - name: Publish to NuGet
         env:
@@ -111,7 +111,7 @@ jobs:
           SOURCE: https://api.nuget.org/v3/index.json
         if: github.ref_type == 'tag' && env.NUGET_TOKEN_EXISTS == 'true' # Skip NuGet publish for scheduled nightly builds or if run on a fork without the secret
         shell: pwsh
-        run: dotnet nuget push "./artifacts/package/release/*.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
+        run: dotnet nuget push "artifacts/package/release/*.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
 
   post-build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Follow up to #2816

## Changes

It should fix Publish to MyGet step as

```log
  dotnet nuget push "./artifacts/package/release/*.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    PROJECT_PATH: opentelemetry-dotnet-contrib.proj
    BUILD_COMPONENT: 
    DOTNET_ROOT: C:\Program Files\dotnet
    MYGET_TOKEN_EXISTS: true
    API_KEY: ***
    SOURCE: https://www.myget.org/F/opentelemetry/api/v2/package
error: File does not exist (./artifacts/package/release/*.nupkg).
Error: Process completed with exit code 1.
```



## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
