### PR TITLE
[Infra] Skip FOSSA scan on forks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   fossa:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     steps:


### PR DESCRIPTION
## Changes

Don't run the FOSSA workflow on forks to avoid noise from failed workflows due to missing secrets.

<img width="1304" height="696" alt="image" src="https://github.com/user-attachments/assets/5dcaa5c1-2475-412b-beba-7c401361fad4" />

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
