### PR TITLE
[OpAmp] use CloseOutputAsync to fix flaky WsTransport test

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
@@ -13,6 +13,7 @@ internal sealed class OpAmpClientEventSource : EventSource
 
     // General events 1-499
     private const int EventIdInvalidWsFrame = 1;
+    private const int EventIdTransportCloseFailure = 2;
 
     // Service events 500-999
     private const int EventIdHeartbeatServiceStart = 500;
@@ -41,6 +42,21 @@ internal sealed class OpAmpClientEventSource : EventSource
     public void InvalidWsFrame(string errorMessage)
     {
         this.WriteEvent(EventIdInvalidWsFrame, errorMessage);
+    }
+
+    [NonEvent]
+    public void TransportCloseException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.TransportCloseFailure(ex.ToInvariantString());
+        }
+    }
+
+    [Event(EventIdTransportCloseFailure, Message = "WebSocket close failed: {0}", Level = EventLevel.Warning)]
+    public void TransportCloseFailure(string exception)
+    {
+        this.WriteEvent(EventIdTransportCloseFailure, exception);
     }
 
     [Event(EventIdHeartbeatServiceStart, Message = "Heartbeat service started.", Level = EventLevel.Informational)]

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
@@ -53,9 +53,23 @@ internal sealed class WsTransport : IOpAmpTransport, IDisposable
 
     public async Task StopAsync(CancellationToken token = default)
     {
-        await this.ws
-            .CloseAsync(WebSocketCloseStatus.NormalClosure, "Client closed connection", token)
-            .ConfigureAwait(false);
+        if (this.ws.State is not (WebSocketState.Open or WebSocketState.CloseReceived))
+        {
+            return;
+        }
+
+        try
+        {
+            await this.ws
+                .CloseAsync(WebSocketCloseStatus.NormalClosure, "Client closed connection", token)
+                .ConfigureAwait(false);
+        }
+        catch (WebSocketException ex)
+        {
+            // The WsReceiver may consume the peer's close frame before
+            // CloseAsync sees it, causing a WebSocketException under load.
+            OpAmpClientEventSource.Log.TransportCloseException(ex);
+        }
     }
 
     public Task SendAsync<T>(T message, CancellationToken token = default)


### PR DESCRIPTION
`StopAsync` was calling `CloseAsync`, which does a full close handshake (send close frame + wait for peer's close frame). The `WsReceiver` running on a background thread consumes the peer's close frame via its own `ReceiveAsync` first, so `CloseAsync` never gets it and throws a `WebSocketException` under CI load.

switched to `CloseOutputAsync` which only sends the close frame without blocking for the response. also added a state guard so `StopAsync` is a no-op if the socket is already closed.

Fixes #4085