### PR TITLE
[Instrumentation.AspNet] Rename Enrich metrics options

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/PublicAPI.Unshipped.txt
@@ -1,8 +1,8 @@
 OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions
 OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.AspNetMetricsInstrumentationOptions() -> void
-OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Enrich.get -> OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichFunc?
-OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Enrich.set -> void
-OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichFunc
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichWithHttpContext.get -> OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichWithHttpContextAction?
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichWithHttpContext.set -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichWithHttpContextAction
 OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions
 OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.AspNetTraceInstrumentationOptions() -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.EnrichWithException.get -> System.Action<System.Diagnostics.Activity!, System.Exception!>?
@@ -21,4 +21,4 @@ static OpenTelemetry.Metrics.AspNetInstrumentationMeterProviderBuilderExtensions
 static OpenTelemetry.Metrics.AspNetInstrumentationMeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Trace.AspNetInstrumentationTracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
 static OpenTelemetry.Trace.AspNetInstrumentationTracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!
-virtual OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichFunc.Invoke(System.Web.HttpContext! context, ref System.Diagnostics.TagList tags) -> void
+virtual OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.EnrichWithHttpContextAction.Invoke(System.Web.HttpContext! context, ref System.Diagnostics.TagList tags) -> void

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
@@ -19,7 +19,7 @@ public sealed class AspNetMetricsInstrumentationOptions
     public delegate void EnrichWithHttpContextAction(HttpContext context, ref TagList tags);
 
     /// <summary>
-    /// Gets or sets a function to enrich a recorded metric with additional custom tags.
+    /// Gets or sets a delegate to enrich a recorded metric with additional custom tags.
     /// </summary>
     public EnrichWithHttpContextAction? EnrichWithHttpContext { get; set; }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
@@ -16,12 +16,12 @@ public sealed class AspNetMetricsInstrumentationOptions
     /// </summary>
     /// <param name="context"><see cref="HttpContext"/>: the HttpContext object. Both Request and Response are available.</param>
     /// <param name="tags"><see cref="TagList"/>: List of current tags. You can add additional tags to this list. </param>
-    public delegate void EnrichFunc(HttpContext context, ref TagList tags);
+    public delegate void EnrichWithHttpContextAction(HttpContext context, ref TagList tags);
 
     /// <summary>
     /// Gets or sets a function to enrich a recorded metric with additional custom tags.
     /// </summary>
-    public EnrichFunc? Enrich { get; set; }
+    public EnrichWithHttpContextAction? EnrichWithHttpContext { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether emit `server.address` and `server.port` attributes.

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -7,10 +7,18 @@
   `AspNetInstrumentationMeterProviderBuilderExtensions`
   and `AspNetInstrumentationTracerProviderBuilderExtensions` respectively.
   ([#2910](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2910))
+
 * **Breaking Change**: Made metrics generation independent from traces.
   Tracing must no longer be enabled to calculate metrics. A compatible version
   of `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule` is required.
   ([#2970](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2970))
+
+* **Breaking Change**: Metrics related option renamed:
+  * delegate `AspNetMetricsInstrumentationOptions.EnrichFunc` to
+    `AspNetMetricsInstrumentationOptions.EnrichWithHttpContextAction`,
+  * property `AspNetMetricsInstrumentationOptions.Enrich` to
+    `AspNetMetricsInstrumentationOptions.EnrichWithHttpContext`.
+  ([#3070](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3070))
 
 ## 1.12.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -94,11 +94,11 @@ internal sealed class HttpInListener : IDisposable
             tags.Add(SemanticConventions.AttributeHttpRoute, template);
         }
 
-        if (options.Enrich is not null)
+        if (options.EnrichWithHttpContext is not null)
         {
             try
             {
-                options.Enrich(context, ref tags);
+                options.EnrichWithHttpContext(context, ref tags);
             }
             catch (Exception ex)
             {

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -48,7 +48,7 @@ public class HttpInMetricsListenerTests
             {
                 options.EnableServerAttributesForRequestDuration = enableServerAttributesForRequestDuration;
 
-                options.Enrich += (HttpContext context, ref TagList tags) =>
+                options.EnrichWithHttpContext += (HttpContext context, ref TagList tags) =>
                 {
                     if (enrichMode == "throw")
                     {


### PR DESCRIPTION
Towards #2909

## Changes

Change Enrich options to make it consistent with other Enrich methods.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
