### PR TITLE
[Runtime] Use MeterFactory

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
@@ -17,7 +17,7 @@ internal sealed class AspNetInstrumentation : IDisposable
 
     public static readonly Version SemanticConventionsVersion = new(1, 36, 0);
     public static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<AspNetInstrumentation>(SemanticConventionsVersion);
-    public static readonly Meter Meter = MeterFactory.Create<AspNetInstrumentation>(SemanticConventionsVersion);
+    public static readonly Meter Meter = Metrics.MeterFactory.Create<AspNetInstrumentation>(SemanticConventionsVersion);
 
     public static readonly Histogram<double> HttpServerDuration = Meter.CreateHistogram(
         "http.server.request.duration",

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -18,8 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
+#if NET
 using System.Reflection;
-using OpenTelemetry.Internal;
+#endif
 #if NET
 using JitInfo = System.Runtime.JitInfo;
 #endif
@@ -15,11 +16,7 @@ namespace OpenTelemetry.Instrumentation.Runtime;
 /// </summary>
 internal sealed class RuntimeMetrics
 {
-    internal static readonly Assembly Assembly = typeof(RuntimeMetrics).Assembly;
-    internal static readonly AssemblyName AssemblyName = Assembly.GetName();
-#pragma warning disable IDE0370 // Suppression is unnecessary
-    internal static readonly Meter MeterInstance = new(AssemblyName.Name!, Assembly.GetPackageVersion());
-#pragma warning restore IDE0370 // Suppression is unnecessary
+    internal static readonly Meter MeterInstance = Trace.MeterFactory.Create<RuntimeMetrics>(new(0, 0, 0)); // These metrics are not in the Semantic Conventions
 
 #if NET
     private const long NanosecondsPerTick = 100;

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -16,7 +16,7 @@ namespace OpenTelemetry.Instrumentation.Runtime;
 /// </summary>
 internal sealed class RuntimeMetrics
 {
-    internal static readonly Meter MeterInstance = Trace.MeterFactory.Create<RuntimeMetrics>(new(0, 0, 0)); // These metrics are not in the Semantic Conventions
+    internal static readonly Meter MeterInstance = Metrics.MeterFactory.Create<RuntimeMetrics>(null); // These metrics are not in the Semantic Conventions
 
 #if NET
     private const long NanosecondsPerTick = 100;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -17,7 +17,7 @@ internal sealed class SqlTelemetryHelper
 
     public static readonly Version SemanticConventionsVersion = new(1, 33, 0);
     public static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<SqlTelemetryHelper>(SemanticConventionsVersion);
-    public static readonly Meter Meter = MeterFactory.Create<SqlTelemetryHelper>(SemanticConventionsVersion);
+    public static readonly Meter Meter = Metrics.MeterFactory.Create<SqlTelemetryHelper>(SemanticConventionsVersion);
 
     public static readonly Histogram<double> DbClientOperationDuration = Meter.CreateHistogram(
         "db.client.operation.duration",

--- a/src/Shared/MeterFactory.cs
+++ b/src/Shared/MeterFactory.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Trace;
+namespace OpenTelemetry.Metrics;
 
 internal static class MeterFactory
 {
@@ -14,9 +14,10 @@ internal static class MeterFactory
     /// </summary>
     /// <typeparam name="T">The type for which the <see cref="Meter"/> is created for its assembly.</typeparam>
     /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <param name="tags">The optional tags to associate with the created <see cref="Meter"/>.</param>
     /// <returns>A new <see cref="Meter"/> instance.</returns>
-    public static Meter Create<T>(Version semanticConventionsVersion)
-        => Create(typeof(T), semanticConventionsVersion);
+    public static Meter Create<T>(Version? semanticConventionsVersion, IEnumerable<KeyValuePair<string, object?>>? tags = null)
+        => Create(typeof(T), semanticConventionsVersion, tags);
 
     /// <summary>
     /// Creates a new <see cref="Meter"/> for the assembly associated
@@ -24,25 +25,32 @@ internal static class MeterFactory
     /// </summary>
     /// <param name="type">The type for which the <see cref="Meter"/> is created for its assembly.</param>
     /// <param name="semanticConventionsVersion">The version of the semantic conventions.</param>
+    /// <param name="tags">The optional tags to associate with the created <see cref="Meter"/>.</param>
+    /// <param name="name">The optional name to use for the <see cref="Meter"/> instead of the assembly name associated with <paramref name="type"/>.</param>
     /// <returns>A new <see cref="Meter"/> instance.</returns>
-    public static Meter Create(Type type, Version semanticConventionsVersion)
+    public static Meter Create(Type type, Version? semanticConventionsVersion, IEnumerable<KeyValuePair<string, object?>>? tags = null, string? name = null)
     {
         Guard.ThrowIfNull(type);
-        Guard.ThrowIfNull(semanticConventionsVersion);
 
         var assembly = type.Assembly;
         var assemblyName = assembly.GetName();
-#pragma warning disable IDE0370 // Suppression is unnecessary
-        var name = assemblyName.Name!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
         var version = assembly.GetPackageVersion();
+
+#pragma warning disable IDE0370 // Suppression is unnecessary
+        name ??= assemblyName.Name!;
+#pragma warning restore IDE0370 // Suppression is unnecessary
 
         var options = new MeterOptions(name)
         {
             Version = version,
         };
 
-        if (semanticConventionsVersion is not { Major: 0, Minor: 0, Build: 0 })
+        if (tags is not null)
+        {
+            options.Tags = tags;
+        }
+
+        if (semanticConventionsVersion is not null)
         {
             options.TelemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
         }

--- a/src/Shared/MeterFactory.cs
+++ b/src/Shared/MeterFactory.cs
@@ -30,8 +30,6 @@ internal static class MeterFactory
         Guard.ThrowIfNull(type);
         Guard.ThrowIfNull(semanticConventionsVersion);
 
-        string telemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
-
         var assembly = type.Assembly;
         var assemblyName = assembly.GetName();
 #pragma warning disable IDE0370 // Suppression is unnecessary
@@ -41,9 +39,13 @@ internal static class MeterFactory
 
         var options = new MeterOptions(name)
         {
-            TelemetrySchemaUrl = telemetrySchemaUrl,
             Version = version,
         };
+
+        if (semanticConventionsVersion is not { Major: 0, Minor: 0, Build: 0 })
+        {
+            options.TelemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
+        }
 
         return new(options);
     }

--- a/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;


### PR DESCRIPTION
## Changes

- Use `MeterFactory` to create `Meter`.
- Allow `null` for the semantic conventions version.
- Fix incorrect `MeterFactory` namespace.
- Add support for optional tags.
- Add support for overriding the meter name.

~~I didn't realise the runtime instrumentation doesn't implement a semantic convention at all (at least I don't _think_ it does), so also special-cases a `0.0.0` version to allow opting-out (to avoid needing a suppression in #4068), but I'm open to alternative approaches - I just want to make it a pit of failure to _not_ specify a version.~~

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
