### PR TITLE
Add tests for MSSQL bracketed identifers

### DIFF
--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorAdditionalTestCases.json
@@ -883,5 +883,31 @@
       ],
       "db.query.summary": "SELECT TableA TableB"
     }
+  },
+  {
+    "name": "bracketed_identifier",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT [a], [b] FROM [TableA], [TableB]"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT [a], [b] FROM [TableA], [TableB]"
+      ],
+      "db.query.summary": "SELECT TableA TableB"
+    }
+  },
+  {
+    "name": "bracketed_identifier_with_single_quote",
+    "input": {
+      "db.system.name": "other_sql",
+      "query": "SELECT [a], [b] FROM [Table'A], [TableB]"
+    },
+    "expected": {
+      "db.query.text": [
+        "SELECT [a], [b] FROM [Table"
+      ],
+      "db.query.summary": "SELECT Table"
+    }
   }
 ]


### PR DESCRIPTION
Related to #3574

Adds a couple test cases for MSSQL's bracketed identifiers. This PR just illustrates status quo. When encountering a single quote in a bracketed identifier `db.query.text` and `db.query.summary` are prematurely truncated.

This issue is related to a [discussion](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3116#discussion_r2349205949) about making our parser overly aggressive and taking a stance to prioritize security over correctness.

I support making improvements to handle these type of scenarios more elegantly so long as we strive not to compromise security. I'd also support moving forward with releasing SqlClient instrumentation without addressing all edge cases. I suspect we'll continue to find new edge cases over time. These could be addressed in future improvements.