### PR TITLE
[Geneva] Remove unreachable code

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MessagePackSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MessagePackSerializer.cs
@@ -346,16 +346,11 @@ internal static class MessagePackSerializer
         {
             cursor += 1;
             cb = Encoding.ASCII.GetBytes(value, 0, cch, buffer, cursor);
-            if (cb <= LIMIT_MAX_FIX_STRING_LENGTH_IN_BYTES)
-            {
-                cursor += cb;
-                buffer[start] = unchecked((byte)(MIN_FIX_STR | cb));
-                return cursor;
-            }
-            else
-            {
-                ThrowNonAsciiString(value);
-            }
+
+            cursor += cb;
+            buffer[start] = unchecked((byte)(MIN_FIX_STR | cb));
+
+            return cursor;
         }
 
         if (cch <= LIMIT_MAX_STR8_LENGTH_IN_BYTES)
@@ -363,16 +358,11 @@ internal static class MessagePackSerializer
             cursor += 2;
             cb = Encoding.ASCII.GetBytes(value, 0, cch, buffer, cursor);
             cursor += cb;
-            if (cb <= LIMIT_MAX_STR8_LENGTH_IN_BYTES)
-            {
-                buffer[start] = STR8;
-                buffer[start + 1] = unchecked((byte)cb);
-                return cursor;
-            }
-            else
-            {
-                ThrowNonAsciiString(value);
-            }
+
+            buffer[start] = STR8;
+            buffer[start + 1] = unchecked((byte)cb);
+
+            return cursor;
         }
 
         cursor += 3;
@@ -670,10 +660,4 @@ internal static class MessagePackSerializer
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe int Float32ToInt32(float value) => *(int*)&value;
-
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
-#endif
-    private static void ThrowNonAsciiString(string value, [CallerArgumentExpression(nameof(value))] string? paramName = default)
-        => throw new ArgumentException($"The input string: \"{value}\" has non-ASCII characters in it.", paramName);
 }


### PR DESCRIPTION
## Changes

Remove unreachable code identified in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3828#issuecomment-3816898953.

If it _should_ be reachable, either someone needs to suggest a test case that hits them (I couldn't find one, including various values Copilot insisted would work that didn't), or there's a flaw in the how the existing code attempts to detect non-ASCII characters that doesn't work.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
