### PR TITLE
[AspNet] Instrumentation reports telemetry schema URL v1.36.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationMeterProviderBuilderExtensions.cs
@@ -49,7 +49,7 @@ public static class AspNetInstrumentationMeterProviderBuilderExtensions
                 {
                     return AspNetInstrumentation.Instance.HandleManager.AddMetricHandle();
                 });
-                meterProviderBuilder.AddMeter(AspNetInstrumentation.MeterName);
+                meterProviderBuilder.AddMeter(AspNetInstrumentation.Meter.Name);
             });
         });
     }

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationTracerProviderBuilderExtensions.cs
@@ -52,7 +52,7 @@ public static class AspNetInstrumentationTracerProviderBuilderExtensions
                 {
                     return AspNetInstrumentation.Instance.HandleManager.AddTracingHandle();
                 });
-                tracerProviderBuilder.AddSource(AspNetInstrumentation.ActivitySourceName);
+                tracerProviderBuilder.AddSource(AspNetInstrumentation.ActivitySource.Name);
             });
         });
     }

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Metrics and spans report telemetry schema URL v1.36.0.
+  ([#3686](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3686))
+
 ## 1.14.0
 
 Released 2025-Nov-27


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/issues/6164

## Changes

[AspNet] Instrumentation reports telemetry schema URL v1.36.0
#2909 while working on stabilization v1.36.0 was the baseline, so this version is used.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~

