### PR TITLE
[repo] Add Martin Costello as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 
 [@open-telemetry/dotnet-contrib-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-approvers):
 
-* [Martin Costello](https://github.com/martincostello), Grafana Labs
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
 * [Timothy "Mothra" Lee](https://github.com/TimothyMothra)
 
@@ -96,6 +95,7 @@ repository](https://github.com/open-telemetry/community/blob/main/guides/contrib
 [@open-telemetry/dotnet-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-contrib-maintainers):
 
 * [Alan West](https://github.com/alanwest), New Relic
+* [Martin Costello](https://github.com/martincostello), Grafana Labs
 * [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
 * [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 


### PR DESCRIPTION
Let me welcome @martincostello as a maintainer.

Over couple last months Martin make significant improvements across whole code bases. He is also very active in responding on the newly reported issues.

Martin, thanks for all your current contributions and looking for more.

---------

Nomination was already discussed on the last SIG meeting and internally across all maintainers.