### PR TITLE
[Infra] Avoid running CodeQL in PRs for trivia

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,6 @@ jobs:
   lint-misspell-sanitycheck:
     uses: ./.github/workflows/sanitycheck.yml
 
-  code-ql:
-    uses: ./.github/workflows/codeql-analysis-steps.yml
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
   detect-changes:
     runs-on: windows-latest
     outputs:
@@ -82,6 +75,19 @@ jobs:
           resources-processruntime: ['*/OpenTelemetry.Resources.ProcessRuntime/**', '*/OpenTelemetry.Resources.ProcessRuntime.Tests/**', '!**/*.md']
           sampler-aws: ['*/OpenTelemetry.Sampler.AWS*/**', '!**/*.md']
           semanticconventions: ['*/OpenTelemetry.SemanticConventions*/**', '!**/*.md']
+
+  code-ql:
+    needs: detect-changes
+    if: |
+      github.event_name == 'push' ||
+      contains(needs.detect-changes.outputs.changes, 'build') ||
+      contains(needs.detect-changes.outputs.changes, 'code') ||
+      contains(needs.detect-changes.outputs.changes, 'yml')
+    uses: ./.github/workflows/codeql-analysis-steps.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
   lint-md:
     needs: detect-changes


### PR DESCRIPTION
## Changes

Only run CodeQL in `main` (so every commit has a SAST scan) or if GitHub Actions or .NET code is changed.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
