### PR TITLE
Add `HttpClientFactory` setting to `OpAmpClientSettings`

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -36,6 +36,8 @@ OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.ConnectionType.get -> Op
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.ConnectionType.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Heartbeat.get -> OpenTelemetry.OpAmp.Client.Settings.HeartbeatSettings!
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Heartbeat.set -> void
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient!>!
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.HttpClientFactory.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Identification.get -> OpenTelemetry.OpAmp.Client.Settings.IdentificationSettings!
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Identification.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.InstanceUid.get -> System.Guid

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Add setting to configure the factory used to create HttpClient instances used for
+* the OpAMP Plain HTTP transport.
+  (TODO LINK)
+
 ## 0.1.0-alpha.3
 
 Released 2025-Nov-13

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Add setting to configure the factory used to create `HttpClient` instances
-* used for the OpAMP Plain HTTP transport.
+  used for the OpAMP Plain HTTP transport.
   ([#3589](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3589))
 
 ## 0.1.0-alpha.3

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Add setting to configure the factory used to create `HttpClient` instances used for
-* the OpAMP Plain HTTP transport.
+* Add setting to configure the factory used to create `HttpClient` instances
+* used for the OpAMP Plain HTTP transport.
   ([#3589](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3589))
 
 ## 0.1.0-alpha.3

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add setting to configure the factory used to create HttpClient instances used for
 * the OpAMP Plain HTTP transport.
-  (TODO LINK)
+  ([#3589](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3589))
 
 ## 0.1.0-alpha.3
 

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add setting to configure the factory used to create HttpClient instances used for
+* Add setting to configure the factory used to create `HttpClient` instances used for
 * the OpAMP Plain HTTP transport.
   ([#3589](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3589))
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/Http/PlainHttpTransport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/Http/PlainHttpTransport.cs
@@ -25,7 +25,7 @@ internal sealed class PlainHttpTransport : IOpAmpTransport, IDisposable
 
         this.uri = settings.ServerUrl;
         this.processor = processor;
-        this.httpClient = settings.HttpClientFactory.Invoke();
+        this.httpClient = settings.HttpClientFactory();
     }
 
     public async Task SendAsync<T>(T message, CancellationToken token)

--- a/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
@@ -93,7 +93,7 @@ public sealed class OpAmpClient : IDisposable
         return settings.ConnectionType switch
         {
             ConnectionType.WebSocket => new WsTransport(settings.ServerUrl, processor),
-            ConnectionType.Http => new PlainHttpTransport(settings.ServerUrl, processor),
+            ConnectionType.Http => new PlainHttpTransport(settings, processor),
             _ => throw new NotSupportedException("Unsupported transport type"),
         };
     }

--- a/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
@@ -1,6 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+
+using OpenTelemetry.Internal;
+
 namespace OpenTelemetry.OpAmp.Client.Settings;
 
 /// <summary>
@@ -8,6 +14,8 @@ namespace OpenTelemetry.OpAmp.Client.Settings;
 /// </summary>
 public sealed class OpAmpClientSettings
 {
+    private readonly Func<HttpClient> defaultHttpClientFactory = () => new HttpClient();
+
     private Uri? serverUrl;
 
     /// <summary>
@@ -91,4 +99,27 @@ public sealed class OpAmpClientSettings
     /// Gets or sets the heartbeat settings.
     /// </summary>
     public HeartbeatSettings Heartbeat { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the factory function called to create the <see
+    /// cref="HttpClient"/> instance that will be used at runtime to
+    /// transmit OpAmp messages over HTTP. The returned instance will
+    /// be reused for all communication.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>This is only invoked for the <see
+    /// cref="ConnectionType.Http"/> protocol.</item>
+    /// </list>
+    /// </remarks>
+    public Func<HttpClient> HttpClientFactory
+    {
+        get => field ?? this.defaultHttpClientFactory;
+        set
+        {
+            Guard.ThrowIfNull(value);
+            field = value;
+        }
+    }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTest.cs
@@ -1,8 +1,13 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Transport.Http;
+using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
 using Xunit;
@@ -19,12 +24,13 @@ public class PlainHttpTransportTest
         // Arrange
         using var opAmpServer = new OpAmpFakeHttpServer(useSmallPackets);
         var opAmpEndpoint = opAmpServer.Endpoint;
+        var settings = new OpAmpClientSettings { ServerUrl = opAmpEndpoint };
 
         using var mockListener = new MockListener();
         var frameProcessor = new FrameProcessor();
         frameProcessor.Subscribe(mockListener);
 
-        var httpTransport = new PlainHttpTransport(opAmpEndpoint, frameProcessor);
+        var httpTransport = new PlainHttpTransport(settings, frameProcessor);
 
         var mockFrame = FrameGenerator.GenerateMockAgentFrame(useSmallPackets);
 
@@ -41,5 +47,38 @@ public class PlainHttpTransportTest
 
         Assert.Single(clientReceivedFrames);
         Assert.StartsWith("This is a mock server frame for testing purposes.", receivedTextData);
+    }
+
+    [Fact]
+    public async Task PlainHttpTransport_UsesConfiguredHttpClientFactory()
+    {
+        // Arrange
+        using var opAmpServer = new OpAmpFakeHttpServer(false);
+        var opAmpEndpoint = opAmpServer.Endpoint;
+        var settings = new OpAmpClientSettings
+        {
+            ServerUrl = opAmpEndpoint,
+            HttpClientFactory = () =>
+            {
+                var client = new HttpClient();
+                client.DefaultRequestHeaders.Add("X-Custom-Header", "CustomValue");
+                return client;
+            },
+        };
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        var httpTransport = new PlainHttpTransport(settings, frameProcessor);
+
+        var mockFrame = FrameGenerator.GenerateMockAgentFrame(false);
+
+        // Act
+        await httpTransport.SendAsync(mockFrame.Frame, CancellationToken.None);
+
+        // Assert
+        var serverReceivedHeaders = opAmpServer.GetHeaders();
+        Assert.Contains(serverReceivedHeaders, headers => headers["X-Custom-Header"] == "CustomValue");
     }
 }


### PR DESCRIPTION
Fixes #3588

## Changes

Introduces a new `HttpClientFactory` setting in the `OpAmpClientSettings` class to allow customization of `HttpClient` instances for OpAMP HTTP transport. Updates `PlainHttpTransport` to utilize this factory, removing the `HttpClientHandler` and modifies `OpAmpClient` to pass settings to `PlainHttpTransport`.

This mostly copies the approach used for the `OtlpExporterOptions` in the main SDK.

- Adds a test to verify the use of the configured `HttpClientFactory`, including custom headers. 
- Updates `OpAmpFakeHttpServer` to capture HTTP request headers and provide a method to retrieve them for testing.

Update `CHANGELOG.md` and `PublicAPI.Unshipped.txt` to document the new setting.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
