### PR TITLE
[Extensions.AWS] ensure aws-xray-propagator maintains trace state

### DIFF
--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* test: ensure aws xray propagator maintains context from previous propagator
+  ([#3145](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3145))
+
 ## 1.12.1
 
 Released 2025-Sep-03

--- a/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
@@ -261,4 +261,20 @@ public class AWSXRayPropagatorTests
 
         Assert.Equal(new PropagationContext(activityContext, default), this.awsXRayPropagator.Extract(default, carrier, Getter));
     }
+
+    [Fact]
+    public void TestExtractTraceHeaderFromUpstreamPropagator()
+    {
+        var carrier = new Dictionary<string, string>()
+        {
+            { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1" },
+        };
+        var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+        var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+        var traceState = "key=val,foo=bar";
+        var context = new PropagationContext(new ActivityContext(traceId, parentId, ActivityTraceFlags.Recorded, traceState), default);
+
+        // Extraction is expected to fast-exit, returning the original context
+        Assert.Equal(context, this.awsXRayPropagator.Extract(context, carrier, Getter));
+    }
 }


### PR DESCRIPTION
## Fixes: N/A
AWSXRayPropagator up until now overwrites the trace state to the default as it does not check if this has been set previously by, for example, the W3CTraceContextPropagator.

The desired behaviour is that the AWS X-Ray Propagator does not fill it in itself but also does not overwrite the information by a previously set propagator, e.g. `OTEL_PROPAGATORS=tracecontext,xray` and `OTEL_PROPAGATORS=xray,tracecontext` should lead to the same behaviour.

## Changes
- Updated the parsing function to take in the context and propagate the value of the trace state from the context as part of the newly created context
- Updated unit test and changelog accordingly

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable): N/A
