### PR TITLE
[OpenTelemetry.Extensions] Trace RateLimitingSampler reject non-positive values

### DIFF
--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 
+* Fixed `RateLimitingSampler` to reject non-positive `maxTracesPerSecond` values.
+  ([#4127](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4127))
+
 ## 1.14.0-beta.1
 
 Released 2025-Nov-13

--- a/src/OpenTelemetry.Extensions/Trace/RateLimitingSampler.cs
+++ b/src/OpenTelemetry.Extensions/Trace/RateLimitingSampler.cs
@@ -28,6 +28,11 @@ public class RateLimitingSampler : Sampler
     /// <param name="maxTracesPerSecond">The maximum number of traces that will be emitted each second.</param>
     public RateLimitingSampler(int maxTracesPerSecond)
     {
+        if (maxTracesPerSecond <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxTracesPerSecond), maxTracesPerSecond, "Value must be greater than zero.");
+        }
+
         var maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
         this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);
         var attributes = new Dictionary<string, object>()

--- a/test/OpenTelemetry.Extensions.Tests/Trace/RateLimitingSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/RateLimitingSamplerTests.cs
@@ -8,6 +8,16 @@ namespace OpenTelemetry.Extensions.Tests.Trace;
 
 public class RateLimitingSamplerTests
 {
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_ThrowsArgumentOutOfRangeException_WhenMaxTracesPerSecondIsNotPositive(int maxTracesPerSecond)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new RateLimitingSampler(maxTracesPerSecond));
+
+        Assert.Equal("maxTracesPerSecond", exception.ParamName);
+    }
+
     [Fact]
     public void ShouldSample_ReturnsRecordAndSample_WhenWithinRateLimit()
     {


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

`RateLimitingSampler` reject non-positive `maxTracesPerSecond` values instead of creating an invalid internal rate limiter state.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
