### PR TITLE
[SqlClient/EFCore] summary optimization phase 2

### DIFF
--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -689,9 +689,17 @@ internal static class SqlProcessor
         // In this case, we fast-path to the closing parenthesis and replace the entire contents with a single '?'.
 
         if (state.SanitizedPosition > 0 && buffer[state.SanitizedPosition - 1] == OpenParenChar
-            && state.PreviousTokenEndPosition - state.PreviousTokenStartPosition == 2
-            && sql.Slice(state.PreviousTokenStartPosition, 2).Equals("in", StringComparison.OrdinalIgnoreCase))
+            && state.PreviousTokenEndPosition - state.PreviousTokenStartPosition == 2)
         {
+            // Check the token is actually "IN" (case-insensitive) to avoid false positives.
+            var firstChar = sql[state.PreviousTokenStartPosition];
+            var secondChar = sql[state.PreviousTokenStartPosition + 1];
+
+            if (!((firstChar == 'i' || firstChar == 'I') && (secondChar == 'n' || secondChar == 'N')))
+            {
+                return false;
+            }
+
             var closingParenIndex = sql.Slice(parsePosition).IndexOf(CloseParenChar);
 
             if (closingParenIndex > 0)

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -765,10 +765,22 @@ internal static class SqlProcessor
             ViewKeyword = new("view", SqlKeyword.View, DdlKeywords);
 
             // Phase 2: Build arrays that depend on instances
-            DdlSubKeywords = [
-                TableKeyword, IndexKeyword, ViewKeyword, ProcedureKeyword, TriggerKeyword,
-                DatabaseKeyword, SchemaKeyword, FunctionKeyword, UserKeyword, RoleKeyword, SequenceKeyword, UniqueKeyword,
-                ClusteredKeyword, NonClusteredKeyword
+            DdlSubKeywords =
+            [
+                TableKeyword,
+                IndexKeyword,
+                ViewKeyword,
+                ProcedureKeyword,
+                TriggerKeyword,
+                DatabaseKeyword,
+                SchemaKeyword,
+                FunctionKeyword,
+                UserKeyword,
+                RoleKeyword,
+                SequenceKeyword,
+                UniqueKeyword,
+                ClusteredKeyword,
+                NonClusteredKeyword,
             ];
 
             // Phase 3: Wire follow relationships

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -719,8 +719,11 @@ internal static class SqlProcessor
         // Used on keywords that are only included in the summary if they are the first keyword in the statement.
         private static readonly SqlKeyword[] Unknown = [SqlKeyword.Unknown];
 
-        private static readonly SqlKeyword[] DdlKeywords = [
-            SqlKeyword.Create, SqlKeyword.Drop, SqlKeyword.Alter
+        private static readonly SqlKeyword[] DdlKeywords =
+        [
+            SqlKeyword.Create,
+            SqlKeyword.Drop,
+            SqlKeyword.Alter,
         ];
 
         private readonly SqlKeyword[]? captureInSummaryWhenPrevious;

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -16,7 +16,6 @@ internal static class SqlProcessor
     private const char SpaceChar = ' ';
     private const char CommaChar = ',';
     private const char OpenParenChar = '(';
-    private const char CloseParenChar = ')';
     private const char DashChar = '-';
     private const char ForwardSlashChar = '/';
     private const char SingleQuoteChar = '\'';

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -1,14 +1,81 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Text;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Instrumentation;
 
 internal static class SqlProcessor
 {
     private const int CacheCapacity = 1000;
-    private static readonly Dictionary<string, SqlStatementInfo> Cache = [];
+
+    private static readonly ConcurrentDictionary<string, SqlStatementInfo> Cache = new();
+
+#if NET
+    private static readonly SearchValues<char> WhitespaceSearchValues = SearchValues.Create([' ', '\t', '\r', '\n']);
+#endif
+
+    // We can extend this in the future to include more keywords if needed.
+    // The keywords should be ordered by frequency of use to optimize performance.
+    // This only includes keywords that are standalone or which are often the first keyword in a statement.
+    private static readonly SqlKeywordInfo[] SqlKeywords =
+    [
+        SqlKeywordInfo.SelectKeyword,
+        SqlKeywordInfo.InsertKeyword,
+        SqlKeywordInfo.UpdateKeyword,
+        SqlKeywordInfo.DeleteKeyword,
+        SqlKeywordInfo.CreateKeyword,
+        SqlKeywordInfo.AlterKeyword,
+        SqlKeywordInfo.DropKeyword,
+    ];
+
+    // This is a special case used when handling sub-queries in parentheses.
+    private static readonly SqlKeywordInfo[] SelectOnlyKeywordArray =
+    [
+        SqlKeywordInfo.SelectKeyword,
+    ];
+
+    // Maintain our own approximate count to avoid ConcurrentDictionary.Count on hot path.
+    // We only increment on successful TryAdd. This may result in a slightly oversized cache under high concurrency
+    // but this is acceptable for the use case.
+    private static int approxCacheCount;
+
+    private enum SqlKeyword
+    {
+        Unknown,
+        Select,
+        Insert,
+        Update,
+        Delete,
+        From,
+        Into,
+        Join,
+        Create,
+        Alter,
+        Drop,
+        Table,
+        Index,
+        Procedure,
+        View,
+        Database,
+        Trigger,
+        Union,
+        Unique,
+        NonClustered,
+        Clustered,
+        Distinct,
+        On,
+        Schema,
+        Function,
+        User,
+        Role,
+        Sequence,
+        If,
+        Not,
+        Exists,
+    }
 
     public static SqlStatementInfo GetSanitizedSql(string? sql)
     {
@@ -17,66 +84,349 @@ internal static class SqlProcessor
             return default;
         }
 
-        if (!Cache.TryGetValue(sql, out var sqlStatementInfo))
+        if (Cache.TryGetValue(sql, out var sqlStatementInfo))
         {
-            sqlStatementInfo = SanitizeSql(sql);
-
-            if (Cache.Count == CacheCapacity)
-            {
-                return sqlStatementInfo;
-            }
-
-            lock (Cache)
-            {
-                if (!Cache.ContainsKey(sql))
-                {
-                    if (Cache.Count < CacheCapacity)
-                    {
-                        Cache[sql] = sqlStatementInfo;
-                    }
-                }
-            }
+            return sqlStatementInfo;
         }
+
+        sqlStatementInfo = SanitizeSql(sql.AsSpan());
+
+        // Fast-path capacity check using our own approximate count to avoid ConcurrentDictionary.Count cost.
+        if (Volatile.Read(ref approxCacheCount) >= CacheCapacity)
+        {
+            return sqlStatementInfo;
+        }
+
+        // Attempt to add when under capacity. Increment our count only on successful add.
+        if (Cache.TryAdd(sql, sqlStatementInfo))
+        {
+            Interlocked.Increment(ref approxCacheCount);
+            return sqlStatementInfo;
+        }
+
+        // If another thread added meanwhile, return the cached value if available.
+        return Cache.TryGetValue(sql, out var existing) ? existing : sqlStatementInfo;
+    }
+
+#if !NET
+    // Private helpers (kept after public methods to satisfy analyzers)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAsciiLetter(char c)
+    {
+        var lower = (char)(c | 0x20);
+        return lower >= 'a' && lower <= 'z';
+    }
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAsciiDigit(char c) =>
+#if NET
+        char.IsAsciiDigit(c);
+#else
+        c >= '0' && c <= '9';
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAsciiIdentifierChar(char c) =>
+#if NET
+        char.IsAsciiLetter(c) || char.IsAsciiDigit(c) || c == '_' || c == '.';
+#else
+        IsAsciiLetter(c) || IsAsciiDigit(c) || c == '_' || c == '.';
+#endif
+
+    private static SqlStatementInfo SanitizeSql(ReadOnlySpan<char> sql)
+    {
+        // We use a single buffer for both sanitized SQL and DB query summary
+        // DB query summary starts from the index of the length of the input SQL
+        // We rent a buffer twice the size of the input SQL to ensure we have enough space
+        var rentedBuffer = ArrayPool<char>.Shared.Rent(sql.Length * 2);
+
+        var buffer = rentedBuffer.AsSpan();
+
+        ParseState state = default;
+
+        // Precompute the summary buffer slice once and carry it via state to avoid repeated Span.Slice calls.
+        state.SummaryBuffer = buffer.Slice(rentedBuffer.Length / 2);
+
+        while (state.ParsePosition < sql.Length)
+        {
+            if (SkipComment(sql, ref state))
+            {
+                continue;
+            }
+
+            if (SanitizeStringLiteral(sql, buffer, ref state) ||
+                SanitizeHexLiteral(sql, buffer, ref state) ||
+                SanitizeNumericLiteral(sql, buffer, ref state))
+            {
+                continue;
+            }
+
+            if (ParseWhitespace(sql, buffer, ref state))
+            {
+                continue;
+            }
+
+            ParseNextToken(sql, buffer, ref state);
+        }
+
+        var summaryLength = Math.Min(state.SummaryPosition, 255);
+
+        // Trim trailing space (if required)
+        if (summaryLength > 0 && state.SummaryBuffer[summaryLength - 1] == ' ')
+        {
+            summaryLength -= 1;
+        }
+
+        var sqlStatementInfo = new SqlStatementInfo(
+            buffer.Slice(0, state.SanitizedPosition).ToString(),
+            state.SummaryBuffer.Slice(0, summaryLength).ToString());
+
+        // We don't clear the buffer as we know the content has been sanitized
+        ArrayPool<char>.Shared.Return(rentedBuffer);
 
         return sqlStatementInfo;
     }
 
-    private static SqlStatementInfo SanitizeSql(string sql)
+    private static void ParseNextToken(
+        ReadOnlySpan<char> sql,
+        Span<char> buffer,
+        ref ParseState state)
     {
-        var state = new SqlProcessorState(sql.Length);
+        var nextChar = sql[state.ParsePosition];
 
-        for (var i = 0; i < sql.Length; ++i)
+        // Quick first-character filter: only attempt keyword matching if the current char is an ASCII letter
+#if NET
+        var mayBeKeyword = char.IsAsciiLetter(nextChar);
+#else
+        var mayBeKeyword = IsAsciiLetter(nextChar);
+#endif
+
+        // As an optimization, we only compare for keywords if we haven't already captured 255 characters for the summary.
+        // Avoid comparing for keywords if the previous token was a keyword that is expected to be followed by an identifier.
+        if (mayBeKeyword)
         {
-            if (SkipComment(sql, ref i))
+            var remainingSql = sql.Slice(state.ParsePosition);
+
+            // Determine the length of the next contiguous ascii-letter run
+            // This allows some fast paths in the comparisons below.
+            var asciiLetterLength = 1;
+            while (asciiLetterLength < remainingSql.Length)
             {
-                continue;
+                var ch = remainingSql[asciiLetterLength];
+#if NET
+                if (!char.IsAsciiLetter(ch))
+#else
+                if (!IsAsciiLetter(ch))
+#endif
+                {
+                    break;
+                }
+
+                asciiLetterLength++;
             }
 
-            if (SanitizeStringLiteral(sql, ref i) ||
-                SanitizeHexLiteral(sql, ref i) ||
-                SanitizeNumericLiteral(sql, ref i))
+            // NOTE: At one stage we tried checking if the length was between 2 and 12 (inclusive)
+            // the range of shortest and longest keywords. This ended up being slower in practice
+            // as many tokens fall into this range and it was faster to skip the length check.
+
+            ReadOnlySpan<SqlKeywordInfo> keywordsToCheck;
+
+            // Check if the previous character is '(', in which case, we only check against the SELECT keyword.
+            // Otherwise, check if the previous keyword may be the start of a keyword chain so we can limit the
+            // number of keyword comparisons we need to do by only comparing for tokens we expect to appear next.
+            if (state.ParsePosition > 0 && sql[state.ParsePosition - 1] == '(')
             {
-                state.SanitizedSql.Append('?');
-                continue;
+                keywordsToCheck = SelectOnlyKeywordArray;
+            }
+            else
+            {
+                var previousKeywordInfo = state.PreviousParsedKeyword;
+
+                keywordsToCheck = previousKeywordInfo != null && previousKeywordInfo.FollowedByKeywords.Length > 0
+                    ? (ReadOnlySpan<SqlKeywordInfo>)previousKeywordInfo.FollowedByKeywords
+                    : (ReadOnlySpan<SqlKeywordInfo>)SqlKeywords;
             }
 
-            WriteToken(sql, ref i, state);
+            for (int i = 0; i < keywordsToCheck.Length; i++)
+            {
+                var potentialKeywordInfo = keywordsToCheck[i];
+
+                var keywordSpan = potentialKeywordInfo.KeywordText.AsSpan();
+                var keywordLength = keywordSpan.Length;
+
+                // If the next token length doesn't match the keyword length, it can't be a match.
+                if (asciiLetterLength != keywordLength)
+                {
+                    continue;
+                }
+
+                // First-letter quick check to reduce comparisons early.
+                // We know the current char is an ASCII letter so this is a safe way to lowercase.
+                // The keyword string is already lowercase so doesn't need to be lowercased here.
+                if ((remainingSql[0] | 0x20) != keywordSpan[0])
+                {
+                    continue;
+                }
+
+                var matchedKeyword = true;
+
+                var sqlToCopy = remainingSql.Slice(0, keywordLength);
+
+                // Compare the potential keyword in a case-insensitive manner
+                for (var charPos = 1; charPos < keywordLength; charPos++)
+                {
+                    if ((sqlToCopy[charPos] | 0x20) != keywordSpan[charPos])
+                    {
+                        matchedKeyword = false;
+                        break;
+                    }
+                }
+
+                if (matchedKeyword)
+                {
+                    sqlToCopy.CopyTo(buffer.Slice(state.SanitizedPosition));
+                    state.SanitizedPosition += keywordLength;
+
+                    // We only capture if we haven't already filled the summary to the max length of 255.
+                    // Check if the keyword should be captured in the summary
+                    if (state.SummaryPosition < 255 && SqlKeywordInfo.CaptureInSummary(in state, potentialKeywordInfo))
+                    {
+                        if (state.SummaryPosition == 0)
+                        {
+                            state.FirstSummaryKeyword = potentialKeywordInfo.SqlKeyword;
+                        }
+
+                        sqlToCopy.CopyTo(state.SummaryBuffer.Slice(state.SummaryPosition));
+                        state.SummaryPosition += keywordLength;
+
+                        // Add a space after the keyword. The trailing space will be trimmed later if needed.
+                        state.SummaryBuffer[state.SummaryPosition++] = ' ';
+
+                        state.PreviousSummaryKeyword = potentialKeywordInfo.SqlKeyword;
+                    }
+
+                    state.CaptureNextTokenInSummary = SqlKeywordInfo.CaptureNextTokenInSummary(in state, potentialKeywordInfo.SqlKeyword);
+                    state.PreviousParsedKeyword = potentialKeywordInfo;
+                    state.ParsePosition += keywordLength;
+
+                    // No further parsing needed for this token
+                    return;
+                }
+            }
         }
 
-        return new SqlStatementInfo(
-            state.SanitizedSql.ToString(),
-            state.DbQuerySummary.ToString());
+        // If we get this far, we have not matched a keyword, so we copy the token as-is
+        if (char.IsLetter(nextChar) || nextChar == '_')
+        {
+            // Scan the identifier token once, then bulk-copy to minimize per-char branching
+            var start = state.ParsePosition;
+            var i = start;
+            while (i < sql.Length)
+            {
+                var ch = sql[i];
+                if (IsAsciiIdentifierChar(ch))
+                {
+                    i++;
+                    continue;
+                }
+
+                break;
+            }
+
+            var length = i - start;
+            if (length > 0)
+            {
+                // Copy to sanitized buffer
+                sql.Slice(start, length).CopyTo(buffer.Slice(state.SanitizedPosition));
+                state.SanitizedPosition += length;
+
+                // Optionally copy to summary buffer
+                if (state.SummaryPosition < 255 && state.CaptureNextTokenInSummary)
+                {
+                    // We may copy paste 255 here which is fine as we slice to max 255 when creating the final string
+                    sql.Slice(start, length).CopyTo(state.SummaryBuffer.Slice(state.SummaryPosition));
+                    state.SummaryPosition += length;
+
+                    // Add a space after the identifier. The trailing space will be trimmed later if needed.
+                    state.SummaryBuffer[state.SummaryPosition++] = ' ';
+                }
+            }
+
+            state.ParsePosition = i;
+            state.CaptureNextTokenInSummary = false;
+        }
+        else
+        {
+            var prevKeyword = state.PreviousParsedKeyword?.SqlKeyword ?? SqlKeyword.Unknown;
+            state.CaptureNextTokenInSummary = prevKeyword == SqlKeyword.From && nextChar == ',';
+
+            buffer[state.SanitizedPosition++] = nextChar;
+            state.ParsePosition++;
+        }
     }
 
-    private static bool SkipComment(string sql, ref int index)
+    private static bool ParseWhitespace(ReadOnlySpan<char> sql, Span<char> buffer, ref ParseState state)
     {
-        var i = index;
+        var foundWhitespace = false;
+
+        while (state.ParsePosition < sql.Length)
+        {
+            var nextChar = sql[state.ParsePosition];
+
+#if NET
+            if (WhitespaceSearchValues.Contains(nextChar))
+#else
+            if (nextChar == ' ' || nextChar == '\t' || nextChar == '\r' || nextChar == '\n')
+#endif
+            {
+                foundWhitespace = true;
+                buffer[state.SanitizedPosition++] = nextChar;
+                state.ParsePosition++;
+                continue; // keep consuming contiguous whitespace
+            }
+
+            break; // stop when nextChar is not whitespace
+        }
+
+        return foundWhitespace;
+    }
+
+    private static bool SkipComment(ReadOnlySpan<char> sql, ref ParseState state)
+    {
+        var i = state.ParsePosition;
         var ch = sql[i];
         var length = sql.Length;
 
         // Scan past multi-line comment
         if (ch == '/' && i + 1 < length && sql[i + 1] == '*')
         {
+#if NET
+            var rest = sql.Slice(i + 2);
+            while (!rest.IsEmpty)
+            {
+                var starIdx = rest.IndexOf('*');
+                if (starIdx < 0)
+                {
+                    // Unterminated comment, consume to end
+                    state.ParsePosition = length;
+                    return true;
+                }
+
+                // Check for closing */
+                if (starIdx + 1 < rest.Length && rest[starIdx + 1] == '/')
+                {
+                    state.ParsePosition = i + 2 + starIdx + 2; // position after */
+                    return true;
+                }
+
+                // Continue searching after this '*'
+                rest = rest.Slice(starIdx + 1);
+            }
+
+            state.ParsePosition = length;
+            return true;
+#else
             for (i += 2; i < length; ++i)
             {
                 ch = sql[i];
@@ -87,62 +437,111 @@ internal static class SqlProcessor
                 }
             }
 
-            index = i;
+            state.ParsePosition = ++i;
             return true;
+#endif
         }
 
         // Scan past single-line comment
         if (ch == '-' && i + 1 < length && sql[i + 1] == '-')
         {
+#if NET
+            // Find next line break efficiently and preserve the newline for whitespace handling
+            var rest = sql.Slice(i + 2);
+            var idx = rest.IndexOfAny('\r', '\n');
+            if (idx >= 0)
+            {
+                // Position at the newline so ParseWhitespace can copy it
+                state.ParsePosition = i + 2 + idx;
+            }
+            else
+            {
+                state.ParsePosition = sql.Length;
+            }
+
+            return true;
+#else
             for (i += 2; i < length; ++i)
             {
                 ch = sql[i];
-                if (ch is '\r' or '\n')
+                if (ch == '\r' || ch == '\n')
                 {
                     i -= 1;
                     break;
                 }
             }
 
-            index = i;
+            state.ParsePosition = ++i;
             return true;
+#endif
         }
 
         return false;
     }
 
-    private static bool SanitizeStringLiteral(string sql, ref int index)
+    private static bool SanitizeStringLiteral(ReadOnlySpan<char> sql, Span<char> buffer, ref ParseState state)
     {
-        var ch = sql[index];
-        if (ch == '\'')
+        var nextChar = sql[state.ParsePosition];
+        if (nextChar == '\'')
         {
-            var i = index + 1;
+#if NET
+            var rest = sql.Slice(state.ParsePosition + 1);
+            while (!rest.IsEmpty)
+            {
+                var idx = rest.IndexOf('\'');
+                if (idx < 0)
+                {
+                    state.ParsePosition = sql.Length;
+                    return true;
+                }
+
+                if (idx + 1 < rest.Length && rest[idx + 1] == '\'')
+                {
+                    // Skip escaped quote ('')
+                    rest = rest.Slice(idx + 2);
+                    continue;
+                }
+
+                // Found terminating quote
+                state.ParsePosition = sql.Length - rest.Length + idx + 1;
+
+                buffer[state.SanitizedPosition++] = '?';
+                return true;
+            }
+
+            buffer[state.SanitizedPosition++] = '?';
+            return true;
+#else
+            var i = state.ParsePosition + 1;
             var length = sql.Length;
             for (; i < length; ++i)
             {
-                ch = sql[i];
-                if (ch == '\'' && i + 1 < length && sql[i + 1] == '\'')
+                nextChar = sql[i];
+                if (nextChar == '\'' && i + 1 < length && sql[i + 1] == '\'')
                 {
                     ++i;
                     continue;
                 }
 
-                if (ch == '\'')
+                if (nextChar == '\'')
                 {
                     break;
                 }
             }
 
-            index = i;
+            state.ParsePosition = ++i;
+
+            buffer[state.SanitizedPosition++] = '?';
             return true;
+#endif
         }
 
         return false;
     }
 
-    private static bool SanitizeHexLiteral(string sql, ref int index)
+    private static bool SanitizeHexLiteral(ReadOnlySpan<char> sql, Span<char> buffer, ref ParseState state)
     {
-        var i = index;
+        var i = state.ParsePosition;
         var ch = sql[i];
         var length = sql.Length;
 
@@ -151,7 +550,13 @@ internal static class SqlProcessor
             for (i += 2; i < length; ++i)
             {
                 ch = sql[i];
-                if (char.IsDigit(ch) ||
+#if NET
+                if (char.IsAsciiHexDigit(ch))
+                {
+                    continue;
+                }
+#else
+                if (IsAsciiDigit(ch) ||
                     ch == 'A' || ch == 'a' ||
                     ch == 'B' || ch == 'b' ||
                     ch == 'C' || ch == 'c' ||
@@ -161,58 +566,86 @@ internal static class SqlProcessor
                 {
                     continue;
                 }
+#endif
 
                 i -= 1;
                 break;
             }
 
-            index = i;
+            state.ParsePosition = ++i;
+
+            buffer[state.SanitizedPosition++] = '?';
             return true;
         }
 
         return false;
     }
 
-    private static bool SanitizeNumericLiteral(string sql, ref int index)
+    private static bool SanitizeNumericLiteral(ReadOnlySpan<char> sql, Span<char> buffer, ref ParseState state)
     {
-        var i = index;
-        var ch = sql[i];
+        var i = state.ParsePosition;
+        var nextChar = sql[i];
         var length = sql.Length;
 
+        // If the digit follows an open bracket, check for a parenthesized digit sequence
+        if (i > 0 && sql[i - 1] == '('
+            && IsAsciiDigit(nextChar))
+        {
+            int start = i;
+            int j = i;
+
+            // Scan until closing ')', ensure all are digits
+            while (j < length && IsAsciiDigit(sql[j]))
+            {
+                j++;
+            }
+
+            if (j < length && sql[j] == ')')
+            {
+                // Copy the digits and the closing bracket to the buffer
+                sql.Slice(start, j - start + 1).CopyTo(buffer.Slice(state.SanitizedPosition));
+                state.SanitizedPosition += j - start + 1;
+                state.ParsePosition = j + 1;
+                return true;
+            }
+
+            // If not a valid parenthesized digit sequence, fall through to normal logic
+        }
+
         // Scan past leading sign
-        if ((ch == '-' || ch == '+') && i + 1 < length && (char.IsDigit(sql[i + 1]) || sql[i + 1] == '.'))
+        if ((nextChar == '-' || nextChar == '+') && i + 1 < length && (IsAsciiDigit(sql[i + 1]) || sql[i + 1] == '.'))
         {
             i += 1;
-            ch = sql[i];
+            nextChar = sql[i];
         }
 
         // Scan past leading decimal point
         var periodMatched = false;
-        if (ch == '.' && i + 1 < length && char.IsDigit(sql[i + 1]))
+        if (nextChar == '.' && i + 1 < length && IsAsciiDigit(sql[i + 1]))
         {
             periodMatched = true;
             i += 1;
-            ch = sql[i];
+            nextChar = sql[i];
         }
 
-        if (char.IsDigit(ch))
+        if (IsAsciiDigit(nextChar))
         {
             var exponentMatched = false;
             for (i += 1; i < length; ++i)
             {
-                ch = sql[i];
-                if (char.IsDigit(ch))
+                nextChar = sql[i];
+                if (IsAsciiDigit(nextChar))
                 {
                     continue;
                 }
 
-                if (!periodMatched && ch == '.')
+                if (!periodMatched && nextChar == '.')
                 {
                     periodMatched = true;
                     continue;
                 }
 
-                if (!exponentMatched && (ch == 'e' || ch == 'E'))
+                if (!exponentMatched && (nextChar == 'e' || nextChar == 'E'))
                 {
                     // Scan past sign in exponent
                     if (i + 1 < length && (sql[i + 1] == '-' || sql[i + 1] == '+'))
@@ -228,177 +661,241 @@ internal static class SqlProcessor
                 break;
             }
 
-            index = i;
+            state.ParsePosition = ++i;
+
+            buffer[state.SanitizedPosition++] = '?';
             return true;
         }
 
         return false;
     }
 
-    private static void WriteToken(string sql, ref int index, SqlProcessorState state)
+    private ref struct ParseState
     {
-        var i = index;
-        var ch = sql[i];
+        // ParseState intentionally uses public fields (not properties):
+        // - This is a ref struct that lives on the stack and is passed by ref through hot paths.
+        // - Fields avoid property accessor calls in tight loops and yield smaller/faster code after inlining.
+        // - Grouping Span<> and larger struct fields first helps layout and may reduce padding.
+        // - Keeping the struct simple and flat minimizes stack pressure and lets the JIT keep values in registers.
 
-        if (LookAhead("SELECT", sql, ref i, state) ||
-            LookAhead("UPDATE", sql, ref i, state) ||
-            LookAhead("INSERT", sql, ref i, state) ||
-            LookAhead("DELETE", sql, ref i, state) ||
-            LookAheadDdl("CREATE", sql, ref i, state) ||
-            LookAheadDdl("ALTER", sql, ref i, state) ||
-            LookAheadDdl("DROP", sql, ref i, state) ||
-            LookAhead("INTO", sql, ref i, state, false, true) ||
-            LookAhead("FROM", sql, ref i, state, false, true, true) ||
-            LookAhead("JOIN", sql, ref i, state, false, true))
-        {
-            i -= 1;
-        }
-        else if (char.IsLetter(ch) || ch == '_')
-        {
-            for (; i < sql.Length; i++)
-            {
-                ch = sql[i];
-                if (char.IsLetter(ch) || ch == '_' || ch == '.' || char.IsDigit(ch))
-                {
-                    state.SanitizedSql.Append(ch);
-                    continue;
-                }
+        // Stored in state to avoid slicing repeatedly.
+        public Span<char> SummaryBuffer; // 16 bytes (on x64)
 
-                break;
-            }
+        public SqlKeywordInfo? PreviousParsedKeyword; // 8 bytes (reference type)
 
-            if (state.CaptureNextTokenAsTarget)
-            {
-                state.CaptureNextTokenAsTarget = false;
-#if NET
-                state.DbQuerySummary.Append(' ').Append(sql.AsSpan(index, i - index));
-#else
-                var collection = sql.Substring(index, i - index);
-                state.DbQuerySummary.Append(' ').Append(collection);
-#endif
-            }
+        public SqlKeyword FirstSummaryKeyword; // 4 bytes (enum, underlying int)
+        public SqlKeyword PreviousSummaryKeyword; // 4 bytes (enum, underlying int)
 
-            i -= 1;
+        // These track the current parse position in the input SQL and the current write position
+        // for the sanitized SQL and summary buffers.
+        public int ParsePosition; // 4 bytes
+        public int SanitizedPosition; // 4 bytes
+        public int SummaryPosition; // 4 bytes
 
-            if (state.InFromClause && ch == ',')
-            {
-                state.CaptureNextTokenAsTarget = true;
-            }
-        }
-        else
-        {
-            state.SanitizedSql.Append(ch);
-        }
-
-        index = i;
+        public bool CaptureNextTokenInSummary; // 1 byte
     }
 
-    private static void AppendNormalized(StringBuilder builder, char ch)
+    private sealed class SqlKeywordInfo
     {
-        if (!char.IsWhiteSpace(ch) || builder.Length == 0 || !char.IsWhiteSpace(builder[builder.Length - 1]))
+        // Used on keywords that are only included in the summary if they are the first keyword in the statement.
+        private static readonly SqlKeyword[] Unknown = [SqlKeyword.Unknown];
+
+        private static readonly SqlKeyword[] DdlKeywords = [
+            SqlKeyword.Create, SqlKeyword.Drop, SqlKeyword.Alter
+        ];
+
+        private readonly SqlKeyword[]? captureInSummaryWhenPrevious;
+
+        static SqlKeywordInfo()
         {
-            builder.Append(ch);
+            // Phase 1: Create all static instances.
+            // We will compare the SQL we are parsing in lowercase, so we store these in lowercase also.
+            AlterKeyword = new("alter", SqlKeyword.Alter, Unknown);
+            ClusteredKeyword = new("clustered", SqlKeyword.Clustered, [SqlKeyword.Unique]);
+            CreateKeyword = new("create", SqlKeyword.Create, Unknown);
+            DatabaseKeyword = new("database", SqlKeyword.Database, DdlKeywords);
+            DeleteKeyword = new("delete", SqlKeyword.Delete, Unknown);
+            DistinctKeyword = new("distinct", SqlKeyword.Distinct, [SqlKeyword.Select]);
+            DropKeyword = new("drop", SqlKeyword.Drop, Unknown);
+            ExistsKeyword = new("exists", SqlKeyword.Exists);
+            FromKeyword = new("from", SqlKeyword.From);
+            FunctionKeyword = new("function", SqlKeyword.Function, DdlKeywords);
+            IfKeyword = new("if", SqlKeyword.If);
+            IndexKeyword = new("index", SqlKeyword.Index, [.. DdlKeywords, SqlKeyword.Unique, SqlKeyword.Clustered, SqlKeyword.NonClustered]);
+            InsertKeyword = new("insert", SqlKeyword.Insert, Unknown);
+            IntoKeyword = new("into", SqlKeyword.Into);
+            JoinKeyword = new("join", SqlKeyword.Join);
+            NonClusteredKeyword = new("nonclustered", SqlKeyword.NonClustered, [SqlKeyword.Unique]);
+            NotKeyword = new("not", SqlKeyword.Not);
+            OnKeyword = new("on", SqlKeyword.On);
+            ProcedureKeyword = new("procedure", SqlKeyword.Procedure, DdlKeywords);
+            RoleKeyword = new("role", SqlKeyword.Role, DdlKeywords);
+            SchemaKeyword = new("schema", SqlKeyword.Schema, DdlKeywords);
+            SelectKeyword = new("select", SqlKeyword.Select, [SqlKeyword.Select, SqlKeyword.Unknown]);
+            SequenceKeyword = new("sequence", SqlKeyword.Sequence, DdlKeywords);
+            TableKeyword = new("table", SqlKeyword.Table, DdlKeywords);
+            TriggerKeyword = new("trigger", SqlKeyword.Trigger, DdlKeywords);
+            UnionKeyword = new("union", SqlKeyword.Union);
+            UniqueKeyword = new("unique", SqlKeyword.Unique, DdlKeywords);
+            UnknownKeyword = new(string.Empty, SqlKeyword.Unknown);
+            UpdateKeyword = new("update", SqlKeyword.Update, Unknown);
+            UserKeyword = new("user", SqlKeyword.User, DdlKeywords);
+            ViewKeyword = new("view", SqlKeyword.View, DdlKeywords);
+
+            // Phase 2: Build arrays that depend on instances
+            DdlSubKeywords = [
+                TableKeyword, IndexKeyword, ViewKeyword, ProcedureKeyword, TriggerKeyword,
+                DatabaseKeyword, SchemaKeyword, FunctionKeyword, UserKeyword, RoleKeyword, SequenceKeyword, UniqueKeyword,
+                ClusteredKeyword, NonClusteredKeyword
+            ];
+
+            // Phase 3: Wire follow relationships
+            AlterKeyword.FollowedByKeywords = DdlSubKeywords;
+            ClusteredKeyword.FollowedByKeywords = [IndexKeyword];
+            CreateKeyword.FollowedByKeywords = DdlSubKeywords;
+            DatabaseKeyword.FollowedByKeywords = [IfKeyword];
+            DistinctKeyword.FollowedByKeywords = [FromKeyword];
+            DropKeyword.FollowedByKeywords = DdlSubKeywords;
+            FromKeyword.FollowedByKeywords = [JoinKeyword, UnionKeyword];
+            FunctionKeyword.FollowedByKeywords = [IfKeyword];
+            IfKeyword.FollowedByKeywords = [NotKeyword, ExistsKeyword];
+            IndexKeyword.FollowedByKeywords = [OnKeyword, IfKeyword];
+            InsertKeyword.FollowedByKeywords = [IntoKeyword];
+            JoinKeyword.FollowedByKeywords = [OnKeyword];
+            NonClusteredKeyword.FollowedByKeywords = [IndexKeyword];
+            NotKeyword.FollowedByKeywords = [ExistsKeyword];
+            OnKeyword.FollowedByKeywords = [JoinKeyword];
+            ProcedureKeyword.FollowedByKeywords = [IfKeyword];
+            RoleKeyword.FollowedByKeywords = [IfKeyword];
+            SchemaKeyword.FollowedByKeywords = [IfKeyword, UnionKeyword];
+            SelectKeyword.FollowedByKeywords = [FromKeyword, DistinctKeyword];
+            SequenceKeyword.FollowedByKeywords = [IfKeyword];
+            TableKeyword.FollowedByKeywords = [IfKeyword];
+            TriggerKeyword.FollowedByKeywords = [IfKeyword];
+            UnionKeyword.FollowedByKeywords = [SelectKeyword];
+            UniqueKeyword.FollowedByKeywords = [IndexKeyword, ClusteredKeyword, NonClusteredKeyword];
+            UserKeyword.FollowedByKeywords = [IfKeyword];
+            ViewKeyword.FollowedByKeywords = [IfKeyword];
         }
-    }
 
-    private static bool LookAheadDdl(string operation, string sql, ref int index, SqlProcessorState state)
-    {
-        var initialIndex = index;
-
-        if (LookAhead(operation, sql, ref index, state, false, false))
+        private SqlKeywordInfo(
+            string keyword,
+            SqlKeyword sqlKeyword,
+            SqlKeyword[]? captureInSummaryWhenPrevious = null)
         {
-            for (; index < sql.Length && char.IsWhiteSpace(sql[index]); ++index)
-            {
-                state.SanitizedSql.Append(sql[index]);
-            }
-
-            if (LookAhead("TABLE", sql, ref index, state, false, false) ||
-                LookAhead("INDEX", sql, ref index, state, false, false) ||
-                LookAhead("PROCEDURE", sql, ref index, state, false, false) ||
-                LookAhead("VIEW", sql, ref index, state, false, false) ||
-                LookAhead("DATABASE", sql, ref index, state, false, false))
-            {
-                state.CaptureNextTokenAsTarget = true;
-            }
-
-            for (var i = initialIndex; i < index; ++i)
-            {
-                AppendNormalized(state.DbQuerySummary, sql[i]);
-            }
-
-            return true;
+            this.KeywordText = keyword;
+            this.SqlKeyword = sqlKeyword;
+            this.captureInSummaryWhenPrevious = captureInSummaryWhenPrevious;
+            this.FollowedByKeywords = [];
         }
 
-        return false;
-    }
+        public static SqlKeywordInfo AlterKeyword { get; }
 
-    private static bool LookAhead(string compare, string sql, ref int index, SqlProcessorState state, bool isOperation = true, bool captureNextTokenAsTarget = false, bool inFromClause = false)
-    {
-        int i = index;
-        var sqlLength = sql.Length;
-        var compareLength = compare.Length;
+        public static SqlKeywordInfo ClusteredKeyword { get; }
 
-        for (var j = 0; i < sqlLength && j < compareLength; ++i, ++j)
+        public static SqlKeywordInfo CreateKeyword { get; }
+
+        public static SqlKeywordInfo DatabaseKeyword { get; }
+
+        public static SqlKeywordInfo DeleteKeyword { get; }
+
+        public static SqlKeywordInfo DistinctKeyword { get; }
+
+        public static SqlKeywordInfo DropKeyword { get; }
+
+        public static SqlKeywordInfo ExistsKeyword { get; }
+
+        public static SqlKeywordInfo FromKeyword { get; }
+
+        public static SqlKeywordInfo FunctionKeyword { get; }
+
+        public static SqlKeywordInfo IfKeyword { get; }
+
+        public static SqlKeywordInfo IndexKeyword { get; }
+
+        public static SqlKeywordInfo InsertKeyword { get; }
+
+        public static SqlKeywordInfo IntoKeyword { get; }
+
+        public static SqlKeywordInfo JoinKeyword { get; }
+
+        public static SqlKeywordInfo NonClusteredKeyword { get; }
+
+        public static SqlKeywordInfo NotKeyword { get; }
+
+        public static SqlKeywordInfo OnKeyword { get; }
+
+        public static SqlKeywordInfo ProcedureKeyword { get; }
+
+        public static SqlKeywordInfo RoleKeyword { get; }
+
+        public static SqlKeywordInfo SchemaKeyword { get; }
+
+        public static SqlKeywordInfo SelectKeyword { get; }
+
+        public static SqlKeywordInfo SequenceKeyword { get; }
+
+        public static SqlKeywordInfo TableKeyword { get; }
+
+        public static SqlKeywordInfo TriggerKeyword { get; }
+
+        public static SqlKeywordInfo UnionKeyword { get; }
+
+        public static SqlKeywordInfo UniqueKeyword { get; }
+
+        public static SqlKeywordInfo UnknownKeyword { get; }
+
+        public static SqlKeywordInfo UpdateKeyword { get; }
+
+        public static SqlKeywordInfo UserKeyword { get; }
+
+        public static SqlKeywordInfo ViewKeyword { get; }
+
+        public static SqlKeywordInfo[] DdlSubKeywords { get; }
+
+        public string KeywordText { get; }
+
+        public SqlKeyword SqlKeyword { get; }
+
+        public SqlKeywordInfo[] FollowedByKeywords { get; private set; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CaptureNextTokenInSummary(in ParseState state, SqlKeyword currentKeyword) => currentKeyword switch
         {
-            if (char.ToUpperInvariant(sql[i]) != compare[j])
+            SqlKeyword.From => state.PreviousSummaryKeyword is SqlKeyword.Select or SqlKeyword.Distinct,
+            SqlKeyword.Into => state.FirstSummaryKeyword is SqlKeyword.Insert,
+            SqlKeyword.Join => state.FirstSummaryKeyword is SqlKeyword.Select or SqlKeyword.Join,
+            SqlKeyword.Database or SqlKeyword.Schema or SqlKeyword.Table or SqlKeyword.Index or SqlKeyword.View
+                or SqlKeyword.Procedure or SqlKeyword.Trigger or SqlKeyword.Function or SqlKeyword.User
+                or SqlKeyword.Role or SqlKeyword.Sequence => state.FirstSummaryKeyword is SqlKeyword.Create or SqlKeyword.Alter or SqlKeyword.Drop,
+            SqlKeyword.Exists => state.FirstSummaryKeyword is SqlKeyword.Create or SqlKeyword.Alter or SqlKeyword.Drop,
+            _ => false,
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool CaptureInSummary(in ParseState state, SqlKeywordInfo currentKeyword)
+        {
+            if (currentKeyword.captureInSummaryWhenPrevious == null || currentKeyword.captureInSummaryWhenPrevious.Length == 0)
             {
                 return false;
             }
-        }
 
-        if (i >= sqlLength)
-        {
-            // when the sql ends with the beginning of the compare string
+            var prev = state.PreviousParsedKeyword?.SqlKeyword ?? SqlKeyword.Unknown;
+            for (int i = 0; i < currentKeyword.captureInSummaryWhenPrevious.Length; i++)
+            {
+                if (currentKeyword.captureInSummaryWhenPrevious[i] == prev)
+                {
+                    return true;
+                }
+            }
+
+            if (currentKeyword.SqlKeyword == SqlKeyword.Select
+                && state.FirstSummaryKeyword is not SqlKeyword.Create && state.PreviousParsedKeyword?.SqlKeyword is not SqlKeyword.Union)
+            {
+                return true;
+            }
+
             return false;
         }
-
-        var ch = sql[i];
-        if (char.IsLetter(ch) || ch == '_' || char.IsDigit(ch))
-        {
-            return false;
-        }
-
-        if (isOperation)
-        {
-            if (state.DbQuerySummary.Length > 0)
-            {
-                state.DbQuerySummary.Append(' ');
-            }
-
-            for (var k = index; k < i; ++k)
-            {
-                state.DbQuerySummary.Append(sql[k]);
-                state.SanitizedSql.Append(sql[k]);
-            }
-        }
-        else
-        {
-            for (var k = index; k < i; ++k)
-            {
-                state.SanitizedSql.Append(sql[k]);
-            }
-        }
-
-        index = i;
-        state.CaptureNextTokenAsTarget = captureNextTokenAsTarget;
-        state.InFromClause = inFromClause;
-        return true;
-    }
-
-    internal class SqlProcessorState
-    {
-        public SqlProcessorState(int maxCapacity)
-        {
-            this.SanitizedSql = new StringBuilder(maxCapacity);
-            this.DbQuerySummary = new StringBuilder(maxCapacity);
-        }
-
-        public StringBuilder SanitizedSql { get; set; }
-
-        public StringBuilder DbQuerySummary { get; set; }
-
-        public bool CaptureNextTokenAsTarget { get; set; }
-
-        public bool InFromClause { get; set; }
     }
 }

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -704,11 +704,9 @@ internal static class SqlProcessor
             // Phase 1: Create all static instances.
             // We will compare the SQL we are parsing in lowercase, so we store these in lowercase also.
             AlterKeyword = new("alter", SqlKeyword.Alter, Unknown);
-            ClusteredKeyword = new("clustered", SqlKeyword.Clustered, [SqlKeyword.Unique]);
             CreateKeyword = new("create", SqlKeyword.Create, Unknown);
             DatabaseKeyword = new("database", SqlKeyword.Database, DdlKeywords);
             DeleteKeyword = new("delete", SqlKeyword.Delete, Unknown);
-            DistinctKeyword = new("distinct", SqlKeyword.Distinct, [SqlKeyword.Select]);
             DropKeyword = new("drop", SqlKeyword.Drop, Unknown);
             ExecKeyword = new("exec", SqlKeyword.Exec, Unknown);
             ExistsKeyword = new("exists", SqlKeyword.Exists);
@@ -719,7 +717,6 @@ internal static class SqlProcessor
             InsertKeyword = new("insert", SqlKeyword.Insert, Unknown);
             IntoKeyword = new("into", SqlKeyword.Into);
             JoinKeyword = new("join", SqlKeyword.Join);
-            NonClusteredKeyword = new("nonclustered", SqlKeyword.NonClustered, [SqlKeyword.Unique]);
             NotKeyword = new("not", SqlKeyword.Not);
             OnKeyword = new("on", SqlKeyword.On);
             ProcedureKeyword = new("procedure", SqlKeyword.Procedure, DdlKeywords);
@@ -730,7 +727,6 @@ internal static class SqlProcessor
             TableKeyword = new("table", SqlKeyword.Table, DdlKeywords);
             TriggerKeyword = new("trigger", SqlKeyword.Trigger, DdlKeywords);
             UnionKeyword = new("union", SqlKeyword.Union);
-            UniqueKeyword = new("unique", SqlKeyword.Unique, DdlKeywords);
             UnknownKeyword = new(string.Empty, SqlKeyword.Unknown);
             UpdateKeyword = new("update", SqlKeyword.Update, Unknown);
             UserKeyword = new("user", SqlKeyword.User, DdlKeywords);
@@ -743,9 +739,6 @@ internal static class SqlProcessor
             [
                 TableKeyword,
                 IndexKeyword,
-                UniqueKeyword,
-                ClusteredKeyword,
-                NonClusteredKeyword,
                 ViewKeyword,
                 ProcedureKeyword,
                 TriggerKeyword,
@@ -759,10 +752,8 @@ internal static class SqlProcessor
 
             // Phase 3: Wire follow relationships
             AlterKeyword.FollowedByKeywords = DdlSubKeywords;
-            ClusteredKeyword.FollowedByKeywords = [IndexKeyword];
             CreateKeyword.FollowedByKeywords = DdlSubKeywords;
             DatabaseKeyword.FollowedByKeywords = [IfKeyword];
-            DistinctKeyword.FollowedByKeywords = [FromKeyword];
             DropKeyword.FollowedByKeywords = DdlSubKeywords;
             FromKeyword.FollowedByKeywords = [JoinKeyword, UnionKeyword];
             FunctionKeyword.FollowedByKeywords = [IfKeyword];
@@ -770,18 +761,16 @@ internal static class SqlProcessor
             IndexKeyword.FollowedByKeywords = [OnKeyword, IfKeyword];
             InsertKeyword.FollowedByKeywords = [IntoKeyword];
             JoinKeyword.FollowedByKeywords = [OnKeyword];
-            NonClusteredKeyword.FollowedByKeywords = [IndexKeyword];
             NotKeyword.FollowedByKeywords = [ExistsKeyword];
             OnKeyword.FollowedByKeywords = [JoinKeyword];
             ProcedureKeyword.FollowedByKeywords = [IfKeyword];
             RoleKeyword.FollowedByKeywords = [IfKeyword];
             SchemaKeyword.FollowedByKeywords = [IfKeyword, UnionKeyword];
-            SelectKeyword.FollowedByKeywords = [FromKeyword, DistinctKeyword];
+            SelectKeyword.FollowedByKeywords = [FromKeyword];
             SequenceKeyword.FollowedByKeywords = [IfKeyword];
             TableKeyword.FollowedByKeywords = [IfKeyword];
             TriggerKeyword.FollowedByKeywords = [IfKeyword];
             UnionKeyword.FollowedByKeywords = [SelectKeyword];
-            UniqueKeyword.FollowedByKeywords = [IndexKeyword, ClusteredKeyword, NonClusteredKeyword];
             UserKeyword.FollowedByKeywords = [IfKeyword];
             ViewKeyword.FollowedByKeywords = [IfKeyword];
         }
@@ -799,15 +788,11 @@ internal static class SqlProcessor
 
         public static SqlKeywordInfo AlterKeyword { get; }
 
-        public static SqlKeywordInfo ClusteredKeyword { get; }
-
         public static SqlKeywordInfo CreateKeyword { get; }
 
         public static SqlKeywordInfo DatabaseKeyword { get; }
 
         public static SqlKeywordInfo DeleteKeyword { get; }
-
-        public static SqlKeywordInfo DistinctKeyword { get; }
 
         public static SqlKeywordInfo DropKeyword { get; }
 
@@ -829,8 +814,6 @@ internal static class SqlProcessor
 
         public static SqlKeywordInfo JoinKeyword { get; }
 
-        public static SqlKeywordInfo NonClusteredKeyword { get; }
-
         public static SqlKeywordInfo NotKeyword { get; }
 
         public static SqlKeywordInfo OnKeyword { get; }
@@ -850,8 +833,6 @@ internal static class SqlProcessor
         public static SqlKeywordInfo TriggerKeyword { get; }
 
         public static SqlKeywordInfo UnionKeyword { get; }
-
-        public static SqlKeywordInfo UniqueKeyword { get; }
 
         public static SqlKeywordInfo UnknownKeyword { get; }
 

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -28,8 +28,10 @@ internal static class SqlProcessor
 
     private static readonly ConcurrentDictionary<string, SqlStatementInfo> Cache = new();
 
+    private static readonly char[] WhitespaceChars = [SpaceChar, TabChar, CarriageReturnChar, NewLineChar];
+
 #if NET
-    private static readonly SearchValues<char> WhitespaceSearchValues = SearchValues.Create([SpaceChar, TabChar, CarriageReturnChar, NewLineChar]);
+    private static readonly SearchValues<char> WhitespaceSearchValues = SearchValues.Create(WhitespaceChars);
 #endif
 
     // We can extend this in the future to include more keywords if needed.
@@ -203,7 +205,7 @@ internal static class SqlProcessor
 #if NET
             var indexOfLastWhitespace = summary.Slice(0, MaxSummaryLength).LastIndexOfAny(WhitespaceSearchValues);
 #else
-            var indexOfLastWhitespace = summary.Slice(0, MaxSummaryLength).LastIndexOfAny([SpaceChar, TabChar, CarriageReturnChar, NewLineChar]);
+            var indexOfLastWhitespace = summary.Slice(0, MaxSummaryLength).LastIndexOfAny(WhitespaceChars);
 #endif
 
             summary = summary.Slice(0, indexOfLastWhitespace);
@@ -242,7 +244,7 @@ internal static class SqlProcessor
 #if NET
         var indexOfNextWhitespace = sql.Slice(start).IndexOfAny(WhitespaceSearchValues);
 #else
-        var indexOfNextWhitespace = sql.Slice(start).IndexOfAny([SpaceChar, TabChar, CarriageReturnChar, NewLineChar]);
+        var indexOfNextWhitespace = sql.Slice(start).IndexOfAny(WhitespaceChars);
 #endif
 
         var length = indexOfNextWhitespace >= 0 ? indexOfNextWhitespace : sql.Length - start;

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -45,6 +45,7 @@ internal static class SqlProcessor
         SqlKeywordInfo.CreateKeyword,
         SqlKeywordInfo.AlterKeyword,
         SqlKeywordInfo.DropKeyword,
+        SqlKeywordInfo.ExecKeyword,
     ];
 
     // This is a special case used when handling sub-queries in parentheses.
@@ -68,6 +69,7 @@ internal static class SqlProcessor
         Delete,
         Distinct,
         Drop,
+        Exec,
         Exists,
         From,
         Function,
@@ -708,6 +710,7 @@ internal static class SqlProcessor
             DeleteKeyword = new("delete", SqlKeyword.Delete, Unknown);
             DistinctKeyword = new("distinct", SqlKeyword.Distinct, [SqlKeyword.Select]);
             DropKeyword = new("drop", SqlKeyword.Drop, Unknown);
+            ExecKeyword = new("exec", SqlKeyword.Exec, Unknown);
             ExistsKeyword = new("exists", SqlKeyword.Exists);
             FromKeyword = new("from", SqlKeyword.From);
             FunctionKeyword = new("function", SqlKeyword.Function, DdlKeywords);
@@ -808,6 +811,8 @@ internal static class SqlProcessor
 
         public static SqlKeywordInfo DropKeyword { get; }
 
+        public static SqlKeywordInfo ExecKeyword { get; }
+
         public static SqlKeywordInfo ExistsKeyword { get; }
 
         public static SqlKeywordInfo FromKeyword { get; }
@@ -867,6 +872,7 @@ internal static class SqlProcessor
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CaptureNextTokenInSummary(in ParseState state, SqlKeyword currentKeyword) => currentKeyword switch
         {
+            SqlKeyword.Exec => true,
             SqlKeyword.From => state.PreviousSummaryKeyword is SqlKeyword.Select or SqlKeyword.Distinct,
             SqlKeyword.Into => state.FirstSummaryKeyword is SqlKeyword.Insert,
             SqlKeyword.Join => state.FirstSummaryKeyword is SqlKeyword.Select or SqlKeyword.Join,

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -667,7 +667,7 @@ internal static class SqlProcessor
         // - Keeping the struct simple and flat minimizes stack pressure and lets the JIT keep values in registers.
 
         // Stored in state to avoid slicing repeatedly.
-        public Span<char> SummaryBuffer; // 16 bytes (on x64)
+        public Span<char> SummaryBuffer;
 
         public SqlKeywordInfo? PreviousParsedKeyword; // 8 bytes (reference type)
 

--- a/src/Shared/SqlStatementInfo.cs
+++ b/src/Shared/SqlStatementInfo.cs
@@ -3,7 +3,7 @@
 
 namespace OpenTelemetry.Instrumentation;
 
-internal struct SqlStatementInfo
+internal readonly struct SqlStatementInfo
 {
     public SqlStatementInfo(string sanitizedSql, string dbQuerySummaryText)
     {

--- a/test/OpenTelemetry.Contrib.Shared.Benchmarks/BenchmarkResults/results/OpenTelemetry.Instrumentation.Benchmarks.SqlProcessorBenchmarks-report-github.md
+++ b/test/OpenTelemetry.Contrib.Shared.Benchmarks/BenchmarkResults/results/OpenTelemetry.Instrumentation.Benchmarks.SqlProcessorBenchmarks-report-github.md
@@ -8,14 +8,14 @@ Unknown processor
 
 
 ```
-| Method          | Sql                  | Mean     | Error    | StdDev    | Median   | Allocated |
-|---------------- |--------------------- |---------:|---------:|----------:|---------:|----------:|
-| **GetSanitizedSql** | **CREAT(...)s(Id) [56]** | **420.6 ns** | **22.18 ns** |  **60.71 ns** | **428.3 ns** |     **584 B** |
-| **GetSanitizedSql** | **DELET(...) = 42 [32]** | **255.7 ns** |  **7.11 ns** |  **20.18 ns** | **252.0 ns** |     **448 B** |
-| **GetSanitizedSql** | **INSER(...)3e-5) [76]** | **514.4 ns** | **16.39 ns** |  **48.33 ns** | **513.3 ns** |     **680 B** |
-| **GetSanitizedSql** | **SELEC(...)ls od [39]** | **439.8 ns** | **39.56 ns** | **116.65 ns** | **374.5 ns** |     **528 B** |
-| **GetSanitizedSql** | **SELE(...)tory [111]**  | **584.5 ns** | **11.55 ns** |  **24.36 ns** | **583.5 ns** |    **1056 B** |
-| **GetSanitizedSql** | **SELEC(...)table [69]** | **269.9 ns** |  **8.34 ns** |  **23.79 ns** | **271.8 ns** |     **600 B** |
-| **GetSanitizedSql** | **SELEC(...) c.Id [74]** | **563.1 ns** | **22.71 ns** |  **66.25 ns** | **553.4 ns** |     **736 B** |
-| **GetSanitizedSql** | **SELE(...)_id) [101]**  | **691.8 ns** | **19.53 ns** |  **56.02 ns** | **693.5 ns** |     **912 B** |
-| **GetSanitizedSql** | **UPDAT(...) = 42 [44]** | **328.1 ns** | **11.58 ns** |  **33.40 ns** | **329.8 ns** |     **504 B** |
+| Method          | Sql                  | Mean     | Error   | StdDev  | Allocated |
+|---------------- |--------------------- |---------:|--------:|--------:|----------:|
+| **GetSanitizedSql** | **CREAT(...)s(Id) [56]** | **237.5 ns** | **3.17 ns** | **2.97 ns** |     **248 B** |
+| **GetSanitizedSql** | **DELET(...) = 42 [32]** | **177.5 ns** | **3.34 ns** | **3.57 ns** |     **128 B** |
+| **GetSanitizedSql** | **INSER(...)3e-5) [76]** | **272.8 ns** | **3.13 ns** | **2.62 ns** |     **192 B** |
+| **GetSanitizedSql** | **SELEC(...)ls od [39]** | **160.5 ns** | **2.06 ns** | **1.83 ns** |     **184 B** |
+| **GetSanitizedSql** | **SELE(...)tory [111]**  | **276.9 ns** | **2.23 ns** | **1.98 ns** |     **424 B** |
+| **GetSanitizedSql** | **SELEC(...)table [69]** | **114.1 ns** | **1.51 ns** | **1.41 ns** |     **128 B** |
+| **GetSanitizedSql** | **SELEC(...) c.Id [74]** | **255.5 ns** | **1.71 ns** | **1.52 ns** |     **264 B** |
+| **GetSanitizedSql** | **SELE(...)_id) [101]**  | **303.3 ns** | **2.41 ns** | **2.25 ns** |     **312 B** |
+| **GetSanitizedSql** | **UPDAT(...) = 42 [44]** | **199.8 ns** | **2.29 ns** | **2.14 ns** |     **144 B** |

--- a/test/OpenTelemetry.Contrib.Shared.Benchmarks/BenchmarkResults/results/OpenTelemetry.Instrumentation.Benchmarks.SqlProcessorBenchmarks-report-github.md
+++ b/test/OpenTelemetry.Contrib.Shared.Benchmarks/BenchmarkResults/results/OpenTelemetry.Instrumentation.Benchmarks.SqlProcessorBenchmarks-report-github.md
@@ -1,16 +1,21 @@
 ```
 
-BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.4946)
+BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.6584/24H2/2024Update/HudsonValley)
 Unknown processor
 .NET SDK 9.0.304
-  [Host]     : .NET 9.0.8 (9.0.825.36511), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
-  DefaultJob : .NET 9.0.8 (9.0.825.36511), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
+  DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
 
 
 ```
-| Method | Sql                  | Iterations | Mean      | Error     | StdDev    | Allocated |
-|------- |--------------------- |----------- |----------:|----------:|----------:|----------:|
-| **Simple** | **SELEC(...)ls od [39]** | **1**          |  **16.42 ns** |  **0.362 ns** |  **0.818 ns** |         **-** |
-| **Simple** | **SELEC(...)ls od [39]** | **20**         | **335.73 ns** |  **6.616 ns** |  **9.698 ns** |         **-** |
-| **Simple** | **SELE(...)_id) [101]**  | **1**          |  **33.42 ns** |  **0.700 ns** |  **1.445 ns** |         **-** |
-| **Simple** | **SELE(...)_id) [101]**  | **20**         | **654.29 ns** | **12.859 ns** | **13.759 ns** |         **-** |
+| Method          | Sql                  | Mean     | Error    | StdDev    | Median   | Allocated |
+|---------------- |--------------------- |---------:|---------:|----------:|---------:|----------:|
+| **GetSanitizedSql** | **CREAT(...)s(Id) [56]** | **420.6 ns** | **22.18 ns** |  **60.71 ns** | **428.3 ns** |     **584 B** |
+| **GetSanitizedSql** | **DELET(...) = 42 [32]** | **255.7 ns** |  **7.11 ns** |  **20.18 ns** | **252.0 ns** |     **448 B** |
+| **GetSanitizedSql** | **INSER(...)3e-5) [76]** | **514.4 ns** | **16.39 ns** |  **48.33 ns** | **513.3 ns** |     **680 B** |
+| **GetSanitizedSql** | **SELEC(...)ls od [39]** | **439.8 ns** | **39.56 ns** | **116.65 ns** | **374.5 ns** |     **528 B** |
+| **GetSanitizedSql** | **SELE(...)tory [111]**  | **584.5 ns** | **11.55 ns** |  **24.36 ns** | **583.5 ns** |    **1056 B** |
+| **GetSanitizedSql** | **SELEC(...)table [69]** | **269.9 ns** |  **8.34 ns** |  **23.79 ns** | **271.8 ns** |     **600 B** |
+| **GetSanitizedSql** | **SELEC(...) c.Id [74]** | **563.1 ns** | **22.71 ns** |  **66.25 ns** | **553.4 ns** |     **736 B** |
+| **GetSanitizedSql** | **SELE(...)_id) [101]**  | **691.8 ns** | **19.53 ns** |  **56.02 ns** | **693.5 ns** |     **912 B** |
+| **GetSanitizedSql** | **UPDAT(...) = 42 [44]** | **328.1 ns** | **11.58 ns** |  **33.40 ns** | **329.8 ns** |     **504 B** |

--- a/test/OpenTelemetry.Contrib.Shared.Benchmarks/BenchmarkResults/results/OpenTelemetry.Instrumentation.Benchmarks.SqlProcessorBenchmarks-report-github.md
+++ b/test/OpenTelemetry.Contrib.Shared.Benchmarks/BenchmarkResults/results/OpenTelemetry.Instrumentation.Benchmarks.SqlProcessorBenchmarks-report-github.md
@@ -2,7 +2,7 @@
 
 BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.6584/24H2/2024Update/HudsonValley)
 Unknown processor
-.NET SDK 9.0.304
+.NET SDK 9.0.305
   [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
   DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
 
@@ -10,12 +10,12 @@ Unknown processor
 ```
 | Method          | Sql                  | Mean     | Error   | StdDev  | Allocated |
 |---------------- |--------------------- |---------:|--------:|--------:|----------:|
-| **GetSanitizedSql** | **CREAT(...)s(Id) [56]** | **237.5 ns** | **3.17 ns** | **2.97 ns** |     **248 B** |
-| **GetSanitizedSql** | **DELET(...) = 42 [32]** | **177.5 ns** | **3.34 ns** | **3.57 ns** |     **128 B** |
-| **GetSanitizedSql** | **INSER(...)3e-5) [76]** | **272.8 ns** | **3.13 ns** | **2.62 ns** |     **192 B** |
-| **GetSanitizedSql** | **SELEC(...)ls od [39]** | **160.5 ns** | **2.06 ns** | **1.83 ns** |     **184 B** |
-| **GetSanitizedSql** | **SELE(...)tory [111]**  | **276.9 ns** | **2.23 ns** | **1.98 ns** |     **424 B** |
-| **GetSanitizedSql** | **SELEC(...)table [69]** | **114.1 ns** | **1.51 ns** | **1.41 ns** |     **128 B** |
-| **GetSanitizedSql** | **SELEC(...) c.Id [74]** | **255.5 ns** | **1.71 ns** | **1.52 ns** |     **264 B** |
-| **GetSanitizedSql** | **SELE(...)_id) [101]**  | **303.3 ns** | **2.41 ns** | **2.25 ns** |     **312 B** |
-| **GetSanitizedSql** | **UPDAT(...) = 42 [44]** | **199.8 ns** | **2.29 ns** | **2.14 ns** |     **144 B** |
+| **GetSanitizedSql** | **CREAT(...)s(Id) [56]** | **214.9 ns** | **4.30 ns** | **8.18 ns** |     **248 B** |
+| **GetSanitizedSql** | **DELET(...) = 42 [32]** | **177.8 ns** | **3.53 ns** | **3.47 ns** |     **128 B** |
+| **GetSanitizedSql** | **INSER(...)3e-5) [76]** | **263.4 ns** | **4.11 ns** | **3.85 ns** |     **192 B** |
+| **GetSanitizedSql** | **SELEC(...)ls od [39]** | **153.8 ns** | **1.68 ns** | **1.57 ns** |     **184 B** |
+| **GetSanitizedSql** | **SELE(...)tory [111]**  | **252.8 ns** | **4.04 ns** | **4.33 ns** |     **424 B** |
+| **GetSanitizedSql** | **SELEC(...)table [69]** | **109.7 ns** | **1.29 ns** | **1.14 ns** |     **128 B** |
+| **GetSanitizedSql** | **SELEC(...) c.Id [74]** | **246.8 ns** | **4.52 ns** | **4.23 ns** |     **264 B** |
+| **GetSanitizedSql** | **SELE(...)_id) [101]**  | **291.8 ns** | **5.12 ns** | **4.79 ns** |     **312 B** |
+| **GetSanitizedSql** | **UPDAT(...) = 42 [44]** | **189.6 ns** | **3.69 ns** | **5.05 ns** |     **144 B** |

--- a/test/OpenTelemetry.Contrib.Shared.Benchmarks/Program.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Benchmarks/Program.cs
@@ -5,28 +5,22 @@ using System.Diagnostics;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using JetBrains.Profiler.Api;
-using OpenTelemetry.Instrumentation.Benchmarks;
+using OpenTelemetry.Instrumentation;
 
 if (Debugger.IsAttached || (args.Length > 0 && args[0] == "execute"))
 {
-    var benchmarks = new SqlProcessorBenchmarks
-    {
-        Sql = "SELECT * FROM Orders o, OrderDetails od",
-        Iterations = 100,
-    };
-
     MemoryProfiler.CollectAllocations(true);
 
     MemoryProfiler.GetSnapshot();
 
-    benchmarks.Simple();
+    SqlProcessor.GetSanitizedSql("SELECT * FROM Orders o, OrderDetails od");
 
     MemoryProfiler.GetSnapshot();
 }
 else
 {
     var config = ManualConfig.Create(DefaultConfig.Instance)
-        .WithArtifactsPath(@"..\..\..\BenchmarkResults");
+        .WithArtifactsPath("BenchmarkResults");
 
     BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
 }

--- a/test/OpenTelemetry.Contrib.Shared.Benchmarks/SqlProcessorBenchmarks.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Benchmarks/SqlProcessorBenchmarks.cs
@@ -2,24 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
 
 namespace OpenTelemetry.Instrumentation.Benchmarks;
 
-[MemoryDiagnoser]
+[MemoryDiagnoser(displayGenColumns: false)]
 public class SqlProcessorBenchmarks
 {
-    [Params("SELECT * FROM Orders o, OrderDetails od", "SELECT order_date\nFROM   (SELECT *\nFROM   orders o\nJOIN customers c\nON o.customer_id = c.customer_id)")]
+    [Params(
+         "SELECT * FROM Orders o, OrderDetails od",
+         "SELECT order_date\nFROM   (SELECT *\nFROM   orders o\nJOIN customers c\nON o.customer_id = c.customer_id)",
+         "INSERT INTO Orders(Id, Name, Bin, Rate) VALUES(1, 'abc''def', 0xFF, 1.23e-5)",
+         "UPDATE Orders SET Name = 'foo' WHERE Id = 42",
+         "DELETE FROM Orders WHERE Id = 42",
+         "CREATE UNIQUE CLUSTERED INDEX IX_Orders_Id ON Orders(Id)",
+         "SELECT DISTINCT o.Id FROM Orders o JOIN Customers c ON o.CustomerId = c.Id",
+         "SELECT column -- end of line comment\nFROM /* block \n comment */ table",
+         "SELECT Col1, Col2, Col3, Col4, Col5 FROM VeryLongTableName_Sales2024_Q4, Another_Very_Long_Table_Name_Inventory")]
     public string Sql { get; set; } = string.Empty;
 
-    [Params(1, 20)]
-    public int Iterations { get; set; }
-
     [Benchmark]
-    public void Simple()
-    {
-        for (int i = 0; i < this.Iterations; i++)
-        {
-            SqlProcessor.GetSanitizedSql(this.Sql);
-        }
-    }
+    public void GetSanitizedSql() => SqlProcessor.GetSanitizedSql(this.Sql);
 }

--- a/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
@@ -31,8 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="SqlProcessorTestCases.json" LogicalName="SqlProcessorTestCases.json" />
-    <EmbeddedResource Include="SqlProcessorAdditionalTestCases.json" LogicalName="SqlProcessorAdditionalTestCases.json" />
+    <EmbeddedResource Include="*.json" LogicalName="%(FileName)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="SqlProcessorTestCases.json" LogicalName="SqlProcessorTestCases.json" />
+    <EmbeddedResource Include="SqlProcessorAdditionalTestCases.json" LogicalName="SqlProcessorAdditionalTestCases.json" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Contrib.Shared.Tests/README.md
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/README.md
@@ -1,0 +1,10 @@
+# OpenTelemetry Shared Tests
+
+## SqlProcessor Tests
+
+SqlProcessorTestCases.json contains test cases for the SqlProcessor class. This is synced from
+https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/database-test-cases/db-sql-test-cases.json
+and should not be modified directly.
+
+SqlProcessorAdditionalTestCases.json contains additional test cases which may be contributed back
+to the semantic conventions repo.

--- a/test/OpenTelemetry.Contrib.Shared.Tests/README.md
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/README.md
@@ -2,9 +2,9 @@
 
 ## SqlProcessor Tests
 
-SqlProcessorTestCases.json contains test cases for the SqlProcessor class. This is synced from
-https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/database-test-cases/db-sql-test-cases.json
+`SqlProcessorTestCases.json` contains test cases for the `SqlProcessor` class.
+This is synced from the [Semantic Conventions repository](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/database-test-cases/db-sql-test-cases.json)
 and should not be modified directly.
 
-SqlProcessorAdditionalTestCases.json contains additional test cases which may be contributed back
-to the semantic conventions repo.
+`SqlProcessorAdditionalTestCases.json` contains additional test cases which
+may be contributed back to the semantic conventions repo.

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -61,7 +61,7 @@
       "db.query.text": [
         "SELECT DISTINCT Country FROM Countries"
       ],
-      "db.query.summary": "SELECT DISTINCT Countries"
+      "db.query.summary": "SELECT Countries"
     }
   },
   {
@@ -74,7 +74,7 @@
       "db.query.text": [
         "SELECT DISTINCT o.Id FROM Orders o JOIN Customers c ON o.CustomerId = c.Id"
       ],
-      "db.query.summary": "SELECT DISTINCT Orders Customers"
+      "db.query.summary": "SELECT Orders Customers"
     }
   },
   {
@@ -390,35 +390,35 @@
     }
   },
   {
-    "name": "create_sequence_tsql",
+    "name": "create_sequence",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "other_sql",
       "query": "CREATE SEQUENCE SalesSeq START WITH 1 INCREMENT BY 1;"
     },
     "expected": {
       "db.query.text": [
-        "CREATE SEQUENCE SalesSeq START WITH 1 INCREMENT BY 1;"
+        "CREATE SEQUENCE SalesSeq START WITH ? INCREMENT BY ?;"
       ],
       "db.query.summary": "CREATE SEQUENCE SalesSeq"
     }
   },
   {
-    "name": "alter_sequence_tsql",
+    "name": "alter_sequence",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "other_sql",
       "query": "ALTER SEQUENCE SalesSeq RESTART WITH 100;"
     },
     "expected": {
       "db.query.text": [
-        "ALTER SEQUENCE SalesSeq RESTART WITH 100;"
+        "ALTER SEQUENCE SalesSeq RESTART WITH ?;"
       ],
       "db.query.summary": "ALTER SEQUENCE SalesSeq"
     }
   },
   {
-    "name": "drop_sequence_tsql",
+    "name": "drop_sequence",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "other_sql",
       "query": "DROP SEQUENCE SalesSeq;"
     },
     "expected": {
@@ -431,7 +431,7 @@
   {
     "name": "create_function_tsql",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "microsoft.sql_server",
       "query": "CREATE FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b; END;"
     },
     "expected": {
@@ -444,7 +444,7 @@
   {
     "name": "alter_function_tsql",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "microsoft.sql_server",
       "query": "ALTER FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a * @b; END;"
     },
     "expected": {
@@ -457,7 +457,7 @@
   {
     "name": "drop_function_tsql",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "microsoft.sql_server",
       "query": "DROP FUNCTION dbo.GetTotal;"
     },
     "expected": {
@@ -559,14 +559,14 @@
     }
   },
   {
-    "name": "exec_sp_rename_table",
+    "name": "exec_sp_rename_table_tsql",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "microsoft.sql_server",
       "query": "EXEC sp_rename 'OldTable', 'NewTable';"
     },
     "expected": {
       "db.query.text": [
-        "EXEC sp_rename 'OldTable', 'NewTable';"
+        "EXEC sp_rename ?, ?;"
       ],
       "db.query.summary": "EXEC sp_rename"
     }
@@ -574,7 +574,7 @@
   {
     "name": "exec_stored_procedure_no_params",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "other_sql",
       "query": "EXEC GetAllEmployees;"
     },
     "expected": {
@@ -587,7 +587,7 @@
   {
     "name": "exec_stored_procedure_with_params",
     "input": {
-      "db.system.name": "mssql",
+      "db.system.name": "other_sql",
       "query": "EXEC GetEmployeeById @EmployeeId = 42;"
     },
     "expected": {

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -1,0 +1,600 @@
+[
+  {
+    "name": "keyword_prefix_for_target",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM SelectedData"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM SelectedData"
+      ],
+      "db.query.summary": "SELECT SelectedData"
+    }
+  },
+  {
+    "name": "summary_truncated",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM Vecnzotjejucwitzgrfifscuevittljlnrlpbruvkezeptqciyvbjhsytmbucbhwttidayecnthaztxbyppbyztcqccedeirgkxzrfezjxfwbtuqxeusroqgbvulgmsvnelovkxqsaqmlogomkhtjuirzhaocxlrmerihnmwaelullionarkmxwdamhduwrbooknqsnilurutgyerxphokeqnnoumbpcfjtmqrbpukjllofiwaltyoawkp o, OrderDetails od"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM Vecnzotjejucwitzgrfifscuevittljlnrlpbruvkezeptqciyvbjhsytmbucbhwttidayecnthaztxbyppbyztcqccedeirgkxzrfezjxfwbtuqxeusroqgbvulgmsvnelovkxqsaqmlogomkhtjuirzhaocxlrmerihnmwaelullionarkmxwdamhduwrbooknqsnilurutgyerxphokeqnnoumbpcfjtmqrbpukjllofiwaltyoawkp o, OrderDetails od"
+      ],
+      "db.query.summary": "SELECT Vecnzotjejucwitzgrfifscuevittljlnrlpbruvkezeptqciyvbjhsytmbucbhwttidayecnthaztxbyppbyztcqccedeirgkxzrfezjxfwbtuqxeusroqgbvulgmsvnelovkxqsaqmlogomkhtjuirzhaocxlrmerihnmwaelullionarkmxwdamhduwrbooknqsnilurutgyerxphokeqnnoumbpcfjtmqrbpukjllofiwaltyoaw"
+    }
+  },
+  {
+    "name": "create_unique_clustered_index",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE UNIQUE CLUSTERED INDEX IX_Employee_Email ON Employees (Email);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE UNIQUE CLUSTERED INDEX IX_Employee_Email ON Employees (Email);"
+      ],
+      "db.query.summary": "CREATE UNIQUE CLUSTERED INDEX IX_Employee_Email"
+    }
+  },
+  {
+    "name": "create_unique_index",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE UNIQUE INDEX IX_Employee_Email ON Employees (Email);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE UNIQUE INDEX IX_Employee_Email ON Employees (Email);"
+      ],
+      "db.query.summary": "CREATE UNIQUE INDEX IX_Employee_Email"
+    }
+  },
+  {
+    "name": "select_distinct",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT DISTINCT Country FROM Countries"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT DISTINCT Country FROM Countries"
+      ],
+      "db.query.summary": "SELECT DISTINCT Countries"
+    }
+  },
+  {
+    "name": "select_distinct_with_join",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT DISTINCT o.Id FROM Orders o JOIN Customers c ON o.CustomerId = c.Id"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT DISTINCT o.Id FROM Orders o JOIN Customers c ON o.CustomerId = c.Id"
+      ],
+      "db.query.summary": "SELECT DISTINCT Orders Customers"
+    }
+  },
+  {
+    "name": "create_table_with_if_not_exists",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TABLE IF NOT EXISTS Users (Id INT PRIMARY KEY, Name NVARCHAR(100));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE IF NOT EXISTS Users (Id INT PRIMARY KEY, Name NVARCHAR(100));"
+      ],
+      "db.query.summary": "CREATE TABLE Users"
+    }
+  },
+  {
+    "name": "create_view_with_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = 1;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = ?;"
+      ],
+      "db.query.summary": "CREATE VIEW ActiveUsers"
+    }
+  },
+  {
+    "name": "alter_table_add_column",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(50);"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(50);"
+      ],
+      "db.query.summary": "ALTER TABLE Orders"
+    }
+  },
+  {
+    "name": "alter_table_rename_column",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TABLE Orders RENAME COLUMN OldName TO NewName;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TABLE Orders RENAME COLUMN OldName TO NewName;"
+      ],
+      "db.query.summary": "ALTER TABLE Orders"
+    }
+  },
+  {
+    "name": "create_procedure_with_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE PROCEDURE GetUserById @UserId INT AS SELECT * FROM Users WHERE Id = @UserId;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE PROCEDURE GetUserById @UserId INT AS SELECT * FROM Users WHERE Id = @UserId;"
+      ],
+      "db.query.summary": "CREATE PROCEDURE GetUserById"
+    }
+  },
+  {
+    "name": "alter_view_as_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = 1;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER VIEW ActiveUsers AS SELECT * FROM Users WHERE IsActive = ?;"
+      ],
+      "db.query.summary": "ALTER VIEW ActiveUsers"
+    }
+  },
+  {
+    "name": "create_trigger_on_table",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TRIGGER trg_UpdateTimestamp ON Orders AFTER UPDATE AS BEGIN UPDATE Orders SET UpdatedAt = GETDATE() WHERE Id IN (SELECT Id FROM inserted); END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TRIGGER trg_UpdateTimestamp ON Orders AFTER UPDATE AS BEGIN UPDATE Orders SET UpdatedAt = GETDATE() WHERE Id IN (SELECT Id FROM inserted); END;"
+      ],
+      "db.query.summary": "CREATE TRIGGER trg_UpdateTimestamp"
+    }
+  },
+  {
+    "name": "alter_procedure_with_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER PROCEDURE UpdateUserEmail @UserId INT, @Email NVARCHAR(100) AS UPDATE Users SET Email = @Email WHERE Id = @UserId;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER PROCEDURE UpdateUserEmail @UserId INT, @Email NVARCHAR(100) AS UPDATE Users SET Email = @Email WHERE Id = @UserId;"
+      ],
+      "db.query.summary": "ALTER PROCEDURE UpdateUserEmail"
+    }
+  },
+  {
+    "name": "create_index_with_include",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE INDEX IX_Orders_CustomerId ON Orders (CustomerId) INCLUDE (OrderDate, TotalAmount);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE INDEX IX_Orders_CustomerId ON Orders (CustomerId) INCLUDE (OrderDate, TotalAmount);"
+      ],
+      "db.query.summary": "CREATE INDEX IX_Orders_CustomerId"
+    }
+  },
+  {
+    "name": "alter_table_drop_column",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TABLE Orders DROP COLUMN TempColumn;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TABLE Orders DROP COLUMN TempColumn;"
+      ],
+      "db.query.summary": "ALTER TABLE Orders"
+    }
+  },
+  {
+    "name": "drop_trigger",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP TRIGGER IF EXISTS trg_AfterInsert;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP TRIGGER IF EXISTS trg_AfterInsert;"
+      ],
+      "db.query.summary": "DROP TRIGGER trg_AfterInsert"
+    }
+  },
+  {
+    "name": "alter_trigger",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER TRIGGER trg_AfterInsert ON Employees AFTER INSERT AS BEGIN INSERT INTO AuditLog (EmployeeId, Action) SELECT Id, 'INSERT' FROM inserted; END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER TRIGGER trg_AfterInsert ON Employees AFTER INSERT AS BEGIN INSERT INTO AuditLog (EmployeeId, Action) SELECT Id, ? FROM inserted; END;"
+      ],
+      "db.query.summary": "ALTER TRIGGER trg_AfterInsert"
+    }
+  },
+  {
+    "name": "create_procedure_with_multiple_params",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE PROCEDURE AddEmployee @Name NVARCHAR(100), @Email NVARCHAR(100) AS INSERT INTO Employees (Name, Email) VALUES (@Name, @Email);"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE PROCEDURE AddEmployee @Name NVARCHAR(100), @Email NVARCHAR(100) AS INSERT INTO Employees (Name, Email) VALUES (@Name, @Email);"
+      ],
+      "db.query.summary": "CREATE PROCEDURE AddEmployee"
+    }
+  },
+  {
+    "name": "drop_procedure",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP PROCEDURE IF EXISTS RemoveEmployee;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP PROCEDURE IF EXISTS RemoveEmployee;"
+      ],
+      "db.query.summary": "DROP PROCEDURE RemoveEmployee"
+    }
+  },
+  {
+    "name": "alter_procedure_add_param",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER PROCEDURE UpdateEmployeeEmail @EmployeeId INT, @Email NVARCHAR(100) AS UPDATE Employees SET Email = @Email WHERE Id = @EmployeeId;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER PROCEDURE UpdateEmployeeEmail @EmployeeId INT, @Email NVARCHAR(100) AS UPDATE Employees SET Email = @Email WHERE Id = @EmployeeId;"
+      ],
+      "db.query.summary": "ALTER PROCEDURE UpdateEmployeeEmail"
+    }
+  },
+  {
+    "name": "select_with_multiple_joins_and_group_by",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT o.Id, c.Name, SUM(oi.Quantity) FROM Orders o JOIN Customers c ON o.CustomerId = c.Id JOIN OrderItems oi ON o.Id = oi.OrderId GROUP BY o.Id, c.Name;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT o.Id, c.Name, SUM(oi.Quantity) FROM Orders o JOIN Customers c ON o.CustomerId = c.Id JOIN OrderItems oi ON o.Id = oi.OrderId GROUP BY o.Id, c.Name;"
+      ],
+      "db.query.summary": "SELECT Orders Customers OrderItems"
+    }
+  },
+  {
+    "name": "select_with_distinct_and_window_function",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT DISTINCT Department, COUNT(*) OVER (PARTITION BY Department) AS DeptCount FROM Employees;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT DISTINCT Department, COUNT(*) OVER (PARTITION BY Department) AS DeptCount FROM Employees;"
+      ],
+      "db.query.summary": "SELECT DISTINCT Employees"
+    }
+  },
+  {
+    "name": "select_with_union_and_order_by",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT Id, Name FROM Customers UNION SELECT Id, Name FROM Suppliers ORDER BY Name;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT Id, Name FROM Customers UNION SELECT Id, Name FROM Suppliers ORDER BY Name;"
+      ],
+      "db.query.summary": "SELECT Customers Suppliers"
+    }
+  },
+  {
+    "name": "create_database",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE DATABASE TestDb;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE DATABASE TestDb;"
+      ],
+      "db.query.summary": "CREATE DATABASE TestDb"
+    }
+  },
+  {
+    "name": "alter_database",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER DATABASE TestDb MODIFY NAME = NewTestDb;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER DATABASE TestDb MODIFY NAME = NewTestDb;"
+      ],
+      "db.query.summary": "ALTER DATABASE TestDb"
+    }
+  },
+  {
+    "name": "drop_database",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP DATABASE IF EXISTS TestDb;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP DATABASE IF EXISTS TestDb;"
+      ],
+      "db.query.summary": "DROP DATABASE TestDb"
+    }
+  },
+  {
+    "name": "create_schema",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE SCHEMA Reporting;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE SCHEMA Reporting;"
+      ],
+      "db.query.summary": "CREATE SCHEMA Reporting"
+    }
+  },
+  {
+    "name": "alter_schema",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER SCHEMA Reporting TRANSFER dbo.OldTable;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER SCHEMA Reporting TRANSFER dbo.OldTable;"
+      ],
+      "db.query.summary": "ALTER SCHEMA Reporting"
+    }
+  },
+  {
+    "name": "drop_schema",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP SCHEMA IF EXISTS Reporting;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP SCHEMA IF EXISTS Reporting;"
+      ],
+      "db.query.summary": "DROP SCHEMA Reporting"
+    }
+  },
+  {
+    "name": "create_sequence_tsql",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "CREATE SEQUENCE SalesSeq START WITH 1 INCREMENT BY 1;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE SEQUENCE SalesSeq START WITH 1 INCREMENT BY 1;"
+      ],
+      "db.query.summary": "CREATE SEQUENCE SalesSeq"
+    }
+  },
+  {
+    "name": "alter_sequence_tsql",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "ALTER SEQUENCE SalesSeq RESTART WITH 100;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER SEQUENCE SalesSeq RESTART WITH 100;"
+      ],
+      "db.query.summary": "ALTER SEQUENCE SalesSeq"
+    }
+  },
+  {
+    "name": "drop_sequence_tsql",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "DROP SEQUENCE SalesSeq;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP SEQUENCE SalesSeq;"
+      ],
+      "db.query.summary": "DROP SEQUENCE SalesSeq"
+    }
+  },
+  {
+    "name": "create_function_tsql",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "CREATE FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b; END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b; END;"
+      ],
+      "db.query.summary": "CREATE FUNCTION dbo.GetTotal"
+    }
+  },
+  {
+    "name": "alter_function_tsql",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "ALTER FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a * @b; END;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER FUNCTION dbo.GetTotal(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a * @b; END;"
+      ],
+      "db.query.summary": "ALTER FUNCTION dbo.GetTotal"
+    }
+  },
+  {
+    "name": "drop_function_tsql",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "DROP FUNCTION dbo.GetTotal;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP FUNCTION dbo.GetTotal;"
+      ],
+      "db.query.summary": "DROP FUNCTION dbo.GetTotal"
+    }
+  },
+  {
+    "name": "create_user",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE USER johndoe WITH PASSWORD = 'password';"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE USER johndoe WITH PASSWORD = ?;"
+      ],
+      "db.query.summary": "CREATE USER johndoe"
+    }
+  },
+  {
+    "name": "alter_user",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER USER johndoe WITH PASSWORD = 'newpassword';"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER USER johndoe WITH PASSWORD = ?;"
+      ],
+      "db.query.summary": "ALTER USER johndoe"
+    }
+  },
+  {
+    "name": "drop_user",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP USER IF EXISTS johndoe;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP USER IF EXISTS johndoe;"
+      ],
+      "db.query.summary": "DROP USER johndoe"
+    }
+  },
+  {
+    "name": "create_role",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE ROLE app_admin;"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE ROLE app_admin;"
+      ],
+      "db.query.summary": "CREATE ROLE app_admin"
+    }
+  },
+  {
+    "name": "alter_role",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER ROLE app_admin ADD MEMBER johndoe;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER ROLE app_admin ADD MEMBER johndoe;"
+      ],
+      "db.query.summary": "ALTER ROLE app_admin"
+    }
+  },
+  {
+    "name": "drop_role",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "DROP ROLE IF EXISTS app_admin;"
+    },
+    "expected": {
+      "db.query.text": [
+        "DROP ROLE IF EXISTS app_admin;"
+      ],
+      "db.query.summary": "DROP ROLE app_admin"
+    }
+  },
+  {
+    "name": "alter_index",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER INDEX IX_Employee_Email ON Employees REBUILD;"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER INDEX IX_Employee_Email ON Employees REBUILD;"
+      ],
+      "db.query.summary": "ALTER INDEX IX_Employee_Email"
+    }
+  },
+  {
+    "name": "exec_sp_rename_table",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "EXEC sp_rename 'OldTable', 'NewTable';"
+    },
+    "expected": {
+      "db.query.text": [
+        "EXEC sp_rename 'OldTable', 'NewTable';"
+      ],
+      "db.query.summary": "EXEC sp_rename"
+    }
+  },
+  {
+    "name": "exec_stored_procedure_no_params",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "EXEC GetAllEmployees;"
+    },
+    "expected": {
+      "db.query.text": [
+        "EXEC GetAllEmployees;"
+      ],
+      "db.query.summary": "EXEC GetAllEmployees"
+    }
+  },
+  {
+    "name": "exec_stored_procedure_with_params",
+    "input": {
+      "db.system.name": "mssql",
+      "query": "EXEC GetEmployeeById @EmployeeId = 42;"
+    },
+    "expected": {
+      "db.query.text": [
+        "EXEC GetEmployeeById @EmployeeId = ?;"
+      ],
+      "db.query.summary": "EXEC GetEmployeeById"
+    }
+  }
+]

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -22,7 +22,7 @@
       "db.query.text": [
         "SELECT * FROM Vecnzotjejucwitzgrfifscuevittljlnrlpbruvkezeptqciyvbjhsytmbucbhwttidayecnthaztxbyppbyztcqccedeirgkxzrfezjxfwbtuqxeusroqgbvulgmsvnelovkxqsaqmlogomkhtjuirzhaocxlrmerihnmwaelullionarkmxwdamhduwrbooknqsnilurutgyerxphokeqnnoumbpcfjtmqrbpukjllofiwaltyoawkp o, OrderDetails od"
       ],
-      "db.query.summary": "SELECT Vecnzotjejucwitzgrfifscuevittljlnrlpbruvkezeptqciyvbjhsytmbucbhwttidayecnthaztxbyppbyztcqccedeirgkxzrfezjxfwbtuqxeusroqgbvulgmsvnelovkxqsaqmlogomkhtjuirzhaocxlrmerihnmwaelullionarkmxwdamhduwrbooknqsnilurutgyerxphokeqnnoumbpcfjtmqrbpukjllofiwaltyoaw"
+      "db.query.summary": "SELECT"
     }
   },
   {
@@ -85,6 +85,7 @@
     },
     "expected": {
       "db.query.text": [
+        "CREATE TABLE IF NOT EXISTS Users (Id INT PRIMARY KEY, Name NVARCHAR(?));",
         "CREATE TABLE IF NOT EXISTS Users (Id INT PRIMARY KEY, Name NVARCHAR(100));"
       ],
       "db.query.summary": "CREATE TABLE Users"
@@ -111,6 +112,7 @@
     },
     "expected": {
       "db.query.text": [
+        "ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(?);",
         "ALTER TABLE Orders ADD COLUMN OrderStatus NVARCHAR(50);"
       ],
       "db.query.summary": "ALTER TABLE Orders"
@@ -176,6 +178,7 @@
     },
     "expected": {
       "db.query.text": [
+        "ALTER PROCEDURE UpdateUserEmail @UserId INT, @Email NVARCHAR(?) AS UPDATE Users SET Email = @Email WHERE Id = @UserId;",
         "ALTER PROCEDURE UpdateUserEmail @UserId INT, @Email NVARCHAR(100) AS UPDATE Users SET Email = @Email WHERE Id = @UserId;"
       ],
       "db.query.summary": "ALTER PROCEDURE UpdateUserEmail"
@@ -241,6 +244,7 @@
     },
     "expected": {
       "db.query.text": [
+        "CREATE PROCEDURE AddEmployee @Name NVARCHAR(?), @Email NVARCHAR(?) AS INSERT INTO Employees (Name, Email) VALUES (@Name, @Email);",
         "CREATE PROCEDURE AddEmployee @Name NVARCHAR(100), @Email NVARCHAR(100) AS INSERT INTO Employees (Name, Email) VALUES (@Name, @Email);"
       ],
       "db.query.summary": "CREATE PROCEDURE AddEmployee"
@@ -267,6 +271,7 @@
     },
     "expected": {
       "db.query.text": [
+        "ALTER PROCEDURE UpdateEmployeeEmail @EmployeeId INT, @Email NVARCHAR(?) AS UPDATE Employees SET Email = @Email WHERE Id = @EmployeeId;",
         "ALTER PROCEDURE UpdateEmployeeEmail @EmployeeId INT, @Email NVARCHAR(100) AS UPDATE Employees SET Email = @Email WHERE Id = @EmployeeId;"
       ],
       "db.query.summary": "ALTER PROCEDURE UpdateEmployeeEmail"
@@ -595,6 +600,179 @@
         "EXEC GetEmployeeById @EmployeeId = ?;"
       ],
       "db.query.summary": "EXEC GetEmployeeById"
+    }
+  },
+  {
+    "name": "insert_values_parenthesized_number",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "INSERT INTO T (A) VALUES (123)"
+    },
+    "expected": {
+      "db.query.text": [
+        "INSERT INTO T (A) VALUES (?)"
+      ],
+      "db.query.summary": "INSERT T"
+    }
+  },
+  {
+    "name": "parenthesized_constant_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT (123) AS C;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT (?) AS C;"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "update_set_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "UPDATE T SET A = (999);"
+    },
+    "expected": {
+      "db.query.text": [
+        "UPDATE T SET A = (?);"
+      ],
+      "db.query.summary": "UPDATE"
+    }
+  },
+  {
+    "name": "create_table_default_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TABLE T (A INT DEFAULT (123));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE T (A INT DEFAULT (?));"
+      ],
+      "db.query.summary": "CREATE TABLE T"
+    }
+  },
+  {
+    "name": "nested_parentheses_constant_select",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT ((123)) AS C;"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT ((?)) AS C;"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "function_arg_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT ABS((123));"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT ABS((?));"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "between_parenthesized_constants",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM T WHERE Amount BETWEEN (10) AND (20);"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM T WHERE Amount BETWEEN (?) AND (?);"
+      ],
+      "db.query.summary": "SELECT T"
+    }
+  },
+  {
+    "name": "coalesce_first_arg_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM T WHERE Id = COALESCE((123), 0);"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM T WHERE Id = COALESCE((?), ?);"
+      ],
+      "db.query.summary": "SELECT T"
+    }
+  },
+  {
+    "name": "cast_parenthesized_constant",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT CAST((123) AS INT);"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT CAST((?) AS INT);"
+      ],
+      "db.query.summary": "SELECT"
+    }
+  },
+  {
+    "name": "valid_type_length_specifiers_varchar_char",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "CREATE TABLE Table (Name VARCHAR(255), Code CHAR(10));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE Table (Name VARCHAR(?), Code CHAR(?));",
+        "CREATE TABLE Table (Name VARCHAR(255), Code CHAR(10));"
+      ],
+      "db.query.summary": "CREATE TABLE Table"
+    }
+  },
+  {
+    "name": "valid_type_length_specifiers_varbinary_datetime2_time",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "CREATE TABLE Table (Payload VARBINARY(16), EventTime DATETIME2(7), Duration TIME(7));"
+    },
+    "expected": {
+      "db.query.text": [
+        "CREATE TABLE Table (Payload VARBINARY(?), EventTime DATETIME2(?), Duration TIME(?));",
+        "CREATE TABLE Table (Payload VARBINARY(16), EventTime DATETIME2(7), Duration TIME(7));"
+      ],
+      "db.query.summary": "CREATE TABLE Table"
+    }
+  },
+  {
+    "name": "valid_top_with_parentheses",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "SELECT TOP (10) * FROM Employees"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT TOP (?) * FROM Employees",
+        "SELECT TOP (10) * FROM Employees"
+      ],
+      "db.query.summary": "SELECT Employees"
+    }
+  },
+  {
+    "name": "sanitized_top_without_parentheses",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "SELECT TOP 10 * FROM Employees"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT TOP ? * FROM Employees",
+        "SELECT TOP 10 * FROM Employees"
+      ],
+      "db.query.summary": "SELECT Employees"
     }
   }
 ]

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -35,7 +35,7 @@
       "db.query.text": [
         "CREATE UNIQUE CLUSTERED INDEX IX_Employee_Email ON Employees (Email);"
       ],
-      "db.query.summary": "CREATE UNIQUE CLUSTERED INDEX IX_Employee_Email"
+      "db.query.summary": "CREATE INDEX IX_Employee_Email"
     }
   },
   {
@@ -48,7 +48,7 @@
       "db.query.text": [
         "CREATE UNIQUE INDEX IX_Employee_Email ON Employees (Email);"
       ],
-      "db.query.summary": "CREATE UNIQUE INDEX IX_Employee_Email"
+      "db.query.summary": "CREATE INDEX IX_Employee_Email"
     }
   },
   {
@@ -295,7 +295,7 @@
       "db.query.text": [
         "SELECT DISTINCT Department, COUNT(*) OVER (PARTITION BY Department) AS DeptCount FROM Employees;"
       ],
-      "db.query.summary": "SELECT DISTINCT Employees"
+      "db.query.summary": "SELECT Employees"
     }
   },
   {

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -774,5 +774,88 @@
       ],
       "db.query.summary": "SELECT Employees"
     }
+  },
+  {
+    "name": "in_clause_starting_with_negative_literal",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN (-123, .456, 'abc', 0.12, 1e10)"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?)",
+        "SELECT * FROM table WHERE value IN (?, ?, ?, ?, ?)"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "in_clause_starting_with_hex_literal",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN (0xAB, .456, 'abc', 0.12, 1e10)"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?)",
+        "SELECT * FROM table WHERE value IN (?, ?, ?, ?, ?)"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "in_clause_starting_with_string_literal",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN ('abc', 0xAB, .456, 0.12, 1e10)"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?)",
+        "SELECT * FROM table WHERE value IN (?, ?, ?, ?, ?)"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "malformed_in_clause",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT * FROM table WHERE value IN ('abc', 0xAB, .456,"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT * FROM table WHERE value IN (?, ?, ?,"
+      ],
+      "db.query.summary": "SELECT table"
+    }
+  },
+  {
+    "name": "malformed_alter_table_example_one",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER  TABLE MyTable ADD Name varchar(255) 'mypassword' 1234"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER  TABLE MyTable ADD Name varchar(255) ? ?",
+        "ALTER  TABLE MyTable ADD Name varchar(?) ? ?"
+      ],
+      "db.query.summary": "ALTER TABLE MyTable"
+    }
+  },
+  {
+    "name": "malformed_alter_table_example_two",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "ALTER  TABLE MyTable 'mypassword' ADD 123 Name varchar(255)"
+    },
+    "expected": {
+      "db.query.text": [
+        "ALTER  TABLE MyTable ? ADD ? Name varchar(255)",
+        "ALTER  TABLE MyTable ? ADD ? Name varchar(?)"
+      ],
+      "db.query.summary": "ALTER TABLE MyTable"
+    }
   }
 ]

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
@@ -21,12 +21,50 @@ public static class SqlProcessorTestCases
 
     public static TheoryData<TestCase> GetSemanticConventionsTestCases()
     {
+        var data = new TheoryData<TestCase>();
+
         var assembly = Assembly.GetExecutingAssembly();
         var input = JsonSerializer.Deserialize<TestCase[]>(
             assembly.GetManifestResourceStream("SqlProcessorTestCases.json")!,
             JsonSerializerOptions)!;
 
-        var data = new TheoryData<TestCase>();
+        if (input is not null)
+        {
+            foreach (var testCase in input)
+            {
+                // Skipping this for now as we need to discuss the expected output.
+                if (testCase.Name == "alter_table")
+                {
+                    continue;
+                }
+
+                if (DbSystemTestCasesToExecute.Contains(testCase.Input.DbSystemName))
+                {
+                    data.Add(testCase);
+                }
+            }
+        }
+
+        // Reintroduce "alter_table" with a revised expected output.
+        // We don't expect the number '255' to be redacted when defining the size of a column.
+        data.Add(new()
+        {
+            Name = "alter_table",
+            Input = new()
+            {
+                DbSystemName = "other_sql",
+                Query = "ALTER  TABLE MyTable ADD Name varchar(255)",
+            },
+            Expected = new()
+            {
+                SanitizedQueryText = ["ALTER  TABLE MyTable ADD Name varchar(255)"],
+                Summary = "ALTER TABLE MyTable",
+            },
+        });
+
+        input = JsonSerializer.Deserialize<TestCase[]>(
+            assembly.GetManifestResourceStream("SqlProcessorAdditionalTestCases.json")!,
+            JsonSerializerOptions)!;
 
         if (input is not null)
         {

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
@@ -17,7 +17,7 @@ public static class SqlProcessorTestCases
         Converters = { new JsonStringEnumConverter() },
     };
 
-    private static readonly HashSet<string> DbSystemTestCasesToExecute = ["other_sql"];
+    private static readonly HashSet<string> DbSystemTestCasesToExecute = ["other_sql", "microsoft.sql_server"];
 
     public static TheoryData<TestCase> GetSemanticConventionsTestCases()
     {

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
@@ -57,7 +57,7 @@ public static class SqlProcessorTestCases
             },
             Expected = new()
             {
-                SanitizedQueryText = ["ALTER  TABLE MyTable ADD Name varchar(255)"],
+                SanitizedQueryText = ["ALTER  TABLE MyTable ADD Name varchar(?)", "ALTER  TABLE MyTable ADD Name varchar(255)"],
                 Summary = "ALTER TABLE MyTable",
             },
         });

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
@@ -21,7 +21,7 @@ public class SqlProcessorTests
     [MemberData(nameof(TestData))]
     public void TestGetSanitizedSql(SqlProcessorTestCases.TestCase testCase)
     {
-        this.output.WriteLine($"Running test case for query: {testCase.Input.Query}");
+        this.output.WriteLine($"Input: {testCase.Input.Query}");
 
         var sqlStatementInfo = SqlProcessor.GetSanitizedSql(testCase.Input.Query);
 
@@ -34,6 +34,9 @@ public class SqlProcessorTests
                 break;
             }
         }
+
+        this.output.WriteLine($"Sanitized: {sqlStatementInfo.SanitizedSql}");
+        this.output.WriteLine($"Summary: {sqlStatementInfo.DbQuerySummary}");
 
         Assert.True(
             succeeded,


### PR DESCRIPTION
Contributes to #2238

## Changes

This is a rather large refactor of the `SqlProcessor`. The initial work focused on removing all allocation overhead. Further work optimised the non-cached execution time with `Span`-based code. Several iterations have led to the code in this PR which is a balance between readability and performance. In all cases, the execution time is reduced compared to the existing code.

Further work has been introduced to support additional SQL keywords and less common statements. This is not exhaustive but builds upon those previously supported.

@alanwest I'll add some PR comments around some specific items that may need discussion. I've included `SqlProcessorAdditionalTestCases.json` with more statements. We could eventually contribute these into the semantic conventions. These will need a careful review to check we are happy the expected summaries align with the intent from the semantic conventions.

### Before
```
| Method          | Sql                  | Mean     | Error    | StdDev    | Median   | Allocated |
|---------------- |--------------------- |---------:|---------:|----------:|---------:|----------:|
| GetSanitizedSql | CREAT(...)s(Id) [56] | 420.6 ns | 22.18 ns |  60.71 ns | 428.3 ns |     584 B |
| GetSanitizedSql | DELET(...) = 42 [32] | 255.7 ns |  7.11 ns |  20.18 ns | 252.0 ns |     448 B |
| GetSanitizedSql | INSER(...)3e-5) [76] | 514.4 ns | 16.39 ns |  48.33 ns | 513.3 ns |     680 B |
| GetSanitizedSql | SELEC(...)ls od [39] | 439.8 ns | 39.56 ns | 116.65 ns | 374.5 ns |     528 B |
| GetSanitizedSql | SELE(...)tory [111]  | 584.5 ns | 11.55 ns |  24.36 ns | 583.5 ns |    1056 B |
| GetSanitizedSql | SELEC(...)table [69] | 269.9 ns |  8.34 ns |  23.79 ns | 271.8 ns |     600 B |
| GetSanitizedSql | SELEC(...) c.Id [74] | 563.1 ns | 22.71 ns |  66.25 ns | 553.4 ns |     736 B |
| GetSanitizedSql | SELE(...)_id) [101]  | 691.8 ns | 19.53 ns |  56.02 ns | 693.5 ns |     912 B |
| GetSanitizedSql | UPDAT(...) = 42 [44] | 328.1 ns | 11.58 ns |  33.40 ns | 329.8 ns |     504 B |
```

### After
```
| Method          | Sql                  | Mean     | Error   | StdDev  | Median   | Allocated |
|---------------- |--------------------- |---------:|--------:|--------:|---------:|----------:|
| GetSanitizedSql | CREAT(...)s(Id) [56] | 207.9 ns | 4.12 ns | 7.54 ns | 205.0 ns |     248 B |
| GetSanitizedSql | DELET(...) = 42 [32] | 161.2 ns | 1.90 ns | 1.59 ns | 161.2 ns |     128 B |
| GetSanitizedSql | INSER(...)3e-5) [76] | 254.1 ns | 2.37 ns | 2.22 ns | 253.8 ns |     192 B |
| GetSanitizedSql | SELEC(...)ls od [39] | 146.3 ns | 1.98 ns | 1.65 ns | 145.8 ns |     184 B |
| GetSanitizedSql | SELE(...)tory [111]  | 267.8 ns | 1.41 ns | 1.32 ns | 268.0 ns |     424 B |
| GetSanitizedSql | SELEC(...)table [69] | 106.5 ns | 2.13 ns | 3.45 ns | 104.7 ns |     128 B |
| GetSanitizedSql | SELEC(...) c.Id [74] | 246.1 ns | 1.65 ns | 1.29 ns | 246.3 ns |     264 B |
| GetSanitizedSql | SELE(...)_id) [101]  | 294.1 ns | 2.04 ns | 1.81 ns | 294.1 ns |     312 B |
| GetSanitizedSql | UPDAT(...) = 42 [44] | 196.9 ns | 0.97 ns | 0.86 ns | 197.2 ns |     144 B |
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~