### PR TITLE
[Exporter.Geneva] Opt in resources

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
@@ -14,7 +14,7 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterOptions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.get -> System.Collections.Generic.IEnumerable<string!>?
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.init -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string!>?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
@@ -13,8 +13,8 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WantedResourceAttributes.get -> System.Collections.Generic.IEnumerable<string!>?
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WantedResourceAttributes.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WithResourceAttributes.get -> System.Collections.Generic.IEnumerable<string!>?
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WithResourceAttributes.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string!>?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
@@ -13,6 +13,8 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WantedResourceAttributes.get -> System.Collections.Generic.IEnumerable<string!>?
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WantedResourceAttributes.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string!>?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
@@ -13,8 +13,8 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterHelperExtensions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WithResourceAttributes.get -> System.Collections.Generic.IEnumerable<string!>?
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.WithResourceAttributes.set -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.get -> System.Collections.Generic.IEnumerable<string!>?
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string!>?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode

--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Shipped.txt
@@ -14,7 +14,7 @@ OpenTelemetry.Exporter.Geneva.GenevaExporterOptions
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.get -> string?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ConnectionString.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.get -> System.Collections.Generic.IEnumerable<string!>?
-OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.init -> void
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.ResourceFieldNames.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.get -> System.Collections.Generic.IEnumerable<string!>?
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFields.set -> void
 OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.EventNameExportMode.get -> OpenTelemetry.Exporter.Geneva.EventNameExportMode

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Add WithResourceAttributes to filter resource attributes to send to Geneva
-  ([#3367](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3367))
+  ([#3552](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3552))
 
 ## 1.14.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add WithResourceAttributes to filter resource attributes to send to Geneva
+* Add ResourceFieldNames to filter resource attributes to send to Geneva
   ([#3552](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3552))
 
 ## 1.14.0

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add WithResourceAttributes to filter resource attributes to send to Geneva
+
 ## 1.14.0
 
 Released 2025-Nov-13
@@ -22,7 +24,6 @@ Released 2025-Oct-29
 * Support for specifying resource attributes, including
   `service.name`, `service.instanceId`, and custom attributes.
   ([#3214](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3214))
-
 * Allow custom string size limit in custom fields.
   ([#3360](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3360))
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add WithResourceAttributes to filter resource attributes to send to Geneva
+  ([#3367](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3367))
 
 ## 1.14.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -155,6 +155,12 @@ public class GenevaExporterOptions
                         throw new ArgumentException($"Type `{entry.Value.GetType()}` (key = `{entry.Key}`) is not allowed. Only bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, and string are supported.");
                 }
 
+                if (entry.Key == Schema.V40.PartA.Ver)
+                {
+                    // This key is now set by the exporters, and is only accepted for legacy reasons.
+                    continue;
+                }
+
                 copy[entry.Key] = val; // shallow copy
             }
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -11,10 +11,7 @@ namespace OpenTelemetry.Exporter.Geneva;
 /// </summary>
 public class GenevaExporterOptions
 {
-    private IReadOnlyDictionary<string, object> fields = new Dictionary<string, object>(1)
-    {
-        [Schema.V40.PartA.Ver] = "4.0",
-    };
+    private IReadOnlyDictionary<string, object> fields = new Dictionary<string, object>();
 
     private IReadOnlyDictionary<string, string>? tableNameMappings;
 
@@ -118,16 +115,9 @@ public class GenevaExporterOptions
         {
             Guard.ThrowIfNull(value);
 
-            var schemaVersion = "4.0";
-
-            if (value.ContainsKey(Schema.V40.PartA.Ver))
+            if (value.ContainsKey(Schema.V40.PartA.Ver) && value[Schema.V40.PartA.Ver] as string is not "4.0")
             {
-                schemaVersion = value[Schema.V40.PartA.Ver] as string;
-            }
-
-            if (schemaVersion is not "2.1" and not "4.0")
-            {
-                throw new ArgumentException("Unsupported schema version, only 2.1 and 4.0 are supported.");
+                throw new ArgumentException("Unsupported schema version, only 4.0 is supported.");
             }
 
             if (value.ContainsKey(Schema.V40.PartA.Name))
@@ -140,7 +130,7 @@ public class GenevaExporterOptions
                 throw new ArgumentException("Event timestamp cannot be pre-populated.");
             }
 
-            var copy = new Dictionary<string, object>(value.Count + 1) { [Schema.V40.PartA.Ver] = schemaVersion };
+            var copy = new Dictionary<string, object>(value.Count + 1);
             foreach (var entry in value)
             {
                 var val = entry.Value;

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -31,14 +31,14 @@ public class GenevaExporterOptions
     public IEnumerable<string>? CustomFields { get; set; }
 
     /// <summary>
-    /// Gets or sets ResourceFieldNames.
+    /// Gets ResourceFieldNames.
     ///
     /// ResourceFieldNames specifies which resource attribute fields should be sent to Geneva.
     ///
     /// Any resource attributes not in ResourceFieldNames are ignored.
     /// If ResourceFieldNames is not provided, no resource attributes will be sent to Geneva.
     /// </summary>
-    public IEnumerable<string>? ResourceFieldNames { get; set; }
+    public IEnumerable<string>? ResourceFieldNames { get; init; }
 
     /// <summary>
     /// Gets or sets the exception stack trace export mode.

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -39,7 +39,7 @@ public class GenevaExporterOptions
     /// WithResourceAttributes specifies which resource attribute fields should be sent to Geneva.
     ///
     /// Any resource attributes not in WithResourceAttributes are ignored.
-    /// If WithResourceAttributes is not provided, all resource attributes will be sent to Geneva.
+    /// If WithResourceAttributes is not provided, no resource attributes will be sent to Geneva.
     /// </summary>
     public IEnumerable<string>? WithResourceAttributes { get; set; }
 

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -34,14 +34,14 @@ public class GenevaExporterOptions
     public IEnumerable<string>? CustomFields { get; set; }
 
     /// <summary>
-    /// Gets or sets WantedResourceAttributes.
+    /// Gets or sets WithResourceAttributes.
     ///
-    /// WantedResourceAttributes specifies which resource attribute fields should be sent to Geneva.
+    /// WithResourceAttributes specifies which resource attribute fields should be sent to Geneva.
     ///
-    /// Any resource attributes not in WantedResourceAttributes are ignored.
-    /// If WantedResourceAttributes is not provided, all resource attributes will be sent to Geneva.
+    /// Any resource attributes not in WithResourceAttributes are ignored.
+    /// If WithResourceAttributes is not provided, all resource attributes will be sent to Geneva.
     /// </summary>
-    public IEnumerable<string>? WantedResourceAttributes { get; set; }
+    public IEnumerable<string>? WithResourceAttributes { get; set; }
 
     /// <summary>
     /// Gets or sets the exception stack trace export mode.

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -34,6 +34,16 @@ public class GenevaExporterOptions
     public IEnumerable<string>? CustomFields { get; set; }
 
     /// <summary>
+    /// Gets or sets WantedResourceAttributes.
+    ///
+    /// WantedResourceAttributes specifies which resource attribute fields should be sent to Geneva.
+    ///
+    /// Any resource attributes not in WantedResourceAttributes are ignored.
+    /// If WantedResourceAttributes is not provided, all resource attributes will be sent to Geneva.
+    /// </summary>
+    public IEnumerable<string>? WantedResourceAttributes { get; set; }
+
+    /// <summary>
     /// Gets or sets the exception stack trace export mode.
     /// </summary>
     public ExceptionStackExportMode ExceptionStackExportMode { get; set; }

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -11,7 +11,7 @@ namespace OpenTelemetry.Exporter.Geneva;
 /// </summary>
 public class GenevaExporterOptions
 {
-    private IReadOnlyDictionary<string, object> fields = new Dictionary<string, object>();
+    private IReadOnlyDictionary<string, object> prepopulatedFields = new Dictionary<string, object>();
 
     private IReadOnlyDictionary<string, string>? tableNameMappings;
 
@@ -31,14 +31,14 @@ public class GenevaExporterOptions
     public IEnumerable<string>? CustomFields { get; set; }
 
     /// <summary>
-    /// Gets or sets WithResourceAttributes.
+    /// Gets or sets ResourceFieldNames.
     ///
-    /// WithResourceAttributes specifies which resource attribute fields should be sent to Geneva.
+    /// ResourceFieldNames specifies which resource attribute fields should be sent to Geneva.
     ///
-    /// Any resource attributes not in WithResourceAttributes are ignored.
-    /// If WithResourceAttributes is not provided, no resource attributes will be sent to Geneva.
+    /// Any resource attributes not in ResourceFieldNames are ignored.
+    /// If ResourceFieldNames is not provided, no resource attributes will be sent to Geneva.
     /// </summary>
-    public IEnumerable<string>? WithResourceAttributes { get; set; }
+    public IEnumerable<string>? ResourceFieldNames { get; set; }
 
     /// <summary>
     /// Gets or sets the exception stack trace export mode.
@@ -110,7 +110,7 @@ public class GenevaExporterOptions
     /// </summary>
     public IReadOnlyDictionary<string, object> PrepopulatedFields
     {
-        get => this.fields;
+        get => this.prepopulatedFields;
         set
         {
             Guard.ThrowIfNull(value);
@@ -158,7 +158,7 @@ public class GenevaExporterOptions
                 copy[entry.Key] = val; // shallow copy
             }
 
-            this.fields = copy;
+            this.prepopulatedFields = copy;
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -31,14 +31,14 @@ public class GenevaExporterOptions
     public IEnumerable<string>? CustomFields { get; set; }
 
     /// <summary>
-    /// Gets ResourceFieldNames.
+    /// Gets or sets ResourceFieldNames.
     ///
     /// ResourceFieldNames specifies which resource attribute fields should be sent to Geneva.
     ///
     /// Any resource attributes not in ResourceFieldNames are ignored.
     /// If ResourceFieldNames is not provided, no resource attributes will be sent to Geneva.
     /// </summary>
-    public IEnumerable<string>? ResourceFieldNames { get; init; }
+    public IEnumerable<string>? ResourceFieldNames { get; set; }
 
     /// <summary>
     /// Gets or sets the exception stack trace export mode.

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaTraceExporter.cs
@@ -66,14 +66,9 @@ public class GenevaTraceExporter : GenevaBaseExporter<Activity>
                 throw new NotSupportedException($"Protocol '{connectionStringBuilder.Protocol}' is not supported");
         }
 
-        Resources.Resource ResourceProvider()
-        {
-            return connectionStringBuilder.HonorResourceAttributes ? this.ParentProvider.GetResource() : Resources.Resource.Empty;
-        }
-
         if (useMsgPackExporter)
         {
-            var msgPackTraceExporter = new MsgPackTraceExporter(options, ResourceProvider);
+            var msgPackTraceExporter = new MsgPackTraceExporter(options, this.ParentProvider.GetResource);
             this.IsUsingUnixDomainSocket = msgPackTraceExporter.IsUsingUnixDomainSocket;
             this.exportActivity = msgPackTraceExporter.Export;
             this.exporter = msgPackTraceExporter;

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -82,9 +82,6 @@ internal sealed class ConnectionStringBuilder
     public bool PrivatePreviewEnableAFDCorrelationIdEnrichment => this.parts.TryGetValue(nameof(this.PrivatePreviewEnableAFDCorrelationIdEnrichment), out var value)
                 && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
 
-    public bool HonorResourceAttributes => this.parts.TryGetValue(nameof(this.HonorResourceAttributes), out var value)
-                && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
-
     public int PrivatePreviewLogMessagePackStringSizeLimit
     {
         get

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackLogExporter.cs
@@ -257,6 +257,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
         }
 
         cursor = AddPartAField(buffer, cursor, Schema.V40.PartA.Ver, "4.0");
+        cntFields += 1;
 
         cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "env_time");
         cursor = MessagePackSerializer.SerializeUtcDateTime(buffer, cursor, timestamp); // LogRecord.Timestamp should already be converted to UTC format in the SDK

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackLogExporter.cs
@@ -256,6 +256,8 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
             cntFields += 1;
         }
 
+        cursor = AddPartAField(buffer, cursor, Schema.V40.PartA.Ver, "4.0");
+
         cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "env_time");
         cursor = MessagePackSerializer.SerializeUtcDateTime(buffer, cursor, timestamp); // LogRecord.Timestamp should already be converted to UTC format in the SDK
         cntFields += 1;

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -58,11 +58,9 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
 #if NET
     internal readonly FrozenSet<string>? CustomFields;
-    internal readonly FrozenSet<string>? WithResourceAttributes;
     internal readonly FrozenSet<string>? DedicatedFields;
 #else
     internal readonly HashSet<string>? CustomFields;
-    internal readonly HashSet<string>? WithResourceAttributes;
     internal readonly HashSet<string>? DedicatedFields;
 #endif
 
@@ -70,16 +68,22 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
     private static readonly string INVALID_SPAN_ID = default(ActivitySpanId).ToHexString();
 
-    private readonly byte[] bufferEpilogue;
-    private readonly int timestampPatchIndex;
-    private readonly int mapSizePatchIndex;
     private readonly IDataTransport dataTransport;
-    private readonly bool shouldIncludeTraceState;
-    private readonly Func<Resource> resourceProvider;
-    private readonly List<string> prepopulatedFields;
-    private readonly Dictionary<string, object> propertiesEntries;
 
-    private byte[] bufferPrologue;
+    // this is a reference to the eponymous options field.
+    // It would make more sense as a HashSet/FrozenSet, but it's only used once,
+    // so constructing a whole new data structure for it is overkill.
+    private readonly IEnumerable<string>? withResourceAttributes;
+    private readonly bool shouldIncludeTraceState;
+    private readonly string partAName;
+    private readonly Func<Resource> resourceProvider;
+
+    private byte[]? bufferPrologue;
+    private byte[]? bufferEpilogue;
+    private int timestampPatchIndex;
+    private int mapSizePatchIndex;
+
+    private Dictionary<string, object> prepopulatedFields;
 
     private bool isDisposed;
 
@@ -96,6 +100,8 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         {
             partAName = customTableName;
         }
+
+        this.partAName = partAName;
 
         var connectionStringBuilder = new ConnectionStringBuilder(options.ConnectionString);
         switch (connectionStringBuilder.Protocol)
@@ -168,65 +174,14 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 #endif
         }
 
-        if (options.WithResourceAttributes != null)
-        {
-#if NET
-            this.WithResourceAttributes = options.WithResourceAttributes.ToFrozenSet(StringComparer.Ordinal);
-#else
-            this.WithResourceAttributes = [.. options.WithResourceAttributes];
-#endif
-        }
-
-        this.shouldIncludeTraceState = options.IncludeTraceStateForSpan;
-
-        var buffer = new byte[BUFFER_SIZE];
-
-        var cursor = 0;
-
-        /* Fluentd Forward Mode:
-        [
-            "Span",
-            [
-                [ <timestamp>, { "env_ver": "4.0", ... } ]
-            ],
-            { "TimeFormat": "DateTime" }
-        ]
-        */
-        cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 3);
-        cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, partAName);
-        cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 1);
-        cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 2);
-
-        // timestamp
-        cursor = MessagePackSerializer.WriteTimestamp96Header(buffer, cursor);
-        this.timestampPatchIndex = cursor;
-        cursor += 12; // reserve 12 bytes for the timestamp
-
-        cursor = MessagePackSerializer.WriteMapHeader(buffer, cursor, ushort.MaxValue); // Note: always use Map16 for perf consideration
-        this.mapSizePatchIndex = cursor - 2;
-
         this.prepopulatedFields = [];
-
-        // TODO: Do we support PartB as well?
-        // Part A - core envelope
-        cursor = AddPartAField(buffer, cursor, Schema.V40.PartA.Name, partAName);
-        this.prepopulatedFields.Add(Schema.V40.PartA.Name);
-
         foreach (var entry in options.PrepopulatedFields)
         {
-            cursor = AddPartAField(buffer, cursor, entry.Key, entry.Value);
-            this.prepopulatedFields.Add(entry.Key);
+            this.prepopulatedFields.Add(entry.Key, entry.Value);
         }
 
-        this.propertiesEntries = [];
-
-        this.bufferPrologue = new byte[cursor - 0];
-        System.Buffer.BlockCopy(buffer, 0, this.bufferPrologue, 0, cursor - 0);
-
-        cursor = MessagePackSerializer.Serialize(buffer, 0, new Dictionary<string, object> { { "TimeFormat", "DateTime" } });
-
-        this.bufferEpilogue = new byte[cursor - 0];
-        System.Buffer.BlockCopy(buffer, 0, this.bufferEpilogue, 0, cursor - 0);
+        this.withResourceAttributes = options.WithResourceAttributes;
+        this.shouldIncludeTraceState = options.IncludeTraceStateForSpan;
     }
 
     internal bool IsUsingUnixDomainSocket => this.dataTransport is UnixDomainSocketDataTransport;
@@ -329,76 +284,120 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         return urlStringBuilder.ToString();
     }
 
-    internal int AppendResourceAttributesToBuffer(byte[] buffer, int cursor)
+    /// <summary>
+    /// Populates this.bufferPrologue and this.bufferEpilogue.
+    /// </summary>
+    internal void CreateFraming()
     {
-        foreach (var entry in this.resourceProvider().Attributes)
+        var buffer = new byte[BUFFER_SIZE];
+
+        var cursor = 0;
+
+        /* Fluentd Forward Mode:
+        [
+            "Span",
+            [
+                [ <timestamp>, { "env_ver": "4.0", ... } ]
+            ],
+            { "TimeFormat": "DateTime" }
+        ]
+        */
+        cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 3);
+        cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, this.partAName);
+        cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 1);
+        cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 2);
+
+        // timestamp
+        cursor = MessagePackSerializer.WriteTimestamp96Header(buffer, cursor);
+        this.timestampPatchIndex = cursor;
+        cursor += 12; // reserve 12 bytes for the timestamp
+
+        cursor = MessagePackSerializer.WriteMapHeader(buffer, cursor, ushort.MaxValue); // Note: always use Map16 for perf consideration
+        this.mapSizePatchIndex = cursor - 2;
+
+        // TODO: Do we support PartB as well?
+        // Part A - core envelope
+        cursor = AddPartAField(buffer, cursor, Schema.V40.PartA.Name, this.partAName);
+        cursor = AddPartAField(buffer, cursor, Schema.V40.PartA.Ver, "4.0");
+
+        var resourceAttributes = this.resourceProvider().Attributes;
+
+        if (this.withResourceAttributes != null)
         {
-            string key = entry.Key;
-            bool isDedicatedField = false;
+            // if withResourceAttributes is set, it overrides the existing prepopulated fields setting.
+            this.prepopulatedFields = [];
+        }
 
-            if (entry.Value is string resourceValue)
+        foreach (var resourceAttribute in resourceAttributes)
+        {
+            var key = resourceAttribute.Key;
+            var value = resourceAttribute.Value;
+
+            var isWantedAttribute = false;
+            if (this.withResourceAttributes != null)
             {
-                switch (key)
+                // this might seem inefficient, but it's only run once and I don't expect there to be many resource attributes
+                foreach (var wantedAttribute in this.withResourceAttributes!)
                 {
-                    case "service.name":
-                        key = Schema.V40.PartA.Extensions.Cloud.Role;
-                        isDedicatedField = true;
+                    if (wantedAttribute == key)
+                    {
+                        isWantedAttribute = true;
                         break;
-                    case "service.instanceId":
-                        key = Schema.V40.PartA.Extensions.Cloud.RoleInstance;
-                        isDedicatedField = true;
-                        break;
+                    }
                 }
             }
 
-            if (!isDedicatedField && (this.WithResourceAttributes == null || !this.WithResourceAttributes.Contains(entry.Key)))
+            if (key == "service.name")
             {
-                continue;
+                key = Schema.V40.PartA.Extensions.Cloud.Role;
+                isWantedAttribute = true;
             }
 
-            if (isDedicatedField || this.CustomFields == null || this.CustomFields.Contains(key))
+            if (key == "service.instanceId")
             {
-                if (this.prepopulatedFields.Contains(key))
-                {
-                    // pre-populated fields take priority over resource attributes.
-                    // TODO: log warning? error out?
-                    continue;
-                }
-
-                cursor = AddPartAField(buffer, cursor, key, entry.Value);
-                this.prepopulatedFields.Add(key);
+                key = Schema.V40.PartA.Extensions.Cloud.RoleInstance;
+                isWantedAttribute = true;
             }
-            else
+
+            if (isWantedAttribute)
             {
-                this.propertiesEntries.Add(key, entry.Value);
+                this.prepopulatedFields.Add(key, value);
             }
         }
 
-        return cursor;
+        foreach (var entry in this.prepopulatedFields)
+        {
+            cursor = AddPartAField(buffer, cursor, entry.Key, entry.Value);
+        }
+
+        this.bufferPrologue = new byte[cursor - 0];
+        System.Buffer.BlockCopy(buffer, 0, this.bufferPrologue, 0, cursor - 0);
+
+        // Now generate the epilogue
+        cursor = MessagePackSerializer.Serialize(buffer, 0, new Dictionary<string, object> { { "TimeFormat", "DateTime" } });
+
+        this.bufferEpilogue = new byte[cursor - 0];
+        System.Buffer.BlockCopy(buffer, 0, this.bufferEpilogue, 0, cursor - 0);
     }
 
     internal ArraySegment<byte> SerializeActivity(Activity activity)
     {
         var buffer = this.Buffer.Value;
-        int cursor;
         if (buffer == null)
         {
+            this.CreateFraming();
             buffer = new byte[BUFFER_SIZE]; // TODO: handle OOM
-            System.Buffer.BlockCopy(this.bufferPrologue, 0, buffer, 0, this.bufferPrologue.Length);
-
-            // Augment the prologue now that we have the resource attributes.
-            cursor = this.AppendResourceAttributesToBuffer(buffer, this.bufferPrologue.Length);
-            this.bufferPrologue = new byte[cursor];
-            System.Buffer.BlockCopy(buffer, 0, this.bufferPrologue, 0, cursor);
-
+            System.Buffer.BlockCopy(this.bufferPrologue!, 0, buffer, 0, this.bufferPrologue!.Length);
             this.Buffer.Value = buffer;
         }
-        else
-        {
-            cursor = this.bufferPrologue.Length;
-        }
 
-        var cntFields = (ushort)this.prepopulatedFields.Count;
+        // These are guaranteed to not be null because CreateFraming must be called.
+        Guard.ThrowIfNull(this.bufferPrologue);
+        Guard.ThrowIfNull(this.bufferEpilogue);
+
+        var cursor = this.bufferPrologue.Length;
+
+        var cntFields = (ushort)(this.prepopulatedFields.Count + 2); // the +2 here is because of the Name and Ver field which is in the framing
         var dtBegin = activity.StartTimeUtc;
         var tsBegin = dtBegin.Ticks;
         var tsEnd = tsBegin + activity.Duration.Ticks;
@@ -556,7 +555,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             }
         }
 
-        if (hasEnvProperties || this.propertiesEntries.Count > 0)
+        if (hasEnvProperties)
         {
             // Anything that's not a dedicated field gets put into a part C field called properties
             ushort envPropertiesCount = 0;
@@ -564,28 +563,18 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             cursor = MessagePackSerializer.WriteMapHeader(buffer, cursor, ushort.MaxValue);
             var idxMapSizeEnvPropertiesPatch = cursor - 2;
 
-            if (hasEnvProperties)
+            foreach (ref readonly var entry in activity.EnumerateTagObjects())
             {
-                foreach (ref readonly var entry in activity.EnumerateTagObjects())
+                if (this.DedicatedFields!.Contains(entry.Key))
                 {
-                    if (this.DedicatedFields!.Contains(entry.Key))
-                    {
-                        continue;
-                    }
-                    else
-                    {
-                        cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
-                        cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
-                        envPropertiesCount += 1;
-                    }
+                    continue;
                 }
-            }
-
-            foreach (var entry in this.propertiesEntries)
-            {
-                cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
-                cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
-                envPropertiesCount += 1;
+                else
+                {
+                    cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, entry.Key);
+                    cursor = MessagePackSerializer.Serialize(buffer, cursor, entry.Value);
+                    envPropertiesCount += 1;
+                }
             }
 
             cntFields += 1;

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -351,7 +351,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                 }
             }
 
-            if (this.WithResourceAttributes != null && !this.WithResourceAttributes.Contains(entry.Key))
+            if (this.WithResourceAttributes == null || !this.WithResourceAttributes.Contains(entry.Key))
             {
                 continue;
             }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -58,11 +58,11 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
 #if NET
     internal readonly FrozenSet<string>? CustomFields;
-
+    internal readonly FrozenSet<string>? WantedResourceAttributes;
     internal readonly FrozenSet<string>? DedicatedFields;
 #else
     internal readonly HashSet<string>? CustomFields;
-
+    internal readonly HashSet<string>? WantedResourceAttributes;
     internal readonly HashSet<string>? DedicatedFields;
 #endif
 
@@ -165,6 +165,15 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             this.DedicatedFields = dedicatedFields.ToFrozenSet(StringComparer.Ordinal);
 #else
             this.DedicatedFields = dedicatedFields;
+#endif
+        }
+
+        if (options.WantedResourceAttributes != null)
+        {
+#if NET
+            this.WantedResourceAttributes = options.WantedResourceAttributes.ToFrozenSet(StringComparer.Ordinal);
+#else
+            this.WantedResourceAttributes = [.. options.WantedResourceAttributes];
 #endif
         }
 
@@ -340,6 +349,11 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                         isDedicatedField = true;
                         break;
                 }
+            }
+
+            if (this.WantedResourceAttributes != null && !this.WantedResourceAttributes.Contains(entry.Key))
+            {
+                continue;
             }
 
             if (isDedicatedField || this.CustomFields == null || this.CustomFields.Contains(key))

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -374,9 +374,28 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                             case string:
                                 break;
                             case null:
-                                throw new ArgumentNullException(key, "Resource attribute must not have a null value.");
+                                // This should be impossible because Resource attributes cannot have null values.
+                                // But just in case, turn it into something serializable to avoid crashing.
+                                value = "<NULL>";
+                                break;
                             default:
-                                throw new ArgumentException($"Type `{value.GetType()}` (resource attribute key = `{key}`) is not allowed. Only bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, and string are supported.");
+                                // Try to construct a value that communicates that the type is not supported.
+                                try
+                                {
+                                    var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+                                    if (stringValue == null)
+                                    {
+                                        value = "<Unsupported type>";
+                                    }
+
+                                    value = $"<Unsupported type: {stringValue}>";
+                                }
+                                catch
+                                {
+                                    value = "<Unsupported type>";
+                                }
+
+                                break;
                         }
 
                         isWantedAttribute = true;

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -83,7 +83,11 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
     private int timestampPatchIndex;
     private int mapSizePatchIndex;
 
-    private Dictionary<string, object> prepopulatedFields;
+    // this stores the prepopulated fields until CreateFraming can consume them into the prologue.
+    // after CreateFraming is called, this dictionary is set to null, so don't use it after that.
+    private Dictionary<string, object>? prepopulatedFields;
+
+    private ushort prepopulatedFieldsCount;
 
     private bool isDisposed;
 
@@ -326,10 +330,15 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         cursor = MessagePackSerializer.WriteMapHeader(buffer, cursor, ushort.MaxValue); // Note: always use Map16 for perf consideration
         this.mapSizePatchIndex = cursor - 2;
 
+        this.prepopulatedFieldsCount = 0;
+
         // TODO: Do we support PartB as well?
         // Part A - core envelope
         cursor = AddPartAField(buffer, cursor, Schema.V40.PartA.Name, this.partAName);
+        this.prepopulatedFieldsCount++;
+
         cursor = AddPartAField(buffer, cursor, Schema.V40.PartA.Ver, "4.0");
+        this.prepopulatedFieldsCount++;
 
         var resourceAttributes = this.resourceProvider().Attributes;
 
@@ -338,6 +347,9 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             // if ResourceFieldNames is set, it overrides the existing prepopulated fields setting.
             this.prepopulatedFields = [];
         }
+
+        // this is guaranteed to not be null because it's set in the constructor
+        Guard.ThrowIfNull(this.prepopulatedFields);
 
         foreach (var resourceAttribute in resourceAttributes)
         {
@@ -402,6 +414,8 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
             cursor = AddPartAField(buffer, cursor, entry.Key, entry.Value);
         }
 
+        this.prepopulatedFieldsCount += (ushort)this.prepopulatedFields.Count;
+
         this.bufferPrologue = new byte[cursor - 0];
         System.Buffer.BlockCopy(buffer, 0, this.bufferPrologue, 0, cursor - 0);
 
@@ -410,6 +424,9 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
         this.bufferEpilogue = new byte[cursor - 0];
         System.Buffer.BlockCopy(buffer, 0, this.bufferEpilogue, 0, cursor - 0);
+
+        // We can release the prepopulatedFields dictionary because we finished using it in the prologue
+        this.prepopulatedFields = null;
     }
 
     internal ArraySegment<byte> SerializeActivity(Activity activity)
@@ -429,7 +446,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
         var cursor = this.bufferPrologue.Length;
 
-        var cntFields = (ushort)(this.prepopulatedFields.Count + 2); // the +2 here is because of the Name and Ver field which is in the framing
+        var cntFields = this.prepopulatedFieldsCount;
         var dtBegin = activity.StartTimeUtc;
         var tsBegin = dtBegin.Ticks;
         var tsEnd = tsBegin + activity.Duration.Ticks;

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -58,11 +58,11 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
 #if NET
     internal readonly FrozenSet<string>? CustomFields;
-    internal readonly FrozenSet<string>? WantedResourceAttributes;
+    internal readonly FrozenSet<string>? WithResourceAttributes;
     internal readonly FrozenSet<string>? DedicatedFields;
 #else
     internal readonly HashSet<string>? CustomFields;
-    internal readonly HashSet<string>? WantedResourceAttributes;
+    internal readonly HashSet<string>? WithResourceAttributes;
     internal readonly HashSet<string>? DedicatedFields;
 #endif
 
@@ -168,12 +168,12 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 #endif
         }
 
-        if (options.WantedResourceAttributes != null)
+        if (options.WithResourceAttributes != null)
         {
 #if NET
-            this.WantedResourceAttributes = options.WantedResourceAttributes.ToFrozenSet(StringComparer.Ordinal);
+            this.WithResourceAttributes = options.WithResourceAttributes.ToFrozenSet(StringComparer.Ordinal);
 #else
-            this.WantedResourceAttributes = [.. options.WantedResourceAttributes];
+            this.WithResourceAttributes = [.. options.WithResourceAttributes];
 #endif
         }
 
@@ -351,7 +351,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                 }
             }
 
-            if (this.WantedResourceAttributes != null && !this.WantedResourceAttributes.Contains(entry.Key))
+            if (this.WithResourceAttributes != null && !this.WithResourceAttributes.Contains(entry.Key))
             {
                 continue;
             }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -383,12 +383,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                                 try
                                 {
                                     var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
-                                    if (stringValue == null)
-                                    {
-                                        value = "<Unsupported type>";
-                                    }
-
-                                    value = $"<Unsupported type: {stringValue}>";
+                                    value = stringValue == null ? "<Unsupported type>" : $"<Unsupported type: {stringValue}>";
                                 }
                                 catch
                                 {

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -351,7 +351,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                 }
             }
 
-            if (this.WithResourceAttributes == null || !this.WithResourceAttributes.Contains(entry.Key))
+            if (!isDedicatedField && (this.WithResourceAttributes == null || !this.WithResourceAttributes.Contains(entry.Key)))
             {
                 continue;
             }

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\IsExternalInit.cs" Link="Includes\IsExternalInit.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
+++ b/src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\IsExternalInit.cs" Link="Includes\IsExternalInit.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -125,12 +125,13 @@ A list of resource attribute keys which should be sent to Geneva.
 
 * If null, no resource attributes will be stored.
 * If non-null, only those resource attributes named in the list will be stored.
+  This will disable PrepopulatedFields (see below).
 
 #### `PrepopulatedFields` (optional)
 
 This is a collection of fields that will be applied to all the Logs and Traces
-sent through this exporter. If a field is present in both PrepopulatedFields and
-resource attributes, the field in PrepopulatedFields takes precedence.
+sent through this exporter. If ResourceFieldNames is also specified,
+PrepopulatedFields has no effect.
 
 #### `IncludeTraceStateForSpan` (optional)
 

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -123,7 +123,7 @@ A list of fields which should be stored as individual table columns.
 
 A list of resource attribute keys which should be sent to Geneva.
 
-* If null, all resource attributes will be stored.
+* If null, no resource attributes will be stored.
 * If non-null, only those resource attributes named in the list will be stored.
 
 #### `PrepopulatedFields` (optional)

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -119,7 +119,7 @@ A list of fields which should be stored as individual table columns.
 * If non-null, only those fields named in the list will be stored as individual
   columns.
 
-#### `WithResourceAttributes` (optional)
+#### `ResourceFieldNames` (optional)
 
 A list of resource attribute keys which should be sent to Geneva.
 

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -119,6 +119,13 @@ A list of fields which should be stored as individual table columns.
 * If non-null, only those fields named in the list will be stored as individual
   columns.
 
+#### `WantedResourceAttributes` (optional)
+
+A list of resource attribute keys which should be sent to Geneva.
+
+* If null, all resource attributes will be stored.
+* If non-null, only those resource attributes named in the list will be stored.
+
 #### `PrepopulatedFields` (optional)
 
 This is a collection of fields that will be applied to all the Logs and Traces

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -119,7 +119,7 @@ A list of fields which should be stored as individual table columns.
 * If non-null, only those fields named in the list will be stored as individual
   columns.
 
-#### `WantedResourceAttributes` (optional)
+#### `WithResourceAttributes` (optional)
 
 A list of resource attribute keys which should be sent to Geneva.
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualBasic;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -380,6 +380,10 @@ public class GenevaTraceExporterTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// The purpose of this test is to ensure that if a field exists both in prepopulated fields and is a resource attribute,
+    /// that the prepopulated field takes precedence over the resource attribute.
+    /// </summary>
     [Fact]
     public void GenevaTraceExporter_Prepopulated_Overwrites_Resource()
     {
@@ -441,6 +445,93 @@ public class GenevaTraceExporterTests : IDisposable
             using (var activity = source.StartActivity("Activity"))
             {
                 this.ExpectSpanFromActivity(activity, (mapping) => { });
+            }
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    /// <summary>
+    /// The purpose of this test is to make sure that when WantedResourceAttributes is set,
+    /// that only resource attributes specified make it to Geneva.
+    /// </summary>
+    [Fact]
+    public void GenevaTraceExporter_WantedResourceAttributes()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions
+            {
+                PrepopulatedFields = new Dictionary<string, object>
+                {
+                    ["unaffected prepopulated"] = "should be present",
+                },
+                WantedResourceAttributes = new HashSet<string>
+                {
+                    "wanted",
+                },
+            };
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GetRandomFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            Dictionary<string, object> resourceAttributes = new Dictionary<string, object>
+            {
+                { "wanted", "should be present" },
+                { "unwanted", "should not be present" },
+            };
+            var resource = new Resource(resourceAttributes);
+
+            using var exporter = new MsgPackTraceExporter(exporterOptions, () => resource);
+            var m_buffer = exporter.Buffer;
+
+            // Add an ActivityListener to serialize the activity and assert that it was valid on ActivityStopped event
+
+            // Set the ActivitySourceName to the unique value of the test method name to avoid interference with
+            // the ActivitySource used by other unit tests.
+            var sourceName = GetTestMethodName();
+
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = (activitySource) => activitySource.Name == sourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded;
+            listener.ActivityStopped = (activity) =>
+            {
+                _ = exporter.SerializeActivity(activity);
+                var fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Options);
+                this.CheckSpanForActivity(exporterOptions, fluentdData, activity, exporter.DedicatedFields, resourceAttributes);
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var source = new ActivitySource(sourceName);
+            using (var activity = source.StartActivity("Activity"))
+            {
+                this.ExpectSpanFromActivity(activity, (mapping) =>
+                {
+                    this.AssertMappingEntry(mapping, "wanted", "should be present");
+                    this.AssertMappingEntry(mapping, "unaffected prepopulated", "should be present");
+                    Assert.DoesNotContain("unwanted", mapping);
+                });
             }
         }
         finally

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -464,7 +464,7 @@ public class GenevaTraceExporterTests : IDisposable
     }
 
     [Fact]
-    public void GenevaTraceExporter_InvalidResourceAttrType_Throws()
+    public void GenevaTraceExporter_InvalidResourceAttrType_PlaceholderMessage()
     {
         var path = string.Empty;
         Socket server = null;
@@ -985,6 +985,9 @@ public class GenevaTraceExporterTests : IDisposable
 
             // Set the ActivitySourceName to the unique value of the test method name to avoid interference with
             // the ActivitySource used by other unit tests.
+
+            var rb = ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object> { ["hello"] = "there" });
+
             var sourceName = GetTestMethodName();
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
@@ -997,6 +1000,7 @@ public class GenevaTraceExporterTests : IDisposable
                         ["cloud.roleVer"] = "9.0.15289.2",
                     };
                 })
+                .SetResourceBuilder(rb)
                 .Build();
             using var serverSocket = server.Accept();
             serverSocket.ReceiveTimeout = 10000;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -461,11 +461,11 @@ public class GenevaTraceExporterTests : IDisposable
     }
 
     /// <summary>
-    /// The purpose of this test is to make sure that when WantedResourceAttributes is set,
+    /// The purpose of this test is to make sure that when WithResourceAttributes is set,
     /// that only resource attributes specified make it to Geneva.
     /// </summary>
     [Fact]
-    public void GenevaTraceExporter_WantedResourceAttributes()
+    public void GenevaTraceExporter_WithResourceAttributes()
     {
         var path = string.Empty;
         Socket server = null;
@@ -477,7 +477,7 @@ public class GenevaTraceExporterTests : IDisposable
                 {
                     ["unaffected prepopulated"] = "should be present",
                 },
-                WantedResourceAttributes = new HashSet<string>
+                WithResourceAttributes = new HashSet<string>
                 {
                     "wanted",
                 },

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -43,13 +43,23 @@ public class GenevaTraceExporterTests : IDisposable
                 ConnectionString = null,
             });
         });
+        string connectionString;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            connectionString = "EtwSession=OpenTelemetry";
+        }
+        else
+        {
+            var path = GetRandomFilePath();
+            connectionString = "Endpoint=unix:" + path;
+        }
 
         // null value in the PrepopulatedFields
         Assert.Throws<ArgumentNullException>(() =>
         {
             using var exporter = new GenevaTraceExporter(new GenevaExporterOptions
             {
-                ConnectionString = "EtwSession=OpenTelemetry",
+                ConnectionString = connectionString,
                 PrepopulatedFields = new Dictionary<string, object>
                 {
                     ["cloud.roleVer"] = null,
@@ -62,8 +72,8 @@ public class GenevaTraceExporterTests : IDisposable
         {
             using var exporter = new GenevaTraceExporter(new GenevaExporterOptions
             {
-                ConnectionString = "EtwSession=OpenTelemetry",
-                ResourceFieldNames = ["cloud.roleVer"],
+                ConnectionString = connectionString,
+                ResourceFieldNames = ["env_cloud_role"],
             });
         });
 
@@ -72,7 +82,7 @@ public class GenevaTraceExporterTests : IDisposable
         {
             using var exporter = new GenevaTraceExporter(new GenevaExporterOptions
             {
-                ConnectionString = "EtwSession=OpenTelemetry",
+                ConnectionString = connectionString,
                 PrepopulatedFields = new Dictionary<string, object>
                 {
                     ["cloud.roleVer"] = (char)106,
@@ -85,7 +95,7 @@ public class GenevaTraceExporterTests : IDisposable
         {
             _ = new GenevaExporterOptions
             {
-                ConnectionString = "EtwSession=OpenTelemetry",
+                ConnectionString = connectionString,
                 PrepopulatedFields = new Dictionary<string, object>
                 {
                     ["bool"] = true,

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -206,6 +206,7 @@ public class GenevaTraceExporterTests : IDisposable
                     ["cloud.roleVer"] = "9.0.15289.2",
                     ["resourceAndPrepopulated"] = "comes from prepopulated",
                 },
+                WithResourceAttributes = ["resourceAttribute", "resourceAndPrepopulated"],
             };
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -207,7 +207,7 @@ public class GenevaTraceExporterTests : IDisposable
                     ["cloud.roleVer"] = "9.0.15289.2",
                     ["resourceAndPrepopulated"] = "comes from prepopulated",
                 },
-                WithResourceAttributes = ["resourceAttribute", "resourceAndPrepopulated"],
+                ResourceFieldNames = ["resourceAttribute", "resourceAndPrepopulated"],
             };
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -445,7 +445,7 @@ public class GenevaTraceExporterTests : IDisposable
     }
 
     /// <summary>
-    /// The purpose of this test is to make sure that when WithResourceAttributes is not set,
+    /// The purpose of this test is to make sure that when ResourceFieldNames is not set,
     /// that no resource attributes make it to Geneva.
     /// </summary>
     [Fact]
@@ -462,7 +462,7 @@ public class GenevaTraceExporterTests : IDisposable
                     ["unaffected prepopulated"] = "should be present",
                 },
 
-                // WithResourceAttributes not set
+                // ResourceFieldNames not set
             };
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -532,11 +532,11 @@ public class GenevaTraceExporterTests : IDisposable
     }
 
     /// <summary>
-    /// The purpose of this test is to make sure that when WithResourceAttributes is set,
+    /// The purpose of this test is to make sure that when ResourceFieldNames is set,
     /// that only resource attributes specified make it to Geneva.
     /// </summary>
     [Fact]
-    public void GenevaTraceExporter_WithResourceAttributes()
+    public void GenevaTraceExporter_ResourceFieldNames()
     {
         var path = string.Empty;
         Socket server = null;
@@ -548,7 +548,7 @@ public class GenevaTraceExporterTests : IDisposable
                 {
                     ["overridden prepopulated"] = "should not be present",
                 },
-                WithResourceAttributes = new HashSet<string>
+                ResourceFieldNames = new HashSet<string>
                 {
                     "wanted",
                 },
@@ -1066,7 +1066,7 @@ public class GenevaTraceExporterTests : IDisposable
         var verKey = MsgPackExporter.V40_PART_A_MAPPING[Schema.V40.PartA.Ver];
         this.AssertMappingEntry(mapping, verKey, partAVer);
 
-        if (exporterOptions.WithResourceAttributes == null)
+        if (exporterOptions.ResourceFieldNames == null)
         {
             foreach (var item in exporterOptions.PrepopulatedFields)
             {
@@ -1081,7 +1081,7 @@ public class GenevaTraceExporterTests : IDisposable
         }
         else
         {
-            foreach (var item in exporterOptions.WithResourceAttributes)
+            foreach (var item in exporterOptions.ResourceFieldNames)
             {
                 if (resourceAttributes.TryGetValue(item, out var val))
                 {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -57,6 +57,16 @@ public class GenevaTraceExporterTests : IDisposable
             });
         });
 
+        // reserved field in ResourceFieldNames
+        Assert.Throws<ArgumentException>(() =>
+        {
+            using var exporter = new GenevaTraceExporter(new GenevaExporterOptions
+            {
+                ConnectionString = "EtwSession=OpenTelemetry",
+                ResourceFieldNames = ["cloud.roleVer"],
+            });
+        });
+
         // unsupported types(char) for PrepopulatedFields
         Assert.Throws<ArgumentException>(() =>
         {
@@ -443,6 +453,73 @@ public class GenevaTraceExporterTests : IDisposable
         }
     }
 
+    [Fact]
+    public void GenevaTraceExporter_InvalidResourceAttrType_Throws()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions
+            {
+                ResourceFieldNames = ["badresource"],
+            };
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GetRandomFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            Dictionary<string, object> resourceAttributes = new Dictionary<string, object>
+            {
+                { "badresource", new int[1] }, // the exporter does not accept complex resource types like an array
+            };
+            var resource = new Resource(resourceAttributes);
+
+            using var exporter = new MsgPackTraceExporter(exporterOptions, () => resource);
+            var m_buffer = exporter.Buffer;
+
+            // Add an ActivityListener to serialize the activity and assert that it was valid on ActivityStopped event
+
+            // Set the ActivitySourceName to the unique value of the test method name to avoid interference with
+            // the ActivitySource used by other unit tests.
+            var sourceName = GetTestMethodName();
+
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = (activitySource) => activitySource.Name == sourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded;
+            listener.ActivityStopped = (activity) =>
+            {
+                Assert.Throws<ArgumentException>(() => exporter.SerializeActivity(activity));
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var source = new ActivitySource(sourceName);
+            using (var activity = source.StartActivity("Activity"))
+            {
+            }
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
     /// <summary>
     /// The purpose of this test is to make sure that when ResourceFieldNames is not set,
     /// that no resource attributes make it to Geneva.
@@ -462,6 +539,93 @@ public class GenevaTraceExporterTests : IDisposable
                 },
 
                 // ResourceFieldNames not set
+            };
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GetRandomFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            Dictionary<string, object> resourceAttributes = new Dictionary<string, object>
+            {
+                { "resourceAttributes", "should not be present" },
+            };
+            var resource = new Resource(resourceAttributes);
+
+            using var exporter = new MsgPackTraceExporter(exporterOptions, () => resource);
+            var m_buffer = exporter.Buffer;
+
+            // Add an ActivityListener to serialize the activity and assert that it was valid on ActivityStopped event
+
+            // Set the ActivitySourceName to the unique value of the test method name to avoid interference with
+            // the ActivitySource used by other unit tests.
+            var sourceName = GetTestMethodName();
+
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = (activitySource) => activitySource.Name == sourceName;
+            listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded;
+            listener.ActivityStopped = (activity) =>
+            {
+                _ = exporter.SerializeActivity(activity);
+                var fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Options);
+                this.CheckSpanForActivity(exporterOptions, fluentdData, activity, exporter.DedicatedFields, resourceAttributes);
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var source = new ActivitySource(sourceName);
+            using (var activity = source.StartActivity("Activity"))
+            {
+                this.ExpectSpanFromActivity(activity, (mapping) =>
+                {
+                    Assert.DoesNotContain("resourceAttributes", mapping);
+                    if (mapping.ContainsKey("env_properties"))
+                    {
+                        var env_properties = mapping["env_properties"] as Dictionary<object, object> ?? [];
+                        Assert.DoesNotContain("resourceAttributes", env_properties);
+                    }
+                });
+            }
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    /// <summary>
+    /// The purpose of this test is to make sure that when ResourceFieldNames is set to empty,
+    /// that no resource attributes make it to Geneva.
+    /// </summary>
+    [Fact]
+    public void GenevaTraceExporter_WithEmptyResourceAttributes()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions
+            {
+                PrepopulatedFields = new Dictionary<string, object>
+                {
+                    ["unaffected prepopulated"] = "should be present",
+                },
+
+                ResourceFieldNames = [], // ResourceFieldNames empty
             };
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -477,6 +477,7 @@ public class GenevaTraceExporterTests : IDisposable
                 {
                     ["unaffected prepopulated"] = "should be present",
                 },
+
                 // WithResourceAttributes not set
             };
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
This is a re-submission of https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3367 , after @cijothomas recommend that it should be re-introduced.

I did change the name of the config option to WithResourceAttributes to match the Rust option in the [user events log exporter](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/opentelemetry-user-events-logs/src/logs/processor.rs#L142-L171)

I also changed the logic when this field is not provided. The default is now to include no resource attributes except for mapped fields (eg., service.name -> Part A cloud extension)

## Changes

Allows users of the Geneva exporter to specify which resource attributes they want sent to Geneva. This prevents excessive trace data from being exported if there are many resource attributes which do not need to be stored.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
