### PR TITLE
[OpAMP] Add remote config settings and ensure correct capabilities

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -56,8 +56,14 @@ OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Identification.set -> vo
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.InstanceUid.get -> System.Guid
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.InstanceUid.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.OpAmpClientSettings() -> void
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.RemoteConfiguration.get -> OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings!
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.RemoteConfiguration.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.ServerUrl.get -> System.Uri!
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.ServerUrl.set -> void
+OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings
+OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings.AcceptsRemoteConfig.get -> bool
+OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings.AcceptsRemoteConfig.set -> void
+OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings.RemoteConfigSettings() -> void
 override OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.Equals(object? obj) -> bool
 override OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.GetHashCode() -> int
 static OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.operator !=(OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion left, OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion right) -> bool

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -16,7 +16,7 @@
   ([#3614](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3614))
 
 * Add settings for remote configuration and update advertised capabilities.
-  (TODO)
+  ([#3618](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3618))
 
 ## 0.1.0-alpha.3
 

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Expose public `RemoteConfigMessage`.
   ([#3614](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3614))
 
+* Add settings for remote configuration and update advertised capabilities.
+  (TODO)
+
 ## 0.1.0-alpha.3
 
 Released 2025-Nov-13

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
@@ -132,9 +132,20 @@ internal sealed class FrameBuilder : IFrameBuilder
         this.EnsureInitialized();
 
         // TODO: Update the actual capabilities when features are implemented.
-        this.currentMessage.Capabilities = (ulong)(AgentCapabilities.ReportsStatus
-            | AgentCapabilities.ReportsHealth
-            | AgentCapabilities.ReportsHeartbeat);
+
+        var capabilities = AgentCapabilities.ReportsStatus;
+
+        if (this.settings.Heartbeat.IsEnabled)
+        {
+            capabilities |= AgentCapabilities.ReportsHeartbeat | AgentCapabilities.ReportsHealth;
+        }
+
+        if (this.settings.RemoteConfiguration.AcceptsRemoteConfig)
+        {
+            capabilities |= AgentCapabilities.AcceptsRemoteConfig;
+        }
+
+        this.currentMessage.Capabilities = (ulong)capabilities;
 
         return this;
     }

--- a/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
@@ -101,6 +101,11 @@ public sealed class OpAmpClientSettings
     public HeartbeatSettings Heartbeat { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the remote configuration settings.
+    /// </summary>
+    public RemoteConfigSettings RemoteConfiguration { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the factory function called to create the <see
     /// cref="HttpClient"/> instance that will be used at runtime to
     /// transmit OpAmp messages over HTTP. The returned instance will

--- a/src/OpenTelemetry.OpAmp.Client/Settings/RemoteConfigSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Settings/RemoteConfigSettings.cs
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Settings;
+
+/// <summary>
+/// Configuration settings for the remote configuration capability of the client.
+/// </summary>
+public sealed class RemoteConfigSettings
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the client accepts remote configuration.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if remote configuration is accepted and should be sent by the server; otherwise, <c>false</c>.
+    /// Default is <c>false</c>.
+    /// </value>
+    public bool AcceptsRemoteConfig { get; set; }
+}

--- a/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
@@ -1,10 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
+using OpenTelemetry.OpAmp.Client.Tests.Tools;
 using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;

--- a/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
@@ -1,12 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
-using OpenTelemetry.OpAmp.Client.Tests.Tools;
 using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
@@ -43,7 +43,7 @@ public class PlainHttpTransportTests
         var receivedTextData = clientReceivedFrames.First().CustomMessage.Data.ToStringUtf8();
 
         Assert.Single(serverReceivedFrames);
-        Assert.Equal(mockFrame.Uid, serverReceivedFrames.First().InstanceUid);
+        Assert.Equal(mockFrame.Uid, serverReceivedFrames[0].InstanceUid);
 
         Assert.Single(clientReceivedFrames);
         Assert.StartsWith("This is a mock server frame for testing purposes.", receivedTextData);

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
@@ -42,8 +42,8 @@ public class PlainHttpTransportTests
         var clientReceivedFrames = mockListener.Messages;
         var receivedTextData = clientReceivedFrames.First().CustomMessage.Data.ToStringUtf8();
 
-        Assert.Single(serverReceivedFrames);
-        Assert.Equal(mockFrame.Uid, serverReceivedFrames[0].InstanceUid);
+        var frame = Assert.Single(serverReceivedFrames);
+        Assert.Equal(mockFrame.Uid, frame.InstanceUid);
 
         Assert.Single(clientReceivedFrames);
         Assert.StartsWith("This is a mock server frame for testing purposes.", receivedTextData);
@@ -71,7 +71,6 @@ public class PlainHttpTransportTests
         frameProcessor.Subscribe(mockListener);
 
         var httpTransport = new PlainHttpTransport(settings, frameProcessor);
-
         var mockFrame = FrameGenerator.GenerateMockAgentFrame(false);
 
         // Act

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeHttpServer.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeHttpServer.cs
@@ -45,7 +45,7 @@ internal class OpAmpFakeHttpServer : IDisposable
 
     public Uri Endpoint { get; }
 
-    public IReadOnlyCollection<AgentToServer> GetFrames()
+    public IReadOnlyList<AgentToServer> GetFrames()
     {
         return this.frames.ToArray();
     }


### PR DESCRIPTION
Fixes #3617

## Changes

- Introduce `RemoteConfigSettings` to allow configuring remote configuration support in the OpAMP client.
- Update capability advertisement logic to include `AcceptsRemoteConfig` when enabled.
- Add and update tests to verify capability flags and heartbeat behavior.
- Update unshipped public API.

## Design notes

For this initial PR, this exposes a single property on `RemoteConfigSettings` to identify that the client can handle remote configuration. The intent is that this can be later expanded once we expose APIs for sending the effictive config and remote config status.

I've also updated the advertised capabilities to not set the health or heartbeat flags when heartbeat is disabled based on an assumption of how that should work. I believe we should only advertise features we know the client implements (and are enabled) or consumers implement by confguring the client and registering subscribers.

I also wonder if we should avoid dispatching the `RemoteConfigMessage` to listeners if this feature is disabled. In theory, we should never receive it from the server unless we advertise the capability, but we could take a precaution to drop the message should it somehow arrive. This only really matters if for some reason a listener is registered for `RemoteConfigMessage` but the feature is disabled in the settings.

### Alternative design to consider

We may want to consider avoiding this extra `RemoteConfigSettings` type entirely and instead, we could potentially infer the capability based on registered subscribers. I've not prototyped that to know if it's definititely possible and it would also only work if all subscribed `IOpAmpListerner`s are added registered before `StartAsync` is called. In one respect, I like the idea that all a consumer would need to do is register the listener and our implementation works out the rest, but it might be a little too much magic. We may want to support binding configuration from other sources at some point so having a settings class we can bind to is useful there. If we don't include the settings type, it would also prevent a consumer from easily disabling the feature through code (temporily) but leaving their listener registered. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)