### PR TITLE
[Resources.Azure] Rename deployment.environment to deployment.environment.name

### DIFF
--- a/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
@@ -13,7 +13,7 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
     internal static readonly IReadOnlyDictionary<string, string> AppServiceResourceAttributes = new Dictionary<string, string>
     {
         { ResourceSemanticConventions.AttributeCloudRegion, ResourceAttributeConstants.AppServiceRegionNameEnvVar },
-        { ResourceSemanticConventions.AttributeDeploymentEnvironment, ResourceAttributeConstants.AppServiceSlotNameEnvVar },
+        { ResourceSemanticConventions.AttributeDeploymentEnvironmentName, ResourceAttributeConstants.AppServiceSlotNameEnvVar },
         { ResourceSemanticConventions.AttributeHostId, ResourceAttributeConstants.AppServiceHostNameEnvVar },
         { ResourceSemanticConventions.AttributeServiceInstance, ResourceAttributeConstants.AppServiceInstanceIdEnvVar },
         { ResourceAttributeConstants.AzureAppServiceStamp, ResourceAttributeConstants.AppServiceStampNameEnvVar },

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Renamed `deployment.environment` attribute to `deployment.environment.name`
+  in Azure App Service Resource Detector.
+  ([#3366](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3366))
+
 ## 1.13.0-beta.1
 
 Released 2025-Oct-22

--- a/src/OpenTelemetry.Resources.Azure/README.md
+++ b/src/OpenTelemetry.Resources.Azure/README.md
@@ -48,17 +48,17 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 });
 ```
 
-| Attribute               | Description                                                                                                                                                                                               |
-|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| azure.app.service.stamp | The specific "stamp" cluster within Azure where the App Service is running, e.g., "waws-prod-sn1-001".                                                                                                    |
-| cloud.platform          | The cloud platform. Here, it's always "azure_app_service".                                                                                                                                                |
-| cloud.provider          | The cloud service provider. In this context, it's always "azure".                                                                                                                                         |
-| cloud.resource_id       | The Azure Resource Manager URI uniquely identifying the Azure App Service. Typically in the format "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Web/sites/{siteName}". |
-| cloud.region            | The Azure region where the App Service is hosted, e.g., "East US", "West Europe", etc.                                                                                                                    |
-| deployment.environment  | The deployment slot where the Azure App Service is running, such as "staging", "production", etc.                                                                                                         |
-| host.id                 | The primary hostname for the app, excluding any custom hostnames.                                                                                                                                         |
-| service.instance.id     | The specific instance of the Azure App Service, useful in a scaled-out configuration.                                                                                                                     |
-| service.name            | The name of the Azure App Service.                                                                                                                                                                        |
+| Attribute                   | Description                                                                                                                                                                                               |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| azure.app.service.stamp     | The specific "stamp" cluster within Azure where the App Service is running, e.g., "waws-prod-sn1-001".                                                                                                    |
+| cloud.platform              | The cloud platform. Here, it's always "azure_app_service".                                                                                                                                                |
+| cloud.provider              | The cloud service provider. In this context, it's always "azure".                                                                                                                                         |
+| cloud.resource_id           | The Azure Resource Manager URI uniquely identifying the Azure App Service. Typically in the format "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Web/sites/{siteName}". |
+| cloud.region                | The Azure region where the App Service is hosted, e.g., "East US", "West Europe", etc.                                                                                                                    |
+| deployment.environment.name | The deployment slot where the Azure App Service is running, such as "staging", "production", etc.                                                                                                         |
+| host.id                     | The primary hostname for the app, excluding any custom hostnames.                                                                                                                                         |
+| service.instance.id         | The specific instance of the Azure App Service, useful in a scaled-out configuration.                                                                                                                     |
+| service.name                | The name of the Azure App Service.                                                                                                                                                                        |
 
 ## VM Resource Detector
 
@@ -81,19 +81,19 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .Build();
 ```
 
-| Attribute                | Description                                                                                                                                                                                                                         |
-|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| azure.vm.scaleset.name   | The name of the Virtual Machine Scale Set if the VM is part of one.                                                                                                                                                                 |
-| cloud.platform           | The cloud platform, which is always set to "azure_vm" in this context.                                                                                                                                                              |
-| cloud.provider           | The cloud service provider, which is always set to "azure" in this context.                                                                                                                                                         |
-| cloud.region             | The Azure region where the Virtual Machine is hosted, such as "East US", "West Europe", etc.                                                                                                                                        |
-| cloud.resource_id        | The Azure Resource Manager URI uniquely identifying the Azure Virtual Machine. It typically follows this format: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Compute/virtualMachines/{vmName}". |
-| host.id                  | A unique identifier for the VM host, for instance, "02aab8a4-74ef-476e-8182-f6d2ba4166a6".                                                                                                                                          |
-| host.name                | The name of the host machine.                                                                                                                                                                                                       |
-| host.type                | The size of the VM instance, for example, "Standard_D2s_v3".                                                                                                                                                                        |
-| os.type                  | The type of operating system running on the VM, such as "Linux" or "Windows".                                                                                                                                                       |
-| os.version               | The version of the operating system running on the VM.                                                                                                                                                                              |
-| service.instance.id      | An identifier for a specific instance of the service running on the Azure VM, for example, "02aab8a4-74ef-476e-8182-f6d2ba4166a6".                                                                                                  |
+| Attribute              | Description                                                                                                                                                                                                                         |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| azure.vm.scaleset.name | The name of the Virtual Machine Scale Set if the VM is part of one.                                                                                                                                                                 |
+| cloud.platform         | The cloud platform, which is always set to "azure_vm" in this context.                                                                                                                                                              |
+| cloud.provider         | The cloud service provider, which is always set to "azure" in this context.                                                                                                                                                         |
+| cloud.region           | The Azure region where the Virtual Machine is hosted, such as "East US", "West Europe", etc.                                                                                                                                        |
+| cloud.resource_id      | The Azure Resource Manager URI uniquely identifying the Azure Virtual Machine. It typically follows this format: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Compute/virtualMachines/{vmName}". |
+| host.id                | A unique identifier for the VM host, for instance, "02aab8a4-74ef-476e-8182-f6d2ba4166a6".                                                                                                                                          |
+| host.name              | The name of the host machine.                                                                                                                                                                                                       |
+| host.type              | The size of the VM instance, for example, "Standard_D2s_v3".                                                                                                                                                                        |
+| os.type                | The type of operating system running on the VM, such as "Linux" or "Windows".                                                                                                                                                       |
+| os.version             | The version of the operating system running on the VM.                                                                                                                                                                              |
+| service.instance.id    | An identifier for a specific instance of the service running on the Azure VM, for example, "02aab8a4-74ef-476e-8182-f6d2ba4166a6".                                                                                                  |
 
 ## Azure Container Apps Resource Detector
 
@@ -116,10 +116,10 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .Build();
 ```
 
-| Attribute               | Description                                                                                                                                                                                               |
-|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cloud.platform          | The cloud platform. Here, it's always "azure_container_apps".                                                                                                                                             |
-| cloud.provider          | The cloud service provider. In this context, it's always "azure".                                                                                                                                         |
-| service.instance.id     | Represents the specific instance ID of Azure Container Apps, useful in scaled-out configurations.                                                                                                         |
-| service.name            | The name of the Azure Container Apps or Azure Container Apps job.                                                                                                                                         |
-| service.version         | The current revision or version of Azure Container Apps, or in case of a Azure Container Apps job - the job execution name.                                                                               |
+| Attribute           | Description                                                                                                                 |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| cloud.platform      | The cloud platform. Here, it's always "azure_container_apps".                                                               |
+| cloud.provider      | The cloud service provider. In this context, it's always "azure".                                                           |
+| service.instance.id | Represents the specific instance ID of Azure Container Apps, useful in scaled-out configurations.                           |
+| service.name        | The name of the Azure Container Apps or Azure Container Apps job.                                                           |
+| service.version     | The current revision or version of Azure Container Apps, or in case of a Azure Container Apps job - the job execution name. |

--- a/src/Shared/ResourceSemanticConventions.cs
+++ b/src/Shared/ResourceSemanticConventions.cs
@@ -55,5 +55,5 @@ internal static class ResourceSemanticConventions
     public const string AttributeOsType = "os.type";
     public const string AttributeOsVersion = "os.version";
 
-    public const string AttributeDeploymentEnvironment = "deployment.environment";
+    public const string AttributeDeploymentEnvironmentName = "deployment.environment.name";
 }


### PR DESCRIPTION
Releated to https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/deployment-environment.md
Old version was deprecated.

## Changes

[Resources.Azure] Rename `deployment.environment` to `deployment.environment.name`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
