### PR TITLE
[infra] allow to auto-execute release process for OpAmp.* packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -8,6 +8,7 @@ on:
       - 'Extensions.*-*'
       - 'Extensions-*'
       - 'Instrumentation.*-*'
+      - 'OpAmp.*-*'
       - 'PersistentStorage-*'
       - 'Resources.*-*'
       - 'Sampler.*-*'


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3142#issuecomment-3323153054

## Changes

allow to auto-execute release process for OpAmp.* packages

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
