### PR TITLE
Add host.arch attribute to HostDetector and update tests

### DIFF
--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added support for the `host.arch` resource attribute in `HostDetector`, reporting the host architecture (e.g., `X64`, `Arm64`) using `System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture`.
+
 ## 1.12.0-beta.1
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Resources.Host/HostDetector.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetector.cs
@@ -94,6 +94,14 @@ internal sealed class HostDetector : IResourceDetector
             {
                 attributes.Add(new(HostSemanticConventions.AttributeHostId, machineId));
             }
+#if !NETFRAMEWORK
+            // Architecture is only supported in .NET 5+
+            var arch = RuntimeInformation.ProcessArchitecture.ToString();
+            if (arch != null && !string.IsNullOrEmpty(arch))
+            {
+                attributes.Add(new(HostSemanticConventions.AttributeHostArch, arch));
+            }
+#endif
 
             return new Resource(attributes);
         }

--- a/src/OpenTelemetry.Resources.Host/HostSemanticConventions.cs
+++ b/src/OpenTelemetry.Resources.Host/HostSemanticConventions.cs
@@ -7,4 +7,5 @@ internal static class HostSemanticConventions
 {
     public const string AttributeHostName = "host.name";
     public const string AttributeHostId = "host.id";
+    public const string AttributeHostArch = "host.arch";
 }

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -2,7 +2,7 @@
 
 | Status      |           |
 | ----------- | --------- |
-| Stability   | [Beta](../../README.md#beta) |                                                 |
+| Stability   | [Beta](../../README.md#beta) |
 | Code Owners | [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Host)](https://www.nuget.org/packages/OpenTelemetry.Resources.Host)

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -1,8 +1,8 @@
 # Host Resource Detectors
 
-| Status      |                                                                                |
-| ----------- | ------------------------------------------------------------------------------ |
-| Stability   | [Beta](../../README.md#beta)                                                   |
+| Status      |           |
+| ----------- | --------- |
+| Stability   | [Beta](../../README.md#beta) |                                                 |
 | Code Owners | [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Host)](https://www.nuget.org/packages/OpenTelemetry.Resources.Host)

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -54,11 +54,11 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 The resource detectors will record the following metadata based on where
 your application is running:
 
--   **HostDetector**:
-    -   `host.id` (when running on non-containerized systems)
-    -   `host.name`
-    -   `host.arch` (the host architecture, e.g., `X64`, `Arm64`)
+- **HostDetector**:
+  - `host.id` (when running on non-containerized systems)
+  - `host.name`
+  - `host.arch` (the host architecture, e.g., `X64`, `Arm64`)
 
 ## References
 
--   [OpenTelemetry Project](https://opentelemetry.io/)
+- [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -1,8 +1,8 @@
 # Host Resource Detectors
 
-| Status      |           |
-| ----------- | --------- |
-| Stability   | [Beta](../../README.md#beta) |
+| Status      |                                                                                |
+| ----------- | ------------------------------------------------------------------------------ |
+| Stability   | [Beta](../../README.md#beta)                                                   |
 | Code Owners | [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Host)](https://www.nuget.org/packages/OpenTelemetry.Resources.Host)
@@ -54,8 +54,11 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 The resource detectors will record the following metadata based on where
 your application is running:
 
-- **HostDetector**: `host.id` (when running on non-containerized systems), `host.name`.
+-   **HostDetector**:
+    -   `host.id` (when running on non-containerized systems)
+    -   `host.name`
+    -   `host.arch` (the host architecture, e.g., `X64`, `Arm64`)
 
 ## References
 
-- [OpenTelemetry Project](https://opentelemetry.io/)
+-   [OpenTelemetry Project](https://opentelemetry.io/)

--- a/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
@@ -51,10 +51,18 @@ public class HostDetectorTests
 
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 
+#if NET
+        Assert.Equal(3, resourceAttributes.Count);
+#else
         Assert.Equal(2, resourceAttributes.Count);
+#endif
 
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostName]);
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
+#if NET
+        Assert.NotEmpty(resourceAttributes["host.arch"]);
+        Assert.Equal(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString(), resourceAttributes["host.arch"]);
+#endif
     }
 
 #if NET


### PR DESCRIPTION
Partially implements #1516

## Changes

Adds detection and reporting of the host architecture (host.arch) using `System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture` in the `HostDetector`.

The host.arch attribute is now included in the detected resource attributes on supported platforms. The README has been updated to document the new attribute, and unit tests have been enhanced to verify that host.arch is present and correctly set. 

This improves observability by providing architecture information as part of the host resource metadata.

<img width="1942" height="856" alt="CleanShot 2025-09-24 at 20 04 16@2x" src="https://github.com/user-attachments/assets/b0f15636-9be6-4881-ba51-2ad352fa7f84" />



## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
