### PR TITLE
[Redis] Target latest in tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
+    <PackageReference Include="StackExchange.Redis" VersionOverride="2.12.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Relates to #4019.

## Changes

Update the Redis tests to use the latest version of StackExchange.Redis.

While working on #4019, I hit a NullReferenceException in the debugger (https://github.com/StackExchange/StackExchange.Redis/issues/2576) which was fixed over two years ago.

Having this package reference updated will also give us notifications via renovate of new versions as well as helping validate against them.

For example, I discovered they [shipped a preview of a new v3 version yesterday](https://www.nuget.org/packages/StackExchange.Redis/3.0.2-preview).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
