### PR TITLE
[Infra] Update dependabot config to enable automated dependency submission

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 # This file is retained solely for automated tooling to see we do automated
 # dependency updates as not all such scanners recognize the use of Renovate.
+# It also works around a limitation that Automatic dependency submission does
+# not automatically detect .slnx files to signify the use of .NET in a repo.
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: yearly


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/admin/issues/514.

## Changes

Switch to NuGet so that automated dependency submission works.

Can switch back to GitHub Actions if/when [`.slnx` is supported](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-automatic-dependency-submission-for-your-repository#net-projects).

> .NET autosubmission runs if the repository's dependabot.yml defines nuget as a [`package-ecosystem`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-) or when there is a supported manifest file in the root directory of the repository. Supported manifest files include `.sln`, `.csproj`, `packages.config`, `.vbproj`, `.vcxproj`, and `.fsproj`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
