### PR TITLE
[infra] Add sleep to prevent race condition on PR unlock

### DIFF
--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -202,6 +202,9 @@ function CreateReleaseTagAndPostNoticeOnPullRequest {
 
   gh pr unlock $pullRequestNumber
 
+  # Avoid race condition between the PR being unlocked and being able to post a comment
+  sleep 10
+
   $body =
 @"
 I just pushed the [$tag](https://github.com/$gitRepository/releases/tag/$tag) tag.


### PR DESCRIPTION
## Changes

Added sleep to avoid race condition when unlocking PR.

The release workflow for #3915 failed with [this error](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/22669313318/job/65709007627#step:4:20):

```
GraphQL: Unable to create comment because issue is locked (addComment)
```

However, it did unlock:

https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3915#event-23259358714

I guess there's an eventual-consistency/race-condition in the GitHub backend that can cause it to fail.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
