### PR TITLE
ci: migrate from actions/attest-build-provenance to actions/attest

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -32,7 +32,6 @@ jobs:
       attestations: write
       contents: read
       id-token: write
-     
 
     runs-on: windows-latest
 


### PR DESCRIPTION
Suggested by @Kielek in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4882#issuecomment-3982421214
Related issue open-telemetry/opentelemetry-dotnet-instrumentation#4880

## Changes
As of v4, actions/attest-build-provenance is a wrapper around actions/attest. Migrate to actions/attest@v4.1.0 directly as recommended by GitHub.

Also, add artifact-metadata: write permission to create-release job as required by actions/attest docs.

- Replaced actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f with actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 (v4.1.0) in publish-packages.yml
- Added artifact-metadata: write permission to the create-release job as recommended in the actions/attest docs
- The subject-path input is unchanged; it is supported identically by actions/attest.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
