### PR TITLE
[repo] Extend release request title by placeholders for package name and version

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_request.yml
+++ b/.github/ISSUE_TEMPLATE/release_request.yml
@@ -1,5 +1,5 @@
 name: Release request
-title: "[release request] "
+title: "[release request] {Package Name} {Version}"
 description: Request a release for a component
 labels: ["release"]
 body:


### PR DESCRIPTION
## Changes

Extend release request title by placeholders for package name and version
For now, when the title does not contain any other information then the release process is not executed.
I hope it will remind end-users to fill that placeholders.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
