### PR TITLE
[Infra] Fix release workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -155,7 +155,7 @@ jobs:
           CreateRelease `
             -gitRepository ${env:GITHUB_REPOSITORY} `
             -tag ${env:GITHUB_REF_NAME} `
-            -releaseFiles "${env:GITHUB_WORKSPACE}/artifacts/${env:GITHUB_REF_NAME}-packages.zip#Packages"
+            -releaseFiles "${env:GITHUB_WORKSPACE}/artifacts/${env:GITHUB_REF_NAME}-packages.zip"
 
       - name: Post notice when packages are ready
         shell: pwsh


### PR DESCRIPTION
## Changes

The ZIP artifact is now flattened, so the `Packages` subdirectory no longer exists.

<img width="783" height="389" alt="image" src="https://github.com/user-attachments/assets/6cb08dcc-e40e-4994-97e8-a55227f49401" />

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
