### PR TITLE
[Infra] Update Testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,6 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Instrumentation.EntityFrameworkCore]
       code-cov-name: Instrumentation.EntityFrameworkCore
-      os-list: '[ "windows-latest", "ubuntu-22.04", "macos-latest" ]'
 
   build-test-instrumentation-eventcounters:
     needs: detect-changes
@@ -422,7 +421,6 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Instrumentation.SqlClient]
       code-cov-name: Instrumentation.SqlClient
-      os-list: '[ "windows-latest", "ubuntu-22.04", "macos-latest" ]'
 
   build-test-instrumentation-stackexchangeredis:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Instrumentation.EntityFrameworkCore]
       code-cov-name: Instrumentation.EntityFrameworkCore
+      os-list: '[ "windows-latest", "ubuntu-22.04", "macos-latest" ]'
 
   build-test-instrumentation-eventcounters:
     needs: detect-changes
@@ -421,6 +422,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Instrumentation.SqlClient]
       code-cov-name: Instrumentation.SqlClient
+      os-list: '[ "windows-latest", "ubuntu-22.04", "macos-latest" ]'
 
   build-test-instrumentation-stackexchangeredis:
     needs: detect-changes

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -11,8 +11,6 @@ using Npgsql;
 using OpenTelemetry.Instrumentation.SqlClient.Tests;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Testcontainers.MsSql;
-using Testcontainers.SqlEdge;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests;
@@ -341,15 +339,12 @@ public sealed class EntityFrameworkIntegrationTests :
         Assert.Equal(37, activity.GetTagValue("db.query.parameter.@y"));
     }
 
-    private static object CreateParameter(string provider, string name, object value)
+    private static object CreateParameter(string provider, string name, object value) => provider switch
     {
-        return provider switch
-        {
-            SqliteProvider => new SqliteParameter(name, value),
-            SqlServerProvider => new SqlParameter(name, value),
-            _ => throw new NotSupportedException($"Unsupported provider: {provider}"),
-        };
-    }
+        SqliteProvider => new SqliteParameter(name, value),
+        SqlServerProvider => new SqlParameter(name, value),
+        _ => throw new NotSupportedException($"Unsupported provider: {provider}"),
+    };
 
     private static void VerifyActivityData(
         bool captureTextCommandContent,
@@ -391,12 +386,8 @@ public sealed class EntityFrameworkIntegrationTests :
         Assert.DoesNotContain(activity.Tags, tag => tag.Key.StartsWith("db.query.parameter.", StringComparison.Ordinal));
     }
 
-    private string GetSqlServerConnectionString() => this.sqlServerFixture.DatabaseContainer switch
-    {
-        SqlEdgeContainer container => container.GetConnectionString(),
-        MsSqlContainer container => container.GetConnectionString(),
-        _ => throw new InvalidOperationException($"Container type '${this.sqlServerFixture.DatabaseContainer.GetType().Name}' is not supported."),
-    };
+    private string GetSqlServerConnectionString()
+        => this.sqlServerFixture.DatabaseContainer.GetConnectionString();
 
     private void ConfigureProvider(string provider, DbContextOptionsBuilder<ItemsContext> builder)
     {

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
@@ -13,10 +13,9 @@
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryCoreLatestVersion)" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
-    <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
-    <PackageReference Include="Testcontainers.MySql" Version="3.10.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
-    <PackageReference Include="Testcontainers.SqlEdge" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.7.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.7.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/OpenTelemetry.Instrumentation.SqlClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/OpenTelemetry.Instrumentation.SqlClient.Tests.csproj
@@ -20,8 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
-    <PackageReference Include="Testcontainers.SqlEdge" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.7.0" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
 
     <!-- System.Runtime.Caching is indirect reference through Microsoft.Data.SqlClient package. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-qj66-m88j-hmgj -->

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -9,8 +9,6 @@ using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Testcontainers.MsSql;
-using Testcontainers.SqlEdge;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
@@ -337,12 +335,8 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
                    && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDbSystem);
     }
 
-    private string GetConnectionString() => this.fixture.DatabaseContainer switch
-    {
-        SqlEdgeContainer container => container.GetConnectionString(),
-        MsSqlContainer container => container.GetConnectionString(),
-        _ => throw new InvalidOperationException($"Container type '${this.fixture.DatabaseContainer.GetType().Name}' is not supported."),
-    };
+    private string GetConnectionString()
+        => this.fixture.DatabaseContainer.GetConnectionString();
 
     private sealed class SemanticConventionScope(string? previous) : IDisposable
     {

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTestsFixture.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTestsFixture.cs
@@ -1,46 +1,21 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Runtime.InteropServices;
-using DotNet.Testcontainers.Containers;
 using Testcontainers.MsSql;
-using Testcontainers.SqlEdge;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 
 public sealed class SqlClientIntegrationTestsFixture : IAsyncLifetime
 {
-    // The Microsoft SQL Server Docker image is not compatible with ARM devices, such as Macs with Apple Silicon.
-    // See https://github.com/microsoft/mssql-docker/issues/881.
-    public IContainer DatabaseContainer { get; } = Architecture.Arm64.Equals(RuntimeInformation.ProcessArchitecture) ? CreateSqlEdge() : CreateMsSql();
+    public MsSqlContainer DatabaseContainer { get; } = CreateMsSql();
 
-    public Task InitializeAsync()
-    {
-        return this.DatabaseContainer.StartAsync();
-    }
+    public Task InitializeAsync() => this.DatabaseContainer.StartAsync();
 
-    public Task DisposeAsync()
-    {
-        return this.DatabaseContainer.DisposeAsync().AsTask();
-    }
-
-    private static SqlEdgeContainer CreateSqlEdge()
-    {
-        // Note: The Testcontainers.SqlEdge package has been deprecated. Seems
-        // it will not work with newer GitHub-hosted runners. Need to find an
-        // alternative solution. See:
-        // https://github.com/testcontainers/testcontainers-dotnet/pull/1265
-        return new SqlEdgeBuilder().Build();
-    }
+    public Task DisposeAsync() => this.DatabaseContainer.DisposeAsync().AsTask();
 
     private static MsSqlContainer CreateMsSql()
-    {
-        // Note: This "WithImage" line can most likely be removed when there is
-        // a new version (>3.10.0) of Testcontainers.MsSql released. See:
-        // https://github.com/testcontainers/testcontainers-dotnet/pull/1265
-        return new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-CU20-ubuntu-22.04")
-            .Build();
-    }
+        => new MsSqlBuilder()
+               .WithImage("mcr.microsoft.com/mssql/server:2022-CU20-GDR1-ubuntu-22.04")
+               .Build();
 }

--- a/test/Shared/DockerHelper.cs
+++ b/test/Shared/DockerHelper.cs
@@ -57,6 +57,11 @@ internal static class DockerHelper
             process.BeginErrorReadLine();
             process.WaitForExit();
         }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Thrown if Docker is not installed
+            return false;
+        }
         finally
         {
             process.OutputDataReceived -= AppendStdout;


### PR DESCRIPTION
## Changes

- Update to the latest release of Testcontainers.
- Update to the latest SQL Server container image.
- Remove SQL Edge as it is out of support.
- Fix tests not being skipped if Docker is not installed and failing instead.

Have manually checked that the Ubuntu jobs are running the Docker tests. Windows still skips as the Linux engine is not available, and macOS ARM64 images do not have Docker installed at all.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
