### PR TITLE
[Infra] Avoid running automation workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -90,7 +90,7 @@ jobs:
       github.event_name == 'workflow_dispatch'
       ||
       (
-        github.event_name == 'pull_request' && 
+        github.event_name == 'pull_request' &&
         github.event.action == 'closed' &&
         github.event.pull_request.merged == true &&
         startsWith(github.event.pull_request.title, '[release] Prepare release ')

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -84,6 +84,29 @@ permissions:
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
+
+    # Partial combination of simplified child jobs condition to avoid running jobs at all
+    if: |
+      github.event_name == 'workflow_dispatch'
+      ||
+      (
+        github.event_name == 'pull_request' && 
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true &&
+        startsWith(github.event.pull_request.title, '[release] Prepare release ')
+      )
+      ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.issue.title, '[release] Prepare release ')
+      )
+      ||
+      (
+        startsWith(github.event.issue.title, '[release request] ') &&
+        github.event.issue.pull_request == null
+      )
+
     secrets:
       OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
 


### PR DESCRIPTION
## Changes

I noticed that the [`prepare-release.yml`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/metrics/usage?sort=workflowExecutions&filters=workflow_file_name%3Aprepare-release.yml) runs quite a lot as it has a lot of triggers, which mostly just run the `automation.yml` shared workflow and then skip everything else.

This seems a bit wasteful, so this PR adds a condition that is a simplified composite of the child jobs' conditions to avoid running the `automation` workflow every time a PR is closed, an issue is opened or edited, or a comment is made.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
