### PR TITLE
[OpAMP.Client] WebSocket Transport for NetFx

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -7,6 +7,5 @@
 * Added support for OpAMP Plain HTTP transport.
   ([#2926](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2926))
 * Added support for OpAMP WebSocket transport.
-  ([#3064](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3064))
-* Added support for OpAMP WebSocket transport for .NET Framework.
-  ([#3092](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3092))
+  ([#3064](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3064),
+  [#3092](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3092))

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -7,4 +7,6 @@
 * Added support for OpAMP Plain HTTP transport.
   ([#2926](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2926))
 * Added support for OpAMP WebSocket transport.
-  ([#2926](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3064))
+  ([#3064](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3064))
+* Added support for OpAMP WebSocket transport for .NET Framework.
+  ([#3092](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3092))

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
@@ -8,10 +8,7 @@ using OpAmp.Proto.V1;
 using OpenTelemetry.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Listeners;
 using OpenTelemetry.OpAmp.Client.Internal.Listeners.Messages;
-
-#if NET
 using OpenTelemetry.OpAmp.Client.Internal.Utils;
-#endif
 
 namespace OpenTelemetry.OpAmp.Client.Internal;
 
@@ -55,7 +52,6 @@ internal sealed class FrameProcessor
         this.Deserialize(sequence);
     }
 
-#if NET
     public void OnServerFrame(ReadOnlySequence<byte> sequence, int count, bool verifyHeader)
     {
         var headerSize = 0;
@@ -79,7 +75,6 @@ internal sealed class FrameProcessor
         var dataSegment = sequence.Slice(headerSize, count - headerSize);
         this.Deserialize(dataSegment);
     }
-#endif
 
     private void Deserialize(ReadOnlySequence<byte> sequence)
     {

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClient.cs
@@ -3,6 +3,7 @@
 
 using OpenTelemetry.OpAmp.Client.Internal.Transport;
 using OpenTelemetry.OpAmp.Client.Internal.Transport.Http;
+using OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 
 namespace OpenTelemetry.OpAmp.Client.Internal;
 
@@ -19,13 +20,11 @@ internal sealed class OpAmpClient
         this.transport = ConstructTransport(this.settings, this.processor);
     }
 
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance
     private static IOpAmpTransport ConstructTransport(OpAmpClientSettings settings, FrameProcessor processor)
-#pragma warning restore CA1859 // Use concrete types when possible for improved performance
     {
         return settings.ConnectionType switch
         {
-            ConnectionType.WebSocket => throw new NotImplementedException("WebSocket transport is not available."),
+            ConnectionType.WebSocket => new WsTransport(settings.ServerUrl, processor),
             ConnectionType.Http => new PlainHttpTransport(settings.ServerUrl, processor),
             _ => throw new NotSupportedException("Unsupported transport type"),
         };

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
@@ -1,15 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET
-
 using System.Buffers;
 using System.Net.WebSockets;
 using OpenTelemetry.Internal;
-using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Utils;
 
-namespace OpenTelemetry.OpAmp.Client.Transport.WebSocket;
+namespace OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 
 internal sealed class WsReceiver : IDisposable
 {
@@ -148,5 +145,3 @@ internal sealed class WsReceiver : IDisposable
         ReturnRentalBuffers(rentalBuffers);
     }
 }
-
-#endif

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransmitter.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransmitter.cs
@@ -1,14 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET
-
 using System.Net.WebSockets;
 using Google.Protobuf;
 using OpenTelemetry.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Utils;
 
-namespace OpenTelemetry.OpAmp.Client.Transport.WebSocket;
+namespace OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 
 internal sealed class WsTransmitter
 {
@@ -27,7 +25,7 @@ internal sealed class WsTransmitter
 
     public async Task SendAsync(IMessage message, CancellationToken token = default)
     {
-        var headerSize = OpAmpWsHeaderHelper.WriteHeader(this.buffer);
+        var headerSize = OpAmpWsHeaderHelper.WriteHeader(new ArraySegment<byte>(this.buffer));
         var size = message.CalculateSize();
 
         // fits to the buffer, send completely
@@ -50,5 +48,3 @@ internal sealed class WsTransmitter
         }
     }
 }
-
-#endif

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -1,12 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET
-
 using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
-using OpenTelemetry.OpAmp.Client.Transport.WebSocket;
 using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
@@ -54,6 +52,3 @@ public class WsTransportTest
         Assert.StartsWith("This is a mock server frame for testing purposes.", receivedTextData);
     }
 }
-
-#endif
-


### PR DESCRIPTION
## Changes

* Fixes namespace errors
* Adds net framework support for WebSocket transport

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes