### PR TITLE
Introduce HTTP client trace enrichment

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -56,6 +56,7 @@
     <OpenTelemetryCoreLatestVersion>[1.12.0,2.0)</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.11.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
     <OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>[1.12.0,2.0)</OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>
+    <OpenTelemetryInstrumentationHttpLatestStableVersion>[1.12.0,2.0)</OpenTelemetryInstrumentationHttpLatestStableVersion>
     <StackExchangeRedisPkgVer>[2.6.122,3.0)</StackExchangeRedisPkgVer>
     <ConfluentKafkaPkgVer>[2.4.0,3.0)</ConfluentKafkaPkgVer>
     <CassandraCSharpDriverPkgVer>[3.17.0,4.0)</CassandraCSharpDriverPkgVer>

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions
+OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher
+OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.HttpClientTraceEnricher() -> void
+OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher! enricher) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Func<System.IServiceProvider!, T!>! enricherImplementationFactory) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder! builder, OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher! enricher) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Func<System.IServiceProvider!, T!>! enricherImplementationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder!
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithException(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Exception! exception) -> void
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithRequest(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Net.HttpWebRequest! request) -> void
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithResponse(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Net.HttpWebResponse! response) -> void

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions
+OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher
+OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.HttpClientTraceEnricher() -> void
+OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher! enricher) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Func<System.IServiceProvider!, T!>! enricherImplementationFactory) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder! builder, OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher! enricher) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Func<System.IServiceProvider!, T!>! enricherImplementationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder!
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithException(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Exception! exception) -> void
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithRequest(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Net.Http.HttpRequestMessage! request) -> void
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithResponse(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Net.Http.HttpResponseMessage! response) -> void

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions
+OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher
+OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.HttpClientTraceEnricher() -> void
+OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher! enricher) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Func<System.IServiceProvider!, T!>! enricherImplementationFactory) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher(this OpenTelemetry.Trace.TracerProviderBuilder! builder, OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher! enricher) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
+static OpenTelemetry.Trace.HttpClientEnrichmentTracerProviderBuilderExtensions.TryAddHttpClientTraceEnricher<T>(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Func<System.IServiceProvider!, T!>! enricherImplementationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder!
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithException(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Exception! exception) -> void
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithRequest(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Net.Http.HttpRequestMessage! request) -> void
+virtual OpenTelemetry.Extensions.Enrichment.Http.HttpClientTraceEnricher.EnrichWithResponse(in OpenTelemetry.Extensions.Enrichment.TraceEnrichmentBag bag, System.Net.Http.HttpResponseMessage! response) -> void

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/HttpClientEnrichmentServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/HttpClientEnrichmentServiceCollectionExtensions.cs
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Extensions.Enrichment.Http;
+using OpenTelemetry.Instrumentation.Http;
+using OpenTelemetry.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods to register ASP.NET Core specific telemetry trace enrichers.
+/// </summary>
+public static class HttpClientEnrichmentServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the specified <typeparamref name="T"/> implementation as a Singleton <see cref="HttpClientTraceEnricher"/> service
+    /// to the <paramref name="services"/> if the same service and implementation does not already exist in <paramref name="services"/>.
+    /// </summary>
+    /// <typeparam name="T">Concrete <see cref="HttpClientTraceEnricher"/> implementation type.</typeparam>
+    /// <param name="services"><see cref="IServiceCollection"/> being configured.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+    /// <returns>The instance of <see cref="IServiceCollection"/> to chain the calls.</returns>
+#if NET
+    public static IServiceCollection TryAddHttpClientTraceEnricher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services)
+#else
+    public static IServiceCollection TryAddHttpClientTraceEnricher<T>(this IServiceCollection services)
+#endif
+        where T : HttpClientTraceEnricher
+    {
+        Guard.ThrowIfNull(services);
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<HttpClientTraceEnricher, T>());
+
+        return services.TryAddHttpClientEnrichment();
+    }
+
+    /// <summary>
+    /// Adds the specified <paramref name="enricher"/> implementation as a Singleton <see cref="HttpClientTraceEnricher"/> service
+    /// to the <paramref name="services"/> if the same service and implementation does not already exist in <paramref name="services"/>.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/> being configured.</param>
+    /// <param name="enricher">The <see cref="HttpClientTraceEnricher"/> instance being added.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+    /// <returns>The instance of <see cref="IServiceCollection"/> to chain the calls.</returns>
+    public static IServiceCollection TryAddHttpClientTraceEnricher(this IServiceCollection services, HttpClientTraceEnricher enricher)
+    {
+        Guard.ThrowIfNull(services);
+        Guard.ThrowIfNull(enricher);
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton(enricher));
+
+        return services.TryAddHttpClientEnrichment();
+    }
+
+    /// <summary>
+    /// Adds the specified <typeparamref name="T"/> implementation produced by the supplied factory as a Singleton <see cref="HttpClientTraceEnricher"/> service
+    /// to the <paramref name="services"/> if the same service and implementation does not already exist in <paramref name="services"/>.
+    /// </summary>
+    /// <typeparam name="T">Concrete <see cref="HttpClientTraceEnricher"/> implementation type.</typeparam>
+    /// <param name="services"><see cref="IServiceCollection"/> being configured.</param>
+    /// <param name="enricherImplementationFactory">Factory used to create the <typeparamref name="T"/> instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="enricherImplementationFactory"/> is <see langword="null"/>.</exception>
+    /// <returns>The instance of <see cref="IServiceCollection"/> to chain the calls.</returns>
+    public static IServiceCollection TryAddHttpClientTraceEnricher<T>(this IServiceCollection services, Func<IServiceProvider, T> enricherImplementationFactory)
+        where T : HttpClientTraceEnricher
+    {
+        Guard.ThrowIfNull(services);
+        Guard.ThrowIfNull(enricherImplementationFactory);
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<HttpClientTraceEnricher, T>((serviceProvider) => enricherImplementationFactory(serviceProvider)));
+
+        return services.TryAddHttpClientEnrichment();
+    }
+
+    private static IServiceCollection TryAddHttpClientEnrichment(this IServiceCollection services)
+    {
+        services
+            .AddOptions()
+            .TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<HttpClientTraceInstrumentationOptions>, ConfigureHttpClientTraceInstrumentationOptions>());
+
+        services.TryAddSingleton<HttpClientTraceEnrichmentProcessor>();
+
+        return services;
+    }
+}

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/HttpClientEnrichmentTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/HttpClientEnrichmentTracerProviderBuilderExtensions.cs
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Extensions.Enrichment.Http;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Extension methods to register telemetry enrichers.
+/// </summary>
+public static class HttpClientEnrichmentTracerProviderBuilderExtensions
+{
+    /// <summary>
+    /// Adds the specified <typeparamref name="T"/> implementation as a Singleton <see cref="HttpClientTraceEnricher"/> service
+    /// to the <paramref name="builder"/> if the same service and implementation does not already exist.
+    /// </summary>
+    /// <typeparam name="T">Concrete <see cref="HttpClientTraceEnricher"/> implementation type.</typeparam>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+#if NET
+    public static TracerProviderBuilder TryAddHttpClientTraceEnricher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this TracerProviderBuilder builder)
+#else
+    public static TracerProviderBuilder TryAddHttpClientTraceEnricher<T>(this TracerProviderBuilder builder)
+#endif
+        where T : HttpClientTraceEnricher
+    {
+        Guard.ThrowIfNull(builder);
+
+        return builder.ConfigureServices(services => services.TryAddHttpClientTraceEnricher<T>());
+    }
+
+    /// <summary>
+    /// Adds the specified <paramref name="enricher"/> implementation as a Singleton <see cref="HttpClientTraceEnricher"/> service
+    /// to the <paramref name="builder"/> if the same service and implementation does not already exist.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="enricher">The <see cref="HttpClientTraceEnricher"/> instance being added.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder TryAddHttpClientTraceEnricher(this TracerProviderBuilder builder, HttpClientTraceEnricher enricher)
+    {
+        Guard.ThrowIfNull(builder);
+        Guard.ThrowIfNull(enricher);
+
+        return builder.ConfigureServices(services => services.TryAddHttpClientTraceEnricher(enricher));
+    }
+
+    /// <summary>
+    /// Adds the specified <typeparamref name="T"/> implementation produced by the supplied factory as a Singleton <see cref="HttpClientTraceEnricher"/> service
+    /// to the <paramref name="builder"/> if the same service and implementation does not already exist.
+    /// </summary>
+    /// <typeparam name="T">Concrete <see cref="HttpClientTraceEnricher"/> implementation type.</typeparam>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="enricherImplementationFactory">Factory used to create the <typeparamref name="T"/> instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="enricherImplementationFactory"/> is <see langword="null"/>.</exception>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder TryAddHttpClientTraceEnricher<T>(this TracerProviderBuilder builder, Func<IServiceProvider, T> enricherImplementationFactory)
+        where T : HttpClientTraceEnricher
+    {
+        Guard.ThrowIfNull(builder);
+        Guard.ThrowIfNull(enricherImplementationFactory);
+
+        return builder.ConfigureServices(services => services.TryAddHttpClientTraceEnricher(enricherImplementationFactory));
+    }
+}

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/Internal/ConfigureHttpClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/Internal/ConfigureHttpClientTraceInstrumentationOptions.cs
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Instrumentation.Http;
+
+namespace OpenTelemetry.Extensions.Enrichment.Http;
+
+#pragma warning disable CA1812 // Class is instantiated through dependency injection
+internal sealed class ConfigureHttpClientTraceInstrumentationOptions : IConfigureOptions<HttpClientTraceInstrumentationOptions>
+#pragma warning restore CA1812 // Class is instantiated through dependency injection
+{
+    private readonly HttpClientTraceEnrichmentProcessor processor;
+
+    public ConfigureHttpClientTraceInstrumentationOptions(HttpClientTraceEnrichmentProcessor processor)
+    {
+        this.processor = processor;
+    }
+
+    public void Configure(HttpClientTraceInstrumentationOptions options)
+    {
+#if NETFRAMEWORK
+        options.EnrichWithHttpWebRequest += this.processor.EnrichWithRequest;
+        options.EnrichWithHttpWebResponse += this.processor.EnrichWithResponse;
+#else
+        options.EnrichWithHttpRequestMessage += this.processor.EnrichWithRequest;
+        options.EnrichWithHttpResponseMessage += this.processor.EnrichWithResponse;
+#endif
+
+        options.EnrichWithException += this.processor.EnrichWithException;
+    }
+}

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/Internal/HttpClientTraceEnrichmentProcessor.cs
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/Internal/HttpClientTraceEnrichmentProcessor.cs
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+#if NETFRAMEWORK
+using System.Net;
+#endif
+
+namespace OpenTelemetry.Extensions.Enrichment.Http;
+
+internal sealed class HttpClientTraceEnrichmentProcessor
+{
+    private readonly HttpClientTraceEnricher[] enrichers;
+
+    public HttpClientTraceEnrichmentProcessor(IEnumerable<HttpClientTraceEnricher> enrichers)
+    {
+        this.enrichers = [.. enrichers];
+    }
+
+#if NETFRAMEWORK
+    public void EnrichWithRequest(Activity activity, HttpWebRequest request)
+#else
+    public void EnrichWithRequest(Activity activity, HttpRequestMessage request)
+#endif
+    {
+        var propertyBag = new TraceEnrichmentBag(activity);
+
+        foreach (var enricher in this.enrichers)
+        {
+            enricher.EnrichWithRequest(in propertyBag, request);
+        }
+    }
+
+#if NETFRAMEWORK
+    public void EnrichWithResponse(Activity activity, HttpWebResponse response)
+#else
+    public void EnrichWithResponse(Activity activity, HttpResponseMessage response)
+#endif
+    {
+        var propertyBag = new TraceEnrichmentBag(activity);
+
+        foreach (var enricher in this.enrichers)
+        {
+            enricher.EnrichWithResponse(in propertyBag, response);
+        }
+    }
+
+    public void EnrichWithException(Activity activity, Exception exception)
+    {
+        var propertyBag = new TraceEnrichmentBag(activity);
+
+        foreach (var enricher in this.enrichers)
+        {
+            enricher.EnrichWithException(in propertyBag, exception);
+        }
+    }
+}

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/OpenTelemetry.Extensions.Enrichment.Http.csproj
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/OpenTelemetry.Extensions.Enrichment.Http.csproj
@@ -13,5 +13,14 @@
   <PropertyGroup>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationHttpLatestStableVersion)" />
+    <PackageReference Include="OpenTelemetry.Extensions.Enrichment" Version="1.12.0-alpha.1" />
+  </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/README.md
@@ -21,7 +21,7 @@ information that you would like to be present in traces for outgoing HTTP reques
 
 With the HTTP Telemetry enrichment framework, you don't need to worry
 about attaching the information carefully to each telemetry object you touch.
-Instead, if you implement your enricher class inherited from `HttpTraceEnricher`,
+Instead, if you implement your enricher class inherited from `HttpClientTraceEnricher`,
 it  takes care of the details automatically. You simply register your class with
 the enrichment framework and the enrichment framework will make sure to call the
 enrichment methods of your class for every outgoing HTTP request in your app.

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/Trace/HttpClientTraceEnricher.cs
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/Trace/HttpClientTraceEnricher.cs
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NETFRAMEWORK
+using System.Net;
+#endif
+
+namespace OpenTelemetry.Extensions.Enrichment.Http;
+
+/// <summary>
+/// Class for implementing enrichers of outgoing requests for traces.
+/// </summary>
+public abstract class HttpClientTraceEnricher
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpClientTraceEnricher"/> class.
+    /// </summary>
+    protected HttpClientTraceEnricher()
+    {
+    }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Enriches a trace with additional tags.
+    /// </summary>
+    /// <param name="bag"><see cref="TraceEnrichmentBag"/> object to be used to add tags to enrich the traces.</param>
+    /// <param name="request"><see cref="HttpWebRequest"/> object from which additional information can be extracted to enrich the trace.</param>
+    public virtual void EnrichWithRequest(in TraceEnrichmentBag bag, HttpWebRequest request)
+#else
+    /// <summary>
+    /// Enriches a trace with additional tags.
+    /// </summary>
+    /// <param name="bag"><see cref="TraceEnrichmentBag"/> object to be used to add tags to enrich the traces.</param>
+    /// <param name="request"><see cref="HttpRequestMessage"/> object from which additional information can be extracted to enrich the trace.</param>
+    public virtual void EnrichWithRequest(in TraceEnrichmentBag bag, HttpRequestMessage request)
+#endif
+    {
+    }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Enriches a trace with additional tags.
+    /// </summary>
+    /// <param name="bag"><see cref="TraceEnrichmentBag"/> object to be used to add tags to enrich the traces.</param>
+    /// <param name="response"><see cref="HttpWebResponse"/> object from which additional information can be extracted to enrich the trace.</param>
+    public virtual void EnrichWithResponse(in TraceEnrichmentBag bag, HttpWebResponse response)
+#else
+    /// <summary>
+    /// Enriches a trace with additional tags.
+    /// </summary>
+    /// <param name="bag"><see cref="TraceEnrichmentBag"/> object to be used to add tags to enrich the traces.</param>
+    /// <param name="response"><see cref="HttpResponseMessage"/> object from which additional information can be extracted to enrich the trace.</param>
+    public virtual void EnrichWithResponse(in TraceEnrichmentBag bag, HttpResponseMessage response)
+#endif
+    {
+    }
+
+    /// <summary>
+    /// Enriches a trace with additional tags.
+    /// </summary>
+    /// <param name="bag"><see cref="TraceEnrichmentBag"/> object to be used to add tags to enrich the traces.</param>
+    /// <param name="exception"><see cref="Exception"/> object from which additional information can be extracted to enrich the trace.</param>
+    public virtual void EnrichWithException(in TraceEnrichmentBag bag, Exception exception)
+    {
+    }
+}

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -50,9 +50,12 @@
     <TrimmerRootAssembly Update="@(TrimmerRootAssembly)" Path="$(RepoRoot)\src\%(Identity)\%(Identity).csproj" />
     <ProjectReference Include="@(TrimmerRootAssembly->'%(Path)')" />
 
-    <!-- Exclude projects that are transitively referenced by OpenTelemetry.Extensions.Enrichment.AspNetCore:-->
+    <!-- Exclude projects that are transitively referenced by
+      OpenTelemetry.Extensions.Enrichment.AspNetCore and OpenTelemetry.Extensions.Enrichment.Http:
+    -->
     <ProjectReference Remove="$(RepoRoot)\src\OpenTelemetry.Extensions.Enrichment\OpenTelemetry.Extensions.Enrichment.csproj"/>
     <ProjectReference Remove="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj"/>
+    <ProjectReference Remove="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Http\OpenTelemetry.Instrumentation.Http.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/AcceptanceTestEnricher.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/AcceptanceTestEnricher.cs
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
+
+internal sealed class AcceptanceTestEnricher : HttpClientTraceEnricher
+{
+    public override void EnrichWithRequest(
+        in TraceEnrichmentBag bag,
+        HttpRequestMessage request) =>
+        bag.Add(
+            "accept.request.method",
+            request.Method.Method);
+
+    public override void EnrichWithResponse(
+        in TraceEnrichmentBag bag,
+        HttpResponseMessage response) =>
+        bag.Add(
+            "accept.response.status",
+            (int)response.StatusCode);
+
+    public override void EnrichWithException(
+        in TraceEnrichmentBag bag,
+        Exception exception) =>
+        bag.Add(
+            "accept.exception",
+            exception.GetType().Name);
+}

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/ConfigureHttpClientTraceInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/ConfigureHttpClientTraceInstrumentationOptionsTests.cs
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Instrumentation.Http;
+using Xunit;
+
+namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
+
+public class ConfigureHttpClientTraceInstrumentationOptionsTests
+{
+    [Fact]
+    public void WhenEnricherAdded_RegistersOptions()
+    {
+        var services = new ServiceCollection();
+        services.TryAddHttpClientTraceEnricher<TestEnricher>();
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<HttpClientTraceInstrumentationOptions>>().Value;
+
+        Assert.NotNull(options.EnrichWithHttpRequestMessage);
+        Assert.NotNull(options.EnrichWithHttpResponseMessage);
+        Assert.NotNull(options.EnrichWithException);
+    }
+
+    [Fact]
+    public void OptionsDelegates_InvokeEnricher()
+    {
+        var services = new ServiceCollection();
+        services.TryAddHttpClientTraceEnricher<TestEnricher>();
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<HttpClientTraceInstrumentationOptions>>().Value;
+        var enricher = provider.GetServices<HttpClientTraceEnricher>().OfType<TestEnricher>().Single();
+
+        using var activity = new Activity("test").Start();
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        var ex = new InvalidOperationException("boom");
+
+        options.EnrichWithHttpRequestMessage!(activity, request);
+        options.EnrichWithHttpResponseMessage!(activity, response);
+        options.EnrichWithException!(activity, ex);
+        activity.Stop();
+
+        Assert.Equal(1, enricher.RequestCount);
+        Assert.Equal(1, enricher.ResponseCount);
+        Assert.Equal(1, enricher.ExceptionCount);
+
+        // Verify tags set via bag
+        Assert.Contains(activity.TagObjects, t => t.Key == "test.request" && (string?)t.Value == "ok");
+        Assert.Contains(activity.TagObjects, t => t.Key == "test.response" && (int?)t.Value == 200);
+        Assert.Contains(activity.TagObjects, t => t.Key == "test.exception" && (string?)t.Value == "InvalidOperationException");
+    }
+}

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentServiceCollectionExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentServiceCollectionExtensionsTests.cs
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
+
+public class HttpClientEnrichmentServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void GenericMethod_AddsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.TryAddHttpClientTraceEnricher<TestEnricher>();
+        var provider = services.BuildServiceProvider();
+        var enricher = provider.GetService<HttpClientTraceEnricher>();
+        Assert.NotNull(enricher);
+        Assert.IsType<TestEnricher>(enricher);
+    }
+
+    [Fact]
+    public void InstanceMethod_AddsSingleton()
+    {
+        var services = new ServiceCollection();
+        var instance = new TestEnricher();
+        services.TryAddHttpClientTraceEnricher(instance);
+        var provider = services.BuildServiceProvider();
+        var enricher = provider.GetService<HttpClientTraceEnricher>();
+        Assert.Same(instance, enricher);
+    }
+
+    [Fact]
+    public void FactoryMethod_AddsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.TryAddHttpClientTraceEnricher<TestEnricher>(_ => new TestEnricher());
+        var provider = services.BuildServiceProvider();
+        var enricher = provider.GetService<HttpClientTraceEnricher>();
+        Assert.NotNull(enricher);
+        Assert.IsType<TestEnricher>(enricher);
+    }
+
+    [Fact]
+    public void AllMethods_ThrowOnNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<TestEnricher>(null!));
+        Assert.Throws<ArgumentNullException>(() => HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher(null!, new TestEnricher()));
+        Assert.Throws<ArgumentNullException>(() => HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher(new ServiceCollection(), null!));
+        Assert.Throws<ArgumentNullException>(() => HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<TestEnricher>(null!, _ => new TestEnricher()));
+        Assert.Throws<ArgumentNullException>(() => HttpClientEnrichmentServiceCollectionExtensions.TryAddHttpClientTraceEnricher<TestEnricher>(new ServiceCollection(), null!));
+    }
+}

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentTracerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentTracerProviderBuilderExtensionsTests.cs
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
+
+public class HttpClientEnrichmentTracerProviderBuilderExtensionsTests
+{
+    [Fact]
+    public void GenericMethod_AddsSingleton()
+    {
+        IServiceCollection? captured = null;
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .TryAddHttpClientTraceEnricher<TestEnricher>()
+            .ConfigureServices(services => captured = services)
+            .Build();
+
+        var serviceProvider = captured!.BuildServiceProvider();
+        var enricher = serviceProvider.GetService<HttpClientTraceEnricher>();
+        Assert.NotNull(enricher);
+        Assert.IsType<TestEnricher>(enricher);
+    }
+
+    [Fact]
+    public void InstanceMethod_AddsSingleton()
+    {
+        var instance = new TestEnricher();
+        IServiceCollection? captured = null;
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .TryAddHttpClientTraceEnricher(instance)
+            .ConfigureServices(services => captured = services)
+            .Build();
+
+        var serviceProvider = captured!.BuildServiceProvider();
+        var enricher = serviceProvider.GetService<HttpClientTraceEnricher>();
+        Assert.Same(instance, enricher);
+    }
+
+    [Fact]
+    public void FactoryMethod_AddsSingleton()
+    {
+        IServiceCollection? captured = null;
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .TryAddHttpClientTraceEnricher<TestEnricher>(_ => new TestEnricher())
+            .ConfigureServices(services => captured = services)
+            .Build();
+
+        var serviceProvider = captured!.BuildServiceProvider();
+        var enricher = serviceProvider.GetService<HttpClientTraceEnricher>();
+        Assert.NotNull(enricher);
+        Assert.IsType<TestEnricher>(enricher);
+    }
+
+    [Fact]
+    public void AllMethods_ThrowOnNullArguments()
+    {
+        TracerProviderBuilder? builder = null;
+        Assert.Throws<ArgumentNullException>(() => builder!.TryAddHttpClientTraceEnricher<TestEnricher>());
+        Assert.Throws<ArgumentNullException>(() => builder!.TryAddHttpClientTraceEnricher(new TestEnricher()));
+        Assert.Throws<ArgumentNullException>(() => builder!.TryAddHttpClientTraceEnricher(_ => new TestEnricher()));
+        Assert.Throws<ArgumentNullException>(() => Sdk.CreateTracerProviderBuilder().TryAddHttpClientTraceEnricher((HttpClientTraceEnricher)null!));
+        Assert.Throws<ArgumentNullException>(() => Sdk.CreateTracerProviderBuilder().TryAddHttpClientTraceEnricher<TestEnricher>((Func<IServiceProvider, TestEnricher>)null!));
+    }
+}

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientTraceEnrichmentAcceptanceTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientTraceEnrichmentAcceptanceTests.cs
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Tests;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
+
+public class HttpClientTraceEnrichmentAcceptanceTests : IDisposable
+{
+    private readonly IDisposable serverLifeTime;
+    private readonly string url;
+
+    public HttpClientTraceEnrichmentAcceptanceTests()
+    {
+        this.serverLifeTime = TestHttpServer.RunServer(
+            ctx =>
+            {
+                var responseCode = ctx.Request.Headers["responseCode"];
+                ctx.Response.StatusCode = responseCode != null ? int.Parse(responseCode) : 200;
+                ctx.Response.OutputStream.Close();
+            },
+            out var host,
+            out var port);
+
+        this.url = $"http://{host}:{port}/";
+    }
+
+    [Fact]
+    public async Task GivenHttpRequest_EnrichedOnRequestAndResponse()
+    {
+        var exportedActivities = new List<Activity>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
+            {
+                services.TryAddHttpClientTraceEnricher<AcceptanceTestEnricher>();
+            })
+            .AddHttpClientInstrumentation()
+            .AddInMemoryExporter(exportedActivities)
+            .Build();
+
+        using var httpClient = new HttpClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, this.url);
+
+        // Act
+        using var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var activity = Assert.Single(exportedActivities);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+        Assert.Equal("GET", activity.DisplayName);
+
+        // Enrichment tags
+        Assert.Equal("GET", activity.GetTagItem("accept.request.method"));
+        Assert.Equal(200, activity.GetTagItem("accept.response.status"));
+        Assert.Null(activity.GetTagItem("accept.exception"));
+    }
+
+    [Fact]
+    public async Task GivenFailedRequest_EnrichesOnException()
+    {
+        var exportedActivities = new List<Activity>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services => services.TryAddHttpClientTraceEnricher<AcceptanceTestEnricher>())
+            .AddHttpClientInstrumentation(o => o.RecordException = true)
+            .AddInMemoryExporter(exportedActivities)
+            .Build();
+
+        using var httpClient = new HttpClient();
+        var invalidUrl = new Uri("http://nonexistent.invalid-domain-for-otel-tests-xyz/");
+
+        Exception? thrown = null;
+        try
+        {
+            await httpClient.GetAsync(invalidUrl);
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        Assert.NotNull(thrown); // network failure expected
+
+        var activity = Assert.Single(exportedActivities);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.NotNull(activity.GetTagItem("accept.exception"));
+    }
+
+    public void Dispose()
+    {
+        this.serverLifeTime.Dispose();
+        Activity.Current = null;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/OpenTelemetry.Extensions.Enrichment.Http.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/OpenTelemetry.Extensions.Enrichment.Http.Tests.csproj
@@ -5,4 +5,15 @@
     <Description>Unit test project for OpenTelemetry .NET SDK HTTP telemetry enrichment.</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="../../src/OpenTelemetry.Extensions.Enrichment.Http/OpenTelemetry.Extensions.Enrichment.Http.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="/Includes/TestHttpServer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryExporterInMemoryPkgVer)" />
+  </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/TestEnricher.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/TestEnricher.cs
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
+
+internal sealed class TestEnricher : HttpClientTraceEnricher
+{
+    public int RequestCount { get; private set; }
+
+    public int ResponseCount { get; private set; }
+
+    public int ExceptionCount { get; private set; }
+
+    public override void EnrichWithRequest(in TraceEnrichmentBag bag, HttpRequestMessage request)
+    {
+        this.RequestCount++;
+        bag.Add("test.request", "ok");
+    }
+
+    public override void EnrichWithResponse(in TraceEnrichmentBag bag, HttpResponseMessage response)
+    {
+        this.ResponseCount++;
+        bag.Add("test.response", (int)response.StatusCode);
+    }
+
+    public override void EnrichWithException(in TraceEnrichmentBag bag, Exception exception)
+    {
+        this.ExceptionCount++;
+        bag.Add("test.exception", exception.GetType().Name);
+    }
+}


### PR DESCRIPTION
Design discussion issue #4097.

## Changes

Introducing the HTTP client trace enrichment component - `OpenTelemetry.Extensions.Enrichment.Http`

This is a framework for trace enrichment of outbound HTTP requests. Similar to `OpenTelemetry.Extensions.Enrichment`, it has an abstract class `HttpClientTraceEnricher` for .NET:
```csharp
public abstract class HttpClientTraceEnricher
{
    public virtual void EnrichWithRequest(in TraceEnrichmentBag bag, HttpRequestMessage request) {}
    public virtual void EnrichWithResponse(in TraceEnrichmentBag bag, HttpResponseMessage response) {}
    public virtual void EnrichWithException(in TraceEnrichmentBag bag, Exception exception) {}
}
```

and for .NET Framework:

```csharp
public abstract class HttpClientTraceEnricher
{
    public virtual void EnrichWithRequest(in TraceEnrichmentBag bag, HttpWebRequest request) {}
    public virtual void EnrichWithResponse(in TraceEnrichmentBag bag, HttpWebResponse response) {}
    public virtual void EnrichWithException(in TraceEnrichmentBag bag, Exception exception) {}
}
```

Internally, enrichment is done via the `HttpClientTraceEnrichmentProcessor` class, which hold references to all registered enrichers and calls `Enrich*()` methods on each of them.

Developers can add enrichers by calling extension methods either on `TracerProviderBuilder` or on `IServiceCollection`:

```csharp
public static TracerProviderBuilder TryAddHttpClientTraceEnricher<T>(this TracerProviderBuilder builder) where T : HttpClientTraceEnricher;
public static TracerProviderBuilder TryAddHttpClientTraceEnricher(this TracerProviderBuilder builder, HttpClientTraceEnricher enricher);
public static TracerProviderBuilder TryAddHttpClientTraceEnricher<T>(this TracerProviderBuilder builder, Func<IServiceProvider, T> enricherImplementationFactory) where T : HttpClientTraceEnricher;
public static IServiceCollection TryAddHttpClientTraceEnricher<T>(this IServiceCollection services) where T : HttpClientTraceEnricher;
public static IServiceCollection TryAddHttpClientTraceEnricher(this IServiceCollection services, HttpClientTraceEnricher enricher);
public static IServiceCollection TryAddHttpClientTraceEnricher<T>(this IServiceCollection services, Func<IServiceProvider, T> enricherImplementationFactory) where T : HttpClientTraceEnricher;
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
