### PR TITLE
[WCF] Simplify random port usage in tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForHttpTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForHttpTests.cs
@@ -18,14 +18,13 @@ public class TelemetryBindingElementForHttpTests : IDisposable
 
     public TelemetryBindingElementForHttpTests()
     {
-        var random = new Random();
         var retryCount = WcfTestHelpers.MaxRetries;
         HttpListener? createdListener = null;
         while (retryCount > 0)
         {
             try
             {
-                this.serviceBaseUri = new Uri($"http://localhost:{random.Next(WcfTestHelpers.MinPort, WcfTestHelpers.MaxPort)}/");
+                this.serviceBaseUri = WcfTestHelpers.GetRandomBaseUri(Uri.UriSchemeHttp);
 
                 createdListener = new HttpListener();
                 createdListener.Prefixes.Add(this.serviceBaseUri.OriginalString);

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForTcpTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForTcpTests.netfx.cs
@@ -30,9 +30,7 @@ public class TelemetryBindingElementForTcpTests : IDisposable
     }
 
     public void Dispose()
-    {
-        this.serviceHost?.Close();
-    }
+        => this.serviceHost?.Close();
 
     [Theory]
     [InlineData(true, false)]
@@ -392,13 +390,12 @@ public class TelemetryBindingElementForTcpTests : IDisposable
     private ServiceHost CreateServiceHost(NetTcpBinding binding, X509Certificate2? cert)
     {
         ServiceHost? serviceHost = null;
-        var random = new Random();
         var retryCount = WcfTestHelpers.MaxRetries;
         while (retryCount > 0)
         {
             try
             {
-                var baseUri = new Uri($"net.tcp://localhost:{random.Next(WcfTestHelpers.MinPort, WcfTestHelpers.MaxPort)}/");
+                var baseUri = WcfTestHelpers.GetRandomBaseUri("net.tcp");
                 serviceHost = new ServiceHost(new Service(), baseUri);
                 if (cert != null)
                 {

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryPropagationTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryPropagationTests.netfx.cs
@@ -90,7 +90,6 @@ public class TelemetryPropagationTests
 
         public ServiceHostContext()
         {
-            var random = new Random();
             var attempts = 0;
             var retryCount = WcfTestHelpers.MaxRetries;
             ServiceHost? createdHost = null;
@@ -100,8 +99,8 @@ public class TelemetryPropagationTests
 
                 try
                 {
-                    this.serviceBaseUriTcp = new Uri($"net.tcp://localhost:{random.Next(WcfTestHelpers.MinPort, WcfTestHelpers.MaxPort)}/");
-                    this.serviceBaseUriHttp = new Uri($"http://localhost:{random.Next(WcfTestHelpers.MinPort, WcfTestHelpers.MaxPort)}/");
+                    this.serviceBaseUriTcp = WcfTestHelpers.GetRandomBaseUri("net.tcp");
+                    this.serviceBaseUriHttp = WcfTestHelpers.GetRandomBaseUri(Uri.UriSchemeHttp);
                     createdHost = new ServiceHost(new Service(), this.serviceBaseUriTcp, this.serviceBaseUriHttp);
                     var tcpEndpoint = createdHost.AddServiceEndpoint(typeof(IServiceContract), new NetTcpBinding(), "/tcp");
                     tcpEndpoint.Behaviors.Add(new TelemetryEndpointBehavior());

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/WcfTestHelpers.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/WcfTestHelpers.cs
@@ -12,9 +12,30 @@ namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 /// </summary>
 internal static class WcfTestHelpers
 {
-    internal const int MinPort = 2000;
-    internal const int MaxPort = 5000;
     internal const int MaxRetries = 5;
+
+    private static readonly Random Random =
+#if NET
+        Random.Shared;
+#else
+        new();
+#endif
+
+    public static Uri GetRandomBaseUri(string scheme)
+    {
+        const int MinPort = 2000;
+        const int MaxPort = 5000;
+
+        var port = Random.Next(MinPort, MaxPort);
+
+        return new UriBuilder()
+        {
+            Scheme = scheme,
+            Host = "localhost",
+            Port = port,
+            Path = "/",
+        }.Uri;
+    }
 
     /// <summary>
     /// Asserts common activity properties for outgoing request instrumentation tests.


### PR DESCRIPTION
## Changes

Add helper method to remove duplication for allocating a random port for test services' base address.

Spotted when looking at the diff for #3887.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
