### PR TITLE
[SqlClient] Fix SqlClient integration test for .NET Framework

### DIFF
--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -32,8 +32,9 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
 #if NET
     [InlineData(CommandType.Text, GetContextInfoQuery, GetContextInfoQuery, false, false, false)]
     [InlineData(CommandType.Text, GetContextInfoQuery, GetContextInfoQuery, false, false, true)]
-#endif
     [InlineData(CommandType.StoredProcedure, "sp_who", "sp_who")]
+#endif
+    [InlineData(CommandType.Text, "exec sp_who", "exec sp_who")]
     public void SuccessfulCommandTest(
         CommandType commandType,
         string commandText,


### PR DESCRIPTION
Fixes #3657

We do not know the `CommandType` for .NET Framework, so when `CommandType.StoredProcedure` we cannot properly set `db.query.summary`, `db.operation.name`, and `db.stored_procedure.name`.

I've added an additional test case illustrating that if someone were to use `CommandType.Text` to invoke a stored procedure then things would work as expected.