### PR TITLE
[AspNetCore] Remove redundant setting

### DIFF
--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Benchmarks/Instrumentation/AspNetCoreInstrumentationNewBenchmarks.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Benchmarks/Instrumentation/AspNetCoreInstrumentationNewBenchmarks.cs
@@ -99,7 +99,7 @@ public class AspNetCoreInstrumentationNewBenchmarks
     [GlobalSetup(Target = nameof(GetRequestForAspNetCoreApp))]
     public void GetRequestForAspNetCoreAppGlobalSetup()
     {
-        KeyValuePair<string, string?>[] config = [new("OTEL_SEMCONV_STABILITY_OPT_IN", "http")];
+        KeyValuePair<string, string?>[] config = [];
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(config)
             .Build();


### PR DESCRIPTION
## Changes

`OTEL_SEMCONV_STABILITY_OPT_IN` has no effect in the ASP.NET Core instrumentation since open-telemetry/opentelemetry-dotnet#5066.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
