### PR TITLE
[Resources.Aws] Get ECS container ID on Windows

### DIFF
--- a/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
@@ -108,6 +108,16 @@ internal sealed partial class AWSECSDetector : IResourceDetector
         using var containerResponse = JsonDocument.Parse(metadataV4ContainerResponse);
         using var taskResponse = JsonDocument.Parse(metadataV4TaskResponse);
 
+        // On Linux the container ID is obtained from a file which does not exist on Windows.
+        // The ECS Metadata V4 container endpoint always carries the same ID in the "DockerId" field.
+        // See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-response.html.
+        if (OperatingSystem.IsWindows() &&
+            containerResponse.RootElement.TryGetProperty("DockerId", out var dockerIdElement) &&
+            dockerIdElement.GetString() is string { Length: > 0 } dockerId)
+        {
+            resourceAttributes.AddAttributeContainerId(dockerId);
+        }
+
         if (!containerResponse.RootElement.TryGetProperty("ContainerARN", out var containerArnElement)
             || containerArnElement.GetString() is not string containerArn)
         {

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * Extract `container.id` from the ECS Metadata V4 `DockerId` field for
   Windows containers running on AWS ECS.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4028](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4028))
 
 ## 1.15.0
 

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Updated OpenTelemetry core component version(s) to `1.15.1`.
   ([#4020](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4020))
 
+* Extract `container.id` from the ECS Metadata V4 `DockerId` field for
+  Windows containers running on AWS ECS.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.0
 
 Released 2026-Jan-21

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
@@ -36,9 +36,7 @@ public class AWSECSDetectorTests
 
     [Fact]
     public void TestGetECSContainerId()
-    {
-        Assert.Equal("a4d00c9dd675d67f866c786181419e1b44832d4696780152e61afd44a3e02856", AWSECSDetector.GetECSContainerId(AWSECSMetadataFilePath));
-    }
+        => Assert.Equal("a4d00c9dd675d67f866c786181419e1b44832d4696780152e61afd44a3e02856", AWSECSDetector.GetECSContainerId(AWSECSMetadataFilePath));
 
     [Fact]
     public void TestEcsMetadataV3()
@@ -89,6 +87,11 @@ public class AWSECSDetectorTests
                 Assert.NotStrictEqual(resourceAttributes[ExpectedSemanticConventions.AttributeLogStreamNames], new string[] { "ecs/curl/8f03e41243824aea923aca126495f665" });
                 Assert.NotStrictEqual(resourceAttributes[ExpectedSemanticConventions.AttributeLogStreamArns], new string[] { "arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:log-stream:ecs/curl/8f03e41243824aea923aca126495f665" });
 #pragma warning restore CA1861 // Avoid constant arrays as arguments
+
+                if (OperatingSystem.IsWindows())
+                {
+                    Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeContainerId], "ea32192c8553fbff06c9340478a2ff089b2bb5646fb718b4ee206641c9086d66");
+                }
             }
         }
     }
@@ -126,6 +129,11 @@ public class AWSECSDetectorTests
                 Assert.NotStrictEqual(resourceAttributes[ExpectedSemanticConventions.AttributeLogStreamNames], new string[] { "ecs/curl/cd189a933e5849daa93386466019ab50" });
                 Assert.NotStrictEqual(resourceAttributes[ExpectedSemanticConventions.AttributeLogStreamArns], new string[] { "arn:aws:logs:us-west-2:111122223333:log-group:/ecs/containerlogs:log-stream:ecs/curl/cd189a933e5849daa93386466019ab50" });
 #pragma warning restore CA1861 // Avoid constant arrays as arguments
+
+                if (OperatingSystem.IsWindows())
+                {
+                    Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeContainerId], "cd189a933e5849daa93386466019ab50-2495160603");
+                }
             }
         }
     }
@@ -187,6 +195,7 @@ public class AWSECSDetectorTests
         public const string AttributeCloudAvailabilityZone = "cloud.availability_zone";
         public const string AttributeCloudRegion = "cloud.region";
         public const string AttributeCloudResourceId = "cloud.resource_id";
+        public const string AttributeContainerId = "container.id";
         public const string AttributeEcsContainerArn = "aws.ecs.container.arn";
         public const string AttributeEcsLaunchtype = "aws.ecs.launchtype";
         public const string AttributeEcsTaskArn = "aws.ecs.task.arn";


### PR DESCRIPTION
Fixes #750

## Changes

Detect container ID for Windows ECS containers.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
