### PR TITLE
[Infra] Suppress code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
@@ -100,10 +100,10 @@ internal sealed partial class AWSECSDetector : IResourceDetector
         using var scope = SuppressInstrumentationScope.Begin();
         using var httpClientHandler = new HttpClientHandler();
 
-#pragma warning disable CA2025
+#pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
         var metadataV4ContainerResponse = AsyncHelper.RunSync(() => ResourceDetectorUtils.SendOutRequestAsync(metadataV4Url, HttpMethod.Get, null, httpClientHandler));
         var metadataV4TaskResponse = AsyncHelper.RunSync(() => ResourceDetectorUtils.SendOutRequestAsync($"{metadataV4Url.TrimEnd('/')}/task", HttpMethod.Get, null, httpClientHandler));
-#pragma warning restore CA2025
+#pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 
         using var containerResponse = JsonDocument.Parse(metadataV4ContainerResponse);
         using var taskResponse = JsonDocument.Parse(metadataV4TaskResponse);

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/LogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/LogExporterBenchmarks.cs
@@ -31,7 +31,7 @@ Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmarks;
 
-#pragma warning disable CA1873
+#pragma warning disable CA1873 // Avoid potentially expensive logging
 
 [MemoryDiagnoser]
 public class LogExporterBenchmarks

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDLogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDLogExporterBenchmarks.cs
@@ -27,7 +27,7 @@ Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
 
 namespace OpenTelemetry.Exporter.Geneva.Benchmarks;
 
-#pragma warning disable CA1873
+#pragma warning disable CA1873 // Avoid potentially expensive logging
 
 [MemoryDiagnoser]
 public class TLDLogExporterBenchmarks

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterAFDCorrelationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterAFDCorrelationTests.cs
@@ -101,9 +101,11 @@ public class GenevaLogExporterAFDCorrelationTests
                         // This thread sets AFDCorrelationId before logging
                         var expectedCorrelationId = $"CorrelationId-{threadIndex}";
                         OpenTelemetryContext.SetAFDCorrelationId(expectedCorrelationId);
-#pragma warning disable CA1873, CA2254 // Template should be a static expression
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+#pragma warning disable CA2254 // Template should be a static expression
                         logger.LogInformation($"Thread {threadIndex} with correlation ID");
-#pragma warning restore CA1873, CA2254 // Template should be a static expression
+#pragma warning restore CA2254 // Template should be a static expression
+#pragma warning restore CA1873 // Avoid potentially expensive logging
                         lock (syncObj)
                         {
                             countWithCorrelationId++;
@@ -112,9 +114,11 @@ public class GenevaLogExporterAFDCorrelationTests
                     }
                     else
                     {
-#pragma warning disable CA1873, CA2254 // Template should be a static expression
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+#pragma warning disable CA2254 // Template should be a static expression
                         logger.LogInformation($"Thread {threadIndex} without correlation ID");
-#pragma warning restore CA1873, CA2254 // Template should be a static expression
+#pragma warning restore CA2254 // Template should be a static expression
+#pragma warning restore CA1873 // Avoid potentially expensive logging
                         lock (syncObj)
                         {
                             countWithoutCorrelationId++;
@@ -300,9 +304,9 @@ public class GenevaLogExporterAFDCorrelationTests
 
             // Emit a LogRecord and grab a copy of internal buffer for validation.
             var logger = loggerFactory.CreateLogger<GenevaLogExporterTests>();
-#pragma warning disable CA1873
+#pragma warning disable CA1873 // Avoid potentially expensive logging
             logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
-#pragma warning restore CA1873
+#pragma warning restore CA1873// Avoid potentially expensive logging
             loggerFactory.Dispose();
 
             Assert.Single(exportedData);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 
-#pragma warning disable CA1873
+#pragma warning disable CA1873 // Avoid potentially expensive logging
 
 public class GenevaLogExporterTests
 {

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorIntegrationTests.cs
@@ -90,12 +90,12 @@ public class OneCollectorIntegrationTests
     [SkipUnlessEnvVarFoundFact(OneCollectorInstrumentationKeyEnvName)]
     public void LogWithDataIntegrationTest()
     {
-#pragma warning disable CA1873
+#pragma warning disable CA1873 // Avoid potentially expensive logging
         this.RunIntegrationTest(
             logger => logger.LogInformation("Hello world {StructuredData}", "Goodbye world"),
             out var succeeded,
             out var actualJson);
-#pragma warning restore CA1873
+#pragma warning restore CA1873 // Avoid potentially expensive logging
 
         Assert.True(succeeded);
         Assert.NotNull(actualJson);

--- a/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests;
 
-#pragma warning disable CA1873
+#pragma warning disable CA1873 // Avoid potentially expensive logging
 
 public sealed class ActivityEventAttachingLogProcessorTests : IDisposable
 {

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/Services/GreeterService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/Services/GreeterService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Services.Tests;
 
-#pragma warning disable CA1873
+#pragma warning disable CA1873 // Avoid potentially expensive logging
 
 internal class GreeterService : Greeter.GreeterBase
 {


### PR DESCRIPTION
## Changes

- Suppress code analysis warnings from building the whole solution in Visual Studio 2026.
- Apple some IDE code refactoring suggestions found while working on #3864.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
