### PR TITLE
[AspNet] rename context key

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -24,7 +24,7 @@ internal static class ActivityHelper
     /// <summary>
     /// Key to store the state in HttpContext.
     /// </summary>
-    internal const string ContextKey = "__AspnetInstrumentationContext__";
+    internal const string ContextKey = "__AspnetOpenTelemetryInstrumentationContext__";
 
     /// <summary>
     /// OpenTelemetry.Instrumentation.AspNet <see cref="ActivitySource"/> name.


### PR DESCRIPTION
## Changes

[AspNet] rename context key
old one was used also before donation, need to avoid potential name collision

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
