### PR TITLE
[Instrumentation.AWSLambda] Fix `faas.max_memory` overflow

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix `faas.max_memory` overflow for Lambda memory settings at or above 2048 MB.
+  ([#4125](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4125))
+
 ## 1.15.0
 
 Released 2026-Jan-21

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
@@ -120,7 +120,7 @@ internal class AWSLambdaUtils
     internal static string? GetFunctionVersion()
         => Environment.GetEnvironmentVariable(FunctionVersion);
 
-    internal static int? GetFunctionMemorySize(ILambdaContext? context = null)
+    internal static long? GetFunctionMemorySize(ILambdaContext? context = null)
     {
         var memoryLimitInMB = context?.MemoryLimitInMB;
 
@@ -137,7 +137,7 @@ internal class AWSLambdaUtils
         if (memoryLimitInMB.HasValue)
         {
             // Convert to bytes to match semantic conventions (e.g. 128 to 134217728)
-            return memoryLimitInMB.Value * 1024 * 1024;
+            return memoryLimitInMB.Value * 1024L * 1024L;
         }
 
         return null;

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -366,7 +366,7 @@ public class AWSLambdaWrapperTests : IDisposable
         Assert.Equal("other", activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
         Assert.Equal("111111111111", activity.GetTagValue(ExpectedSemanticConventions.AttributeCloudAccountID));
         Assert.Equal(this.sampleLambdaContext.LogStreamName, activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasInstance));
-        Assert.Equal(this.sampleLambdaContext.MemoryLimitInMB * 1024 * 1024, activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasMaxMemory));
+        Assert.Equal(this.sampleLambdaContext.MemoryLimitInMB * 1024L * 1024L, activity.GetTagValue(ExpectedSemanticConventions.AttributeFaasMaxMemory));
     }
 
     private void AssertSpanException(Activity activity)

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaUtilsTests.cs
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Instrumentation.AWSLambda.Implementation;
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.AWSLambda.Tests.Implementation;
+
+public class AWSLambdaUtilsTests
+{
+    [Fact]
+    public void GetFunctionMemorySize_ConvertsMegabytesToBytesWithoutOverflow()
+    {
+        var context = new SampleLambdaContext
+        {
+            MemoryLimitInMB = 10240,
+        };
+
+        var memorySize = AWSLambdaUtils.GetFunctionMemorySize(context);
+
+        Assert.Equal(10737418240L, memorySize);
+    }
+}


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fix `faas.max_memory` overflow for Lambda memory settings at or above 2048 MB.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
