### PR TITLE
[AWS] Update semantic conventions for v1.40.0

### DIFF
--- a/opentelemetry-dotnet-contrib.slnx
+++ b/opentelemetry-dotnet-contrib.slnx
@@ -222,6 +222,7 @@
     <File Path="src/Shared/AWS/AWSSemanticConventions.Legacy.cs" />
     <File Path="src/Shared/AWS/AWSSemanticConventions.v1.28.0.cs" />
     <File Path="src/Shared/AWS/AWSSemanticConventions.v1.29.0.cs" />
+    <File Path="src/Shared/AWS/AWSSemanticConventions.v1.40.0.cs" />
     <File Path="src/Shared/AWS/SemanticConventionVersion.cs" />
   </Folder>
   <Folder Name="/src/Shared/Configuration/">

--- a/src/OpenTelemetry.Instrumentation.AWS/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWS/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion.V1_40_0 = 3 -> OpenTelemetry.Instrumentation.AWS.SemanticConventionVersion

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -8,6 +8,18 @@
 * Pass AWS attribute values to created meters as tags.
   ([#4063](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4063))
 
+* Capture SNS `TopicArn` as the `aws.sns.topic.arn` span attribute.
+  ([#4043](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4043))
+
+* Add `cloud.region` attribute to all AWS SDK client spans.
+  ([#4043](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4043))
+
+* Add messaging attributes for AWS SNS and SQS.
+  ([#4043](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4043))
+
+* BREAKING: Update latest AWS Semantic Conventions to 1.40.0.
+  ([#4043](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4043))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
@@ -14,6 +14,7 @@ internal class AWSServiceHelper
             semanticConventions
                 .ParameterMappingBuilder
                 .AddAttributeAWSDynamoTableName("TableName")
+                .AddAttributeAWSSNSTopicArn("TopicArn")
                 .AddAttributeAWSSQSQueueUrl("QueueUrl")
                 .AddAttributeGenAiModelId("ModelId")
                 .AddAttributeAWSBedrockAgentId("AgentId")
@@ -22,25 +23,45 @@ internal class AWSServiceHelper
                 .AddAttributeAWSBedrockKnowledgeBaseId("KnowledgeBaseId")
                 .AddAttributeAWSS3BucketName("BucketName")
                 .AddAttributeAWSS3Key("Key")
+                .AddAttributeMessageId("MessageId")
                 .Build();
 
         this.ArrayValueAttributeNames = new(semanticConventions.GetArrayValueAttributeNames(), StringComparer.Ordinal);
     }
 
-    internal static IReadOnlyDictionary<string, List<string>> ServiceRequestParameterMap { get; } = new Dictionary<string, List<string>>()
+    internal static IReadOnlyDictionary<string, List<string>> ServiceRequestParameterMap { get; } = new Dictionary<string, List<string>>(7)
     {
         { AWSServiceType.DynamoDbService, ["TableName"] },
         { AWSServiceType.S3Service, ["BucketName", "Key"] },
+        { AWSServiceType.SNSService, ["TopicArn"] },
         { AWSServiceType.SQSService, ["QueueUrl"] },
         { AWSServiceType.BedrockAgentService, ["AgentId", "KnowledgeBaseId", "DataSourceId"] },
         { AWSServiceType.BedrockAgentRuntimeService, ["AgentId", "KnowledgeBaseId"] },
         { AWSServiceType.BedrockRuntimeService, ["ModelId"] },
     };
 
-    internal static IReadOnlyDictionary<string, List<string>> ServiceResponseParameterMap { get; } = new Dictionary<string, List<string>>()
+    internal static IReadOnlyDictionary<string, List<string>> ServiceResponseParameterMap { get; } = new Dictionary<string, List<string>>(4)
     {
         { AWSServiceType.BedrockService, ["GuardrailId"] },
         { AWSServiceType.BedrockAgentService, ["AgentId", "DataSourceId"] },
+        { AWSServiceType.SNSService, ["MessageId", "TopicArn"] },
+        { AWSServiceType.SQSService, ["MessageId", "QueueUrl"] },
+    };
+
+    internal static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> MessagingOperationTypeMap { get; } = new Dictionary<string, IReadOnlyDictionary<string, string>>(2)
+    {
+        // See https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/registry/attributes/messaging.md#messaging-operation-type
+        [AWSServiceType.SNSService] = new Dictionary<string, string>(2)
+        {
+            ["Publish"] = "send",
+            ["PublishBatch"] = "send",
+        },
+        [AWSServiceType.SQSService] = new Dictionary<string, string>(3)
+        {
+            ["ReceiveMessage"] = "receive",
+            ["SendMessage"] = "send",
+            ["SendMessageBatch"] = "send",
+        },
     };
 
     // for Bedrock Agent operations, we map each supported operation to one resource: Agent, DataSource, or KnowledgeBase

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using Amazon.Runtime.Telemetry;
+using Amazon.Util;
 using OpenTelemetry.AWS;
 using OpenTelemetry.Context.Propagation;
 
@@ -72,6 +73,11 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
     {
         var service = executionContext.RequestContext.ServiceMetaData.ServiceId;
         var responseContext = executionContext.ResponseContext;
+
+        if (responseContext.HttpResponse.IsHeaderPresent(HeaderKeys.XAmzId2Header))
+        {
+            this.awsSemanticConventions.TagBuilder.SetTagAttributeAWSExtendedRequestId(activity, responseContext.HttpResponse.GetHeaderValue(HeaderKeys.XAmzId2Header));
+        }
 
         if (AWSServiceHelper.ServiceResponseParameterMap.TryGetValue(service, out var parameters))
         {
@@ -195,6 +201,88 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
         else if (AWSServiceType.IsBedrockRuntimeService(service))
         {
             this.awsSemanticConventions.TagBuilder.SetTagAttributeGenAiSystemToBedrock(activity);
+        }
+        else if (AWSServiceType.IsSnsService(service))
+        {
+            // See https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/messaging/sns.md
+            this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingSystemToSns(activity);
+
+            var topicArn = activity.GetTagItem("aws.sns.topic.arn");
+
+            if (topicArn is string arn && TryGetLastSplitItem(arn, ':', out var topicName))
+            {
+                this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingDestinationName(activity, topicName!);
+            }
+
+            var operationName = AWSServiceHelper.GetAWSOperationName(requestContext);
+            this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingOperationName(activity, operationName);
+
+            if (AWSServiceHelper.MessagingOperationTypeMap.TryGetValue(AWSServiceType.SNSService, out var map) &&
+                map.TryGetValue(operationName, out var operationType))
+            {
+                this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingOperationType(activity, operationType);
+            }
+        }
+        else if (AWSServiceType.IsSqsService(service))
+        {
+            // See https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/messaging/sqs.md
+            this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingSystemToSqs(activity);
+
+            var queueUrl = activity.GetTagItem("aws.sqs.queue.url");
+
+            if (queueUrl is string url && Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                activity.SetTag("server.address", uri.Host);
+
+                if (uri.GetLeftPart(UriPartial.Path) is { Length: > 0 } path && TryGetLastSplitItem(path, '/', out var queueName))
+                {
+                    this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingDestinationName(activity, queueName!);
+                }
+            }
+
+            var operationName = AWSServiceHelper.GetAWSOperationName(requestContext);
+            this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingOperationName(activity, operationName);
+
+            if (AWSServiceHelper.MessagingOperationTypeMap.TryGetValue(AWSServiceType.SQSService, out var map) &&
+                map.TryGetValue(operationName, out var operationType))
+            {
+                this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingOperationType(activity, operationType);
+            }
+        }
+
+        var region = requestContext.ClientConfig?.RegionEndpoint?.SystemName;
+        if (!string.IsNullOrEmpty(region))
+        {
+            this.awsSemanticConventions.TagBuilder.SetTagAttributeCloudRegion(activity, region);
+        }
+
+        this.awsSemanticConventions.TagBuilder.SetTagAttributeRpcSystemName(activity);
+
+        static bool TryGetLastSplitItem(
+            string value,
+            char delimiter,
+#if NET
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+#endif
+            out string? lastItem)
+        {
+            lastItem = null;
+            bool result = false;
+
+            int index = value.LastIndexOf(delimiter);
+
+            if (index > -1 && index < value.Length - 1)
+            {
+#if NET
+                lastItem = value[(index + 1)..];
+#else
+                lastItem = value.Substring(index + 1);
+#endif
+
+                result = true;
+            }
+
+            return result;
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion.V1_40_0 = 3 -> OpenTelemetry.Instrumentation.AWSLambda.SemanticConventionVersion

--- a/src/OpenTelemetry.Resources.AWS/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Resources.AWS/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.Resources.AWS.SemanticConventionVersion.V1_40_0 = 3 -> OpenTelemetry.Resources.AWS.SemanticConventionVersion

--- a/src/Shared/AWS/AWSSemanticConventions.Base.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.Base.cs
@@ -312,9 +312,26 @@ internal partial class AWSSemanticConventions
         public virtual IReadOnlyCollection<string> ArrayValueAttributeNames { get; } = [];
 
         /// <summary>
-        /// Not yet incorporated in Semantic Conventions repository.
+        /// The messaging system as identified by the client instrumentation for AWS SQS.
+        /// </summary>
+        public virtual string AttributeAWSSQS => string.Empty;
+
+        /// <summary>
+        /// The URL of the AWS SQS Queue. It's a unique identifier for a queue in
+        /// Amazon Simple Queue Service (SQS) and is used to access the queue and perform actions on it.
         /// </summary>
         public virtual string AttributeAWSSQSQueueUrl => string.Empty;
+
+        /// <summary>
+        /// The messaging system as identified by the client instrumentation for AWS SNS.
+        /// </summary>
+        public virtual string AttributeAWSSNS => string.Empty;
+
+        /// <summary>
+        /// The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical
+        /// access point that acts as a communication channel.
+        /// </summary>
+        public virtual string AttributeAWSSNSTopicArn => string.Empty;
 
         /// <summary>
         /// Not yet incorporated in Semantic Conventions repository.
@@ -350,6 +367,11 @@ internal partial class AWSSemanticConventions
         /// The name of the S3 key the request targets.
         /// </summary>
         public virtual string AttributeAWSS3Key => string.Empty;
+
+        /// <summary>
+        /// The AWS extended request ID as returned in the response header <c>x-amz-id-2</c>.
+        /// </summary>
+        public virtual string AttributeAWSExtendedRequestId => string.Empty;
 
         #endregion
 
@@ -604,6 +626,35 @@ internal partial class AWSSemanticConventions
 
         #endregion
 
+        #region MESSAGING Attributes
+
+        /// <summary>
+        /// The message destination name.
+        /// </summary>
+        public virtual string AttributeMessagingDestinationName => string.Empty;
+
+        /// <summary>
+        /// A value used by the messaging system as an identifier for the message, represented as a string.
+        /// </summary>
+        public virtual string AttributeMessagingMessageId => string.Empty;
+
+        /// <summary>
+        /// The system-specific name of the messaging operation.
+        /// </summary>
+        public virtual string AttributeMessagingOperationName => string.Empty;
+
+        /// <summary>
+        /// A string identifying the type of the messaging operation.
+        /// </summary>
+        public virtual string AttributeMessagingOperationType => string.Empty;
+
+        /// <summary>
+        /// The messaging system as identified by the client instrumentation.
+        /// </summary>
+        public virtual string AttributeMessagingSystem => string.Empty;
+
+        #endregion
+
         #region NET Attributes
 
         /// <summary>
@@ -623,6 +674,25 @@ internal partial class AWSSemanticConventions
         /// </remarks>
         [Obsolete("Replaced by <c>server.port</c>.")]
         public virtual string AttributeNetHostPort => string.Empty;
+
+        #endregion
+
+        #region SERVER Attributes
+
+        /// <summary>
+        /// The name of the operation corresponding to the request, as returned by the AWS SDK.
+        /// </summary>
+        public virtual string AttributeRpcService => string.Empty;
+
+        /// <summary>
+        /// The Remote Procedure Call (RPC) system.
+        /// </summary>
+        public virtual string AttributeRpcSystemName => string.Empty;
+
+        /// <summary>
+        /// The Remote Procedure Call (RPC) system value for AWS.
+        /// </summary>
+        public virtual string AttributeRpcSystemNameValue => string.Empty;
 
         #endregion
 

--- a/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
@@ -27,7 +27,6 @@ internal partial class AWSSemanticConventions
         public override string AttributeCloudAvailabilityZone => "cloud.availability_zone";
         public override string AttributeCloudPlatform => "cloud.platform";
         public override string AttributeCloudProvider => "cloud.provider";
-        public override string AttributeCloudRegion => "cloud.region";
         public override string AttributeCloudResourceId => "cloud.resource_id";
         public override string CloudPlatformValuesAwsEc2 => "aws_ec2";
         public override string CloudPlatformValuesAwsEcs => "aws_ecs";
@@ -102,6 +101,11 @@ internal partial class AWSSemanticConventions
 
         // K8s Attributes
         public override string AttributeK8SClusterName => "k8s.cluster.name";
+
+        // RPC Attributes
+        public override string AttributeRpcService => "rpc.service";
+        public override string AttributeRpcSystemName => "rpc.system";
+        public override string AttributeRpcSystemNameValue => "aws-api";
 
         // SERVICE Attributes
         public override string AttributeServiceName => "service.name";

--- a/src/Shared/AWS/AWSSemanticConventions.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.cs
@@ -501,7 +501,8 @@ internal partial class AWSSemanticConventions
 
     internal static Version GetVersion(SemanticConventionVersion semanticConventionVersion) => semanticConventionVersion switch
     {
-        SemanticConventionVersion.Latest or SemanticConventionVersion.V1_29_0 => new(1, 29, 0),
+        SemanticConventionVersion.Latest or SemanticConventionVersion.V1_40_0 => new(1, 40, 0),
+        SemanticConventionVersion.V1_29_0 => new(1, 29, 0),
         SemanticConventionVersion.V1_28_0 => new(1, 28, 0),
         _ => throw new InvalidEnumArgumentException(nameof(semanticConventionVersion), (int)semanticConventionVersion, typeof(SemanticConventionVersion)),
     };

--- a/src/Shared/AWS/AWSSemanticConventions.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.cs
@@ -136,6 +136,10 @@ internal partial class AWSSemanticConventions
         public ParameterMappingBuilderImpl AddAttributeAWSSQSQueueUrl(string value)
             => this.awsSemanticConventions.AddDic(this, x => x.AttributeAWSSQSQueueUrl, value);
 
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeAWSSNSTopicArn"/>
+        public ParameterMappingBuilderImpl AddAttributeAWSSNSTopicArn(string value)
+            => this.awsSemanticConventions.AddDic(this, x => x.AttributeAWSSNSTopicArn, value);
+
         /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeGenAiModelId"/>
         public ParameterMappingBuilderImpl AddAttributeGenAiModelId(string value)
             => this.awsSemanticConventions.AddDic(this, x => x.AttributeGenAiModelId, value);
@@ -163,6 +167,10 @@ internal partial class AWSSemanticConventions
         /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeAWSS3Key"/>
         public ParameterMappingBuilderImpl AddAttributeAWSS3Key(string value)
             => this.awsSemanticConventions.AddDic(this, x => x.AttributeAWSS3Key, value);
+
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeMessagingMessageId"/>
+        public ParameterMappingBuilderImpl AddAttributeMessageId(string value)
+            => this.awsSemanticConventions.AddDic(this, x => x.AttributeMessagingMessageId, value);
         #endregion
     }
 
@@ -439,6 +447,22 @@ internal partial class AWSSemanticConventions
         /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeGenAiSystem"/>
         public Activity? SetTagAttributeGenAiSystemToBedrock(Activity? activity)
             => this.awsSemanticConventions.SetTag(activity, x => x.AttributeGenAiSystem, x => x.AttributeAWSBedrock);
+
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeCloudRegion"/>
+        public Activity? SetTagAttributeCloudRegion(Activity? activity, object? value)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeCloudRegion, value);
+
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeAWSExtendedRequestId"/>
+        public Activity? SetTagAttributeAWSExtendedRequestId(Activity? activity, object? value)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeAWSExtendedRequestId, value);
+
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeGenAiSystem"/>
+        public Activity? SetTagAttributeMessagingSystemToSns(Activity? activity)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeMessagingSystem, x => x.AttributeAWSSNS);
+
+        /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeGenAiSystem"/>
+        public Activity? SetTagAttributeMessagingSystemToSqs(Activity? activity)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeMessagingSystem, x => x.AttributeAWSSQS);
         #endregion
 
         #region Http
@@ -451,6 +475,27 @@ internal partial class AWSSemanticConventions
         /// <inheritdoc cref="AWSSemanticConventionsBase.AttributeHttpResponseStatusCode"/>
         public Activity? SetTagAttributeHttpResponseStatusCode(Activity? activity, int value)
             => this.awsSemanticConventions.SetTag(activity, x => x.AttributeHttpResponseStatusCode, value);
+        #endregion
+
+        #region Messaging
+
+        public Activity? SetTagAttributeMessagingDestinationName(Activity? activity, string value)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeMessagingDestinationName, value);
+
+        public Activity? SetTagAttributeMessagingMessageId(Activity? activity, string value)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeMessagingMessageId, value);
+
+        public Activity? SetTagAttributeMessagingOperationName(Activity? activity, string value)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeMessagingOperationName, value);
+
+        public Activity? SetTagAttributeMessagingOperationType(Activity? activity, string value)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeMessagingOperationType, value);
+
+        #endregion
+
+        #region RPC
+        public Activity? SetTagAttributeRpcSystemName(Activity? activity)
+            => this.awsSemanticConventions.SetTag(activity, x => x.AttributeRpcSystemName, x => x.AttributeRpcSystemNameValue);
         #endregion
     }
 
@@ -518,7 +563,8 @@ internal partial class AWSSemanticConventions
 
     private AWSSemanticConventions_V1_28_0 GetSemanticConventionVersion() => this.semanticConventionVersion switch
     {
-        SemanticConventionVersion.Latest or SemanticConventionVersion.V1_29_0 => new AWSSemanticConventions_V1_29_0(),
+        SemanticConventionVersion.Latest or SemanticConventionVersion.V1_40_0 => new AWSSemanticConventions_V1_40_0(),
+        SemanticConventionVersion.V1_29_0 => new AWSSemanticConventions_V1_29_0(),
         SemanticConventionVersion.V1_28_0 => new AWSSemanticConventions_V1_28_0(),
         _ => throw new InvalidEnumArgumentException(
                 argumentName: nameof(SemanticConventionVersion),

--- a/src/Shared/AWS/AWSSemanticConventions.v1.28.0.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.v1.28.0.cs
@@ -21,7 +21,20 @@ internal partial class AWSSemanticConventions
         public override string AttributeAWSDynamoTableName => "aws.dynamodb.table_names";
 
         // aws.dynamodb.table_names is specified as string[] in the OTel semantic conventions
-        public override IReadOnlyCollection<string> ArrayValueAttributeNames { get; } = ["aws.dynamodb.table_names"];
+        public override IReadOnlyCollection<string> ArrayValueAttributeNames { get; } =
+        [
+            "aws.dynamodb.attribute_definitions",
+            "aws.dynamodb.attributes_to_get",
+            "aws.dynamodb.consumed_capacity",
+            "aws.dynamodb.global_secondary_index_updates",
+            "aws.dynamodb.global_secondary_indexes",
+            "aws.dynamodb.local_secondary_indexes",
+            "aws.dynamodb.table_names",
+            "aws.log.group.arns",
+            "aws.log.group.names",
+            "aws.log.stream.arns",
+            "aws.log.stream.names",
+        ];
 
         // FAAS Attributes
         public override string AttributeFaasID => "cloud.resource_id";

--- a/src/Shared/AWS/AWSSemanticConventions.v1.40.0.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.v1.40.0.cs
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.AWS;
+
+// disable Style Warnings to improve readability of this specific file.
+#pragma warning disable SA1124
+#pragma warning disable SA1005
+#pragma warning disable SA1514
+#pragma warning disable SA1201
+#pragma warning disable SA1516
+
+internal partial class AWSSemanticConventions
+{
+    /// <summary>
+    /// Open Telemetry Semantic Conventions as of 1.40.0:
+    /// https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.40.0.
+    /// </summary>
+    private class AWSSemanticConventions_V1_40_0 : AWSSemanticConventions_V1_29_0
+    {
+        // CLOUD Attributes
+        public override string AttributeCloudRegion => "cloud.region";
+
+        // AWS Attributes
+        public override string AttributeAWSExtendedRequestId => "aws.extended_request_id";
+        public override string AttributeAWSSNS => "aws.sns";
+        public override string AttributeAWSSNSTopicArn => "aws.sns.topic.arn";
+        public override string AttributeAWSSQS => "aws_sqs";
+        public override string AttributeAWSSQSQueueUrl => "aws.sqs.queue.url";
+
+        // MESSAGING Attributes
+        public override string AttributeMessagingDestinationName => "messaging.destination.name";
+        public override string AttributeMessagingMessageId => "messaging.message.id";
+        public override string AttributeMessagingOperationName => "messaging.operation.name";
+        public override string AttributeMessagingOperationType => "messaging.operation.type";
+        public override string AttributeMessagingSystem => "messaging.system";
+
+        // RPC Attributes
+        public override string AttributeRpcService => "rpc.method";
+        public override string AttributeRpcSystemName => "rpc.system.name";
+    }
+}

--- a/src/Shared/AWS/SemanticConventionVersion.cs
+++ b/src/Shared/AWS/SemanticConventionVersion.cs
@@ -90,4 +90,13 @@ public enum SemanticConventionVersion
     /// This version contains conventions marked Experimental and may change in future versions.
     /// </summary>
     V1_29_0 = 2,
+
+    /// <summary>
+    /// Pin to the specific state of all Semantic Conventions as of the 1.40.0
+    /// release. See:
+    /// https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.40.0.
+    /// <para />
+    /// This version contains conventions marked Experimental and may change in future versions.
+    /// </summary>
+    V1_40_0 = 3,
 }

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/AWSClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/AWSClientInstrumentationOptionsTests.cs
@@ -79,6 +79,7 @@ public sealed class AWSClientInstrumentationOptionsTests
 
         using var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         try
         {
@@ -91,7 +92,7 @@ public sealed class AWSClientInstrumentationOptionsTests
             {
                 var client = new AmazonBedrockRuntimeClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
                 var dummyResponse = "{}";
-                CustomResponses.SetResponse(client, dummyResponse, requestId, true);
+                CustomResponses.SetResponse(client, dummyResponse, requestId, extendedRequestId, true);
                 var invokeModelRequest = new InvokeModelRequest { ModelId = "amazon.titan-text-express-v1" };
 
 #if NETFRAMEWORK

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -14,6 +14,7 @@ using Amazon.BedrockRuntime.Model;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using OpenTelemetry.Instrumentation.AWS.Tests.Tools;
@@ -37,6 +38,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .SetSampler(new AlwaysOnSampler())
@@ -49,7 +51,7 @@ public class TestAWSClientInstrumentation
                    .Build())
         {
             var ddb = new AmazonDynamoDBClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
-            CustomResponses.SetResponse(ddb, "{}", requestId, true);
+            CustomResponses.SetResponse(ddb, "{}", requestId, extendedRequestId, true);
             var scan_request = new ScanRequest
             {
                 TableName = "SampleProduct",
@@ -85,6 +87,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .SetSampler(new AlwaysOnSampler())
@@ -97,7 +100,7 @@ public class TestAWSClientInstrumentation
                    .Build())
         {
             var ddb = new TestAmazonDynamoDBClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
-            CustomResponses.SetResponse(ddb, "{}", requestId, true);
+            CustomResponses.SetResponse(ddb, "{}", requestId, extendedRequestId, true);
             var scan_request = new ScanRequest
             {
                 TableName = "SampleProduct",
@@ -120,6 +123,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -196,6 +200,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         SendMessageRequest send_msg_req;
 
@@ -210,8 +215,13 @@ public class TestAWSClientInstrumentation
                    .Build())
         {
             var sqs = new AmazonSQSClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
-            var dummyResponse = "{}";
-            CustomResponses.SetResponse(sqs, dummyResponse, requestId, true);
+            var dummyResponse =
+                """
+                {
+                  "MessageId": "567910cd-659e-55d4-bc19-f29d9g3b2378"
+                }
+                """;
+            CustomResponses.SetResponse(sqs, dummyResponse, requestId, extendedRequestId, true);
             send_msg_req = new SendMessageRequest
             {
                 QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue",
@@ -235,6 +245,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
 
         Assert.Equal(2, send_msg_req.MessageAttributes.Count);
         Assert.Contains(
@@ -256,6 +267,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         SendMessageRequest send_msg_req;
 
@@ -270,8 +282,13 @@ public class TestAWSClientInstrumentation
                    .Build())
         {
             var sqs = new AmazonSQSClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
-            var dummyResponse = "{}";
-            CustomResponses.SetResponse(sqs, dummyResponse, requestId, true);
+            var dummyResponse =
+                """
+                {
+                  "MessageId": "567910cd-659e-55d4-bc19-f29d9g3b2378"
+                }
+                """;
+            CustomResponses.SetResponse(sqs, dummyResponse, requestId, extendedRequestId, true);
             send_msg_req = new SendMessageRequest
             {
                 QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue",
@@ -299,6 +316,62 @@ public class TestAWSClientInstrumentation
 
     [Fact]
 #if NETFRAMEWORK
+    public void TestSNSPublishSuccessful()
+#else
+    public async Task TestSNSPublishSuccessful()
+#endif
+    {
+        var exportedItems = new List<Activity>();
+
+        var parent = new Activity("parent").Start();
+        var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
+
+        using (Sdk.CreateTracerProviderBuilder()
+                  .AddXRayTraceId()
+                  .SetSampler(new AlwaysOnSampler())
+                  .AddAWSInstrumentation(o => o.SemanticConventionVersion = SemanticConventionVersion.Latest)
+                  .AddInMemoryExporter(exportedItems)
+                  .Build())
+        {
+            var sns = new AmazonSimpleNotificationServiceClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
+            var dummyResponse = """
+                <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
+                  <PublishResult>
+                    <MessageId>567910cd-659e-55d4-bc19-f29d9g3b2378</MessageId>
+                  </PublishResult>
+                  <ResponseMetadata>
+                    <RequestId>fakerequ-esti-dfak-ereq-uestidfakere</RequestId>
+                  </ResponseMetadata>
+                </PublishResponse>
+                """;
+            CustomResponses.SetResponse(sns, dummyResponse, requestId, extendedRequestId, true);
+            var publishRequest = new Amazon.SimpleNotificationService.Model.PublishRequest
+            {
+                TopicArn = "arn:aws:sns:us-east-1:123456789:MyTestTopic",
+                Message = "Hello from OT",
+            };
+#if NETFRAMEWORK
+            sns.Publish(publishRequest);
+#else
+            await sns.PublishAsync(publishRequest);
+#endif
+        }
+
+        Assert.NotEmpty(exportedItems);
+
+        var activity = exportedItems.FirstOrDefault(e => e.DisplayName == "SNS.Publish");
+        Assert.NotNull(activity);
+
+        this.ValidateAWSActivity(activity, parent);
+        this.ValidateSnsActivityTags(activity);
+
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+        Assert.Equal(requestId, Utils.GetTagValue(activity, "aws.request_id"));
+    }
+
+    [Fact]
+#if NETFRAMEWORK
     public void TestBedrockGetGuardrailSuccessful()
 #else
     public async Task TestBedrockGetGuardrailSuccessful()
@@ -308,6 +381,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .AddXRayTraceId()
@@ -321,7 +395,7 @@ public class TestAWSClientInstrumentation
         {
             var bedrock = new AmazonBedrockClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{\"GuardrailId\":\"123456789\"}";
-            CustomResponses.SetResponse(bedrock, dummyResponse, requestId, true);
+            CustomResponses.SetResponse(bedrock, dummyResponse, requestId, extendedRequestId, true);
             var getGuardrailRequest = new GetGuardrailRequest { GuardrailIdentifier = "123456789" };
 #if NETFRAMEWORK
             bedrock.GetGuardrail(getGuardrailRequest);
@@ -339,6 +413,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -352,6 +427,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .AddXRayTraceId()
@@ -365,7 +441,7 @@ public class TestAWSClientInstrumentation
         {
             var bedrockruntime = new AmazonBedrockRuntimeClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{}";
-            CustomResponses.SetResponse(bedrockruntime, dummyResponse, requestId, true);
+            CustomResponses.SetResponse(bedrockruntime, dummyResponse, requestId, extendedRequestId, true);
             var invokeModelRequest = new InvokeModelRequest { ModelId = "amazon.titan-text-express-v1" };
 #if NETFRAMEWORK
             var response = bedrockruntime.InvokeModel(invokeModelRequest);
@@ -383,6 +459,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -396,6 +473,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .AddXRayTraceId()
@@ -409,7 +487,7 @@ public class TestAWSClientInstrumentation
         {
             var bedrockagent = new AmazonBedrockAgentClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{}";
-            CustomResponses.SetResponse(bedrockagent, dummyResponse, requestId, true);
+            CustomResponses.SetResponse(bedrockagent, dummyResponse, requestId, extendedRequestId, true);
             var getAgentRequest = new GetAgentRequest { AgentId = "1234567890" };
 #if NETFRAMEWORK
             var response = bedrockagent.GetAgent(getAgentRequest);
@@ -427,6 +505,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -440,6 +519,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .AddXRayTraceId()
@@ -453,7 +533,7 @@ public class TestAWSClientInstrumentation
         {
             var bedrockagent = new AmazonBedrockAgentClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{}";
-            CustomResponses.SetResponse(bedrockagent, dummyResponse, requestId, true);
+            CustomResponses.SetResponse(bedrockagent, dummyResponse, requestId, extendedRequestId, true);
             var getKnowledgeBaseRequest = new GetKnowledgeBaseRequest { KnowledgeBaseId = "1234567890" };
 #if NETFRAMEWORK
             var response = bedrockagent.GetKnowledgeBase(getKnowledgeBaseRequest);
@@ -471,6 +551,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -484,6 +565,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .AddXRayTraceId()
@@ -497,7 +579,7 @@ public class TestAWSClientInstrumentation
         {
             var bedrockagent = new AmazonBedrockAgentClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{}";
-            CustomResponses.SetResponse(bedrockagent, dummyResponse, requestId, true);
+            CustomResponses.SetResponse(bedrockagent, dummyResponse, requestId, extendedRequestId, true);
             var getDataSourceRequest = new GetDataSourceRequest { DataSourceId = "1234567890", KnowledgeBaseId = "1234567890", };
 #if NETFRAMEWORK
             var response = bedrockagent.GetDataSource(getDataSourceRequest);
@@ -515,6 +597,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -528,6 +611,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .AddXRayTraceId()
@@ -541,7 +625,7 @@ public class TestAWSClientInstrumentation
         {
             var bedrockAgentRuntimeClient = new AmazonBedrockAgentRuntimeClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{}";
-            CustomResponses.SetResponse(bedrockAgentRuntimeClient, dummyResponse, requestId, true);
+            CustomResponses.SetResponse(bedrockAgentRuntimeClient, dummyResponse, requestId, extendedRequestId, true);
             var invokeAgentRequest = new InvokeAgentRequest
             {
                 AgentId = "123456789",
@@ -565,6 +649,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -578,6 +663,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .AddXRayTraceId()
@@ -591,7 +677,7 @@ public class TestAWSClientInstrumentation
         {
             var bedrockagentruntime = new AmazonBedrockAgentRuntimeClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{}";
-            CustomResponses.SetResponse(bedrockagentruntime, dummyResponse, requestId, true);
+            CustomResponses.SetResponse(bedrockagentruntime, dummyResponse, requestId, extendedRequestId, true);
             var retrieveRequest = new RetrieveRequest { KnowledgeBaseId = "123456789" };
 #if NETFRAMEWORK
             var response = bedrockagentruntime.Retrieve(retrieveRequest);
@@ -609,6 +695,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     [Fact]
@@ -622,6 +709,7 @@ public class TestAWSClientInstrumentation
 
         var parent = new Activity("parent").Start();
         var requestId = @"fakerequ-esti-dfak-ereq-uestidfakere";
+        var extendedRequestId = @"wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=";
 
         using (Sdk.CreateTracerProviderBuilder()
                    .SetSampler(new AlwaysOnSampler())
@@ -634,7 +722,7 @@ public class TestAWSClientInstrumentation
                    .Build())
         {
             var s3 = new Amazon.S3.AmazonS3Client(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
-            CustomResponses.SetResponse(s3, "{}", requestId, true);
+            CustomResponses.SetResponse(s3, "{}", requestId, extendedRequestId, true);
             var putRequest = new Amazon.S3.Model.PutObjectRequest
             {
                 BucketName = "my-test-bucket",
@@ -658,6 +746,7 @@ public class TestAWSClientInstrumentation
 
         Assert.Equal(ActivityStatusCode.Unset, awssdk_activity.Status);
         Assert.Equal(requestId, Utils.GetTagValue(awssdk_activity, "aws.request_id"));
+        Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
     private void ValidateAWSActivity(Activity aws_activity, Activity parent)
@@ -674,27 +763,50 @@ public class TestAWSClientInstrumentation
         Assert.Equal("DynamoDB.Scan", ddb_activity.DisplayName);
         Assert.Equal(ExpectedDynamoTableNames, Utils.GetTagValue(ddb_activity, "aws.dynamodb.table_names"));
         Assert.Equal("dynamodb", Utils.GetTagValue(ddb_activity, "db.system"));
-        Assert.Equal("aws-api", Utils.GetTagValue(ddb_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(ddb_activity, "rpc.system.name"));
         Assert.Equal("DynamoDB", Utils.GetTagValue(ddb_activity, "rpc.service"));
         Assert.Equal("Scan", Utils.GetTagValue(ddb_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(ddb_activity, "cloud.region"));
     }
 
     private void ValidateSqsActivityTags(Activity sqs_activity)
     {
         Assert.Equal("SQS.SendMessage", sqs_activity.DisplayName);
-        Assert.Equal("https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue", Utils.GetTagValue(sqs_activity, "aws.queue_url"));
-        Assert.Equal("aws-api", Utils.GetTagValue(sqs_activity, "rpc.system"));
+        Assert.Equal("https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue", Utils.GetTagValue(sqs_activity, "aws.sqs.queue.url"));
+        Assert.Equal("aws-api", Utils.GetTagValue(sqs_activity, "rpc.system.name"));
         Assert.Equal("SQS", Utils.GetTagValue(sqs_activity, "rpc.service"));
         Assert.Equal("SendMessage", Utils.GetTagValue(sqs_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(sqs_activity, "cloud.region"));
+        Assert.Equal("MyTestQueue", Utils.GetTagValue(sqs_activity, "messaging.destination.name"));
+        Assert.Equal("567910cd-659e-55d4-bc19-f29d9g3b2378", Utils.GetTagValue(sqs_activity, "messaging.message.id"));
+        Assert.Equal("SendMessage", Utils.GetTagValue(sqs_activity, "messaging.operation.name"));
+        Assert.Equal("send", Utils.GetTagValue(sqs_activity, "messaging.operation.type"));
+        Assert.Equal("sqs.us-east-1.amazonaws.com", Utils.GetTagValue(sqs_activity, "server.address"));
+        Assert.Equal("aws_sqs", Utils.GetTagValue(sqs_activity, "messaging.system"));
+    }
+
+    private void ValidateSnsActivityTags(Activity sns_activity)
+    {
+        Assert.Equal("SNS.Publish", sns_activity.DisplayName);
+        Assert.Equal("arn:aws:sns:us-east-1:123456789:MyTestTopic", Utils.GetTagValue(sns_activity, "aws.sns.topic.arn"));
+        Assert.Equal("aws-api", Utils.GetTagValue(sns_activity, "rpc.system.name"));
+        Assert.Equal("SNS", Utils.GetTagValue(sns_activity, "rpc.service"));
+        Assert.Equal("Publish", Utils.GetTagValue(sns_activity, "rpc.method"));
+        Assert.Equal("MyTestTopic", Utils.GetTagValue(sns_activity, "messaging.destination.name"));
+        Assert.Equal("567910cd-659e-55d4-bc19-f29d9g3b2378", Utils.GetTagValue(sns_activity, "messaging.message.id"));
+        Assert.Equal("Publish", Utils.GetTagValue(sns_activity, "messaging.operation.name"));
+        Assert.Equal("send", Utils.GetTagValue(sns_activity, "messaging.operation.type"));
+        Assert.Equal("aws.sns", Utils.GetTagValue(sns_activity, "messaging.system"));
     }
 
     private void ValidateBedrockActivityTags(Activity bedrock_activity)
     {
         Assert.Equal("Bedrock.GetGuardrail", bedrock_activity.DisplayName);
         Assert.Equal("123456789", Utils.GetTagValue(bedrock_activity, "aws.bedrock.guardrail.id"));
-        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system.name"));
         Assert.Equal("Bedrock", Utils.GetTagValue(bedrock_activity, "rpc.service"));
         Assert.Equal("GetGuardrail", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "cloud.region"));
     }
 
     private void ValidateBedrockRuntimeActivityTags(Activity bedrock_activity)
@@ -702,54 +814,60 @@ public class TestAWSClientInstrumentation
         Assert.Equal("Bedrock Runtime.InvokeModel", bedrock_activity.DisplayName);
         Assert.Equal("amazon.titan-text-express-v1", Utils.GetTagValue(bedrock_activity, "gen_ai.request.model"));
         Assert.Equal("aws.bedrock", Utils.GetTagValue(bedrock_activity, "gen_ai.system"));
-        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system.name"));
         Assert.Equal("Bedrock Runtime", Utils.GetTagValue(bedrock_activity, "rpc.service"));
         Assert.Equal("InvokeModel", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "cloud.region"));
     }
 
     private void ValidateBedrockAgentAgentOpsActivityTags(Activity bedrock_activity)
     {
         Assert.Equal("Bedrock Agent.GetAgent", bedrock_activity.DisplayName);
         Assert.Equal("1234567890", Utils.GetTagValue(bedrock_activity, "aws.bedrock.agent.id"));
-        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system.name"));
         Assert.Equal("Bedrock Agent", Utils.GetTagValue(bedrock_activity, "rpc.service"));
         Assert.Equal("GetAgent", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "cloud.region"));
     }
 
     private void ValidateBedrockAgentKnowledgeBaseOpsActivityTags(Activity bedrock_activity)
     {
         Assert.Equal("Bedrock Agent.GetKnowledgeBase", bedrock_activity.DisplayName);
         Assert.Equal("1234567890", Utils.GetTagValue(bedrock_activity, "aws.bedrock.knowledge_base.id"));
-        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system.name"));
         Assert.Equal("Bedrock Agent", Utils.GetTagValue(bedrock_activity, "rpc.service"));
         Assert.Equal("GetKnowledgeBase", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "cloud.region"));
     }
 
     private void ValidateBedrockAgentDataSourceOpsActivityTags(Activity bedrock_activity)
     {
         Assert.Equal("Bedrock Agent.GetDataSource", bedrock_activity.DisplayName);
         Assert.Equal("1234567890", Utils.GetTagValue(bedrock_activity, "aws.bedrock.data_source.id"));
-        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system.name"));
         Assert.Equal("Bedrock Agent", Utils.GetTagValue(bedrock_activity, "rpc.service"));
         Assert.Equal("GetDataSource", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "cloud.region"));
     }
 
     private void ValidateBedrockAgentRuntimeAgentOpsActivityTags(Activity bedrock_activity)
     {
         Assert.Equal("Bedrock Agent Runtime.InvokeAgent", bedrock_activity.DisplayName);
         Assert.Equal("123456789", Utils.GetTagValue(bedrock_activity, "aws.bedrock.agent.id"));
-        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system.name"));
         Assert.Equal("Bedrock Agent Runtime", Utils.GetTagValue(bedrock_activity, "rpc.service"));
         Assert.Equal("InvokeAgent", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "cloud.region"));
     }
 
     private void ValidateBedrockAgentRuntimeKnowledgeBaseOpsActivityTags(Activity bedrock_activity)
     {
         Assert.Equal("Bedrock Agent Runtime.Retrieve", bedrock_activity.DisplayName);
         Assert.Equal("123456789", Utils.GetTagValue(bedrock_activity, "aws.bedrock.knowledge_base.id"));
-        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system"));
+        Assert.Equal("aws-api", Utils.GetTagValue(bedrock_activity, "rpc.system.name"));
         Assert.Equal("Bedrock Agent Runtime", Utils.GetTagValue(bedrock_activity, "rpc.service"));
         Assert.Equal("Retrieve", Utils.GetTagValue(bedrock_activity, "rpc.method"));
+        Assert.Equal("us-east-1", Utils.GetTagValue(bedrock_activity, "cloud.region"));
     }
 
     private void ValidateS3ActivityTags(Activity s3_activity)

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientMetricsInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientMetricsInstrumentation.cs
@@ -34,7 +34,7 @@ public class TestAWSClientMetricsInstrumentation
                                       .Build())
         {
             var s3 = new AmazonS3Client(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
-            CustomResponses.SetResponse(s3, null, "test_request_id", true);
+            CustomResponses.SetResponse(s3, null, "test_request_id", "extended_request_id", true);
             var putObjectRequest = new PutObjectRequest
             {
                 BucketName = "TestBucket",
@@ -133,7 +133,7 @@ public class TestAWSClientMetricsInstrumentation
         {
             var sqs = new AmazonSQSClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
             var dummyResponse = "{}";
-            CustomResponses.SetResponse(sqs, dummyResponse, "requestId", true);
+            CustomResponses.SetResponse(sqs, dummyResponse, "requestId", "extended_request_id", true);
             var send_msg_req = new CreateQueueRequest()
             {
                 QueueName = "MyTestQueue",

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Tools/CustomResponses.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Tools/CustomResponses.cs
@@ -15,9 +15,9 @@ internal static class CustomResponses
 {
 #if NETFRAMEWORK
     public static void SetResponse(
-        AmazonServiceClient client, string? content, string requestId, bool isOK)
+        AmazonServiceClient client, string? content, string requestId, string extendedRequestId, bool isOK)
     {
-        var response = Create(content, requestId, isOK);
+        var response = Create(content, requestId, extendedRequestId, isOK);
         SetResponse(client, response);
     }
 
@@ -37,7 +37,10 @@ internal static class CustomResponses
     }
 
     private static Func<MockHttpRequest, HttpWebResponse?> Create(
-        string? content, string requestId, bool isOK)
+        string? content,
+        string requestId,
+        string extendedRequestId,
+        bool isOK)
     {
         var status = isOK ? HttpStatusCode.OK : HttpStatusCode.NotFound;
 
@@ -49,15 +52,20 @@ internal static class CustomResponses
                 headers.Add(HeaderKeys.RequestIdHeader, requestId);
             }
 
+            if (!string.IsNullOrEmpty(extendedRequestId))
+            {
+                headers.Add(HeaderKeys.XAmzId2Header, extendedRequestId);
+            }
+
             var response = MockWebResponse.Create(status, headers, content);
 
             return isOK ? response : throw new HttpErrorResponseException(new HttpWebRequestResponseData(response));
         };
     }
 #else
-    public static void SetResponse(AmazonServiceClient client, string? content, string requestId, bool isOK)
+    public static void SetResponse(AmazonServiceClient client, string? content, string requestId, string extendedRequestId, bool isOK)
     {
-        var response = Create(content, requestId, isOK);
+        var response = Create(content, requestId, extendedRequestId, isOK);
         SetResponse(client, response);
     }
 
@@ -75,7 +83,10 @@ internal static class CustomResponses
     }
 
     private static Func<MockHttpRequest, HttpResponseMessage> Create(
-        string? content, string requestId, bool isOK)
+        string? content,
+        string requestId,
+        string extendedRequestId,
+        bool isOK)
     {
         var status = isOK ? HttpStatusCode.OK : HttpStatusCode.NotFound;
 
@@ -85,6 +96,11 @@ internal static class CustomResponses
             if (!string.IsNullOrEmpty(requestId))
             {
                 headers.Add(HeaderKeys.RequestIdHeader, requestId);
+            }
+
+            if (!string.IsNullOrEmpty(extendedRequestId))
+            {
+                headers.Add(HeaderKeys.XAmzId2Header, extendedRequestId);
             }
 
             var response = MockWebResponse.Create(status, headers, content);


### PR DESCRIPTION
- Fixes #1609
- Fixes #2947

Depends on #4063.

## Changes

- Add AWS semantic conventions for v1.40.0.
- Add more attribute names that should be arrays.
- Add `cloud.region` to AWSSDK spans using v1.40.0+ of the Semantic Conventions.
- Add SNS topic ARN as `aws.sns.topic.arn`.
- Add messaging semantic conventions for SNS and SQS.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
