### PR TITLE
[OpAMP.Client] Invalid WebSocket frame logging

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
@@ -61,7 +61,7 @@ internal sealed class FrameProcessor
         {
             if (!OpAmpWsHeaderHelper.TryVerifyHeader(sequence, out headerSize, out string errorMessage))
             {
-                OpAmpClientEventSource.Log.InvalidWsFrame();
+                OpAmpClientEventSource.Log.InvalidWsFrame(errorMessage);
 
                 return;
             }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
@@ -61,7 +61,7 @@ internal sealed class FrameProcessor
         {
             if (!OpAmpWsHeaderHelper.TryVerifyHeader(sequence, out headerSize, out string errorMessage))
             {
-                // TODO: log error message
+                OpAmpClientEventSource.Log.InvalidWsFrame();
 
                 return;
             }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
@@ -37,7 +37,6 @@ internal class OpAmpClientEventSource : EventSource
         this.WriteEvent(EventIdInvalidWsFrame, errorMessage);
     }
 
-
     [Event(EventIdHeartbeatServiceStart, Message = "Heartbeat service started.", Level = EventLevel.Informational)]
     public void HeartbeatServiceStart()
     {

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
@@ -12,6 +12,7 @@ internal class OpAmpClientEventSource : EventSource
     public static OpAmpClientEventSource Log = new();
 
     // General events 1-499
+    private const int EventIdInvalidWsFrame = 1;
 
     // Service events 500-999
     private const int EventIdHeartbeatServiceStart = 500;
@@ -29,6 +30,13 @@ internal class OpAmpClientEventSource : EventSource
     private const int EventIdFailedToSendIdentificationMessage = 1_100;
     private const int EventIdFailedToSendHeartbeatMessage = 1_101;
     private const int EventIdFailedToSendAgentDisconnectMessage = 1_102;
+
+    [Event(EventIdInvalidWsFrame, Message = "Received invalid WebSocket frame header. Dropping the frame.", Level = EventLevel.Warning)]
+    public void InvalidWsFrame()
+    {
+        this.WriteEvent(EventIdInvalidWsFrame);
+    }
+
 
     [Event(EventIdHeartbeatServiceStart, Message = "Heartbeat service started.", Level = EventLevel.Informational)]
     public void HeartbeatServiceStart()

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
@@ -31,10 +31,10 @@ internal class OpAmpClientEventSource : EventSource
     private const int EventIdFailedToSendHeartbeatMessage = 1_101;
     private const int EventIdFailedToSendAgentDisconnectMessage = 1_102;
 
-    [Event(EventIdInvalidWsFrame, Message = "Received invalid WebSocket frame header. Dropping the frame.", Level = EventLevel.Warning)]
-    public void InvalidWsFrame()
+    [Event(EventIdInvalidWsFrame, Message = "Received invalid WebSocket frame header: {0}. Dropping the frame.", Level = EventLevel.Warning)]
+    public void InvalidWsFrame(string errorMessage)
     {
-        this.WriteEvent(EventIdInvalidWsFrame);
+        this.WriteEvent(EventIdInvalidWsFrame, errorMessage);
     }
 
 


### PR DESCRIPTION
## Changes

* Adds invalid WebSocket frame logging.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
