### PR TITLE
[Infra] Fix flaky tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -162,7 +162,7 @@ public sealed class EntityFrameworkIntegrationTests :
         using var scope = SemanticConventionScope.Get(useNewConventions);
 
         var activities = new List<Activity>();
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        using (Sdk.CreateTracerProviderBuilder()
             .AddInMemoryExporter(activities)
             .AddSqlClientInstrumentation()
             .AddEntityFrameworkCoreInstrumentation(options => options.Filter = ActivityFilter)

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -220,7 +220,7 @@ public class EventCountersMetricsTests
                 Thread.Sleep(100);
                 meterProvider.ForceFlush();
                 metric = exportedItems.FirstOrDefault(x => x.Name == expectedInstrumentName);
-                return metric != null && GetActualValue(metric) != 0;
+                return metric != null && Math.Abs(GetActualValue(metric)) > double.Epsilon;
             },
             10_000);
 


### PR DESCRIPTION
## Changes

- Fix [flaky EFCore test](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/18978234145/job/54203648865?pr=2822#step:8:177) by shutting down the tracer before asserting on the activities.
- Fix [flaky Event Counters test](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/18973713652/job/54187562904?pr=3368#step:8:27) by waiting for the `Metric` to have a non-zero value.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
