### PR TITLE
feat: create surreal instrumentation library

### DIFF
--- a/opentelemetry-dotnet-contrib.slnx
+++ b/opentelemetry-dotnet-contrib.slnx
@@ -134,6 +134,7 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/OpenTelemetry.Events.SurrealDb/OpenTelemetry.Events.SurrealDb.csproj" />
     <Project Path="src/OpenTelemetry.Exporter.Geneva/OpenTelemetry.Exporter.Geneva.csproj" />
     <Project Path="src/OpenTelemetry.Exporter.InfluxDB/OpenTelemetry.Exporter.InfluxDB.csproj" />
     <Project Path="src/OpenTelemetry.Exporter.Instana/OpenTelemetry.Exporter.Instana.csproj" />
@@ -164,6 +165,7 @@
     <Project Path="src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/OpenTelemetry.Instrumentation.ServiceFabricRemoting.csproj" />
     <Project Path="src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj" />
     <Project Path="src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj" />
+    <Project Path="src/OpenTelemetry.Instrumentation.SurrealDb/OpenTelemetry.Instrumentation.SurrealDb.csproj" />
     <Project Path="src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj" />
     <Project Path="src/OpenTelemetry.OpAmp.Client/OpenTelemetry.OpAmp.Client.csproj" />
     <Project Path="src/OpenTelemetry.PersistentStorage.Abstractions/OpenTelemetry.PersistentStorage.Abstractions.csproj" />

--- a/src/OpenTelemetry.Events.SurrealDb/Data/TransientTraceData.cs
+++ b/src/OpenTelemetry.Events.SurrealDb/Data/TransientTraceData.cs
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Events.SurrealDb.Data;
+
+/// <summary>
+/// Data holder for the current trace.
+/// </summary>
+public sealed class TransientTraceData
+{
+    public string? Traceparent { get; set; }
+}

--- a/src/OpenTelemetry.Events.SurrealDb/OpenTelemetry.Events.SurrealDb.csproj
+++ b/src/OpenTelemetry.Events.SurrealDb/OpenTelemetry.Events.SurrealDb.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetStandardMinimumSupportedVersion)</TargetFramework>
+    <Description>OpenTelemetry SurrealDB Events.</Description>
+    <PackageTags>$(PackageTags);SurrealDB</PackageTags>
+    <MinVerTagPrefix>Events.SurrealDb-</MinVerTagPrefix>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
+  <PropertyGroup>
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTelemetry.Events.SurrealDb/SurrealDbAfterExecuteMethod.cs
+++ b/src/OpenTelemetry.Events.SurrealDb/SurrealDbAfterExecuteMethod.cs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Events.SurrealDb;
+
+/// <summary>
+/// Event triggered after any SurrealDB method is executed from the client.
+/// </summary>
+public sealed class SurrealDbAfterExecuteMethod
+{
+    public const string Name = "SurrealDb.Method.AfterExecute";
+
+    public int? BatchSize { get; set; }
+}

--- a/src/OpenTelemetry.Events.SurrealDb/SurrealDbBeforeExecuteMethod.cs
+++ b/src/OpenTelemetry.Events.SurrealDb/SurrealDbBeforeExecuteMethod.cs
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Events.SurrealDb;
+
+/// <summary>
+/// Event triggered before any SurrealDB method is executed from the client.
+/// </summary>
+public sealed class SurrealDbBeforeExecuteMethod
+{
+    public const string Name = "SurrealDb.Method.BeforeExecute";
+
+    public string Summary { get; set; }
+    public string Method { get; set; }
+    public Uri Address { get; set; }
+    public string? ProtocolName { get; set; }
+    public string? Table { get; set; }
+}

--- a/src/OpenTelemetry.Events.SurrealDb/SurrealDbBeforeExecuteQuery.cs
+++ b/src/OpenTelemetry.Events.SurrealDb/SurrealDbBeforeExecuteQuery.cs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Events.SurrealDb;
+
+/// <summary>
+/// Additional information from an event triggered before a "query" method is executed.
+/// </summary>
+public sealed class SurrealDbBeforeExecuteQuery
+{
+    public const string Name = "SurrealDb.Query.BeforeExecute";
+
+    public IReadOnlyDictionary<string, object?> Parameters { get; set; }
+}

--- a/src/OpenTelemetry.Events.SurrealDb/SurrealDbExecuteError.cs
+++ b/src/OpenTelemetry.Events.SurrealDb/SurrealDbExecuteError.cs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Events.SurrealDb;
+
+/// <summary>
+/// Event triggered when a SurrealDB method failed.
+/// </summary>
+public sealed class SurrealDbExecuteError
+{
+    public const string Name = "SurrealDb.Error.Execute";
+
+    public Exception? Exception { get; set; }
+}

--- a/src/OpenTelemetry.Events.SurrealDb/SurrealDbExecuteMethod.cs
+++ b/src/OpenTelemetry.Events.SurrealDb/SurrealDbExecuteMethod.cs
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Events.SurrealDb.Data;
+
+namespace OpenTelemetry.Events.SurrealDb;
+
+/// <summary>
+/// Event triggered when a SurrealDB method is executed from the client.
+/// </summary>
+public sealed class SurrealDbExecuteMethod
+{
+    public const string Name = "SurrealDb.Method.Execute";
+
+    public string? Namespace { get; set; }
+    public string? Database { get; set; }
+    public TransientTraceData? Data { get; set; }
+}

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/Implementation/SurrealDbDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/Implementation/SurrealDbDiagnosticListener.cs
@@ -1,0 +1,272 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry.Events.SurrealDb;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.SurrealDb.Implementation;
+
+internal sealed class SurrealDbDiagnosticListener : ListenerHandler
+{
+    public SurrealDbDiagnosticListener(string sourceName)
+        : base(sourceName)
+    {
+    }
+
+    public override bool SupportsNullActivity => false;
+
+    public override void OnEventWritten(string name, object? payload)
+    {
+        if (SurrealDbInstrumentation.Instance.HandleManager.TracingHandles == 0
+            && SurrealDbInstrumentation.Instance.HandleManager.MetricHandles == 0)
+        {
+            return;
+        }
+
+        switch (name)
+        {
+            case SurrealDbBeforeExecuteMethod.Name:
+                HandleBeforeExecute(payload);
+                break;
+            case SurrealDbBeforeExecuteQuery.Name:
+                HandleBeforeExecuteQuery(payload);
+                break;
+            case SurrealDbExecuteMethod.Name:
+                HandleExecute(payload);
+                break;
+            case SurrealDbAfterExecuteMethod.Name:
+                HandleAfterExecute(payload);
+                break;
+            case SurrealDbExecuteError.Name:
+                HandleExecuteError(payload);
+                break;
+        }
+    }
+
+    private static void HandleBeforeExecute(object? payload)
+    {
+        const string name = SurrealDbBeforeExecuteMethod.Name;
+        if (payload is not SurrealDbBeforeExecuteMethod @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(nameof(SurrealDbDiagnosticListener), name);
+            return;
+        }
+
+        var activity = SurrealDbTelemetryHelper.ActivitySource.StartActivity(
+            @event.Summary,
+            ActivityKind.Client,
+            default(ActivityContext));
+        var options = SurrealDbInstrumentation.TracingOptions;
+
+        if (activity is null)
+            return;
+
+        if (activity.IsAllDataRequested)
+        {
+            activity.AddTag(SemanticConventions.AttributeServerAddress, @event.Address.Host);
+            activity.AddTag(SemanticConventions.AttributeServerPort, @event.Address.Port);
+            activity.SetTag(SemanticConventions.AttributeDbSystemName, SurrealDbTelemetryHelper.SurrealDbSystemName);
+            activity.SetTag(SemanticConventions.AttributeDbOperationName, @event.Method);
+
+            if (!string.IsNullOrEmpty(@event.Table))
+            {
+                activity.SetTag(SemanticConventions.AttributeDbCollectionName, @event.Table);
+                activity.SetTag(SemanticConventions.AttributeDbQuerySummary, @event.Summary);
+            }
+
+            var protocol = @event.Address.Scheme;
+            var networkProtocol = protocol switch
+            {
+                "http" or "https" => "http",
+                "ws" or "wss" => "ws",
+                _ => null,
+            };
+
+            if (!string.IsNullOrEmpty(networkProtocol))
+            {
+                activity.AddTag(SemanticConventions.AttributeNetworkProtocolName, networkProtocol);
+            }
+        }
+
+        if (activity.IsAllDataRequested)
+        {
+            try
+            {
+                if (options.Filter?.Invoke(@event) == false)
+                {
+                    SurrealDbInstrumentationEventSource.Log.MethodIsFilteredOut(activity.OperationName);
+                    activity.IsAllDataRequested = false;
+                    activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+                }
+            }
+            catch (Exception ex)
+            {
+                SurrealDbInstrumentationEventSource.Log.MethodFilterException(ex);
+                activity.IsAllDataRequested = false;
+                activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+            }
+        }
+    }
+
+    private static void HandleBeforeExecuteQuery(object? payload)
+    {
+        const string name = SurrealDbBeforeExecuteQuery.Name;
+        if (payload is not SurrealDbBeforeExecuteQuery @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(nameof(SurrealDbDiagnosticListener), name);
+            return;
+        }
+
+        var activity = Activity.Current;
+        var options = SurrealDbInstrumentation.TracingOptions;
+
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested && options.SetDbQueryParameters)
+        {
+            foreach (var parameter in @event.Parameters)
+            {
+                activity.SetTag($"db.query.parameter.{parameter.Key}", parameter.Value);
+            }
+        }
+    }
+
+    private static void HandleExecute(object? payload)
+    {
+        const string name = SurrealDbExecuteMethod.Name;
+        if (payload is not SurrealDbExecuteMethod @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(nameof(SurrealDbDiagnosticListener), name);
+            return;
+        }
+
+        var activity = Activity.Current;
+        var options = SurrealDbInstrumentation.TracingOptions;
+
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested)
+        {
+            string? dbNamespace = null;
+            if (!string.IsNullOrEmpty(@event.Namespace))
+            {
+                dbNamespace = @event.Namespace;
+                if (!string.IsNullOrEmpty(@event.Database))
+                {
+                    dbNamespace += '|' + @event.Database;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(dbNamespace))
+            {
+                activity.AddTag(SemanticConventions.AttributeDbNamespace, dbNamespace);
+            }
+        }
+
+        if (options.EnableTraceContextPropagation && @event.Data is not null)
+        {
+            var tracedflags = (activity.ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0 ? "01" : "00";
+            @event.Data.Traceparent = $"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-{tracedflags}";
+        }
+    }
+
+    private static void HandleAfterExecute(object? payload)
+    {
+        const string name = SurrealDbAfterExecuteMethod.Name;
+        if (payload is not SurrealDbAfterExecuteMethod @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(nameof(SurrealDbDiagnosticListener), name);
+            return;
+        }
+
+        var activity = Activity.Current;
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested && @event.BatchSize is > 1)
+        {
+            activity.AddTag(SemanticConventions.AttributeDbOperationBatchSize, @event.BatchSize.Value);
+        }
+
+        activity.Stop();
+        RecordDuration(activity);
+    }
+
+    private static void HandleExecuteError(object? payload)
+    {
+        const string name = SurrealDbExecuteError.Name;
+        if (payload is not SurrealDbExecuteError @event)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullPayload(nameof(SurrealDbDiagnosticListener), name);
+            return;
+        }
+
+        var activity = Activity.Current;
+        var options = SurrealDbInstrumentation.TracingOptions;
+
+        if (activity is null)
+        {
+            SurrealDbInstrumentationEventSource.Log.NullActivity(name);
+            return;
+        }
+
+        if (activity.Source != SurrealDbTelemetryHelper.ActivitySource)
+        {
+            return;
+        }
+
+        if (activity.IsAllDataRequested && @event.Exception is not null)
+        {
+            activity.AddTag(SemanticConventions.AttributeErrorType, @event.Exception.GetType().FullName);
+            activity.SetStatus(ActivityStatusCode.Error, @event.Exception.Message);
+
+            if (options.RecordException)
+            {
+                activity.AddException(@event.Exception);
+            }
+        }
+
+        activity.Stop();
+        RecordDuration(activity);
+    }
+
+    private static void RecordDuration(Activity activity)
+    {
+        if (SurrealDbInstrumentation.Instance.HandleManager.MetricHandles == 0)
+        {
+            return;
+        }
+
+        var tags = default(TagList);
+
+        var duration = activity.Duration.TotalSeconds;
+        SurrealDbTelemetryHelper.DbClientOperationDuration.Record(duration, tags);
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/Implementation/SurrealDbInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/Implementation/SurrealDbInstrumentationEventSource.cs
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Instrumentation.SurrealDb.Implementation;
+
+/// <summary>
+/// EventSource events emitted from the project.
+/// </summary>
+[EventSource(Name = "OpenTelemetry-Instrumentation-SurrealDbClient")]
+internal sealed class SurrealDbInstrumentationEventSource : EventSource, IConfigurationExtensionsLogger
+{
+    public static SurrealDbInstrumentationEventSource Log = new();
+
+    [NonEvent]
+    public void UnknownErrorProcessingEvent(string handlerName, string eventName, Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.UnknownErrorProcessingEvent(handlerName, eventName, ex.ToInvariantString());
+        }
+    }
+
+    [Event(
+        1,
+        Message = "Unknown error processing event '{1}' from handler '{0}', Exception: {2}",
+        Level = EventLevel.Error
+    )]
+    public void UnknownErrorProcessingEvent(string handlerName, string eventName, string ex)
+    {
+        this.WriteEvent(1, handlerName, eventName, ex);
+    }
+
+    [Event(
+        2,
+        Message = "Current Activity is NULL in the '{0}' callback. Span will not be recorded.",
+        Level = EventLevel.Warning
+    )]
+    public void NullActivity(string eventName)
+    {
+        this.WriteEvent(2, eventName);
+    }
+
+    [Event(
+        3,
+        Message = "Payload is NULL in event '{1}' from handler '{0}', span will not be recorded.",
+        Level = EventLevel.Warning
+    )]
+    public void NullPayload(string handlerName, string eventName)
+    {
+        this.WriteEvent(3, handlerName, eventName);
+    }
+
+    [Event(6, Message = "Method is filtered out. Activity {0}", Level = EventLevel.Verbose)]
+    public void MethodIsFilteredOut(string activityName)
+    {
+        this.WriteEvent(6, activityName);
+    }
+
+    [NonEvent]
+    public void MethodFilterException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.MethodFilterException(ex.ToInvariantString());
+        }
+    }
+
+    [Event(
+        7,
+        Message = "Method filter threw exception. Method will not be collected. Exception {0}.",
+        Level = EventLevel.Error
+    )]
+    public void MethodFilterException(string exception)
+    {
+        this.WriteEvent(7, exception);
+    }
+
+    [Event(
+        8,
+        Message = "Configuration key '{0}' has an invalid value: '{1}'",
+        Level = EventLevel.Warning
+    )]
+    public void InvalidConfigurationValue(string key, string value)
+    {
+        this.WriteEvent(8, key, value);
+    }
+
+    void IConfigurationExtensionsLogger.LogInvalidConfigurationValue(string key, string value)
+    {
+        this.InvalidConfigurationValue(key, value);
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/Implementation/SurrealDbTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/Implementation/SurrealDbTelemetryHelper.cs
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Instrumentation.SurrealDb.Implementation;
+
+/// <summary>
+/// Helper class to hold common properties used by <see cref="SurrealDbDiagnosticListener"/>.
+/// </summary>
+internal sealed class SurrealDbTelemetryHelper
+{
+    public const string SurrealDbSystemName = "surrealdb";
+
+    private static readonly (ActivitySource ActivitySource, Meter Meter) Telemetry = CreateTelemetry();
+    public static readonly ActivitySource ActivitySource = Telemetry.ActivitySource;
+    public static readonly Meter Meter = Telemetry.Meter;
+
+    public static readonly Histogram<double> DbClientOperationDuration = Meter.CreateHistogram(
+        "db.client.operation.duration",
+        unit: "s",
+        description: "Duration of database client operations.",
+        advice: new InstrumentAdvice<double>
+        {
+            HistogramBucketBoundaries = [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10],
+        }
+    );
+
+    private static (ActivitySource ActivitySource, Meter Meter) CreateTelemetry()
+    {
+        const string telemetrySchemaUrl = "https://opentelemetry.io/schemas/1.33.0";
+        var assembly = typeof(SurrealDbTelemetryHelper).Assembly;
+        var assemblyName = assembly.GetName();
+        var name = assemblyName.Name!;
+        var version = assembly.GetPackageVersion();
+
+        var activitySourceOptions = new ActivitySourceOptions(name)
+        {
+            Version = version,
+            TelemetrySchemaUrl = telemetrySchemaUrl,
+        };
+
+        var meterOptions = new MeterOptions(name)
+        {
+            Version = version,
+            TelemetrySchemaUrl = telemetrySchemaUrl,
+        };
+
+        return (new ActivitySource(activitySourceOptions), new Meter(meterOptions));
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/OpenTelemetry.Instrumentation.SurrealDb.csproj
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/OpenTelemetry.Instrumentation.SurrealDb.csproj
@@ -1,0 +1,40 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetStandardMinimumSupportedVersion)</TargetFramework>
+    <Description>OpenTelemetry SurrealDB Instrumentation.</Description>
+    <PackageTags>$(PackageTags);SurrealDB</PackageTags>
+    <MinVerTagPrefix>Instrumentation.SurrealDb-</MinVerTagPrefix>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <!-- Do not run Package Baseline Validation as this package has never released a stable version.
+  Remove this property once we have released a stable version and add PackageValidationBaselineVersion property. -->
+  <PropertyGroup>
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Configuration\*.cs" Link="Includes\Configuration\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\DiagnosticSourceListener.cs" Link="Includes\DiagnosticSourceListener.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\DiagnosticSourceSubscriber.cs" Link="Includes\DiagnosticSourceSubscriber.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\InstrumentationHandleManager.cs" Link="Includes\InstrumentationHandleManager.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenTelemetry.Events.SurrealDb\OpenTelemetry.Events.SurrealDb.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/SurrealDbInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/SurrealDbInstrumentation.cs
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Events.SurrealDb;
+using OpenTelemetry.Instrumentation.SurrealDb.Implementation;
+
+namespace OpenTelemetry.Instrumentation.SurrealDb;
+
+internal sealed class SurrealDbInstrumentation : IDisposable
+{
+    public static readonly SurrealDbInstrumentation Instance = new();
+
+    public static SurrealDbTraceInstrumentationOptions TracingOptions { get; set; } = new();
+
+    internal const string SurrealDbDiagnosticListenerName = nameof(SurrealDbDiagnosticListener);
+
+    public readonly InstrumentationHandleManager HandleManager = new();
+
+    private static readonly HashSet<string> DiagnosticSourceEvents =
+    [
+        SurrealDbBeforeExecuteMethod.Name,
+        SurrealDbBeforeExecuteQuery.Name,
+        SurrealDbExecuteMethod.Name,
+        SurrealDbAfterExecuteMethod.Name,
+        SurrealDbExecuteError.Name,
+    ];
+
+    private readonly Func<string, object?, object?, bool> isEnabled = (eventName, _, _)
+        => DiagnosticSourceEvents.Contains(eventName);
+
+    private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SurrealDbInstrumentation"/> class.
+    /// </summary>
+    private SurrealDbInstrumentation()
+    {
+        this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
+            name => new SurrealDbDiagnosticListener(name),
+            listener => listener.Name == SurrealDbDiagnosticListenerName,
+            this.isEnabled,
+            SurrealDbInstrumentationEventSource.Log.UnknownErrorProcessingEvent);
+        this.diagnosticSourceSubscriber.Subscribe();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this.diagnosticSourceSubscriber.Dispose();
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/SurrealDbMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/SurrealDbMeterProviderBuilderExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Instrumentation.SurrealDb;
+using OpenTelemetry.Instrumentation.SurrealDb.Implementation;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Extension methods to simplify registering of dependency instrumentation.
+/// </summary>
+public static class SurrealDbMeterProviderBuilderExtensions
+{
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddSurrealDbInstrumentation(
+        this MeterProviderBuilder builder
+    )
+    {
+        Guard.ThrowIfNull(builder);
+
+        builder.AddInstrumentation(sp =>
+        {
+            return SurrealDbInstrumentation.Instance.HandleManager.AddMetricHandle();
+        });
+
+        builder.AddMeter(SurrealDbTelemetryHelper.Meter.Name);
+
+        return builder;
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/SurrealDbTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/SurrealDbTraceInstrumentationOptions.cs
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Events.SurrealDb;
+using OpenTelemetry.Instrumentation.SurrealDb.Implementation;
+
+namespace OpenTelemetry.Instrumentation.SurrealDb;
+
+/// <summary>
+/// Options for <see cref="SurrealDbInstrumentation"/>.
+/// </summary>
+public class SurrealDbTraceInstrumentationOptions
+{
+    internal const string ContextPropagationLevelEnvVar =
+        "OTEL_DOTNET_EXPERIMENTAL_SURREALDB_CLIENT_ENABLE_TRACE_CONTEXT_PROPAGATION";
+    internal const string SetDbQueryParametersEnvVar =
+        "OTEL_DOTNET_EXPERIMENTAL_SURREALDB_CLIENT_ENABLE_TRACE_DB_QUERY_PARAMETERS";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SurrealDbTraceInstrumentationOptions"/> class.
+    /// </summary>
+    public SurrealDbTraceInstrumentationOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build()) { }
+
+    internal SurrealDbTraceInstrumentationOptions(IConfiguration configuration)
+    {
+        if (
+            configuration!.TryGetBoolValue(
+                SurrealDbInstrumentationEventSource.Log,
+                ContextPropagationLevelEnvVar,
+                out var enableTraceContextPropagation
+            )
+        )
+        {
+            this.EnableTraceContextPropagation = enableTraceContextPropagation;
+        }
+
+        if (
+            configuration!.TryGetBoolValue(
+                SurrealDbInstrumentationEventSource.Log,
+                SetDbQueryParametersEnvVar,
+                out var setDbQueryParameters
+            )
+        )
+        {
+            this.SetDbQueryParameters = setDbQueryParameters;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a filter function that determines whether or not to collect telemetry about a method.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>The first parameter passed to the filter function is the event triggered before the method is being executed.</item>
+    /// <item>The return value for the filter function is interpreted as:
+    /// <list type="bullet">
+    /// <item>If filter returns <see langword="true" />, the method is collected.</item>
+    /// <item>If filter returns <see langword="false" /> or throws an exception the method is NOT collected.</item>
+    /// </list></item>
+    /// </list>
+    /// </remarks>
+    public Func<SurrealDbBeforeExecuteMethod, bool>? Filter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the exception will be
+    /// recorded as <see cref="ActivityEvent"/> or not.
+    /// Default value: <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>For specification details see: <see
+    /// href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md"/>.</para>
+    /// </remarks>
+    public bool RecordException { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the <see cref="SurrealDbInstrumentation"/>
+    /// should add the names and values of query parameters as the <c>db.query.parameter.{key}</c> tag.
+    /// Default value: <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>WARNING: SetDbQueryParameters will capture the raw
+    /// <c>Value</c>. Make sure your query parameters never
+    /// contain any sensitive data.</b>
+    /// </para>
+    /// </remarks>
+    internal bool SetDbQueryParameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to send traceparent information to a SurrealDB database.
+    /// </summary>
+    internal bool EnableTraceContextPropagation { get; set; }
+}

--- a/src/OpenTelemetry.Instrumentation.SurrealDb/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SurrealDb/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Instrumentation.SurrealDb;
+using OpenTelemetry.Instrumentation.SurrealDb.Implementation;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Extension methods to simplify registering of dependency instrumentation.
+/// </summary>
+public static class TracerProviderBuilderExtensions
+{
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSurrealDbInstrumentation(
+        this TracerProviderBuilder builder
+    ) =>
+        AddSurrealDbInstrumentation(
+            builder,
+            name: null,
+            configureSurrealDbTraceInstrumentationOptions: null
+        );
+
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="SurrealDbTraceInstrumentationOptions">Callback action for configuring <see cref="SurrealDbTraceInstrumentationOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSurrealDbInstrumentation(
+        this TracerProviderBuilder builder,
+        Action<SurrealDbTraceInstrumentationOptions> configureSurrealDbTraceInstrumentationOptions
+    ) =>
+        AddSurrealDbInstrumentation(
+            builder,
+            name: null,
+            configureSurrealDbTraceInstrumentationOptions
+        );
+
+    /// <summary>
+    /// Enables SurrealDbClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="name">Name which is used when retrieving options.</param>
+    /// <param name="configureSurrealDbTraceInstrumentationOptions">Callback action for configuring <see cref="SurrealDbTraceInstrumentationOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSurrealDbInstrumentation(
+        this TracerProviderBuilder builder,
+        string? name,
+        Action<SurrealDbTraceInstrumentationOptions>? configureSurrealDbTraceInstrumentationOptions
+    )
+    {
+        Guard.ThrowIfNull(builder);
+
+        name ??= Options.DefaultName;
+
+        if (configureSurrealDbTraceInstrumentationOptions != null)
+        {
+            builder.ConfigureServices(services =>
+                services.Configure(name, configureSurrealDbTraceInstrumentationOptions)
+            );
+        }
+
+        builder.AddInstrumentation(sp =>
+        {
+            var surrealDbOptions = sp.GetRequiredService<
+                IOptionsMonitor<SurrealDbTraceInstrumentationOptions>
+            >()
+                .Get(name);
+            SurrealDbInstrumentation.TracingOptions = surrealDbOptions;
+            return SurrealDbInstrumentation.Instance.HandleManager.AddTracingHandle();
+        });
+
+        string[] sources = [SurrealDbTelemetryHelper.ActivitySource.Name, SurrealDbTelemetryHelper.SurrealDbSystemName];
+        builder.AddSource(sources);
+
+        return builder;
+    }
+}


### PR DESCRIPTION
## Changes

Add a new library to do OTEL instrumentation of the .NET SDK for SurrealDB, following the PR started https://github.com/surrealdb/surrealdb.net/pull/219

* Add new library `OpenTelemetry.Instrumentation.SurrealDb`, inspied by the SQL client library
* Add new library `OpenTelemetry.Events.SurrealDb` to share events payload between the .NET client and the OTEL library

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
