### PR TITLE
[OpAMP.Client] WebSocket Transport

### DIFF
--- a/opentelemetry-dotnet-contrib.sln
+++ b/opentelemetry-dotnet-contrib.sln
@@ -370,6 +370,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{70CA77
 		test\Shared\TestHttpServer.cs = test\Shared\TestHttpServer.cs
 		test\Shared\TestSampler.cs = test\Shared\TestSampler.cs
 		test\Shared\TestTextMapPropagator.cs = test\Shared\TestTextMapPropagator.cs
+		test\Shared\TestWebSocketServer.cs = test\Shared\TestWebSocketServer.cs
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{45D29DAA-0DB9-4808-B879-1AECC37EF366}"

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+
+using System.Buffers;
+using System.Net.WebSockets;
+using OpenTelemetry.Internal;
+using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Utils;
+
+namespace OpenTelemetry.OpAmp.Client.Transport.WebSocket;
+
+internal class WsReceiver : IDisposable
+{
+    private const int RentalBufferSize = 4096;
+    private const int ReceiveBufferSize = 8192;
+
+    private readonly ClientWebSocket ws;
+    private readonly Thread receiveThread;
+    private readonly FrameProcessor processor;
+
+    private readonly byte[] receiveBuffer = new byte[ReceiveBufferSize];
+
+    private CancellationToken token;
+
+    public WsReceiver(ClientWebSocket ws, FrameProcessor processor)
+    {
+        Guard.ThrowIfNull(ws, nameof(ws));
+        Guard.ThrowIfNull(processor, nameof(processor));
+
+        this.ws = ws;
+        this.processor = processor;
+        this.receiveThread = new Thread(this.ReceiveLoop);
+    }
+
+    public void Start(CancellationToken token = default)
+    {
+        this.token = token;
+        this.receiveThread.Start();
+    }
+
+    public void Dispose()
+    {
+        this.receiveThread?.Join();
+    }
+
+    private static void ReturnRentalBuffers(List<byte[]>? rentalBuffers)
+    {
+        if (rentalBuffers == null)
+        {
+            return;
+        }
+
+        foreach (var rental in rentalBuffers)
+        {
+            ArrayPool<byte>.Shared.Return(rental);
+        }
+    }
+
+    private async void ReceiveLoop()
+    {
+        while (true)
+        {
+            if (this.token.IsCancellationRequested)
+            {
+                this.token.ThrowIfCancellationRequested();
+            }
+
+            await this.ReceiveAsync(this.token).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ReceiveAsync(CancellationToken token)
+    {
+        var totalCount = 0;
+        var workingCount = 0;
+        var isClosed = false;
+        WebSocketReceiveResult result;
+        byte[] workingBuffer = this.receiveBuffer;
+
+        List<byte[]>? rentalBuffers = null;
+
+        do
+        {
+            if (this.token.IsCancellationRequested)
+            {
+                this.token.ThrowIfCancellationRequested();
+            }
+
+            // out of space, need to rent more
+            if (workingBuffer.Length - workingCount == 0)
+            {
+                if (rentalBuffers == null)
+                {
+                    rentalBuffers = [this.receiveBuffer];
+                }
+
+                workingBuffer = ArrayPool<byte>.Shared.Rent(RentalBufferSize);
+                workingCount = 0;
+                rentalBuffers.Add(workingBuffer);
+            }
+
+            if (this.ws.State != WebSocketState.Open)
+            {
+                // Connection is closed, nothing more to read.
+                isClosed = true;
+                break;
+            }
+
+            var segment1 = new ArraySegment<byte>(workingBuffer, workingCount, workingBuffer.Length - workingCount);
+            result = await this.ws.ReceiveAsync(segment1, token).ConfigureAwait(false);
+
+            isClosed = result.CloseStatus != null;
+            workingCount += result.Count;
+            totalCount += result.Count;
+        }
+        while (!result.EndOfMessage);
+
+        if (!isClosed)
+        {
+            var sequence =
+                rentalBuffers?.Count > 1
+                    ? rentalBuffers.CreateSequenceFromBuffers(workingCount + 1)
+                    : new ReadOnlySequence<byte>(this.receiveBuffer);
+
+            this.processor.OnServerFrame(sequence, totalCount, verifyHeader: true);
+        }
+
+        ReturnRentalBuffers(rentalBuffers);
+    }
+}
+
+#endif

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransmitter.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransmitter.cs
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+
+using System.Net.WebSockets;
+using Google.Protobuf;
+using OpenTelemetry.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Utils;
+
+namespace OpenTelemetry.OpAmp.Client.Transport.WebSocket;
+
+internal class WsTransmitter
+{
+    private const int BufferSize = 4096;
+
+    private readonly byte[] buffer = new byte[BufferSize];
+
+    private readonly ClientWebSocket ws;
+
+    public WsTransmitter(ClientWebSocket ws)
+    {
+        Guard.ThrowIfNull(ws, nameof(ws));
+
+        this.ws = ws;
+    }
+
+    public async Task SendAsync(IMessage message, CancellationToken token = default)
+    {
+        var headerSize = OpAmpWsHeaderHelper.WriteHeader(this.buffer);
+        var size = message.CalculateSize();
+
+        // fits to the buffer, send completely
+        if (size + headerSize <= BufferSize)
+        {
+            var segment = new ArraySegment<byte>(this.buffer, headerSize, size);
+            message.WriteTo(segment);
+
+            // resegment to include the header byte
+            segment = new ArraySegment<byte>(this.buffer, 0, size + headerSize);
+
+            await this.ws.SendAsync(segment, WebSocketMessageType.Binary, true, token).ConfigureAwait(false);
+        }
+
+        // Does not fit, need to chunk the message
+        else
+        {
+            // TODO: Implement chunking logic for large messages
+            throw new NotImplementedException();
+        }
+    }
+}
+
+#endif

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+
+using System.Net.WebSockets;
+using Google.Protobuf;
+using OpenTelemetry.Internal;
+using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Transport;
+
+namespace OpenTelemetry.OpAmp.Client.Transport.WebSocket;
+
+internal class WsTransport : IOpAmpTransport, IDisposable
+{
+    private readonly Uri uri;
+    private readonly SocketsHttpHandler handler = new();
+    private readonly ClientWebSocket ws = new();
+    private readonly WsReceiver receiver;
+    private readonly WsTransmitter transmitter;
+    private readonly FrameProcessor processor;
+
+    public WsTransport(Uri serverUrl, FrameProcessor processor)
+    {
+        Guard.ThrowIfNull(serverUrl, nameof(serverUrl));
+        Guard.ThrowIfNull(processor, nameof(processor));
+
+        // TODO: fix trust all certificates
+#pragma warning disable CA5359 // Do Not Disable Certificate Validation
+        this.handler.SslOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+#pragma warning restore CA5359 // Do Not Disable Certificate Validation
+        this.uri = serverUrl;
+        this.processor = processor;
+        this.receiver = new WsReceiver(this.ws, this.processor);
+        this.transmitter = new WsTransmitter(this.ws);
+    }
+
+    public async Task StartAsync(CancellationToken token = default)
+    {
+        using var invoker = new HttpMessageInvoker(this.handler);
+
+        await this.ws
+            .ConnectAsync(this.uri, invoker, token)
+            .ConfigureAwait(false);
+
+        this.receiver.Start(token);
+    }
+
+    public async Task StopAsync(CancellationToken token = default)
+    {
+        await this.ws
+            .CloseAsync(WebSocketCloseStatus.NormalClosure, "Client closed connection", token)
+            .ConfigureAwait(false);
+    }
+
+    public Task SendAsync<T>(T message, CancellationToken token = default)
+        where T : IMessage<T>
+    {
+        return this.transmitter.SendAsync(message, token);
+    }
+
+    public void Dispose()
+    {
+        this.handler.Dispose();
+        this.ws.Dispose();
+        this.receiver.Dispose();
+    }
+}
+
+#endif

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Utils/BufferSegment.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Utils/BufferSegment.cs
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Buffers;
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Utils;
+
+internal class BufferSegment : ReadOnlySequenceSegment<byte>
+{
+    public BufferSegment(byte[] buffer)
+    {
+        this.Memory = new ReadOnlyMemory<byte>(buffer);
+    }
+
+    public void SetNext(BufferSegment segment)
+    {
+        this.Next = segment;
+
+        segment.RunningIndex = this.RunningIndex + this.Memory.Length;
+    }
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Utils/OpAmpWsHeaderHelper.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Utils/OpAmpWsHeaderHelper.cs
@@ -1,0 +1,89 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Utils;
+
+internal class OpAmpWsHeaderHelper
+{
+    public const int OpAmpProtocolHeader = 0x00;
+    public const int MaxHeaderLength = 10; // Maximum length for varint64 encoding
+
+    public static int WriteHeader(ArraySegment<byte> buffer, ulong header = 0)
+    {
+        if (buffer.Count < MaxHeaderLength)
+        {
+            throw new InvalidOperationException("Ensure 10 bytes for buffer.");
+        }
+
+        return EncodeVarint64(buffer, header);
+    }
+
+    public static bool TryVerifyHeader(ReadOnlyMemory<byte> buffer, out int headerSize)
+    {
+        try
+        {
+            var header = DecodeVarint64(buffer.Span, out headerSize);
+            return header == OpAmpProtocolHeader;
+        }
+        catch (Exception)
+        {
+            headerSize = -1;
+            return false;
+        }
+    }
+
+    public static ulong DecodeVarint64(ReadOnlySpan<byte> buffer, out int bytesRead)
+    {
+        ulong result = 0;
+        int shift = 0;
+        bytesRead = 0;
+
+        foreach (byte b in buffer)
+        {
+            ulong value = (ulong)(b & 0x7F);
+            result |= value << shift;
+            bytesRead++;
+
+            if ((b & 0x80) == 0)
+            {
+                return result;
+            }
+
+            shift += 7;
+
+            // 64 bits max + buffer
+            if (shift >= 70)
+            {
+                throw new OverflowException("Varint is too long for 64-bit integer.");
+            }
+        }
+
+        throw new ArgumentException("Incomplete varint data.");
+    }
+
+    public static int EncodeVarint64(ArraySegment<byte> buffer, ulong value)
+    {
+        int bytesWritten = 0;
+        int offset = buffer.Offset;
+
+        while (value > 0x7F)
+        {
+            if (bytesWritten >= buffer.Count)
+            {
+                throw new ArgumentException("Buffer is too small for varint encoding.");
+            }
+
+            buffer.Array![offset + bytesWritten++] = (byte)((value & 0x7F) | 0x80);
+            value >>= 7;
+        }
+
+        if (bytesWritten >= buffer.Count)
+        {
+            throw new ArgumentException("Buffer is too small for varint encoding.");
+        }
+
+        buffer.Array![offset + bytesWritten++] = (byte)value; // Last byte without continuation bit
+
+        return bytesWritten;
+    }
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Utils/SequenceHelper.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Utils/SequenceHelper.cs
@@ -7,6 +7,21 @@ namespace OpenTelemetry.OpAmp.Client.Internal.Utils;
 
 internal static class SequenceHelper
 {
+    public static ReadOnlyMemory<byte> GetHeaderSegment(ReadOnlySequence<byte> sequence)
+    {
+        if (sequence.IsEmpty)
+        {
+            return default;
+        }
+
+        if (sequence.First.Length < OpAmpWsHeaderHelper.MaxHeaderLength)
+        {
+            throw new InvalidOperationException("Sequence is too small to contain a valid header.");
+        }
+
+        return sequence.First.Slice(0, OpAmpWsHeaderHelper.MaxHeaderLength);
+    }
+
     public static ReadOnlySequence<byte> AsSequence(this byte[] message)
     {
         if (message == null || message.Length == 0)
@@ -15,5 +30,26 @@ internal static class SequenceHelper
         }
 
         return new ReadOnlySequence<byte>(message);
+    }
+
+    public static ReadOnlySequence<byte> CreateSequenceFromBuffers(this IReadOnlyList<byte[]> buffers, int endIndex)
+    {
+        if (buffers == null || buffers.Count == 0)
+        {
+            return ReadOnlySequence<byte>.Empty;
+        }
+
+        BufferSegment segment1 = new BufferSegment(buffers[0]);
+        BufferSegment currentSegment = segment1;
+
+        for (int i = 1; i < buffers.Count; i++)
+        {
+            BufferSegment nextSegment = new BufferSegment(buffers[i]);
+
+            currentSegment.SetNext(nextSegment);
+            currentSegment = nextSegment;
+        }
+
+        return new ReadOnlySequence<byte>(segment1, 0, currentSegment, endIndex);
     }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockListener.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockListener.cs
@@ -9,7 +9,18 @@ namespace OpenTelemetry.OpAmp.Client.Tests.Mocks;
 
 internal class MockListener : IOpAmpListener<CustomMessageMessage>
 {
+    private AutoResetEvent messageEvent = new(false);
+
     public ConcurrentBag<CustomMessageMessage> Messages { get; private set; } = [];
 
-    public void HandleMessage(CustomMessageMessage message) => this.Messages.Add(message);
+    public void HandleMessage(CustomMessageMessage message)
+    {
+        this.Messages.Add(message);
+        this.messageEvent.Set();
+    }
+
+    public void WaitForMessages(TimeSpan timeout)
+    {
+        this.messageEvent.WaitOne(timeout);
+    }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpHeaderHelperTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpHeaderHelperTests.cs
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.OpAmp.Client.Internal.Utils;
+#if NETFRAMEWORK
+using OpenTelemetry.OpAmp.Client.Tests.Tools;
+#endif
+using Xunit;
+
+namespace OpenTelemetry.OpAmp.Client.Tests;
+
+public class OpAmpHeaderHelperTests
+{
+    [Theory]
+    [InlineData(0, new byte[] { 0x00 })]
+    [InlineData(1, new byte[] { 0x01 })]
+    [InlineData(127, new byte[] { 0x7F })]
+    [InlineData(128, new byte[] { 0x80, 0x01 })]
+    [InlineData(987654321, new byte[] { 0xB1, 0xD1, 0xF9, 0xD6, 0x03 })]
+    [InlineData(ulong.MaxValue, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 })]
+    public void OpAmpHeaderHelper_Encode(ulong value, byte[] verifiedEncoded)
+    {
+        var buffer = new ArraySegment<byte>(new byte[10]);
+        var encodedLength = OpAmpWsHeaderHelper.EncodeVarint64(buffer, value);
+
+        Assert.Equal(verifiedEncoded.Length, encodedLength);
+        Assert.Equal(verifiedEncoded, buffer.Slice(0, encodedLength).ToArray());
+    }
+
+    [Theory]
+    [InlineData(0, 1, new byte[] { 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
+    [InlineData(1, 1, new byte[] { 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
+    [InlineData(127, 1, new byte[] { 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
+    [InlineData(128, 2, new byte[] { 0x80, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
+    [InlineData(987654321, 5, new byte[] { 0xB1, 0xD1, 0xF9, 0xD6, 0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })]
+    [InlineData(ulong.MaxValue, 10, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 })]
+    public void OpAmpHeaderHelper_Decode(ulong value, int verifiedLength, byte[] buffer)
+    {
+        var result = OpAmpWsHeaderHelper.DecodeVarint64(new ArraySegment<byte>(buffer), out int bytesRead);
+
+        Assert.Equal(value, result);
+        Assert.Equal(verifiedLength, bytesRead);
+    }
+}

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpenTelemetry.OpAmp.Client.Tests.csproj
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpenTelemetry.OpAmp.Client.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TestWebSocketServer.cs" Link="Includes\TestWebSocketServer.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.OpAmp.Client.Tests/SequenceHelperTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/SequenceHelperTests.cs
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Buffers;
+using OpenTelemetry.OpAmp.Client.Internal.Utils;
+using Xunit;
+
+namespace OpenTelemetry.OpAmp.Client.Tests;
+
+public class SequenceHelperTests
+{
+    [Fact]
+    public void SequenceHelperTests_GetHeaderSegment()
+    {
+        byte[] data = Enumerable.Range(0, 12).Select(i => (byte)i).ToArray();
+        byte[] expexted = Enumerable.Range(0, OpAmpWsHeaderHelper.MaxHeaderLength).Select(i => (byte)i).ToArray();
+
+        var header = SequenceHelper.GetHeaderSegment(data.AsSequence());
+
+        Assert.Equal(expexted, header.ToArray());
+    }
+
+    [Fact]
+    public void SequenceHelperTests_GetHeaderSegment_TooSmallFirstSegment()
+    {
+        byte[] data = Enumerable.Range(0, 5).Select(i => (byte)i).ToArray();
+
+        Assert.Throws<InvalidOperationException>(() => SequenceHelper.GetHeaderSegment(data.AsSequence()));
+    }
+
+    [Fact]
+    public void SequenceHelperTests_AsSequence()
+    {
+        var buffer = new byte[] { 0x04, 0x05, 0x06, 0x07 };
+        var sequence = buffer.AsSequence();
+
+        Assert.Equal(buffer, sequence.ToArray());
+    }
+
+    [Fact]
+    public void SequenceHelperTests_AsSequence_Empty()
+    {
+        var buffer = Array.Empty<byte>();
+        var sequence = buffer.AsSequence();
+
+        Assert.Equal(ReadOnlySequence<byte>.Empty, sequence);
+    }
+
+    [Fact]
+    public void SequenceHelperTests_ReadAllSequence()
+    {
+        var buffer1 = new byte[] { 0x01, 0x02, 0x03 };
+        var buffer2 = new byte[] { 0x04, 0x05, 0x06, 0x07 };
+        var buffer3 = new byte[] { 0x08, 0x09 };
+        var endIndex = buffer3.Length;
+
+        var sequence = SequenceHelper.CreateSequenceFromBuffers([buffer1, buffer2, buffer3], endIndex);
+        var array = sequence.ToArray();
+
+        var expected = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
+        Assert.Equal(expected, array);
+    }
+}

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Tools/ArraySegmentExtensions.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Tools/ArraySegmentExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// A polyfill for ArraySegment.Slice for .NET Framework
+
+#if NETFRAMEWORK
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.OpAmp.Client.Tests.Tools;
+
+internal static class ArraySegmentExtensions
+{
+    public static ArraySegment<T> Slice<T>(this ArraySegment<T> segment, int index, int count)
+    {
+        Guard.ThrowIfNull(segment.Array);
+
+        if ((uint)index > (uint)segment.Count || (uint)count > (uint)(segment.Count - index))
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        return new ArraySegment<T>(segment.Array, segment.Offset + index, count);
+    }
+}
+
+#endif

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeHttpServer.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeHttpServer.cs
@@ -12,16 +12,16 @@ namespace OpenTelemetry.OpAmp.Client.Tests.Tools;
 internal class OpAmpFakeHttpServer : IDisposable
 {
     private readonly IDisposable httpServer;
-    private readonly BlockingCollection<AgentToServer> frames;
+    private readonly BlockingCollection<AgentToServer> frames = [];
 
     public OpAmpFakeHttpServer()
     {
-        this.frames = [];
         this.httpServer = TestHttpServer.RunServer(
             context =>
             {
                 var buffer = new byte[context.Request.ContentLength64];
                 _ = context.Request.InputStream.Read(buffer, 0, buffer.Length);
+
                 var frame = AgentToServer.Parser.ParseFrom(buffer);
 
                 this.frames.Add(frame);

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeWebSocketServer.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeWebSocketServer.cs
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using Google.Protobuf;
+using OpAmp.Proto.V1;
+using OpenTelemetry.OpAmp.Client.Internal.Utils;
+using OpenTelemetry.Tests;
+
+namespace OpenTelemetry.OpAmp.Client.Tests.Tools;
+
+internal class OpAmpFakeWebSocketServer : IDisposable
+{
+    private readonly IDisposable httpServer;
+    private readonly BlockingCollection<AgentToServer> frames = [];
+
+    public OpAmpFakeWebSocketServer()
+    {
+        this.httpServer = TestWebSocketServer.RunServer(
+            async socket =>
+            {
+                var buffer = new byte[8 * 1024];
+                var ms = new MemoryStream();
+
+                try
+                {
+                    while (socket.State == WebSocketState.Open)
+                    {
+                        var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by server", CancellationToken.None);
+
+                            break;
+                        }
+
+                        if (result.Count > 0)
+                        {
+                            ms.Write(buffer, 0, result.Count);
+                        }
+
+                        if (result.EndOfMessage)
+                        {
+                            var frame = ProcessReceive(ms);
+                            this.frames.Add(frame);
+
+                            var response = GenerateResponse(frame);
+                            await socket.SendAsync(response, WebSocketMessageType.Binary, true, CancellationToken.None).ConfigureAwait(false);
+                        }
+                    }
+                }
+                finally
+                {
+                    ms.Dispose();
+
+                    if (socket.State == WebSocketState.Open || socket.State == WebSocketState.CloseReceived)
+                    {
+                        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server disposed", CancellationToken.None);
+                    }
+                }
+            },
+            out var host,
+            out var port);
+
+        this.Endpoint = new Uri($"ws://{host}:{port}/v1/opamp");
+    }
+
+    public Uri Endpoint { get; }
+
+    public IReadOnlyCollection<AgentToServer> GetFrames()
+    {
+        return this.frames.ToArray();
+    }
+
+    public void Dispose()
+    {
+        this.httpServer.Dispose();
+    }
+
+    private static AgentToServer ProcessReceive(MemoryStream ms)
+    {
+        var fullMessageBytes = ms.ToArray();
+        OpAmpWsHeaderHelper.TryVerifyHeader(fullMessageBytes, out var headerSize);
+
+        var messageBytes = fullMessageBytes.AsSpan().Slice(headerSize, fullMessageBytes.Length - headerSize);
+        ms.SetLength(0);
+
+        // Parse protobuf message from the websocket message bytes.
+        var frame = AgentToServer.Parser.ParseFrom(messageBytes);
+
+        return frame;
+    }
+
+    private static ArraySegment<byte> GenerateResponse(AgentToServer frame)
+    {
+        var response = new ServerToAgent
+        {
+            InstanceUid = frame.InstanceUid,
+            CustomMessage = new CustomMessage
+            {
+                Data = ByteString.CopyFromUtf8("Response from OpAmpFakeWebSocketServer"),
+            },
+        };
+
+        var responseLength = response.CalculateSize();
+        var responseBuffer = new byte[responseLength + OpAmpWsHeaderHelper.MaxHeaderLength];
+
+        var headerSize = OpAmpWsHeaderHelper.WriteHeader(new ArraySegment<byte>(responseBuffer));
+
+        var segment = new ArraySegment<byte>(responseBuffer, headerSize, responseLength);
+        response.WriteTo(segment);
+
+        // resegment to include the header byte
+        segment = new ArraySegment<byte>(responseBuffer, 0, responseLength + headerSize);
+
+        return segment;
+    }
+}

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+
+using Google.Protobuf;
+using OpAmp.Proto.V1;
+using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Tests.Mocks;
+using OpenTelemetry.OpAmp.Client.Tests.Tools;
+using OpenTelemetry.OpAmp.Client.Transport.WebSocket;
+using Xunit;
+
+namespace OpenTelemetry.OpAmp.Client.Tests;
+
+public class WsTransportTest
+{
+    [Fact]
+    public async Task WsTransport_SendReceiveCommunication()
+    {
+        // Arrange
+        using var opAmpServer = new OpAmpFakeWebSocketServer();
+        var opAmpEndpoint = opAmpServer.Endpoint;
+
+        var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = new WsTransport(opAmpEndpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+
+        var uid = ByteString.CopyFrom(Guid.NewGuid().ToByteArray());
+        var frame = new AgentToServer() { InstanceUid = uid };
+
+        // Act
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await wsTransport.SendAsync(frame, cts.Token);
+
+        mockListener.WaitForMessages(TimeSpan.FromSeconds(30));
+
+        await wsTransport.StopAsync(cts.Token);
+
+        cts.Cancel();
+
+        // Assert
+        var serverReceivedFrames = opAmpServer.GetFrames();
+        var clientReceivedFrames = mockListener.Messages;
+
+        Assert.Single(serverReceivedFrames);
+        Assert.Equal(uid, serverReceivedFrames.First().InstanceUid);
+
+        Assert.Single(clientReceivedFrames);
+        Assert.Equal("Response from OpAmpFakeWebSocketServer", clientReceivedFrames.First().CustomMessage.Data.ToStringUtf8());
+    }
+}
+
+#endif
+

--- a/test/Shared/TestWebSocketServer.cs
+++ b/test/Shared/TestWebSocketServer.cs
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+using System.Net.WebSockets;
+#if !NETFRAMEWORK
+using System.Security.Cryptography;
+#endif
+
+namespace OpenTelemetry.Tests;
+
+internal static class TestWebSocketServer
+{
+#if !NET
+    private static readonly Random GlobalRandom = new();
+#endif
+
+    public static IDisposable RunServer(Func<WebSocket, Task> handler, out string host, out int port)
+    {
+        host = "localhost";
+        port = 0;
+        RunningServer? server = null;
+
+        var retryCount = 5;
+        while (true)
+        {
+            try
+            {
+#if NET
+                port = RandomNumberGenerator.GetInt32(2000, 5000);
+#else
+#pragma warning disable CA5394 // Do not use insecure randomness
+                port = GlobalRandom.Next(2000, 5000);
+#pragma warning restore CA5394 // Do not use insecure randomness
+#endif
+                server = new RunningServer(handler, host, port);
+                server.Start();
+                break;
+            }
+            catch (HttpListenerException ex)
+            {
+                server?.Dispose();
+                server = null;
+                if (--retryCount <= 0)
+                {
+                    throw new InvalidOperationException("TestWebSocketServer could not be started.", ex);
+                }
+            }
+        }
+
+        return server;
+    }
+
+    private sealed class RunningServer : IDisposable
+    {
+        private readonly Task listenerTask;
+        private readonly HttpListener listener;
+        private readonly AutoResetEvent initialized = new(false);
+
+        public RunningServer(Func<WebSocket, Task> handler, string host, int port)
+        {
+            this.listener = new HttpListener();
+            this.listener.Prefixes.Add($"http://{host}:{port}/");
+            this.listener.Start();
+
+            this.listenerTask = new Task(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        var ctxTask = this.listener.GetContextAsync();
+
+                        this.initialized.Set();
+
+                        var ctx = await ctxTask.ConfigureAwait(false);
+
+                        if (ctx.Request.IsWebSocketRequest)
+                        {
+                            var wsContext = await ctx.AcceptWebSocketAsync(null).ConfigureAwait(false);
+                            await handler(wsContext.WebSocket);
+                        }
+                        else
+                        {
+                            ctx.Response.StatusCode = 400;
+                            ctx.Response.Close();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex is ObjectDisposedException
+                            || (ex is HttpListenerException httpEx && httpEx.ErrorCode == 995))
+                        {
+                            break; // listener closed
+                        }
+
+                        throw;
+                    }
+                }
+            });
+        }
+
+        public void Start()
+        {
+            this.listenerTask.Start();
+            this.initialized.WaitOne();
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                this.listener.Close();
+                this.listenerTask?.Wait();
+                this.initialized.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // swallow this exception just in case
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

Adds WebSockets support for .NET.

Leaving TODO:
- WebSockets for .NET Framework
- WebSockets sending large packages (WsTransmitter.cs)
- Certification handling

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
