### PR TITLE
Add configuration of optional fields in GenevaExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.IncludeSeverityNumber.get -> bool
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.IncludeSeverityNumber.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.IncludeSeverityText.get -> bool
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.IncludeSeverityText.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -49,6 +49,16 @@ public class GenevaExporterOptions
     public bool IncludeTraceStateForSpan { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether or not to include severity text in logs.
+    /// </summary>
+    public bool IncludeSeverityText { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not to include severity number in logs.
+    /// </summary>
+    public bool IncludeSeverityNumber { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets table name mappings.
     /// </summary>
     public IReadOnlyDictionary<string, string>? TableNameMappings


### PR DESCRIPTION
Added a question in comments, I will add a changelog entry once the question has been resolved.

Implements #1807

## Changes

Added the possibility to disable logging of SeverityText and SeverityNumber via GenevaExporterOptions.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
