### PR TITLE
[infra] Migrate to otelbot

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -5,14 +5,12 @@ on:
     outputs:
       enabled:
         value: ${{ jobs.resolve-automation.outputs.enabled == 'true' }}
-      token-secret-name:
-        value: ${{ jobs.resolve-automation.outputs.token-secret-name }}
       username:
         value: ${{ vars.AUTOMATION_USERNAME }}
       email:
         value: ${{ vars.AUTOMATION_EMAIL }}
     secrets:
-      OPENTELEMETRYBOT_GITHUB_TOKEN:
+      OTELBOT_DOTNET_PRIVATE_KEY:
         required: false
 
 permissions:
@@ -25,13 +23,11 @@ jobs:
 
     outputs:
       enabled: ${{ steps.evaluate.outputs.enabled }}
-      token-secret-name: ${{ steps.evaluate.outputs.token-secret-name }}
 
     env:
-      OPENTELEMETRYBOT_GITHUB_TOKEN_EXISTS: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN != '' }}
+      OTELBOT_DOTNET_PRIVATE_KEY_EXISTS: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY != '' }}
 
     steps:
     - id: evaluate
       run: |
-        echo "enabled=${{ env.OPENTELEMETRYBOT_GITHUB_TOKEN_EXISTS == 'true' }}" >> "$GITHUB_OUTPUT"
-        echo "token-secret-name=OPENTELEMETRYBOT_GITHUB_TOKEN" >> "$GITHUB_OUTPUT"
+        echo "enabled=${{ env.OTELBOT_DOTNET_PRIVATE_KEY_EXISTS == 'true' }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -14,7 +14,8 @@ permissions:
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
-    secrets: inherit
+    secrets:
+      OTELBOT_DOTNET_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
 
   core-version-update:
     runs-on: ubuntu-22.04
@@ -23,14 +24,17 @@ jobs:
 
     if: needs.automation.outputs.enabled
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+    - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         ref: ${{ github.event.repository.default_branch }}
-        token: ${{ env.GH_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Setup dotnet
       uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
@@ -38,6 +42,7 @@ jobs:
     - name: Create GitHub Pull Request to update core version in props and update CHANGELOGs in projects
       shell: pwsh
       env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         BOT_USER_EMAIL: ${{ needs.automation.outputs.email }}
         BOT_USER_NAME: ${{ needs.automation.outputs.username }}
         TARGET_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -16,7 +16,8 @@ permissions:
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
-    secrets: inherit
+    secrets:
+      OTELBOT_DOTNET_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
 
   post-release:
     runs-on: ubuntu-22.04
@@ -26,17 +27,20 @@ jobs:
 
     if: needs.automation.outputs.enabled
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+    - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         # Note: By default GitHub only fetches 1 commit. We need all the tags
         # for this work.
         fetch-depth: 0
         ref: ${{ github.event.repository.default_branch }}
-        token: ${{ env.GH_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create GitHub Pull Request to update PackageValidationBaselineVersion in projects
       if: |
@@ -44,6 +48,7 @@ jobs:
         (inputs.tag && !contains(inputs.tag, '-alpha') && !contains(inputs.tag, '-beta') && !contains(inputs.tag, '-rc'))
       shell: pwsh
       env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         BOT_USER_EMAIL: ${{ needs.automation.outputs.email }}
         BOT_USER_NAME: ${{ needs.automation.outputs.username }}
         TARGET_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -82,7 +82,8 @@ permissions:
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
-    secrets: inherit
+    secrets:
+      OTELBOT_DOTNET_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
 
   prepare-release-pr:
     runs-on: ubuntu-22.04
@@ -91,18 +92,22 @@ jobs:
 
     if: github.event_name == 'workflow_dispatch' && needs.automation.outputs.enabled
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+    - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
     - name: Check out code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
-        token: ${{ env.GH_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create GitHub Pull Request to prepare release
       shell: pwsh
       env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         BOT_USER_EMAIL: ${{ needs.automation.outputs.email }}
         BOT_USER_NAME: ${{ needs.automation.outputs.username }}
         COMMENT_USER_NAME: ${{ github.event.sender.login }}
@@ -130,23 +135,27 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
-      github.event.pull_request.user.login == needs.automation.outputs.username &&
+      github.event.pull_request.user.login == 'otelbot[bot]' &&
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.title, '[release] Prepare release ') &&
       needs.automation.outputs.enabled
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+    - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
     - name: Check out code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
-        token: ${{ env.GH_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Lock GitHub Pull Request to prepare release
       shell: pwsh
       env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         BOT_USER_NAME: ${{ needs.automation.outputs.username }}
         ISSUE_NUMBER: ${{ github.event.pull_request.number }}
       run: |
@@ -166,27 +175,31 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.issue.locked == true &&
-      github.event.comment.user.login != needs.automation.outputs.username &&
+      github.event.comment.user.login != 'otelbot[bot]' &&
       contains(github.event.comment.body, '/CreateReleaseTag') &&
       startsWith(github.event.issue.title, '[release] Prepare release ') &&
       github.event.issue.pull_request.merged_at &&
       needs.automation.outputs.enabled
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+    - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
     - name: Check out code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
-        token: ${{ env.GH_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create release tag
       id: create-tag
       shell: pwsh
       env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         BOT_USER_EMAIL: ${{ needs.automation.outputs.email }}
         BOT_USER_NAME: ${{ needs.automation.outputs.username }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -209,27 +222,31 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.issue.state == 'open' &&
-      github.event.comment.user.login != needs.automation.outputs.username &&
+      github.event.comment.user.login != 'otelbot[bot]' &&
       contains(github.event.comment.body, '/UpdateReleaseDates') &&
       startsWith(github.event.issue.title, '[release] Prepare release ') &&
       github.event.issue.pull_request.merged_at == null &&
       needs.automation.outputs.enabled
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+    - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
     - name: Check out code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
-        token: ${{ env.GH_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Update release date
       id: create-tag
       shell: pwsh
       env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         BOT_USER_EMAIL: ${{ needs.automation.outputs.email }}
         BOT_USER_NAME: ${{ needs.automation.outputs.username }}
         COMMENT_USER_NAME: ${{ github.event.comment.user.login }}
@@ -260,21 +277,25 @@ jobs:
         (github.event_name == 'issue_comment' &&
          github.event.issue.state == 'open' &&
          contains(github.event.comment.body, '/PrepareRelease') &&
-         github.event.comment.user.login != needs.automation.outputs.username)
+         github.event.comment.user.login != 'otelbot[bot]')
       )
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+    - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
     - name: Check out code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
-        token: ${{ env.GH_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Process release request issue being opened or commented
       shell: pwsh
       env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         BOT_USER_EMAIL: ${{ needs.automation.outputs.email }}
         BOT_USER_NAME: ${{ needs.automation.outputs.username }}
         ISSUE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -21,7 +21,8 @@ permissions:
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
-    secrets: inherit
+    secrets:
+      OTELBOT_DOTNET_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
 
   build-pack-publish:
 
@@ -124,14 +125,17 @@ jobs:
 
     if: needs.automation.outputs.enabled && github.event_name == 'push'
 
-    env:
-      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
-
     steps:
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ steps.otelbot-token.outputs.token }}
 
       - name: Download Artifacts
         env:
@@ -149,6 +153,8 @@ jobs:
       - name: Create GitHub Release
         if: github.ref_type == 'tag'
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           Import-Module .\build\scripts\post-release.psm1
 
@@ -160,6 +166,7 @@ jobs:
       - name: Post notice when packages are ready
         shell: pwsh
         env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           BOT_USER_NAME: ${{ needs.automation.outputs.username }}
           PACKAGES_URL: ${{ needs.build-pack-publish.outputs.artifact-url }}
         run: |

--- a/.github/workflows/sync-sql-tests.yml
+++ b/.github/workflows/sync-sql-tests.yml
@@ -14,13 +14,19 @@ jobs:
 
     steps:
 
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           filter: 'tree:0'
           persist-credentials: true
           show-progress: false
-          token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          token: ${{ steps.otelbot-token.outputs.token }}
 
       - name: Update SQL test cases from open-telemetry/semantic-conventions
         id: update-sql-tests
@@ -48,7 +54,7 @@ jobs:
             exit 0
           }
 
-          $BranchName = "update-sql-test-cases"
+          $BranchName = "otelbot/update-sql-test-cases"
 
           git config user.email ${env:GIT_COMMIT_USER_EMAIL} | Out-Null
           git config user.name ${env:GIT_COMMIT_USER_NAME} | Out-Null
@@ -81,7 +87,7 @@ jobs:
           UPSTREAM_REF: ${{ steps.update-sql-tests.outputs.upstream-ref }}
           UPSTREAM_REPO_NAME: ${{ steps.update-sql-tests.outputs.upstream-repo-name }}
         with:
-          github-token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          github-token: ${{ steps.otelbot-token.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -163,7 +163,7 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
   $tagPrefix = $match.Groups[1].Value
   $version = $match.Groups[2].Value
 
-  $branch="release/post-stable-${tag}-update"
+  $branch="otelbot/post-stable-${tag}-update"
 
   if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
   {
@@ -330,7 +330,7 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
     Return
   }
 
-  $branch="release/post-core-${version}-update"
+  $branch="otelbot/post-core-${version}-update"
 
   if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
   {

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -28,7 +28,7 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
 
   $minVerTagPrefix = $match.Groups[1].Value
   $tag="${minVerTagPrefix}${version}"
-  $branch="release/prepare-${tag}-release"
+  $branch="otelbot/prepare-${tag}-release"
 
   if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
   {


### PR DESCRIPTION
Towards https://github.com/open-telemetry/community/issues/2863

Importantly for this repo, it will allow you to remove write permissions for the shared opentelemetrybot user and instead limit the access only via fine-grained "otelbot dotnet contrib" app (which I've just created).

`vars.AUTOMATION_USERNAME` will need to be updated to `otelbot`
`vars.AUTOMATION_EMAIL` will need to be updated to `197425009+otelbot@users.noreply.github.com`

Note: the basic `otelbot` app (not `otelbot dotnet contrib` app) is still used for commit username/email since that app has been registered to pass EasyCLA