### PR TITLE
[OpAMP.Client] Add heartbeats

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -9,3 +9,5 @@
 * Added support for OpAMP WebSocket transport.
   ([#3064](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3064),
   [#3092](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3092))
+* Added support for heartbeat messages.
+  ([#3095](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3095))

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
@@ -68,8 +68,8 @@ internal sealed class FrameBuilder : IFrameBuilder
             var component = new ComponentHealth()
             {
                 Healthy = item.IsHealthy,
-                StartTimeUnixNano = (ulong)item.StartTime.ToUnixTimeMilliseconds() * 1000000, // Convert to nanoseconds
-                StatusTimeUnixNano = (ulong)item.StatusTime.ToUnixTimeMilliseconds() * 1000000, // Convert to nanoseconds
+                StartTimeUnixNano = (ulong)item.StartTime.ToUnixTimeMilliseconds() * 1_000_000, // Convert to nanoseconds
+                StatusTimeUnixNano = (ulong)item.StatusTime.ToUnixTimeMilliseconds() * 1_000_000, // Convert to nanoseconds
             };
 
             if (health.Status != null)

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
@@ -3,6 +3,8 @@
 
 using Google.Protobuf;
 using OpAmp.Proto.V1;
+using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
+using OpenTelemetry.OpAmp.Client.Internal.Settings;
 
 namespace OpenTelemetry.OpAmp.Client.Internal;
 
@@ -34,6 +36,55 @@ internal sealed class FrameBuilder : IFrameBuilder
         };
 
         this.currentMessage = message;
+        return this;
+    }
+
+    IFrameBuilder IFrameBuilder.AddHeartbeat(HealthReport health)
+    {
+        if (this.currentMessage == null)
+        {
+            throw new InvalidOperationException("Message base is not initialized.");
+        }
+
+        this.currentMessage.Health = new ComponentHealth()
+        {
+            Healthy = health.IsHealthy,
+            StartTimeUnixNano = health.StartTime,
+            StatusTimeUnixNano = health.StatusTime,
+        };
+
+        if (health.Status != null)
+        {
+            this.currentMessage.Health.Status = health.Status;
+        }
+
+        if (health.LastError != null)
+        {
+            this.currentMessage.Health.LastError = health.LastError;
+        }
+
+        foreach (var item in health.Components)
+        {
+            var component = new ComponentHealth()
+            {
+                Healthy = item.IsHealthy,
+                StartTimeUnixNano = (ulong)item.StartTime.ToUnixTimeMilliseconds() * 1000000, // Convert to nanoseconds
+                StatusTimeUnixNano = (ulong)item.StatusTime.ToUnixTimeMilliseconds() * 1000000, // Convert to nanoseconds
+            };
+
+            if (health.Status != null)
+            {
+                component.Status = health.Status;
+            }
+
+            if (health.LastError != null)
+            {
+                component.LastError = health.LastError;
+            }
+
+            this.currentMessage.Health.ComponentHealthMap[item.ComponentName] = component;
+        }
+
         return this;
     }
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
@@ -72,7 +72,7 @@ internal sealed class FrameDispatcher : IDisposable
                 .AddHeartbeat(report)
                 .Build();
 
-            // TODO: change to debug log message
+            // TODO: change to proper logging
             Console.WriteLine("[debug] Sending hearthbeat message");
 
             await this.transport.SendAsync(message, token)
@@ -80,7 +80,7 @@ internal sealed class FrameDispatcher : IDisposable
         }
         catch (Exception)
         {
-            // TODO: log error
+            // TODO: change to proper logging
             Console.WriteLine("[error] hearthbeat message failure");
 
             this.frameBuilder.Reset(); // Reset the builder in case of failure

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
+using OpenTelemetry.OpAmp.Client.Internal.Settings;
 using OpenTelemetry.OpAmp.Client.Internal.Transport;
 
 namespace OpenTelemetry.OpAmp.Client.Internal;
@@ -35,7 +37,7 @@ internal sealed class FrameDispatcher : IDisposable
                 .Build();
 
             // TODO: change to proper logging
-            Console.WriteLine("Sending identification message.");
+            Console.WriteLine("[debug] Sending identification message.");
 
             await this.transport.SendAsync(message, token)
                 .ConfigureAwait(false);
@@ -43,7 +45,7 @@ internal sealed class FrameDispatcher : IDisposable
         catch (Exception ex)
         {
             // TODO: change to proper logging
-            Console.WriteLine($"[Error]: {ex.Message}");
+            Console.WriteLine($"[error]: {ex.Message}");
 
             this.frameBuilder.Reset(); // Reset the builder in case of failure
         }
@@ -56,5 +58,36 @@ internal sealed class FrameDispatcher : IDisposable
     public void Dispose()
     {
         this.syncRoot.Dispose();
+    }
+
+    public async Task DispatchHeartbeatAsync(HealthReport report, CancellationToken token)
+    {
+        await this.syncRoot.WaitAsync(token)
+            .ConfigureAwait(false);
+
+        try
+        {
+            var message = this.frameBuilder
+                .StartBaseMessage()
+                .AddHeartbeat(report)
+                .Build();
+
+            // TODO: change to debug log message
+            Console.WriteLine("[debug] Sending hearthbeat message");
+
+            await this.transport.SendAsync(message, token)
+                .ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // TODO: log error
+            Console.WriteLine("[error] hearthbeat message failure");
+
+            this.frameBuilder.Reset(); // Reset the builder in case of failure
+        }
+        finally
+        {
+            this.syncRoot.Release();
+        }
     }
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/IFrameBuilder.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/IFrameBuilder.cs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpAmp.Proto.V1;
+using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 
 namespace OpenTelemetry.OpAmp.Client.Internal;
 
 internal interface IFrameBuilder
 {
+    IFrameBuilder AddHeartbeat(HealthReport health);
+
     AgentToServer Build();
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClient.cs
@@ -1,16 +1,21 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpenTelemetry.OpAmp.Client.Internal.Services;
+using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
+using OpenTelemetry.OpAmp.Client.Internal.Settings;
 using OpenTelemetry.OpAmp.Client.Internal.Transport;
 using OpenTelemetry.OpAmp.Client.Internal.Transport.Http;
 using OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 
 namespace OpenTelemetry.OpAmp.Client.Internal;
 
-internal sealed class OpAmpClient
+internal sealed class OpAmpClient : IDisposable
 {
     private readonly OpAmpClientSettings settings = new();
     private readonly FrameProcessor processor = new();
+    private readonly Dictionary<string, IBackgroundService> services = [];
+    private readonly FrameDispatcher dispatcher;
     private readonly IOpAmpTransport transport;
 
     public OpAmpClient(Action<OpAmpClientSettings>? configure = null)
@@ -18,6 +23,14 @@ internal sealed class OpAmpClient
         configure?.Invoke(this.settings);
 
         this.transport = ConstructTransport(this.settings, this.processor);
+        this.dispatcher = new FrameDispatcher(this.transport, this.settings);
+
+        this.ConfigureServices();
+    }
+
+    public void Dispose()
+    {
+        this.dispatcher.Dispose();
     }
 
     private static IOpAmpTransport ConstructTransport(OpAmpClientSettings settings, FrameProcessor processor)
@@ -28,5 +41,24 @@ internal sealed class OpAmpClient
             ConnectionType.Http => new PlainHttpTransport(settings.ServerUrl, processor),
             _ => throw new NotSupportedException("Unsupported transport type"),
         };
+    }
+
+    private void ConfigureServices()
+    {
+        this.ConfigureService<HeartbeatService>(
+            settings => settings.Heartbeat.IsEnabled,
+            () => new(this.dispatcher, this.processor));
+    }
+
+    private void ConfigureService<T>(Predicate<OpAmpClientSettings> isEnabledCallback, Func<T> construct)
+        where T : IBackgroundService
+    {
+        if (isEnabledCallback(this.settings))
+        {
+            var service = construct();
+            service.Configure(this.settings);
+
+            this.services[service.ServiceName] = service;
+        }
     }
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/ComponentHealthStatus.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/ComponentHealthStatus.cs
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
+
+/// <summary>
+/// Represents the health status of a system component.
+/// </summary>
+internal sealed class ComponentHealthStatus
+{
+    public ComponentHealthStatus(string componentName)
+    {
+        this.ComponentName = componentName;
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the component.
+    /// </summary>
+    public string ComponentName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current status of the operation or entity.
+    /// </summary>
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the most recent error encountered.
+    /// </summary>
+    public string? LastError { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the system is in a healthy state.
+    /// </summary>
+    public bool IsHealthy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the start time of the event or operation.
+    /// </summary>
+    public DateTimeOffset StartTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp indicating the current status update time.
+    /// </summary>
+    public DateTimeOffset StatusTime { get; set; }
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HealthReport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HealthReport.cs
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
+
+internal sealed class HealthReport
+{
+    public ulong StartTime { get; set; }
+
+    public ulong StatusTime { get; set; }
+
+    public bool IsHealthy { get; set; }
+
+    public string? Status { get; set; }
+
+    public string? LastError { get; set; }
+
+    public IList<ComponentHealthStatus> Components { get; } = [];
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -7,7 +7,7 @@ using OpenTelemetry.OpAmp.Client.Internal.Settings;
 
 namespace OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 
-internal class HeartbeatService : IBackgroundService, IOpAmpListener<ConnectionSettingsMessage>, IDisposable
+internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<ConnectionSettingsMessage>, IDisposable
 {
     public const string Name = "heartbeat-service";
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -14,10 +14,10 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
     private readonly FrameDispatcher dispatcher;
     private readonly FrameProcessor processor;
     private readonly CancellationTokenSource cts;
+    private readonly object timerUpdateLock = new();
     private Timer? timer;
     private TimeSpan tickInterval;
     private ulong startTime;
-    private object timerUpdateLock = new();
 
     public HeartbeatService(FrameDispatcher dispatcher, FrameProcessor processor)
     {
@@ -77,7 +77,6 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
         lock (this.timerUpdateLock)
         {
             this.timer ??= new Timer(this.HeartbeatTick);
-
             this.timer.Change(interval, interval);
         }
     }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.OpAmp.Client.Internal.Listeners;
+using OpenTelemetry.OpAmp.Client.Internal.Listeners.Messages;
+using OpenTelemetry.OpAmp.Client.Internal.Settings;
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
+
+internal class HeartbeatService : IBackgroundService, IOpAmpListener<ConnectionSettingsMessage>, IDisposable
+{
+    public const string Name = "heartbeat-service";
+
+    private readonly FrameDispatcher dispatcher;
+    private readonly FrameProcessor processor;
+    private readonly CancellationTokenSource cts;
+    private Timer? timer;
+    private TimeSpan tickInterval;
+    private ulong startTime;
+    private object timerUpdateLock = new();
+
+    public HeartbeatService(FrameDispatcher dispatcher, FrameProcessor processor)
+    {
+        this.dispatcher = dispatcher;
+        this.processor = processor;
+        this.cts = new CancellationTokenSource();
+
+        this.processor.Subscribe(this);
+    }
+
+    public string ServiceName => Name;
+
+    public void Configure(OpAmpClientSettings settings)
+    {
+        this.tickInterval = settings.Heartbeat.Interval;
+    }
+
+    public void Start()
+    {
+        this.startTime = GetCurrentTimeInNanoseconds();
+        this.CreateOrUpdateTimer(this.tickInterval);
+    }
+
+    public void Stop()
+    {
+        this.cts.Cancel();
+        this.CreateOrUpdateTimer(Timeout.InfiniteTimeSpan);
+    }
+
+    public void HandleMessage(ConnectionSettingsMessage message)
+    {
+        var newInterval = message.ConnectionSettings.Opamp?.HeartbeatIntervalSeconds ?? 0;
+        if (newInterval > 0)
+        {
+            // TODO: Debug log the new heartbeat interval
+            Console.WriteLine($"[Debug] New heartbeat interval received: {newInterval}s");
+
+            this.CreateOrUpdateTimer(TimeSpan.FromSeconds(newInterval));
+        }
+    }
+
+    public void Dispose()
+    {
+        this.processor.Unsubscribe(this);
+
+        this.cts.Dispose();
+        this.timer?.Dispose();
+    }
+
+    private static ulong GetCurrentTimeInNanoseconds()
+    {
+        return (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000000; // Convert to nanoseconds
+    }
+
+    private void CreateOrUpdateTimer(TimeSpan interval)
+    {
+        lock (this.timerUpdateLock)
+        {
+            if (this.timer == null)
+            {
+                this.timer = new Timer(this.HeartbeatTick);
+            }
+
+            this.timer.Change(interval, interval);
+        }
+    }
+
+    private async void HeartbeatTick(object? state)
+    {
+        try
+        {
+            var report = this.CreateHealthReport();
+
+            await this.dispatcher.DispatchHeartbeatAsync(report, this.cts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore task cancellation
+        }
+        catch (Exception ex)
+        {
+            // TODO: Log the exception (logging not implemented here)
+            Console.WriteLine($"Heartbeat error: {ex.Message}");
+        }
+    }
+
+    private HealthReport CreateHealthReport()
+    {
+        return new HealthReport
+        {
+            StartTime = this.startTime,
+            StatusTime = GetCurrentTimeInNanoseconds(),
+            IsHealthy = true,
+            Status = "OK",
+        };
+    }
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -52,8 +52,8 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
         var newInterval = message.ConnectionSettings.Opamp?.HeartbeatIntervalSeconds ?? 0;
         if (newInterval > 0)
         {
-            // TODO: Debug log the new heartbeat interval
-            Console.WriteLine($"[Debug] New heartbeat interval received: {newInterval}s");
+            // TODO: change to proper logging
+            Console.WriteLine($"[debug] New heartbeat interval received: {newInterval}s");
 
             this.CreateOrUpdateTimer(TimeSpan.FromSeconds(newInterval));
         }
@@ -100,8 +100,8 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
         }
         catch (Exception ex)
         {
-            // TODO: Log the exception (logging not implemented here)
-            Console.WriteLine($"Heartbeat error: {ex.Message}");
+            // TODO: change to proper logging
+            Console.WriteLine($"[error] Heartbeat error: {ex.Message}");
         }
     }
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -76,10 +76,7 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
     {
         lock (this.timerUpdateLock)
         {
-            if (this.timer == null)
-            {
-                this.timer = new Timer(this.HeartbeatTick);
-            }
+            this.timer ??= new Timer(this.HeartbeatTick);
 
             this.timer.Change(interval, interval);
         }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -14,11 +14,7 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
     private readonly FrameDispatcher dispatcher;
     private readonly FrameProcessor processor;
     private readonly CancellationTokenSource cts;
-#if NET9_0_OR_GREATER
     private readonly Lock timerUpdateLock = new();
-#else
-    private readonly object timerUpdateLock = new();
-#endif
     private Timer? timer;
     private TimeSpan tickInterval;
     private ulong startTime;

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -69,7 +69,7 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
 
     private static ulong GetCurrentTimeInNanoseconds()
     {
-        return (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000000; // Convert to nanoseconds
+        return (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000; // Convert to nanoseconds
     }
 
     private void CreateOrUpdateTimer(TimeSpan interval)

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -14,7 +14,11 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
     private readonly FrameDispatcher dispatcher;
     private readonly FrameProcessor processor;
     private readonly CancellationTokenSource cts;
+#if NET9_0_OR_GREATER
+    private readonly Lock timerUpdateLock = new();
+#else
     private readonly object timerUpdateLock = new();
+#endif
     private Timer? timer;
     private TimeSpan tickInterval;
     private ulong startTime;

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/IBackgroundService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/IBackgroundService.cs
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.OpAmp.Client.Internal.Settings;
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Services;
+
+internal interface IBackgroundService
+{
+    /// <summary>
+    /// Gets the name of the service.
+    /// </summary>
+    string ServiceName { get; }
+
+    /// <summary>
+    /// Starts the background service.
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// Stops the background service.
+    /// </summary>
+    void Stop();
+
+    /// <summary>
+    /// Configures the service using the specified OpenAMP settings.
+    /// </summary>
+    /// <param name="settings">The OpenAMP settings to apply.</param>
+    void Configure(OpAmpClientSettings settings);
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Settings/ConnectionType.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Settings/ConnectionType.cs
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Settings;
+
+/// <summary>
+/// Specifies the type of transport protocol to be used for communication.
+/// </summary>
+/// <remarks>This enumeration defines the available transport protocols for communication. Use <see
+/// cref="WebSocket"/> for WebSocket-based communication, or <see cref="Http"/> for
+/// HTTP-based communication.</remarks>
+internal enum ConnectionType
+{
+    /// <summary>
+    /// Use HTTP transport.
+    /// </summary>
+    Http = 0,
+
+    /// <summary>
+    /// Use WebSocket transport.
+    /// </summary>
+    WebSocket = 1,
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Settings/HeartbeatSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Settings/HeartbeatSettings.cs
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Internal.Settings;
+
+internal class HeartbeatSettings
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the heartbeat is enabled.
+    /// </summary>
+    public bool IsEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time interval for the operation.
+    /// </summary>
+    public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(30); // Default to 30 seconds
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Settings/HeartbeatSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Settings/HeartbeatSettings.cs
@@ -3,7 +3,7 @@
 
 namespace OpenTelemetry.OpAmp.Client.Internal.Settings;
 
-internal class HeartbeatSettings
+internal sealed class HeartbeatSettings
 {
     /// <summary>
     /// Gets or sets a value indicating whether the heartbeat is enabled.

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Settings/HeartbeatSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Settings/HeartbeatSettings.cs
@@ -13,5 +13,5 @@ internal sealed class HeartbeatSettings
     /// <summary>
     /// Gets or sets the time interval for the operation.
     /// </summary>
-    public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(30); // Default to 30 seconds
+    public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Settings/OpAmpClientSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Settings/OpAmpClientSettings.cs
@@ -1,26 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-namespace OpenTelemetry.OpAmp.Client.Internal;
-
-/// <summary>
-/// Specifies the type of transport protocol to be used for communication.
-/// </summary>
-/// <remarks>This enumeration defines the available transport protocols for communication. Use <see
-/// cref="WebSocket"/> for WebSocket-based communication, or <see cref="Http"/> for
-/// HTTP-based communication.</remarks>
-internal enum ConnectionType
-{
-    /// <summary>
-    /// Use HTTP transport.
-    /// </summary>
-    Http = 0,
-
-    /// <summary>
-    /// Use WebSocket transport.
-    /// </summary>
-    WebSocket = 1,
-}
+namespace OpenTelemetry.OpAmp.Client.Internal.Settings;
 
 internal class OpAmpClientSettings
 {
@@ -43,4 +24,6 @@ internal class OpAmpClientSettings
     /// Gets or sets the server URL to connect to.
     /// </summary>
     public Uri ServerUrl { get; set; } = new("https://localhost:4320/v1/opamp");
+
+    public HeartbeatSettings Heartbeat { get; set; } = new();
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Settings/OpAmpClientSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Settings/OpAmpClientSettings.cs
@@ -3,7 +3,7 @@
 
 namespace OpenTelemetry.OpAmp.Client.Internal.Settings;
 
-internal class OpAmpClientSettings
+internal sealed class OpAmpClientSettings
 {
     /// <summary>
     /// Gets or sets the unique identifier for the current instance.

--- a/src/OpenTelemetry.OpAmp.Client/OpenTelemetry.OpAmp.Client.csproj
+++ b/src/OpenTelemetry.OpAmp.Client/OpenTelemetry.OpAmp.Client.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.OpAmp.Client/OpenTelemetry.OpAmp.Client.csproj
+++ b/src/OpenTelemetry.OpAmp.Client/OpenTelemetry.OpAmp.Client.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.OpAmp.Client.Tests/FrameDispatcherTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/FrameDispatcherTests.cs
@@ -4,6 +4,7 @@
 #if NET
 
 using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using Xunit;
 
@@ -14,12 +15,12 @@ public class FrameDispatcherTests
     [Fact]
     public async Task FrameDispatcher_IsThreadSafe_WhenDispatchingConcurrently()
     {
-        var transport = new MockTransport();
-        var settings = new OpAmpClientSettings();
-        var dispatcher = new FrameDispatcher(transport, settings);
-
         // Simulate concurrent dispatches
         var taskCount = 20; // Number of concurrent tasks
+
+        var transport = new MockTransport(taskCount);
+        var settings = new OpAmpClientSettings();
+        var dispatcher = new FrameDispatcher(transport, settings);
 
         await Parallel.ForEachAsync(Enumerable.Range(0, taskCount), async (i, token) =>
         {

--- a/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
+using OpenTelemetry.OpAmp.Client.Internal.Settings;
+using OpenTelemetry.OpAmp.Client.Tests.Mocks;
+using Xunit;
+
+namespace OpenTelemetry.OpAmp.Client.Tests;
+
+public class HeartbeatServiceTests
+{
+    [Fact]
+    public void HeartbeatService_EmitsHeartbeats()
+    {
+        const int messagesCount = 3;
+        const int intervalMs = 300;
+
+        var settings = new OpAmpClientSettings
+        {
+            Heartbeat = new HeartbeatSettings
+            {
+                Interval = TimeSpan.FromMilliseconds(intervalMs), // Set a short interval for testing
+            },
+        };
+
+        var transport = new MockTransport(messagesCount);
+        var dispatcher = new FrameDispatcher(transport, settings);
+        var processor = new FrameProcessor();
+        var service = new HeartbeatService(dispatcher, processor);
+
+        service.Configure(settings);
+        service.Start();
+
+        transport.WaitForMessages(timeout: TimeSpan.FromSeconds(5));
+
+        service.Stop();
+
+        var count = transport.Messages.Count;
+        Assert.True(count >= messagesCount, $"Expecting at least {messagesCount} heartbeats, got {count}.");
+    }
+}

--- a/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
@@ -25,10 +25,9 @@ public class HeartbeatServiceTests
             },
         };
 
-        var transport = new MockTransport(messagesCount);
-        var dispatcher = new FrameDispatcher(transport, settings);
-        var processor = new FrameProcessor();
-        var service = new HeartbeatService(dispatcher, processor);
+        using var transport = new MockTransport(messagesCount);
+        using var dispatcher = new FrameDispatcher(transport, settings);
+        using var service = new HeartbeatService(dispatcher, new FrameProcessor());
 
         service.Configure(settings);
         service.Start();

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockListener.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockListener.cs
@@ -9,7 +9,7 @@ namespace OpenTelemetry.OpAmp.Client.Tests.Mocks;
 
 internal class MockListener : IOpAmpListener<CustomMessageMessage>, IDisposable
 {
-    private AutoResetEvent messageEvent = new(false);
+    private readonly AutoResetEvent messageEvent = new(false);
 
     public ConcurrentBag<CustomMessageMessage> Messages { get; private set; } = [];
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockTransport.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockTransport.cs
@@ -11,9 +11,8 @@ namespace OpenTelemetry.OpAmp.Client.Tests.Mocks;
 internal class MockTransport : IOpAmpTransport, IDisposable
 {
     private readonly ConcurrentQueue<AgentToServer> messages = [];
-
-    private AutoResetEvent messageEvent = new(false);
-    private int expectedCount;
+    private readonly AutoResetEvent messageEvent = new(false);
+    private readonly int expectedCount;
 
     public MockTransport(int expectedCount)
     {

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockTransport.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockTransport.cs
@@ -1,24 +1,38 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Concurrent;
 using Google.Protobuf;
 using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal.Transport;
 
 namespace OpenTelemetry.OpAmp.Client.Tests.Mocks;
 
-internal class MockTransport : IOpAmpTransport
+internal class MockTransport : IOpAmpTransport, IDisposable
 {
-    private readonly List<AgentToServer> messages = [];
+    private readonly ConcurrentQueue<AgentToServer> messages = [];
 
-    public IReadOnlyCollection<AgentToServer> Messages => this.messages.AsReadOnly();
+    private AutoResetEvent messageEvent = new(false);
+    private int expectedCount;
+
+    public MockTransport(int expectedCount)
+    {
+        this.expectedCount = expectedCount;
+    }
+
+    public IReadOnlyCollection<AgentToServer> Messages => this.messages.ToList().AsReadOnly();
 
     public Task SendAsync<T>(T message, CancellationToken token)
         where T : IMessage<T>
     {
         if (message is AgentToServer agentToServer)
         {
-            this.messages.Add(agentToServer);
+            this.messages.Enqueue(agentToServer);
+
+            if (this.messages.Count == this.expectedCount)
+            {
+                this.messageEvent.Set();
+            }
         }
         else
         {
@@ -26,5 +40,15 @@ internal class MockTransport : IOpAmpTransport
         }
 
         return Task.CompletedTask;
+    }
+
+    public void WaitForMessages(TimeSpan timeout)
+    {
+        this.messageEvent.WaitOne(timeout);
+    }
+
+    public void Dispose()
+    {
+        this.messageEvent.Dispose();
     }
 }


### PR DESCRIPTION
## Changes

Adds heartbeats to support http transport scenario.

There is no client side api yet to provide info about components etc. Only reports static heartbeats.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
