### PR TITLE
Update codeowners for OpAmpClient

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -168,6 +168,7 @@ components:
     - sablancoleis
   test/OpenTelemetry.OpAmp.Client.Tests/:
     - RassK
+    - stevejgordon
   test/OpenTelemetry.PersistentStorage.FileSystem.Tests/:
     - rajkumar-rangaraj
   test/OpenTelemetry.Resources.AWS.Tests/:

--- a/src/OpenTelemetry.OpAmp.Client/README.md
+++ b/src/OpenTelemetry.OpAmp.Client/README.md
@@ -3,7 +3,7 @@
 | Status | |
 | ------ | --- |
 | Stability | [Development](../../README.md#Development) |
-| Code Owners | [@RassK](https://github.com/RassK) |
+| Code Owners | [@RassK](https://github.com/RassK), [@stevejgordon](https://github.com/stevejgordon) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.OpAmp.Client)](https://www.nuget.org/packages/OpenTelemetry.OpAmp.Client)
 [![NuGet download count badge](https://img.shields.io/nuget/dt/OpenTelemetry.OpAmp.Client)](https://www.nuget.org/packages/OpenTelemetry.OpAmp.Client)


### PR DESCRIPTION
## Changes

Adds me to the codeowners for OpAmpClient, as discussed with @Kielek.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~Unit tests added/updated~
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~
