### PR TITLE
[AspNet] HttpInListener.CalculateDurationFromTimestamp - remove optional parameter

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -32,9 +32,9 @@ internal sealed class HttpInListener : IDisposable
         TelemetryHttpModule.Options.OnExceptionCallback -= this.OnException;
     }
 
-    internal static double CalculateDurationFromTimestamp(long begin, long? end = null)
+    private static double CalculateDurationFromTimestamp(long begin)
     {
-        end ??= Stopwatch.GetTimestamp();
+        var end = Stopwatch.GetTimestamp();
         var delta = end - begin;
         var ticks = (long)(TimestampToTicks * delta);
         var duration = new TimeSpan(ticks);


### PR DESCRIPTION
## Changes

[AspNet] HttpInListener.CalculateDurationFromTimestamp - remove optional parameter

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
