### PR TITLE
[Instrumentation.Hangfire] Use default when `DisplayNameFunc` is null

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Add a fallback to the default Hangfire display name when `DisplayNameFunc`
+  is set to null.
+  ([#4129](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4129))
+
 * Update Hangfire job parameter key used to store the `enqueued-at` timestamp from
   `"OpenTelemetry.EnqueuedAt"` to `"opentelemetry_enqueued_at"` to fix compatibility
   with MongoDB.

--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
@@ -43,7 +43,7 @@ internal sealed class HangfireInstrumentationJobFilterAttribute : JobFilterAttri
 
         if (activity != null)
         {
-            var displayNameFunc = this.options.DisplayNameFunc;
+            var displayNameFunc = this.options.DisplayNameFunc ?? HangfireInstrumentation.DefaultDisplayNameFunc;
 
             activity.DisplayName = displayNameFunc(performingContext.BackgroundJob);
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
@@ -151,8 +151,7 @@ public class HangfireInstrumentationJobFilterAttributeTests : IClassFixture<Hang
         await this.hangfireFixture.WaitJobProcessedAsync(jobId, 5);
 
         // Assert
-        Assert.Single(exportedItems, i => (i.GetTagItem("job.id") as string) == jobId);
-        var activity = exportedItems.Single(i => (i.GetTagItem("job.id") as string) == jobId);
+        var activity = Assert.Single(exportedItems, i => (i.GetTagItem("job.id") as string) == jobId);
         Assert.Contains("JOB TestJob.Execute", activity.DisplayName);
         Assert.Equal(ActivityKind.Internal, activity.Kind);
     }

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
@@ -135,6 +135,28 @@ public class HangfireInstrumentationJobFilterAttributeTests : IClassFixture<Hang
         Assert.Equal(ActivityKind.Internal, activity.Kind);
     }
 
+    [Fact]
+    public async Task Should_Fall_Back_To_Default_DisplayName_When_DisplayNameFunc_Is_Null()
+    {
+        // Arrange
+        var exportedItems = new List<Activity>();
+        using var tel = Sdk.CreateTracerProviderBuilder()
+            .AddHangfireInstrumentation(options => options.DisplayNameFunc = null!)
+            .AddInMemoryExporter(exportedItems)
+            .SetSampler<AlwaysOnSampler>()
+            .Build();
+
+        // Act
+        var jobId = BackgroundJob.Enqueue<TestJob>(x => x.Execute());
+        await this.hangfireFixture.WaitJobProcessedAsync(jobId, 5);
+
+        // Assert
+        Assert.Single(exportedItems, i => (i.GetTagItem("job.id") as string) == jobId);
+        var activity = exportedItems.Single(i => (i.GetTagItem("job.id") as string) == jobId);
+        Assert.Contains("JOB TestJob.Execute", activity.DisplayName);
+        Assert.Equal(ActivityKind.Internal, activity.Kind);
+    }
+
     [Theory]
     [InlineData("null", true)]
     [InlineData("true", true)]


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Restore fallback to the default Hangfire display name when `DisplayNameFunc` is misconfigured to `null`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
