### PR TITLE
[infra] Fix Use Artifacts Output layout v2

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -102,7 +102,7 @@ jobs:
           SOURCE: https://www.myget.org/F/opentelemetry/api/v2/package
         if: env.MYGET_TOKEN_EXISTS == 'true' # Skip MyGet publish if run on a fork without the secret
         shell: pwsh
-        run: dotnet nuget push "artifacts/package/release/*.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
+        run: dotnet nuget push "./artifacts/package/release/**.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
 
       - name: Publish to NuGet
         env:
@@ -111,7 +111,7 @@ jobs:
           SOURCE: https://api.nuget.org/v3/index.json
         if: github.ref_type == 'tag' && env.NUGET_TOKEN_EXISTS == 'true' # Skip NuGet publish for scheduled nightly builds or if run on a fork without the secret
         shell: pwsh
-        run: dotnet nuget push "artifacts/package/release/*.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
+        run: dotnet nuget push "./artifacts/package/release/**.nupkg" --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
 
   post-build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Follow up #3056

## Changes

Fixes push to MyGet and Nuget.

I have executed local tests - downloaded artifacts from GitHub and stored content under: `artifacts/package/release`

* `dotnet nuget push "./artifacts/package/release/*.nupkg" -n true -s C:\temp\nugetFeed` - not working
* `dotnet nuget push "./artifacts/package/release/**.nupkg" -n true -s C:\temp\nugetFeed` - working
* `cd .\artifacts\package\release\ \n dotnet nuget push *.nupkg -n true -s C:\temp\nugetFeed` - working

Id o not know why current solution is not working. Going with option 2.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
