### PR TITLE
Clarify note about Instrumentation.Runtime Meter registration

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/README.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/README.md
@@ -50,7 +50,7 @@ to the application.
 
 > [!NOTE]
 > .NET 9 introduced built-in runtime metrics. As such, when applications target
-  .NET 9 or greater this package registers a `Meter` to receive the built-in
+  .NET 9 or greater this package instead registers a `Meter` to receive the built-in
   `System.Runtime` metrics. See the [.NET Runtime metrics documentation](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-runtime)
   for details of the metric and attribute names for the built-in metrics.
 


### PR DESCRIPTION
## Changes

Add a small clarification in the README about Meter registration for Instrumentation.Runtime on .NET9+ to avoid potential confusion.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
