### PR TITLE
[Sampler.AWS] Limit the max size read for response body getting the sampling rules to 1MB.

### DIFF
--- a/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
+++ b/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
@@ -124,6 +124,10 @@ internal class AWSXRaySamplerClient : IDisposable
 
     private async Task<string> DoRequestAsync(string endpoint, HttpRequestMessage request)
     {
+        // 1 MB is well above any legitimate X-Ray sampling rules/targets
+        // response while still protecting against unbounded reads.
+        const int maxResponseSizeInBytes = 1024 * 1024;
+
         try
         {
             var response = await this.httpClient.SendAsync(request).ConfigureAwait(false);
@@ -133,8 +137,10 @@ internal class AWSXRaySamplerClient : IDisposable
                 return string.Empty;
             }
 
-            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            return responseString;
+            var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var limitedStream = new LimitedStream(stream, maxResponseSizeInBytes);
+            using var reader = new StreamReader(limitedStream);
+            return await reader.ReadToEndAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
+++ b/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
@@ -130,7 +130,10 @@ internal class AWSXRaySamplerClient : IDisposable
 
         try
         {
-            var response = await this.httpClient.SendAsync(request).ConfigureAwait(false);
+            // Use ResponseHeadersRead so the response body is streamed rather
+            // than buffered entirely in memory, allowing LimitedStream to
+            // enforce the cap during download.
+            using var response = await this.httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 AWSSamplerEventSource.Log.FailedToGetSuccessResponse(endpoint, response.StatusCode.ToString());

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 * Limit the max size read for response body getting the sampling rules to 1MB.
+  ([#4100](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4100))
 
 ## 0.1.0-alpha.7
 

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
+* Limit the max size read for response body getting the sampling rules to 1MB.
 
 ## 0.1.0-alpha.7
 

--- a/src/OpenTelemetry.Sampler.AWS/LimitedStream.cs
+++ b/src/OpenTelemetry.Sampler.AWS/LimitedStream.cs
@@ -45,7 +45,7 @@ internal sealed class LimitedStream : Stream
         var remaining = this.maxBytes - this.totalBytesRead;
         if (remaining <= 0)
         {
-            // Allowance exhausted — signal EOF so callers stop reading.
+            // Allowance exhausted - signal EOF so callers stop reading.
             return 0;
         }
 

--- a/src/OpenTelemetry.Sampler.AWS/LimitedStream.cs
+++ b/src/OpenTelemetry.Sampler.AWS/LimitedStream.cs
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Sampler.AWS;
+
+/// <summary>
+/// A read-only stream wrapper that throws <see cref="InvalidOperationException"/>
+/// if the underlying stream exceeds a configured maximum number of bytes.
+/// This protects against denial-of-service when reading from untrusted HTTP responses.
+/// </summary>
+internal sealed class LimitedStream : Stream
+{
+    private readonly Stream innerStream;
+    private readonly long maxBytes;
+    private long totalBytesRead;
+
+    public LimitedStream(Stream innerStream, long maxBytes)
+    {
+        this.innerStream = innerStream ?? throw new ArgumentNullException(nameof(innerStream));
+        this.maxBytes = maxBytes;
+    }
+
+    public override bool CanRead => this.innerStream.CanRead;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var bytesRead = this.innerStream.Read(buffer, offset, count);
+        this.totalBytesRead += bytesRead;
+        if (this.totalBytesRead > this.maxBytes)
+        {
+            throw new InvalidOperationException(
+                $"Response exceeded the maximum allowed size of {this.maxBytes} bytes.");
+        }
+
+        return bytesRead;
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+#if NET
+        return await this.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+#else
+        var bytesRead = await this.innerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        this.totalBytesRead += bytesRead;
+        if (this.totalBytesRead > this.maxBytes)
+        {
+            throw new InvalidOperationException(
+                $"Response exceeded the maximum allowed size of {this.maxBytes} bytes.");
+        }
+
+        return bytesRead;
+#endif
+    }
+
+#if NET
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        var bytesRead = await this.innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        this.totalBytesRead += bytesRead;
+        if (this.totalBytesRead > this.maxBytes)
+        {
+            throw new InvalidOperationException(
+                $"Response exceeded the maximum allowed size of {this.maxBytes} bytes.");
+        }
+
+        return bytesRead;
+    }
+#endif
+
+    public override void Flush() => this.innerStream.Flush();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.innerStream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/OpenTelemetry.Sampler.AWS/LimitedStream.cs
+++ b/src/OpenTelemetry.Sampler.AWS/LimitedStream.cs
@@ -17,6 +17,12 @@ internal sealed class LimitedStream : Stream
     public LimitedStream(Stream innerStream, long maxBytes)
     {
         this.innerStream = innerStream ?? throw new ArgumentNullException(nameof(innerStream));
+
+        if (maxBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "Value must be greater than zero.");
+        }
+
         this.maxBytes = maxBytes;
     }
 
@@ -36,14 +42,16 @@ internal sealed class LimitedStream : Stream
 
     public override int Read(byte[] buffer, int offset, int count)
     {
-        var bytesRead = this.innerStream.Read(buffer, offset, count);
-        this.totalBytesRead += bytesRead;
-        if (this.totalBytesRead > this.maxBytes)
+        var remaining = this.maxBytes - this.totalBytesRead;
+        if (remaining <= 0)
         {
-            throw new InvalidOperationException(
-                $"Response exceeded the maximum allowed size of {this.maxBytes} bytes.");
+            // Allowance exhausted — signal EOF so callers stop reading.
+            return 0;
         }
 
+        var clampedCount = (int)Math.Min(count, remaining);
+        var bytesRead = this.innerStream.Read(buffer, offset, clampedCount);
+        this.totalBytesRead += bytesRead;
         return bytesRead;
     }
 
@@ -52,14 +60,15 @@ internal sealed class LimitedStream : Stream
 #if NET
         return await this.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
 #else
-        var bytesRead = await this.innerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
-        this.totalBytesRead += bytesRead;
-        if (this.totalBytesRead > this.maxBytes)
+        var remaining = this.maxBytes - this.totalBytesRead;
+        if (remaining <= 0)
         {
-            throw new InvalidOperationException(
-                $"Response exceeded the maximum allowed size of {this.maxBytes} bytes.");
+            return 0;
         }
 
+        var clampedCount = (int)Math.Min(count, remaining);
+        var bytesRead = await this.innerStream.ReadAsync(buffer, offset, clampedCount, cancellationToken).ConfigureAwait(false);
+        this.totalBytesRead += bytesRead;
         return bytesRead;
 #endif
     }
@@ -67,14 +76,15 @@ internal sealed class LimitedStream : Stream
 #if NET
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
-        var bytesRead = await this.innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-        this.totalBytesRead += bytesRead;
-        if (this.totalBytesRead > this.maxBytes)
+        var remaining = this.maxBytes - this.totalBytesRead;
+        if (remaining <= 0)
         {
-            throw new InvalidOperationException(
-                $"Response exceeded the maximum allowed size of {this.maxBytes} bytes.");
+            return 0;
         }
 
+        var clampedLength = (int)Math.Min(buffer.Length, remaining);
+        var bytesRead = await this.innerStream.ReadAsync(buffer[..clampedLength], cancellationToken).ConfigureAwait(false);
+        this.totalBytesRead += bytesRead;
         return bytesRead;
     }
 #endif

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
@@ -163,6 +163,18 @@ public class TestAWSXRaySamplerClient : IDisposable
         Assert.Null(targetsResponse);
     }
 
+    [Fact]
+    public async Task TestGetSamplingRulesWithOversizedResponse()
+    {
+        // Create a response larger than the 1 MB limit enforced by DoRequestAsync.
+        var oversizedPayload = new string('x', (1024 * 1024) + 1);
+        this.requestHandler.SetResponse("/GetSamplingRules", oversizedPayload);
+
+        var rules = await this.client.GetSamplingRules();
+
+        Assert.Empty(rules);
+    }
+
     private void CreateResponse(string endpoint, string filePath)
     {
         var mockResponse = File.ReadAllText(filePath);

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestLimitedStreamReader.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestLimitedStreamReader.cs
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
+using Xunit;
+
+namespace OpenTelemetry.Sampler.AWS.Tests;
+
+public class TestLimitedStreamReader
+{
+    [Fact]
+    public async Task ReadWithinLimitSucceeds()
+    {
+        var data = Encoding.UTF8.GetBytes("hello");
+        using var inner = new MemoryStream(data);
+        using var limited = new LimitedStream(inner, maxBytes: 1024);
+        using var reader = new StreamReader(limited);
+
+        var result = await reader.ReadToEndAsync();
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task ReadExactlyAtLimitSucceeds()
+    {
+        var data = Encoding.UTF8.GetBytes("12345");
+        using var inner = new MemoryStream(data);
+        using var limited = new LimitedStream(inner, maxBytes: 5);
+        using var reader = new StreamReader(limited);
+
+        var result = await reader.ReadToEndAsync();
+
+        Assert.Equal("12345", result);
+    }
+
+    [Fact]
+    public async Task ReadExceedingLimitThrows()
+    {
+        var data = Encoding.UTF8.GetBytes(new string('x', 2048));
+        using var inner = new MemoryStream(data);
+        using var limited = new LimitedStream(inner, maxBytes: 1024);
+        using var reader = new StreamReader(limited);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reader.ReadToEndAsync());
+    }
+
+    [Fact]
+    public void SyncReadExceedingLimitThrows()
+    {
+        var data = Encoding.UTF8.GetBytes(new string('x', 2048));
+        using var inner = new MemoryStream(data);
+        using var limited = new LimitedStream(inner, maxBytes: 1024);
+
+        var buffer = new byte[2048];
+        Assert.Throws<InvalidOperationException>(
+            () => limited.Read(buffer, 0, buffer.Length));
+    }
+
+    [Fact]
+    public void CannotWrite()
+    {
+        using var inner = new MemoryStream();
+        using var limited = new LimitedStream(inner, maxBytes: 1024);
+
+        Assert.False(limited.CanWrite);
+        Assert.Throws<NotSupportedException>(
+            () => limited.Write(new byte[1], 0, 1));
+    }
+
+    [Fact]
+    public void CannotSeek()
+    {
+        using var inner = new MemoryStream();
+        using var limited = new LimitedStream(inner, maxBytes: 1024);
+
+        Assert.False(limited.CanSeek);
+        Assert.Throws<NotSupportedException>(
+            () => limited.Seek(0, SeekOrigin.Begin));
+    }
+
+    [Fact]
+    public void ThrowsOnNullInnerStream()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LimitedStream(null!, maxBytes: 1024));
+    }
+}

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestLimitedStreamReader.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestLimitedStreamReader.cs
@@ -35,27 +35,47 @@ public class TestLimitedStreamReader
     }
 
     [Fact]
-    public async Task ReadExceedingLimitThrows()
+    public async Task ReadExceedingLimitTruncates()
     {
         var data = Encoding.UTF8.GetBytes(new string('x', 2048));
         using var inner = new MemoryStream(data);
         using var limited = new LimitedStream(inner, maxBytes: 1024);
         using var reader = new StreamReader(limited);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => reader.ReadToEndAsync());
+        var result = await reader.ReadToEndAsync();
+
+        Assert.Equal(1024, result.Length);
     }
 
     [Fact]
-    public void SyncReadExceedingLimitThrows()
+    public void SyncReadClampsThenReturnsZero()
     {
         var data = Encoding.UTF8.GetBytes(new string('x', 2048));
         using var inner = new MemoryStream(data);
         using var limited = new LimitedStream(inner, maxBytes: 1024);
 
         var buffer = new byte[2048];
-        Assert.Throws<InvalidOperationException>(
-            () => limited.Read(buffer, 0, buffer.Length));
+
+        // First read is clamped to 1024 bytes.
+        var bytesRead = limited.Read(buffer, 0, buffer.Length);
+        Assert.Equal(1024, bytesRead);
+
+        // Second read returns 0 (EOF) because the allowance is exhausted.
+        bytesRead = limited.Read(buffer, 0, buffer.Length);
+        Assert.Equal(0, bytesRead);
+    }
+
+    [Fact]
+    public void SyncReadClampsToRemainingAllowance()
+    {
+        var data = Encoding.UTF8.GetBytes(new string('x', 200));
+        using var inner = new MemoryStream(data);
+        using var limited = new LimitedStream(inner, maxBytes: 100);
+
+        var buffer = new byte[200];
+        var bytesRead = limited.Read(buffer, 0, buffer.Length);
+
+        Assert.Equal(100, bytesRead);
     }
 
     [Fact]
@@ -84,5 +104,15 @@ public class TestLimitedStreamReader
     public void ThrowsOnNullInnerStream()
     {
         Assert.Throws<ArgumentNullException>(() => new LimitedStream(null!, maxBytes: 1024));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void ThrowsOnInvalidMaxBytes(long maxBytes)
+    {
+        using var inner = new MemoryStream();
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LimitedStream(inner, maxBytes));
     }
 }


### PR DESCRIPTION
Fixes #

## Changes
Makes the code reading X-Ray sampling rules more defensive reading the response back from the sampling endpoint. Limits the max read for sampling rules to 1 MB. Well beyond what sampling rules max should be as long as the code is receiving valid sampling rules.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
