### PR TITLE
[Infra] Create releases as drafts before publish

### DIFF
--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -87,6 +87,8 @@ $content
       --draft
   }
 
+  # Move the release out of draft once it has been created and all artifacts uploaded
+  # as immutable releases cannot have assets added to them after they are published.
   gh release edit $tag --draft=false
 }
 


### PR DESCRIPTION
Relates to #3584.

## Changes

Rather than rely on `gh release` doing the right thing and to make the code more explicit, create releases as drafts, then edit them to not be a draft to release them.

This matches the effective behaviour in open-telemetry/opentelemetry-dotnet (see https://github.com/open-telemetry/opentelemetry-dotnet/issues/6748).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
