### PR TITLE
[gRPC] Fix flaky tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -204,12 +204,14 @@ public class GrpcCoreClientInterceptorTests
         callInvoker = callInvoker.Intercept(metadata =>
         {
             // This Func is called as part of an internal MetadataInjector interceptor created by gRPC Core.
-            Assert.NotNull(Activity.Current);
-            Assert.Equal(Activity.Current.Source, GrpcCoreInstrumentation.ActivitySource);
-            Assert.Equal(parentActivity.Id, Activity.Current.ParentId);
+            var activity = Activity.Current;
+
+            Assert.NotNull(activity);
+            Assert.Equal(activity.Source, GrpcCoreInstrumentation.ActivitySource);
+            Assert.Equal(parentActivity.Id, activity.ParentId);
 
             // Set a tag on the Activity and make sure we can see it afterwards
-            Activity.Current.SetTag("foo", "bar");
+            activity.SetTag("foo", "bar");
             return metadata;
         });
 

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/TestActivityTags.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/TestActivityTags.cs
@@ -24,7 +24,7 @@ internal class TestActivityTags
     /// Checks whether the activity has test tags.
     /// </summary>
     /// <param name="activity">The activity.</param>
-    /// <returns>Returns true if the activty has test tags, false otherwise.</returns>
+    /// <returns>Returns true if the activity has test tags, false otherwise.</returns>
     internal bool HasTestTags(Activity activity)
     {
         Guard.ThrowIfNull(activity);

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -333,9 +333,7 @@ public partial class GrpcTests
             var clientActivity = exportedItems.Single(activity => activity.OperationName == OperationNameGrpcOut);
 
             Assert.Equal(clientActivity.ParentSpanId, parentActivity.SpanId);
-
-            // Propagator is not called
-            Assert.False(isPropagatorCalled);
+            Assert.False(isPropagatorCalled, "Propagator was called.");
         }
         finally
         {
@@ -385,7 +383,7 @@ public partial class GrpcTests
             // If suppressed, activity is not emitted and
             // propagation is also not performed.
             Assert.Single(exportedItems);
-            Assert.False(isPropagatorCalled);
+            Assert.False(isPropagatorCalled, "Propagator was called.");
         }
         finally
         {

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
@@ -141,8 +141,8 @@ public partial class GrpcTests : IDisposable
             client.SayHello(new HelloRequest(), headers);
 
             WaitForExporterToReceiveItems(exportedItems, 1);
-            Assert.Single(exportedItems);
-            var activity = exportedItems[0];
+
+            var activity = Assert.Single(exportedItems);
 
             Assert.Equal(ActivityKind.Server, activity.Kind);
 
@@ -194,11 +194,11 @@ public partial class GrpcTests : IDisposable
         // We need to let End callback execute as it is executed AFTER response was returned.
         // In unit tests environment there may be a lot of parallel unit tests executed, so
         // giving some breathing room for the End callback to complete.
-        var timeout = TimeSpan.FromSeconds(1);
+        var timeout = TimeSpan.FromSeconds(5);
         var satisfied = SpinWait.SpinUntil(
             () =>
             {
-                Thread.Sleep(10);
+                Thread.Sleep(25);
                 return itemsReceived.Count >= itemCount;
             },
             timeout);

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
@@ -95,7 +95,9 @@ public partial class GrpcTests : IDisposable
     }
 
 #if NET
-    [Theory(Skip = "Skipping for .NET 6 and higher due to bug #3023")]
+    [Theory(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1778")]
+#else
+    [Theory]
 #endif
     [InlineData(null)]
     [InlineData("true")]


### PR DESCRIPTION
Fix flaky gRPC tests.

[Example](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/18709896893/job/53355621439?pr=3288#step:8:29)

```text
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 8.0.21)
[xUnit.net 00:00:00.12]   Discovering: OpenTelemetry.Instrumentation.GrpcCore.Tests
[xUnit.net 00:00:00.16]   Discovered:  OpenTelemetry.Instrumentation.GrpcCore.Tests
[xUnit.net 00:00:00.16]   Starting:    OpenTelemetry.Instrumentation.GrpcCore.Tests
[xUnit.net 00:00:00.53]     OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.ClientStreamingUnavailable [FAIL]
[xUnit.net 00:00:00.53]       Assert.True() Failure
[xUnit.net 00:00:00.53]       Expected: True
[xUnit.net 00:00:00.53]       Actual:   False
[xUnit.net 00:00:00.54]       Stack Trace:
[xUnit.net 00:00:00.54]         /_/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs(320,0): at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(Activity activity, StatusCode expectedStatusCode, Boolean recordedMessages, Boolean recordedExceptions)
[xUnit.net 00:00:00.54]         /_/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs(507,0): at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.TestHandlerFailure(Func`3 clientRequestFunc, StatusCode statusCode, Boolean validateErrorDescription, String serverUriString)
[xUnit.net 00:00:00.54]         /_/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs(95,0): at OpenTelemetry.Instrumentation.GrpcCore.Tests.GrpcCoreClientInterceptorTests.ClientStreamingUnavailable()
[xUnit.net 00:00:00.54]         --- End of stack trace from previous location ---
```

[Example](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/18710994998/job/53359219275?pr=3288#step:8:88)
```text
[xUnit.net 00:00:52.67]     OpenTelemetry.Instrumentation.Grpc.Tests.GrpcTests.GrpcAspNetCoreInstrumentationAddsCorrectAttributes(enableGrpcAspNetCoreSupport: "False") [FAIL]
[xUnit.net 00:00:52.67]       Assert.True() Failure
[xUnit.net 00:00:52.67]       Expected: True
[xUnit.net 00:00:52.67]       Actual:   False
[xUnit.net 00:00:52.67]       Stack Trace:
[xUnit.net 00:00:52.67]         /_/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs(193,0): at OpenTelemetry.Instrumentation.Grpc.Tests.GrpcTests.WaitForExporterToReceiveItems(List`1 itemsReceived, Int32 itemCount)
[xUnit.net 00:00:52.67]         /_/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs(62,0): at OpenTelemetry.Instrumentation.Grpc.Tests.GrpcTests.GrpcAspNetCoreInstrumentationAddsCorrectAttributes(String enableGrpcAspNetCoreSupport)
```

## Changes

- Fix flaky test if an activity runs quickly enough to have an unset duration by using `IsStopped` instead.
- Address Visual Studio refactor suggestions.
- Fix typo in comment.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
