### PR TITLE
One more botUserName -> expectedPrAuthorUserName

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -167,7 +167,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          BOT_USER_NAME: ${{ needs.automation.outputs.username }}
+          EXPECTED_PR_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-name }}
           PACKAGES_URL: ${{ needs.build-pack-publish.outputs.artifact-url }}
         run: |
           Import-Module .\build\scripts\post-release.psm1
@@ -177,4 +177,4 @@ jobs:
             -tag ${env:GITHUB_REF_NAME} `
             -tagSha ${env:GITHUB_SHA} `
             -packagesUrl ${env:PACKAGES_URL} `
-            -botUserName ${env:BOT_USER_NAME}
+            -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME}

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -94,7 +94,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
     [Parameter(Mandatory=$true)][string]$tag,
     [Parameter(Mandatory=$true)][string]$tagSha,
     [Parameter(Mandatory=$true)][string]$packagesUrl,
-    [Parameter(Mandatory=$true)][string]$botUserName
+    [Parameter(Mandatory=$true)][string]$expectedPrAuthorUserName
   )
 
   $prListResponse = gh pr list --search $tagSha --state merged --json number,author,title,comments | ConvertFrom-Json
@@ -107,7 +107,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
 
   foreach ($pr in $prListResponse)
   {
-    if ($pr.author.login -ne $botUserName -or $pr.title -ne "[release] Prepare release $tag")
+    if ($pr.author.login -ne $expectedPrAuthorUserName -or $pr.title -ne "[release] Prepare release $tag")
     {
       continue
     }
@@ -115,7 +115,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
     $foundComment = $false
     foreach ($comment in $pr.comments)
     {
-      if ($comment.author.login -eq $botUserName -and $comment.body.StartsWith("I just pushed the [$tag]"))
+      if ($comment.author.login -eq $expectedPrAuthorUserName -and $comment.body.StartsWith("I just pushed the [$tag]"))
       {
         $foundComment = $true
         break


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3128

Noticed while porting https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3114 to opentelemetry-dotnet repo.
