### PR TITLE
[Infra] Validate NuGet packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -83,7 +83,7 @@ jobs:
         run: dotnet restore ${env:PROJECT_PATH}
 
       - name: dotnet build ${{ steps.resolve-project.outputs.title }}
-        run: dotnet build ${env:PROJECT_PATH} --configuration Release --no-restore -p:Deterministic=true -p:"BuildNumber=${env:GITHUB_RUN_NUMBER}"
+        run: dotnet build ${env:PROJECT_PATH} --configuration Release --no-restore -p:"BuildNumber=${env:GITHUB_RUN_NUMBER}"
 
       - name: dotnet test ${{ steps.resolve-project.outputs.title }}
         run: dotnet test ${env:PROJECT_PATH} --configuration Release --no-restore --no-build

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -68,10 +68,6 @@
     <None Include=".publicApi\**\PublicAPI.*.txt" Condition="'$(EnablePublicApi)' != 'false'" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Deterministic)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-
   <Target Name="EnsurePackageValidationBaselineVersion"
           BeforeTargets="RunPackageValidation"
           Condition="'$(DisablePackageBaselineValidation)' != 'true' AND '$(PackageValidationBaselineVersion)' == '' AND '$(MinVerTagPrefix)' != 'coreunstable-'">

--- a/build/Common.props
+++ b/build/Common.props
@@ -17,6 +17,12 @@
     <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
+  <!-- Set properties to enable deterministic builds -->
+  <PropertyGroup>
+    <ContinuousIntegrationBuild>$([MSBuild]::ValueOrDefault('$(CI)', 'false'))</ContinuousIntegrationBuild>
+    <Deterministic>$([MSBuild]::ValueOrDefault('$(Deterministic)', 'true'))</Deterministic>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(SignAssembly)' == 'true' ">
     <StrongNamePublicKey>002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898</StrongNamePublicKey>
   </PropertyGroup>


### PR DESCRIPTION
Equivalent of https://github.com/open-telemetry/opentelemetry-dotnet/pull/6592.

## Changes

- Use the `dotnet-validate` and `Meziantou.Framework.NuGetPackageValidation.Tool` tools to validate NuGet packages before publishing.
- Always enable deterministic builds, including for tests.
- Set `ContinuousIntegrationBuild` to the value of `CI`, which is [`true` in GitHub Actions](https://docs.github.com/actions/reference/workflows-and-actions/variables#default-environment-variables).

Validated no issues by running the following commands locally:

```pwsh
$env:CI="true"
dotnet pack --configuration Release

$packages = Get-ChildItem -Path artifacts/package/release/*.nupkg -File | ForEach-Object { $_.FullName }
$invalidPackages = 0
foreach ($package in $packages) {
  $isValid = $true
  dotnet validate package local $package
  if ($LASTEXITCODE -ne 0) {
    Write-Output "::error::validate package local failed for $package."
    $isValid = $false
  }
  meziantou.validate-nuget-package $package
  if ($LASTEXITCODE -ne 0) {
    Write-Output "::error::meziantou.validate-nuget-package failed for $package."
    $isValid = $false
  }
  if (-Not $isValid) {
    $invalidPackages++
  }
}
if ($invalidPackages -gt 0) {
  Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
}
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
