### PR TITLE
[Infra] Try to fix OSSF Scorecard false positive

### DIFF
--- a/.github/workflows/integration-test-reusable.yml
+++ b/.github/workflows/integration-test-reusable.yml
@@ -40,6 +40,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ${{ inputs.os }}
+    env:
+      BUILD_COMPONENT: ${{ inputs.component }}
     steps:
     # Security: When called from pull_request_target with untrusted PR code,
     # this checkout requires prior approval via the 'authorize' job environment.
@@ -50,16 +52,19 @@ jobs:
         persist-credentials: false
         ref: ${{ inputs.checkout-ref }}
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
 
     - name: dotnet restore Component.proj
-      run: dotnet restore build/Projects/Component.proj -p:BUILD_COMPONENT=${{ inputs.component }}
+      run: dotnet restore build/Projects/Component.proj
 
     - name: dotnet build Component.proj
-      run: dotnet build build/Projects/Component.proj --configuration Release --no-restore -p:BUILD_COMPONENT=${{ inputs.component }}
+      run: dotnet build build/Projects/Component.proj --configuration Release --no-restore
 
     - name: dotnet test Component.proj
-      run: dotnet test build/Projects/Component.proj --filter CategoryName=${{ inputs.test-filter }} --framework ${{ inputs.version }} --configuration Release --no-restore --no-build -p:BUILD_COMPONENT=${{ inputs.component }} --logger:"console;verbosity=detailed"
+      run: dotnet test build/Projects/Component.proj --filter "CategoryName=${env:TEST_FILTER}" --framework ${env:FRAMEWORK_VERSION} --configuration Release --no-restore --no-build --logger:"console;verbosity=detailed"
+      shell: pwsh
       env:
+        FRAMEWORK_VERSION: ${{ inputs.version }}
+        TEST_FILTER: ${{ inputs.test-filter }}
         ${{ inputs.env-var-name }}: ${{ secrets.instrumentation-key }}


### PR DESCRIPTION
## Changes

- Try and fix `Warn: nugetCommand not pinned by hash` false positive which marks down the `Pinned-Dependencies` rule by removing explicit MSBuild property value passing from workflow.
- Avoid interpolation in arguments.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
