### PR TITLE
[SqlClient] Implement db.response.returned_rows attribute

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Add `db.response.returned_rows` attribute to query spans if opted into using
+  the `RecordReturnedRows` option or the
+  `OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_RECORD_RETURNED_ROWS`
+  environment variable. Not supported on .NET Framework.
+  ([#3899](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3899))
+
 ## 1.15.0
 
 Released 2026-Jan-28

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -43,6 +43,8 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
     private readonly PropertyFetcher<string> commandTextFetcher = new("CommandText");
     private readonly PropertyFetcher<Exception> exceptionFetcher = new("Exception");
     private readonly PropertyFetcher<int> exceptionNumberFetcher = new("Number");
+    private readonly PropertyFetcher<object> returnValueFetcher = new("ReturnValue");
+    private readonly PropertyFetcher<long> rowsFetcher = new("Rows");
     private readonly AsyncLocal<long> beginTimestamp = new();
 
     public SqlClientDiagnosticListener(string sourceName)
@@ -211,6 +213,18 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                     {
                         this.RecordDuration(null, payload);
                         return;
+                    }
+
+                    if (options.RecordReturnedRows && activity.IsAllDataRequested)
+                    {
+                        if (this.rowsFetcher.TryFetch(payload, out var rows))
+                        {
+                            activity.SetTag(SemanticConventions.AttributeDbResponseReturnedRows, rows);
+                        }
+                        else if (this.returnValueFetcher.TryFetch(payload, out var returnValue) && returnValue is int recordsAffected && recordsAffected != -1)
+                        {
+                            activity.SetTag(SemanticConventions.AttributeDbResponseReturnedRows, recordsAffected);
+                        }
                     }
 
                     activity.Stop();

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
@@ -21,6 +21,7 @@ public class SqlClientTraceInstrumentationOptions
 {
     internal const string ContextPropagationLevelEnvVar = "OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_TRACE_CONTEXT_PROPAGATION";
     internal const string SetDbQueryParametersEnvVar = "OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_TRACE_DB_QUERY_PARAMETERS";
+    internal const string RecordReturnedRowsEnvVar = "OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_RECORD_RETURNED_ROWS";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlClientTraceInstrumentationOptions"/> class.
@@ -49,6 +50,14 @@ public class SqlClientTraceInstrumentationOptions
                 out var setDbQueryParameters))
         {
             this.SetDbQueryParameters = setDbQueryParameters;
+        }
+
+        if (configuration!.TryGetBoolValue(
+                SqlClientInstrumentationEventSource.Log,
+                RecordReturnedRowsEnvVar,
+                out var recordReturnedRows))
+        {
+            this.RecordReturnedRows = recordReturnedRows;
         }
 #endif
     }
@@ -121,6 +130,16 @@ public class SqlClientTraceInstrumentationOptions
     /// </remarks>
     internal bool SetDbQueryParameters { get; set; }
 #endif
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/>
+    /// should add the number of rows returned by the operation as the <c>db.response.returned_rows</c> tag.
+    /// Default value: <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>RecordReturnedRows is only supported on .NET runtimes.</b></para>
+    /// </remarks>
+    internal bool RecordReturnedRows { get; set; }
 
 #if NET
     /// <summary>

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -150,6 +150,7 @@ internal static class SemanticConventions
     public const string AttributeDbQuerySummary = "db.query.summary";
     public const string AttributeDbQueryText = "db.query.text";
     public const string AttributeDbStoredProcedureName = "db.stored_procedure.name";
+    public const string AttributeDbResponseReturnedRows = "db.response.returned_rows";
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/MockCommandExecutor.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/MockCommandExecutor.cs
@@ -11,7 +11,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 
 public class MockCommandExecutor
 {
-    public static void ExecuteCommand(string connectionString, CommandType commandType, string commandText, bool error, SqlClientLibrary library)
+    public static void ExecuteCommand(string connectionString, CommandType commandType, string commandText, bool error, SqlClientLibrary library, int? recordsAffected = null, long? rows = null)
     {
         using var fakeSqlClientDiagnosticSource = new FakeSqlClientDiagnosticSource();
 
@@ -67,6 +67,8 @@ public class MockCommandExecutor
             {
                 OperationId = operationId,
                 Command = sqlCommand,
+                ReturnValue = recordsAffected,
+                Rows = rows,
                 Timestamp = 2000000L,
             };
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
@@ -203,6 +203,54 @@ public class SqlClientTraceInstrumentationOptionsTests
         Assert.Equal(expected, options.SetDbQueryParameters);
     }
 
+    [Theory]
+    [InlineData("", false)]
+    [InlineData("invalid", false)]
+    [InlineData("false", false)]
+    [InlineData("true", true)]
+    public void ShouldAssignRecordReturnedRowsFromEnvironmentVariable(string value, bool expected)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_RECORD_RETURNED_ROWS"] = value })
+            .Build();
+        var options = new SqlClientTraceInstrumentationOptions(configuration);
+        Assert.Equal(expected, options.RecordReturnedRows);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RecordReturnedRowsCollected(bool recordReturnedRows)
+    {
+        var activities = new List<Activity>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation(options =>
+            {
+                options.RecordReturnedRows = recordReturnedRows;
+            })
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        var commandText = "update Foo set Bar = 1";
+        MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, commandText, false, SqlClientLibrary.MicrosoftDataSqlClient, recordsAffected: 10);
+        MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, commandText, false, SqlClientLibrary.MicrosoftDataSqlClient, rows: 20);
+
+        tracerProvider.ForceFlush();
+        Assert.Equal(2, activities.Count);
+
+        if (recordReturnedRows)
+        {
+            Assert.Equal(10, activities[0].GetTagValue(SemanticConventions.AttributeDbResponseReturnedRows));
+            Assert.Equal(20L, activities[1].GetTagValue(SemanticConventions.AttributeDbResponseReturnedRows));
+        }
+        else
+        {
+            Assert.Null(activities[0].GetTagValue(SemanticConventions.AttributeDbResponseReturnedRows));
+            Assert.Null(activities[1].GetTagValue(SemanticConventions.AttributeDbResponseReturnedRows));
+        }
+    }
+
     private static void ActivityEnrichment(Activity activity, object obj)
     {
         activity.SetTag("enriched", "yes");


### PR DESCRIPTION
Fixes [#3898](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/3898) 
Design discussion issue #

## Changes
This PR implements the db.response.returned_rows span attribute for the SQL Client instrumentation, following the
  OpenTelemetry Semantic Conventions for SQL Server (https://opentelemetry.io/docs/specs/semconv/db/sql-server/#spans).


 Key Features:
   - Environment Variable: Added support for OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_RECORD_RETURNED_ROWS to enable
     the feature via configuration.
   - Implementation: Updated SqlClientDiagnosticListener to extract row counts from the ReturnValue (for ExecuteNonQuery
     operations) or the Rows property where available in the DiagnosticSource payload.
   - Testing: Enhanced MockCommandExecutor to simulate row count data and added new unit tests in
     SqlClientTraceInstrumentationOptionsTests.cs.


  Note on Stability:
  Per the OTel specification, this attribute is currently in Developmental status. It has been implemented as an opt-in
  feature with an "EXPERIMENTAL" prefix for the environment variable to align with the current specification status.

  Merge requirement checklist


   * [x] [CONTRIBUTING (https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md)
     guidelines followed
   * [x] Unit tests added/updated
   * [x] Appropriate CHANGELOG.md files updated
   * [x] Changes in public API reviewed