### PR TITLE
[Instrumentation.AspNet] Include some attributes in sampling process

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/.publicApi/PublicAPI.Unshipped.txt
@@ -5,7 +5,7 @@ OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.TelemetryHttpModule() -
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnExceptionCallback.get -> System.Action<System.Diagnostics.Activity?, System.Web.HttpContextBase!, System.Exception!>?
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnExceptionCallback.set -> void
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStartedCallback.get -> System.Action<System.Diagnostics.Activity?, System.Web.HttpContextBase!>?
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStartedCallback.get -> System.Func<System.Web.HttpContextBase!, System.Diagnostics.ActivityContext, System.Diagnostics.Activity?>?
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStartedCallback.set -> void
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStoppedCallback.get -> System.Action<System.Diagnostics.Activity?, System.Web.HttpContextBase!>?
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStoppedCallback.set -> void

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -80,6 +80,9 @@ internal static class ActivityHelper
         var originalHttpMethod = request.HttpMethod;
         RequestDataHelper.SetHttpMethodTag(ref tags, originalHttpMethod);
 
+        var url = request.Url;
+        tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
+
         if (context.Request.Unvalidated?.Path is string path)
         {
             tags.Add(SemanticConventions.AttributeUrlPath, path);

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -90,6 +90,12 @@ internal static class ActivityHelper
             tags.Add(SemanticConventions.AttributeUrlPath, path);
         }
 
+        var userAgent = request.UserAgent;
+        if (!string.IsNullOrEmpty(userAgent))
+        {
+            tags.Add(SemanticConventions.AttributeUserAgentOriginal, userAgent);
+        }
+
         var activity = AspNetSource.StartActivity(AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext, tags);
 
         if (activity != null)

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -17,11 +17,6 @@ namespace OpenTelemetry.Instrumentation.AspNet;
 internal static class ActivityHelper
 {
     /// <summary>
-    /// <see cref="Activity.OperationName"/> for OpenTelemetry.Instrumentation.AspNet created <see cref="Activity"/> objects.
-    /// </summary>
-    internal const string AspNetActivityName = "Microsoft.AspNet.HttpReqIn";
-
-    /// <summary>
     /// Key to store the state in HttpContext.
     /// </summary>
     internal const string ContextKey = "__AspnetOpenTelemetryInstrumentationContext__";
@@ -78,6 +73,7 @@ internal static class ActivityHelper
 
         var request = context.Request;
         var originalHttpMethod = request.HttpMethod;
+        var activityName = RequestDataHelper.GetActivityDisplayName(originalHttpMethod);
         RequestDataHelper.SetHttpMethodTag(ref tags, originalHttpMethod);
 
         var url = request.Url;
@@ -96,7 +92,7 @@ internal static class ActivityHelper
             tags.Add(SemanticConventions.AttributeUserAgentOriginal, userAgent);
         }
 
-        var activity = AspNetSource.StartActivity(AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext, tags);
+        var activity = AspNetSource.StartActivity(activityName, ActivityKind.Server, propagationContext.ActivityContext, tags);
 
         if (activity != null)
         {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -83,6 +83,7 @@ internal static class ActivityHelper
         var url = request.Url;
         tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
         tags.Add(SemanticConventions.AttributeServerPort, url.Port);
+        tags.Add(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
         if (context.Request.Unvalidated?.Path is string path)
         {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -76,6 +76,10 @@ internal static class ActivityHelper
 
         TagList tags = default;
 
+        var request = context.Request;
+        var originalHttpMethod = request.HttpMethod;
+        RequestDataHelper.SetHttpMethodTag(ref tags, originalHttpMethod);
+
         if (context.Request.Unvalidated?.Path is string path)
         {
             tags.Add(SemanticConventions.AttributeUrlPath, path);

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -82,6 +82,7 @@ internal static class ActivityHelper
 
         var url = request.Url;
         tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
+        tags.Add(SemanticConventions.AttributeServerPort, url.Port);
 
         if (context.Request.Unvalidated?.Path is string path)
         {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * **Breaking Change**: This module is no longer responsible for creating activities.
   The contract of `TelemetryHttpModuleOptions.OnRequestStartedCallback` was changed
-  to `Func<HttpContextBase, ActivityContext, Activity?>?`. It means that the consumer
-  is responsible for providing function returning `Activity`.
+  to `Func<HttpContextBase, ActivityContext, Activity?>?`. The consumer is now
+  responsible for providing function returning `Activity`.
   ([#3151](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3151))
 
 ## 1.12.0-beta.2

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* **Breaking Change**: This module is no longer responsible for creating activities.
+  The contract of `TelemetryHttpModuleOptions.OnRequestStartedCallback` was changed
+  to `Func<HttpContextBase, ActivityContext, Activity?>?`. It means that the consumer
+  is responsible for providing function returning `Activity`.
+  ([#3151](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3151))
+
 ## 1.12.0-beta.2
 
 Released 2025-Sep-18

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
@@ -19,6 +19,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
@@ -35,9 +35,9 @@ public class TelemetryHttpModuleOptions
     }
 
     /// <summary>
-    /// Gets or sets a callback action to be fired when a request is started.
+    /// Gets or sets a callback function to be fired when a request is started.
     /// </summary>
-    public Action<Activity?, HttpContextBase>? OnRequestStartedCallback { get; set; }
+    public Func<HttpContextBase, ActivityContext, Activity?>? OnRequestStartedCallback { get; set; }
 
     /// <summary>
     /// Gets or sets a callback action to be fired when a request is stopped.

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
@@ -36,6 +36,7 @@ public class TelemetryHttpModuleOptions
 
     /// <summary>
     /// Gets or sets a callback function to be fired when a request is started.
+    /// This function should return the <see cref="Activity"/> created to represent the request.
     /// </summary>
     public Func<HttpContextBase, ActivityContext, Activity?>? OnRequestStartedCallback { get; set; }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
@@ -18,7 +19,9 @@ internal sealed class AspNetInstrumentation : IDisposable
     public static readonly Assembly Assembly = typeof(HttpInListener).Assembly;
     public static readonly AssemblyName AssemblyName = Assembly.GetName();
     public static readonly string MeterName = AssemblyName.Name!;
+    public static readonly string ActivitySourceName = AssemblyName.Name;
     public static readonly Meter Meter = new(MeterName, Assembly.GetPackageVersion());
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName, Assembly.GetPackageVersion());
     public static readonly Histogram<double> HttpServerDuration = Meter.CreateHistogram(
         "http.server.request.duration",
         unit: "s",

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationTracerProviderBuilderExtensions.cs
@@ -52,7 +52,7 @@ public static class AspNetInstrumentationTracerProviderBuilderExtensions
                 {
                     return AspNetInstrumentation.Instance.HandleManager.AddTracingHandle();
                 });
-                tracerProviderBuilder.AddSource("OpenTelemetry.Instrumentation.AspNet");
+                tracerProviderBuilder.AddSource(AspNetInstrumentation.ActivitySourceName);
             });
         });
     }

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -6,10 +6,10 @@
   * `http.request.method`,
   * `server.address`,
   * `server.port`,
-  * `url.scheme`,
   * `url.path`,
-  * `user_agent.original`,
-  * `url.query`.
+  * `url.query`,
+  * `url.scheme`,
+  * `user_agent.original`.
   ([#3151](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3151))
 
 ## 1.12.0-beta.2

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+* Following attributes are available while sampling:
+  * `http.request.method`,
+  * `server.address`,
+  * `server.port`,
+  * `url.scheme`,
+  * `url.path`,
+  * `user_agent.original`,
+  * `url.query`.
+  ([#3151](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3151))
+
 ## 1.12.0-beta.2
 
 Released 2025-Sep-18

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -20,14 +20,14 @@ internal sealed class HttpInListener : IDisposable
     {
         TelemetryHttpModule.Options.TextMapPropagator = Propagators.DefaultTextMapPropagator;
 
-        TelemetryHttpModule.Options.OnRequestStartedCallback += this.OnStartActivity;
+        TelemetryHttpModule.Options.OnRequestStartedCallback += this.StartActivity;
         TelemetryHttpModule.Options.OnRequestStoppedCallback += this.OnStopActivity;
         TelemetryHttpModule.Options.OnExceptionCallback += this.OnException;
     }
 
     public void Dispose()
     {
-        TelemetryHttpModule.Options.OnRequestStartedCallback -= this.OnStartActivity;
+        TelemetryHttpModule.Options.OnRequestStartedCallback -= this.StartActivity;
         TelemetryHttpModule.Options.OnRequestStoppedCallback -= this.OnStopActivity;
         TelemetryHttpModule.Options.OnExceptionCallback -= this.OnException;
     }
@@ -111,7 +111,7 @@ internal sealed class HttpInListener : IDisposable
         AspNetInstrumentation.HttpServerDuration.Record(duration, tags);
     }
 
-    private void OnStartActivity(Activity? activity, HttpContextBase context)
+    private Activity? StartActivity(HttpContextBase context, ActivityContext activityContext)
     {
         if (AspNetInstrumentation.Instance.HandleManager.TracingHandles == 0)
         {
@@ -122,16 +122,47 @@ internal sealed class HttpInListener : IDisposable
                 this.beginTimestamp.Value = Stopwatch.GetTimestamp();
             }
 
-            return;
+            return null;
         }
+
+        TagList tags = default;
+
+        var request = context.Request;
+        var originalHttpMethod = request.HttpMethod;
+        var activityName = this.requestDataHelper.GetActivityDisplayName(originalHttpMethod);
+        this.requestDataHelper.SetHttpMethodTag(ref tags, originalHttpMethod);
+
+        var url = request.Url;
+        tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
+        tags.Add(SemanticConventions.AttributeServerPort, url.Port);
+        tags.Add(SemanticConventions.AttributeUrlScheme, url.Scheme);
+
+        if (context.Request.Unvalidated?.Path is string path)
+        {
+            tags.Add(SemanticConventions.AttributeUrlPath, path);
+        }
+
+        var userAgent = request.UserAgent;
+        if (!string.IsNullOrEmpty(userAgent))
+        {
+            tags.Add(SemanticConventions.AttributeUserAgentOriginal, userAgent);
+        }
+
+        var query = url.Query;
+        var options = AspNetInstrumentation.Instance.TraceOptions;
+        if (!string.IsNullOrEmpty(query))
+        {
+            var queryString = query.StartsWith("?", StringComparison.Ordinal) ? query.Substring(1) : query;
+            tags.Add(SemanticConventions.AttributeUrlQuery, options.DisableUrlQueryRedaction ? queryString : RedactionHelper.GetRedactedQueryString(queryString));
+        }
+
+        var activity = AspNetInstrumentation.ActivitySource.StartActivity(activityName, ActivityKind.Server, activityContext, tags);
 
         if (activity == null)
         {
-            AspNetInstrumentationEventSource.Log.NullActivity(nameof(this.OnStartActivity));
-            return;
+            AspNetInstrumentationEventSource.Log.NullActivity(nameof(this.StartActivity));
+            return null;
         }
-
-        var options = AspNetInstrumentation.Instance.TraceOptions;
 
         if (activity.IsAllDataRequested)
         {
@@ -148,7 +179,7 @@ internal sealed class HttpInListener : IDisposable
                     AspNetInstrumentationEventSource.Log.RequestIsFilteredOut(activity.OperationName);
                     activity.IsAllDataRequested = false;
                     activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
-                    return;
+                    return activity;
                 }
             }
             catch (Exception ex)
@@ -156,23 +187,13 @@ internal sealed class HttpInListener : IDisposable
                 AspNetInstrumentationEventSource.Log.RequestFilterException(activity.OperationName, ex);
                 activity.IsAllDataRequested = false;
                 activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
-                return;
+                return activity;
             }
-
-            var request = context.Request;
 
             var protocolVersion = RequestDataHelperExtensions.GetHttpProtocolVersion(request);
             if (!string.IsNullOrEmpty(protocolVersion))
             {
                 activity.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, protocolVersion);
-            }
-
-            var url = request.Url;
-            var query = url.Query;
-            if (!string.IsNullOrEmpty(query))
-            {
-                var queryString = query.StartsWith("?", StringComparison.Ordinal) ? query.Substring(1) : query;
-                activity.SetTag(SemanticConventions.AttributeUrlQuery, options.DisableUrlQueryRedaction ? queryString : RedactionHelper.GetRedactedQueryString(queryString));
             }
 
             try
@@ -184,6 +205,8 @@ internal sealed class HttpInListener : IDisposable
                 AspNetInstrumentationEventSource.Log.EnrichmentException("OnStartActivity", ex);
             }
         }
+
+        return activity;
     }
 
     private void OnStopActivity(Activity? activity, HttpContextBase context)

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -179,12 +179,6 @@ internal sealed class HttpInListener : IDisposable
                 activity.SetTag(SemanticConventions.AttributeUrlQuery, options.DisableUrlQueryRedaction ? queryString : RedactionHelper.GetRedactedQueryString(queryString));
             }
 
-            var userAgent = request.UserAgent;
-            if (!string.IsNullOrEmpty(userAgent))
-            {
-                activity.SetTag(SemanticConventions.AttributeUserAgentOriginal, userAgent);
-            }
-
             try
             {
                 options.EnrichWithHttpRequest?.Invoke(activity, request);

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -165,15 +165,13 @@ internal sealed class HttpInListener : IDisposable
             var originalHttpMethod = request.HttpMethod;
             this.requestDataHelper.SetActivityDisplayName(activity, originalHttpMethod);
 
-            var url = request.Url;
-            activity.SetTag(SemanticConventions.AttributeUrlScheme, url.Scheme);
-
             var protocolVersion = RequestDataHelperExtensions.GetHttpProtocolVersion(request);
             if (!string.IsNullOrEmpty(protocolVersion))
             {
                 activity.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, protocolVersion);
             }
 
+            var url = request.Url;
             var query = url.Query;
             if (!string.IsNullOrEmpty(query))
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -161,10 +161,6 @@ internal sealed class HttpInListener : IDisposable
 
             var request = context.Request;
 
-            // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md
-            var originalHttpMethod = request.HttpMethod;
-            this.requestDataHelper.SetActivityDisplayName(activity, originalHttpMethod);
-
             var protocolVersion = RequestDataHelperExtensions.GetHttpProtocolVersion(request);
             if (!string.IsNullOrEmpty(protocolVersion))
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -166,7 +166,6 @@ internal sealed class HttpInListener : IDisposable
             this.requestDataHelper.SetActivityDisplayName(activity, originalHttpMethod);
 
             var url = request.Url;
-            activity.SetTag(SemanticConventions.AttributeServerPort, url.Port);
             activity.SetTag(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
             var protocolVersion = RequestDataHelperExtensions.GetHttpProtocolVersion(request);

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -170,8 +170,6 @@ internal sealed class HttpInListener : IDisposable
             activity.SetTag(SemanticConventions.AttributeServerPort, url.Port);
             activity.SetTag(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
-            this.requestDataHelper.SetHttpMethodTag(activity, originalHttpMethod);
-
             var protocolVersion = RequestDataHelperExtensions.GetHttpProtocolVersion(request);
             if (!string.IsNullOrEmpty(protocolVersion))
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -166,7 +166,6 @@ internal sealed class HttpInListener : IDisposable
             this.requestDataHelper.SetActivityDisplayName(activity, originalHttpMethod);
 
             var url = request.Url;
-            activity.SetTag(SemanticConventions.AttributeServerAddress, url.Host);
             activity.SetTag(SemanticConventions.AttributeServerPort, url.Port);
             activity.SetTag(SemanticConventions.AttributeUrlScheme, url.Scheme);
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -52,7 +52,7 @@ internal sealed class SqlActivitySourceHelper
             ? MicrosoftSqlServerDbSystemName
             : MicrosoftSqlServerDbSystem;
 
-        var tags = new TagList { };
+        TagList tags = default;
 
         if (options.EmitOldAttributes)
         {

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Added server instrumentation support for `RecordException` option.
   ([#2880](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2880))
 
+* **Breaking changes** Adjust to breaking changes from
+  `OpenTelemetry.Instrumentation.AspNet` version `1.12.0-beta.3`.
+  Fixing span hierarchy when hosted in ASP.NET.
+  ([#3151](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3151))
+
 ## 1.12.0-beta.1
 
 Released 2025-May-06

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/AspNetParentSpanCorrector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/AspNetParentSpanCorrector.cs
@@ -160,8 +160,7 @@ internal static class AspNetParentSpanCorrector
             [activityVariable],
             assignActivity,
             conditionalCall,
-            returnActivity
-        );
+            returnActivity);
 
         // Create the combined callback lambda
         var combinedCallbackLambda = Expression.Lambda(callbackType, methodBody, httpContextParam, activityContextParam);

--- a/src/Shared/RequestDataHelper.cs
+++ b/src/Shared/RequestDataHelper.cs
@@ -62,6 +62,17 @@ internal sealed class RequestDataHelper
         }
     }
 
+    public void SetHttpMethodTag(ref TagList tags, string originalHttpMethod)
+    {
+        var normalizedHttpMethod = this.GetNormalizedHttpMethod(originalHttpMethod);
+        tags.Add(SemanticConventions.AttributeHttpRequestMethod, normalizedHttpMethod);
+
+        if (originalHttpMethod != normalizedHttpMethod)
+        {
+            tags.Add(SemanticConventions.AttributeHttpRequestMethodOriginal, originalHttpMethod);
+        }
+    }
+
     public string GetNormalizedHttpMethod(string method)
     {
         return this.knownHttpMethods.TryGetValue(method, out var normalizedMethod)

--- a/src/Shared/RequestDataHelper.cs
+++ b/src/Shared/RequestDataHelper.cs
@@ -82,12 +82,17 @@ internal sealed class RequestDataHelper
 
     public void SetActivityDisplayName(Activity activity, string originalHttpMethod, string? httpRoute = null)
     {
+        activity.DisplayName = this.GetActivityDisplayName(originalHttpMethod, httpRoute);
+    }
+
+    public string GetActivityDisplayName(string originalHttpMethod, string? httpRoute = null)
+    {
         // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md#name
 
         var normalizedHttpMethod = this.GetNormalizedHttpMethod(originalHttpMethod);
         var namePrefix = normalizedHttpMethod == "_OTHER" ? "HTTP" : normalizedHttpMethod;
 
-        activity.DisplayName = string.IsNullOrEmpty(httpRoute) ? namePrefix : $"{namePrefix} {httpRoute}";
+        return string.IsNullOrEmpty(httpRoute) ? namePrefix : $"{namePrefix} {httpRoute}";
     }
 
     internal static string GetHttpProtocolVersion(Version httpVersion)

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -126,7 +126,7 @@ public class ActivityHelperTest : IDisposable
         {
             Assert.NotNull(Activity.Current);
             Assert.Equal(Activity.Current, a);
-            Assert.Equal(ActivityHelper.AspNetActivityName, Activity.Current.OperationName);
+            Assert.Equal("GET", Activity.Current.OperationName);
         });
         var context = HttpContextHelper.GetFakeHttpContextBase();
         using var rootActivity = ActivityHelper.StartAspNetActivity(this.noopTextMapPropagator, context, null)!;

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -26,25 +26,25 @@ public class HttpInListenerTests
     }
 
     [Theory]
-    [InlineData("http://localhost/", "http", "/", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET")]
-    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", QueryRedactionDisableBehavior.DisableViaEnvVar, "localhost", 80, "POST", "POST", null, 0, null, "POST", true)]
-    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", QueryRedactionDisableBehavior.DisableViaIConfiguration, "localhost", 80, "POST", "POST", null, 0, null, "POST", true)]
-    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=Redacted&baz=Redacted", null, "localhost", 80, "POST", "POST", null, 0, null, "POST", true)]
-    [InlineData("https://localhost/", "https", "/", null, null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null, "HTTP")]
-    [InlineData("https://user:pass@localhost/", "https", "/", null, null, "localhost", 443, "GeT", "GET", "GeT", 0, null, "GET")] // Test URL sanitization
-    [InlineData("http://localhost:443/", "http", "/", null, null, "localhost", 443, "GET", "GET", null, 0, null, "GET")] // Test http over 443
-    [InlineData("https://localhost:80/", "https", "/", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET")] // Test https over 80
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", QueryRedactionDisableBehavior.DisableViaEnvVar, "localhost", 80, "GET", "GET", null, 0, null, "GET")] // Test complex URL
-    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=Redacted&q2=Redacted", null, "localhost", 80, "GET", "GET", null, 0, null, "GET")] // Test complex URL
-    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", QueryRedactionDisableBehavior.DisableViaIConfiguration, "localhost", 80, "GET", "GET", null, 0, null, "GET")] // Test complex URL sanitization
-    [InlineData("http://localhost:80/Index", "http", "/Index", null, null, "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}", "GET {controller}/{action}/{id}")]
-    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null, null, "localhost", 443, "HEAD", "HEAD", null, 2, "about_attr_route/{customerId}", "HEAD about_attr_route/{customerId}")]
-    [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", null, null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}", "GET api/{controller}/{id}")]
-    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}", "GET subroute/{customerId}")]
-    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 5, "subroute/{customerId}", "GET subroute/{customerId}")]
-    [InlineData("http://localhost/api/value", "http", "/api/value", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, "/api/value")] // Request will be filtered
-    [InlineData("http://localhost/api/value", "http", "/api/value", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, "{ThrowException}")] // Filter user code will throw an exception
-    [InlineData("http://localhost/", "http", "/", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", false, null, true, "System.InvalidOperationException")] // Test RecordException option
+    [InlineData("http://localhost/", "http", "/", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET")]
+    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", QueryRedactionDisableBehavior.DisableViaEnvVar, "localhost", 80, "POST", "POST", null, 0, null, "POST", "POST", true)]
+    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=bar&baz=test", QueryRedactionDisableBehavior.DisableViaIConfiguration, "localhost", 80, "POST", "POST", null, 0, null, "POST", "POST", true)]
+    [InlineData("http://localhost/?foo=bar&baz=test", "http", "/", "foo=Redacted&baz=Redacted", null, "localhost", 80, "POST", "POST", null, 0, null, "POST", "POST", true)]
+    [InlineData("https://localhost/", "https", "/", null, null, "localhost", 443, "NonStandard", "_OTHER", "NonStandard", 0, null, "HTTP", "HTTP")]
+    [InlineData("https://user:pass@localhost/", "https", "/", null, null, "localhost", 443, "GeT", "GET", "GeT", 0, null, "GET", "GET")] // Test URL sanitization
+    [InlineData("http://localhost:443/", "http", "/", null, null, "localhost", 443, "GET", "GET", null, 0, null, "GET", "GET")] // Test http over 443
+    [InlineData("https://localhost:80/", "https", "/", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET")] // Test https over 80
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", QueryRedactionDisableBehavior.DisableViaEnvVar, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET")] // Test complex URL
+    [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=Redacted&q2=Redacted", null, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET")] // Test complex URL
+    [InlineData("https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https", "/Home/Index.htm", "q1=v1&q2=v2", QueryRedactionDisableBehavior.DisableViaIConfiguration, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET")] // Test complex URL sanitization
+    [InlineData("http://localhost:80/Index", "http", "/Index", null, null, "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}", "GET", "GET {controller}/{action}/{id}")]
+    [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null, null, "localhost", 443, "HEAD", "HEAD", null, 2, "about_attr_route/{customerId}", "HEAD", "HEAD about_attr_route/{customerId}")]
+    [InlineData("http://localhost:1880/api/weatherforecast", "http", "/api/weatherforecast", null, null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}", "GET", "GET api/{controller}/{id}")]
+    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}", "GET", "GET subroute/{customerId}")]
+    [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 5, "subroute/{customerId}", "GET", "GET subroute/{customerId}")]
+    [InlineData("http://localhost/api/value", "http", "/api/value", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET", false, "/api/value")] // Request will be filtered
+    [InlineData("http://localhost/api/value", "http", "/api/value", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET", false, "{ThrowException}")] // Filter user code will throw an exception
+    [InlineData("http://localhost/", "http", "/", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET", false, null, true, "System.InvalidOperationException")] // Test RecordException option
     public void AspNetRequestsAreCollectedSuccessfully(
         string url,
         string expectedUrlScheme,
@@ -58,7 +58,8 @@ public class HttpInListenerTests
         string? expectedOriginalRequestMethod,
         int routeType,
         string? routeTemplate,
-        string expectedName,
+        string expectedNameAfterStart,
+        string expectedNameAfterStop,
         bool setStatusToErrorInEnrich = false,
         string? filter = null,
         bool recordException = false,
@@ -159,7 +160,7 @@ public class HttpInListenerTests
                     Assert.Single(inMemoryEventListener.Events, e => e.EventId == 2);
                 }
 
-                Assert.Equal(ActivityHelper.AspNetActivityName, Activity.Current!.OperationName);
+                Assert.Equal(expectedNameAfterStart, Activity.Current!.DisplayName);
 
                 if (recordException)
                 {
@@ -179,10 +180,9 @@ public class HttpInListenerTests
 
             var span = exportedItems[0];
 
-            Assert.Equal(ActivityHelper.AspNetActivityName, span.OperationName);
             Assert.NotEqual(TimeSpan.Zero, span.Duration);
 
-            Assert.Equal(expectedName, span.DisplayName);
+            Assert.Equal(expectedNameAfterStop, span.DisplayName);
             Assert.Equal(ActivityKind.Server, span.Kind);
             Assert.True(span.Duration != TimeSpan.Zero);
 


### PR DESCRIPTION
Towards #2909

## Changes

Goal - make following attributes available on startup:
  * `http.request.method`,
  * `server.address`,
  * `server.port`,
  * `url.scheme`,
  * `url.path`,
  * `user_agent.original`,
  * `url.query`.

Side effect: breaking changes in IIS module.
It is not responsible for creating activity. It delegates it to the instrumentation package.
2 reasons for this design:
 - keep separation of managing activity context in IIS module and OpenTelemetry deatails in instrumentation package
 - Instrumentation package allows to configure DisableRedactionUrlQuery through IConfiguration. I do not found good way to set it on the IIS module side.

While reviewing you can check commit-by-commit towards this implementation. The last one is the big commit only.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
