### PR TITLE
[Infra] Add factory for ActivitySource and Meter

### DIFF
--- a/opentelemetry-dotnet-contrib.slnx
+++ b/opentelemetry-dotnet-contrib.slnx
@@ -184,6 +184,7 @@
   <Folder Name="/src/Shared/">
     <File Path="src/Shared/ActivityHelperExtensions.cs" />
     <File Path="src/Shared/ActivityInstrumentationHelper.cs" />
+    <File Path="src/Shared/ActivitySourceFactory.cs" />
     <File Path="src/Shared/AssemblyVersionExtensions.cs" />
     <File Path="src/Shared/DatabaseSemanticConventionHelper.cs" />
     <File Path="src/Shared/DiagnosticSourceListener.cs" />
@@ -198,6 +199,7 @@
     <File Path="src/Shared/IsExternalInit.cs" />
     <File Path="src/Shared/ListenerHandler.cs" />
     <File Path="src/Shared/Lock.cs" />
+    <File Path="src/Shared/MeterFactory.cs" />
     <File Path="src/Shared/MultiTypePropertyFetcher.cs" />
     <File Path="src/Shared/NullableAttributes.cs" />
     <File Path="src/Shared/PropertyFetcher.cs" />

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
@@ -4,22 +4,20 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
-using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AspNet;
 
 /// <summary>
-/// Asp.Net Requests instrumentation.
+/// ASP.NET Requests instrumentation.
 /// </summary>
 internal sealed class AspNetInstrumentation : IDisposable
 {
     public static readonly AspNetInstrumentation Instance = new();
 
-    private static readonly (ActivitySource ActivitySource, Meter Meter) Telemetry = CreateTelemetry();
-#pragma warning disable SA1202 // Elements must be ordered by accessibility. Telemetry field should be private and initialized earlier
-    public static readonly ActivitySource ActivitySource = Telemetry.ActivitySource;
-#pragma warning restore SA1202 // Elements must be ordered by accessibility. Telemetry field should be private and initialized earlier
-    public static readonly Meter Meter = Telemetry.Meter;
+    public static readonly Version SemanticConventionsVersion = new(1, 36, 0);
+    public static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<AspNetInstrumentation>(SemanticConventionsVersion);
+    public static readonly Meter Meter = MeterFactory.Create<AspNetInstrumentation>(SemanticConventionsVersion);
 
     public static readonly Histogram<double> HttpServerDuration = Meter.CreateHistogram(
         "http.server.request.duration",
@@ -45,29 +43,4 @@ internal sealed class AspNetInstrumentation : IDisposable
     /// <inheritdoc/>
     public void Dispose()
         => this.httpInListener?.Dispose();
-
-    private static (ActivitySource ActivitySource, Meter Meter) CreateTelemetry()
-    {
-        const string telemetrySchemaUrl = "https://opentelemetry.io/schemas/1.36.0";
-        var assembly = typeof(AspNetInstrumentation).Assembly;
-        var assemblyName = assembly.GetName();
-#pragma warning disable IDE0370 // Suppression is unnecessary
-        var name = assemblyName.Name!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
-        var version = assembly.GetPackageVersion();
-
-        var activitySourceOptions = new ActivitySourceOptions(name)
-        {
-            Version = version,
-            TelemetrySchemaUrl = telemetrySchemaUrl,
-        };
-
-        var meterOptions = new MeterOptions(name)
-        {
-            Version = version,
-            TelemetrySchemaUrl = telemetrySchemaUrl,
-        };
-
-        return (new ActivitySource(activitySourceOptions), new Meter(meterOptions));
-    }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
@@ -18,12 +18,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Configuration\*.cs" Link="Includes\Configuration\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\InstrumentationHandleManager.cs" Link="Includes\InstrumentationHandleManager.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
@@ -16,11 +15,9 @@ internal sealed class SqlTelemetryHelper
 {
     public const string MicrosoftSqlServerDbSystemName = "microsoft.sql_server";
 
-    private static readonly (ActivitySource ActivitySource, Meter Meter) Telemetry = CreateTelemetry();
-#pragma warning disable SA1202 // Elements must be ordered by accessibility. Telemetry field should be private and initialized earlier
-    public static readonly ActivitySource ActivitySource = Telemetry.ActivitySource;
-#pragma warning restore SA1202 // Elements must be ordered by accessibility. Telemetry field should be private and initialized earlier
-    public static readonly Meter Meter = Telemetry.Meter;
+    public static readonly Version SemanticConventionsVersion = new(1, 33, 0);
+    public static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<SqlTelemetryHelper>(SemanticConventionsVersion);
+    public static readonly Meter Meter = MeterFactory.Create<SqlTelemetryHelper>(SemanticConventionsVersion);
 
     public static readonly Histogram<double> DbClientOperationDuration = Meter.CreateHistogram(
         "db.client.operation.duration",
@@ -108,30 +105,5 @@ internal sealed class SqlTelemetryHelper
 #endif
 
         return duration.TotalSeconds;
-    }
-
-    private static (ActivitySource ActivitySource, Meter Meter) CreateTelemetry()
-    {
-        const string telemetrySchemaUrl = "https://opentelemetry.io/schemas/1.33.0";
-        var assembly = typeof(SqlTelemetryHelper).Assembly;
-        var assemblyName = assembly.GetName();
-#pragma warning disable IDE0370 // Suppression is unnecessary
-        var name = assemblyName.Name!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
-        var version = assembly.GetPackageVersion();
-
-        var activitySourceOptions = new ActivitySourceOptions(name)
-        {
-            Version = version,
-            TelemetrySchemaUrl = telemetrySchemaUrl,
-        };
-
-        var meterOptions = new MeterOptions(name)
-        {
-            Version = version,
-            TelemetrySchemaUrl = telemetrySchemaUrl,
-        };
-
-        return (new ActivitySource(activitySourceOptions), new Meter(meterOptions));
     }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Configuration\*.cs" Link="Includes\Configuration\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\DatabaseSemanticConventionHelper.cs" Link="Includes\DatabaseSemanticConventionHelper.cs" />
@@ -26,6 +27,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\InstrumentationHandleManager.cs" Link="Includes\InstrumentationHandleManager.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />

--- a/src/Shared/ActivitySourceFactory.cs
+++ b/src/Shared/ActivitySourceFactory.cs
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+internal static class ActivitySourceFactory
+{
+    /// <summary>
+    /// Creates a new <see cref="ActivitySource"/> for the assembly associated
+    /// with the specified type and semantic conventions version.
+    /// </summary>
+    /// <typeparam name="T">The type for which the <see cref="ActivitySource"/> is created for its assembly.</typeparam>
+    /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <returns>A new <see cref="ActivitySource"/> instance.</returns>
+    public static ActivitySource Create<T>(Version semanticConventionsVersion)
+        => Create(typeof(T), semanticConventionsVersion);
+
+    /// <summary>
+    /// Creates a new <see cref="ActivitySource"/> for the assembly associated
+    /// with the specified type and semantic conventions version.
+    /// </summary>
+    /// <param name="type">The type for which the <see cref="ActivitySource"/> is created for its assembly.</param>
+    /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <returns>A new <see cref="ActivitySource"/> instance.</returns>
+    public static ActivitySource Create(Type type, Version semanticConventionsVersion)
+    {
+        Guard.ThrowIfNull(type);
+        Guard.ThrowIfNull(semanticConventionsVersion);
+
+        string telemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
+
+        var assembly = type.Assembly;
+        var assemblyName = assembly.GetName();
+#pragma warning disable IDE0370 // Suppression is unnecessary
+        var name = assemblyName.Name!;
+#pragma warning restore IDE0370 // Suppression is unnecessary
+        var version = assembly.GetPackageVersion();
+
+        var options = new ActivitySourceOptions(name)
+        {
+            TelemetrySchemaUrl = telemetrySchemaUrl,
+            Version = version,
+        };
+
+        return new(options);
+    }
+}

--- a/src/Shared/MeterFactory.cs
+++ b/src/Shared/MeterFactory.cs
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Metrics;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+internal static class MeterFactory
+{
+    /// <summary>
+    /// Creates a new <see cref="Meter"/> for the assembly associated
+    /// with the specified type and semantic conventions version.
+    /// </summary>
+    /// <typeparam name="T">The type for which the <see cref="Meter"/> is created for its assembly.</typeparam>
+    /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <returns>A new <see cref="Meter"/> instance.</returns>
+    public static Meter Create<T>(Version semanticConventionsVersion)
+        => Create(typeof(T), semanticConventionsVersion);
+
+    /// <summary>
+    /// Creates a new <see cref="Meter"/> for the assembly associated
+    /// with the specified type and semantic conventions version.
+    /// </summary>
+    /// <param name="type">The type for which the <see cref="Meter"/> is created for its assembly.</param>
+    /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <returns>A new <see cref="Meter"/> instance.</returns>
+    public static Meter Create(Type type, Version semanticConventionsVersion)
+    {
+        Guard.ThrowIfNull(type);
+        Guard.ThrowIfNull(semanticConventionsVersion);
+
+        string telemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
+
+        var assembly = type.Assembly;
+        var assemblyName = assembly.GetName();
+#pragma warning disable IDE0370 // Suppression is unnecessary
+        var name = assemblyName.Name!;
+#pragma warning restore IDE0370 // Suppression is unnecessary
+        var version = assembly.GetPackageVersion();
+
+        var options = new MeterOptions(name)
+        {
+            TelemetrySchemaUrl = telemetrySchemaUrl,
+            Version = version,
+        };
+
+        return new(options);
+    }
+}

--- a/test/OpenTelemetry.Contrib.Shared.Tests/ActivitySourceFactoryTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/ActivitySourceFactoryTests.cs
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Contrib.Shared.Tests;
+
+public class ActivitySourceFactoryTests
+{
+    [Fact]
+    public void Create_ReturnsActivitySourceWithGivenName()
+    {
+        // Arrange
+        var semanticConventionsVersion = new Version(1, 2, 3, 4);
+
+        // Act
+        var actual = ActivitySourceFactory.Create<ActivitySourceFactoryTests>(semanticConventionsVersion);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal("OpenTelemetry.Contrib.Shared.Tests", actual.Name);
+        Assert.NotNull(actual.Version);
+        Assert.NotEmpty(actual.Version);
+        Assert.Equal("https://opentelemetry.io/schemas/1.2.3", actual.TelemetrySchemaUrl);
+    }
+}

--- a/test/OpenTelemetry.Contrib.Shared.Tests/ActivitySourceFactoryTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/ActivitySourceFactoryTests.cs
@@ -4,7 +4,7 @@
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Contrib.Shared.Tests;
+namespace OpenTelemetry.Instrumentation.Tests;
 
 public class ActivitySourceFactoryTests
 {

--- a/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
@@ -4,7 +4,7 @@
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Contrib.Shared.Tests;
+namespace OpenTelemetry.Instrumentation.Tests;
 
 public class MeterFactoryTests
 {

--- a/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Contrib.Shared.Tests;
+
+public class MeterFactoryTests
+{
+    [Fact]
+    public void Create_ReturnsMeterWithGivenName()
+    {
+        // Arrange
+        var semanticConventionsVersion = new Version(1, 2, 3, 4);
+
+        // Act
+        var actual = MeterFactory.Create<MeterFactoryTests>(semanticConventionsVersion);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal("OpenTelemetry.Contrib.Shared.Tests", actual.Name);
+        Assert.NotNull(actual.Version);
+        Assert.NotEmpty(actual.Version);
+        Assert.Equal("https://opentelemetry.io/schemas/1.2.3", actual.TelemetrySchemaUrl);
+    }
+}

--- a/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
@@ -15,11 +15,15 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ActivityInstrumentationHelper.cs" Link="Includes\ActivityInstrumentationHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\DatabaseSemanticConventionHelper.cs" Link="Includes\DatabaseSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\GrpcStatusCanonicalCode.cs" Link="Includes\GrpcStatusCanonicalCode.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />


### PR DESCRIPTION
Contributes to #4064.

## Changes

Add shared code to minimise duplication when creating instances of `ActivitySource` and `Meter` to help ensure that telemetry schema URLs are set.

While working on #4078 I realised that there was a lot of duplication starting to happen, so this centralises that code and adopts it for use for AspNet and SqlClient instrumentation which are the only two that currently set `TelemetrySchemaUrl`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
