### PR TITLE
[EventCounters] Use MeterFactory

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add instrumentation scope version and schema URL to metrics.
+  ([#4088](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4088))
+
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -5,7 +5,9 @@ using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
-using OpenTelemetry.Internal;
+#if NET
+using System.Reflection;
+#endif
 
 namespace OpenTelemetry.Instrumentation.EventCounters;
 
@@ -31,8 +33,7 @@ internal sealed class EventCountersMetrics : EventListener
         // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1024.
         _ = EventCountersInstrumentationEventSource.Log;
 
-        var assembly = typeof(EventCountersMetrics).Assembly;
-        MeterInstance = new Meter(assembly.GetName().Name, assembly.GetPackageVersion());
+        MeterInstance = Metrics.MeterFactory.Create<EventCountersMetrics>(null);
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -5,9 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
-#if NET
-using System.Reflection;
-#endif
 
 namespace OpenTelemetry.Instrumentation.EventCounters;
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Contributes to #4064 

## Changes
- Use MeterFactory in `EventCountersMetrics.cs` to initialize MeterInstance
- Add link to shared MeterFactory in `OpenTelemetry.Instrumentation.EventCounters.csproj`

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
