### PR TITLE
[Infra] Fix quotes in curl command for artifact download

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -142,7 +142,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${ARTIFACT_TOKEN}" \
             -L \
-            -o '${GITHUB_WORKSPACE}/artifacts/${GITHUB_REF_NAME}-packages.zip' \
+            -o "${GITHUB_WORKSPACE}/artifacts/${GITHUB_REF_NAME}-packages.zip" \
             --create-dirs \
             "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip"
 


### PR DESCRIPTION
## Changes

Use double quotes so that environment variables are expanded.

Otherwise the files are downloaded to the literal path `${GITHUB_WORKSPACE}/artifacts/${GITHUB_REF_NAME}-packages.zip`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
