### PR TITLE
Fix identifier parsing and improve FROM clause parsing

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix diacritic identifier parsing hang and improve FROM clause parsing.
+([#3368](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3368))
+
 ## 1.13.0-beta.1
 
 Released 2025-Oct-22

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix diacritic identifier parsing hang and improve FROM clause parsing.
+([#3368](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3368))
+
 ## 1.13.0-beta.1
 
 Released 2025-Oct-22

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -468,17 +468,16 @@ internal static class SqlProcessor
             }
 
             var reservedKeywordSpan = reservedKeyword.AsSpan();
-            var isMatch = true;
+
             for (var charPos = 0; charPos < tokenSpan.Length; charPos++)
             {
                 if ((tokenSpan[charPos] | 0x20) != (reservedKeywordSpan[charPos] | 0x20))
                 {
-                    isMatch = false;
-                    break;
+                    return false;
                 }
             }
 
-            return isMatch;
+            return true;
         }
     }
 

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -762,7 +762,7 @@ internal static class SqlProcessor
 
         /// <summary>
         /// Will be set if a keyword has been matched by the parser.
-        /// Not all keywords are neccessarily matched.
+        /// Not all keywords are necessarily matched.
         /// </summary>
         public SqlKeywordInfo? PreviousParsedKeyword; // 8 bytes (reference type)
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -857,5 +857,31 @@
       ],
       "db.query.summary": "ALTER TABLE MyTable"
     }
+  },
+  {
+    "name": "query_with_german_characters",
+    "input": {
+      "db.system.name": "microsoft.sql_server",
+      "query": "DECLARE @__geräteIds_0 nvarchar(4000) = N'[1,2,3]';\n\nSELECT [t].[Id]\nFROM [Tests] AS [t]\nWHERE [t].[Id] IN (\n\tSELECT [g].[value]\n\tFROM OPENJSON(@__geräteIds_0) WITH ([value] bigint '$') AS [g]\n)"
+    },
+    "expected": {
+      "db.query.text": [
+        "DECLARE @__geräteIds_0 nvarchar(?) = N?;\n\nSELECT [t].[Id]\nFROM [Tests] AS [t]\nWHERE [t].[Id] IN (\n\tSELECT [g].[value]\n\tFROM OPENJSON(@__geräteIds_0) WITH ([value] bigint ?) AS [g]\n)"
+      ],
+      "db.query.summary": "SELECT Tests"
+    }
+  },
+  {
+    "name": "cross_join_comma_separated_syntax_followed_by_composite_group_by",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT a, b FROM TableA, TableB GROUP BY a, b"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT a, b FROM TableA, TableB GROUP BY a, b"
+      ],
+      "db.query.summary": "SELECT TableA TableB"
+    }
   }
 ]

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -859,7 +859,7 @@
     }
   },
   {
-    "name": "query_with_german_characters",
+    "name": "query_with_diacritic_characters",
     "input": {
       "db.system.name": "microsoft.sql_server",
       "query": "DECLARE @__geräteIds_0 nvarchar(4000) = N'[1,2,3]';\n\nSELECT [t].[Id]\nFROM [Tests] AS [t]\nWHERE [t].[Id] IN (\n\tSELECT [g].[value]\n\tFROM OPENJSON(@__geräteIds_0) WITH ([value] bigint '$') AS [g]\n)"


### PR DESCRIPTION
Fixes #3351

## Changes

Primarily this fixes #3351 by ensuring we check all valid letters when parsing identifiers.

Also adds support for delimited table identifiers.

This also makes the handling of comma separated tables more robust by tracking the exit of a FROM clause.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
