### PR TITLE
[OpAMP] Harden WebSocket transport

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -69,6 +69,8 @@ OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.EffectiveConfigurationRe
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.EffectiveConfigurationReporting.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Heartbeat.get -> OpenTelemetry.OpAmp.Client.Settings.HeartbeatSettings!
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Heartbeat.set -> void
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.ClientWebSocketFactory.get -> System.Func<System.Net.WebSockets.ClientWebSocket!>!
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.ClientWebSocketFactory.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient!>!
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.HttpClientFactory.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Identification.get -> OpenTelemetry.OpAmp.Client.Settings.IdentificationSettings!

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -14,6 +14,13 @@
 * Apply response size limits for oversized OpAMP responses.
   ([#4116](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4116))
 
+* Harden WebSocket transport:
+  * Enforce maximum server message size.
+  * Use a cancellable receive loop with deterministic disposal.
+  * Add `OpAmpClientSettings.ClientWebSocketFactory`, and remove the insecure
+  default of accepting any server TLS certificate when connecting on .NET.
+  ([#4133](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4133))
+
 * Ensure heartbeat interval is bounded.
   ([#4136](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4136))
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
@@ -14,8 +14,9 @@ internal sealed class OpAmpClientEventSource : EventSource
     // General events 1-499
     private const int EventIdInvalidWsFrame = 1;
     private const int EventIdTransportCloseFailure = 2;
-    private const int EventIdOversizedResponseContentLength = 3;
-    private const int EventIdHttpResponseReceived = 4;
+    private const int EventIdHttpResponseReceived = 3;
+    private const int EventIdOversizedWebSocketMessage = 4;
+    private const int EventIdFrameProcessingFailure = 5;
 
     // Service events 500-999
     private const int EventIdHeartbeatServiceStart = 500;
@@ -61,10 +62,19 @@ internal sealed class OpAmpClientEventSource : EventSource
         this.WriteEvent(EventIdTransportCloseFailure, exception);
     }
 
-    [Event(EventIdOversizedResponseContentLength, Message = "OpAMP server response discarded: Content-Length ({0} bytes) exceeds the {1}-byte limit. The request was delivered but the server response was not processed.", Level = EventLevel.Warning)]
-    public void OversizedResponseContentLength(long contentLengthBytes, int limitBytes)
+    [NonEvent]
+    public void OversizedWebSocketMessageReceived(int minimumBytes, int limitBytes)
     {
-        this.WriteEvent(EventIdOversizedResponseContentLength, contentLengthBytes, limitBytes);
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.OversizedWebSocketMessage(minimumBytes, limitBytes);
+        }
+    }
+
+    [Event(EventIdOversizedWebSocketMessage, Message = "OpAMP server WebSocket message discarded: message is at least {0} bytes, exceeding the {1}-byte limit. The connection will be closed and the frame will not be processed.", Level = EventLevel.Warning)]
+    public void OversizedWebSocketMessage(int minimumBytes, int limitBytes)
+    {
+        this.WriteEvent(EventIdOversizedWebSocketMessage, minimumBytes, limitBytes);
     }
 
     [NonEvent]
@@ -80,6 +90,21 @@ internal sealed class OpAmpClientEventSource : EventSource
     public void HttpResponseReceived(int bytes)
     {
         this.WriteEvent(EventIdHttpResponseReceived, bytes);
+    }
+
+    [NonEvent]
+    public void FrameProcessingException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.FrameProcessingFailure(ex.ToInvariantString());
+        }
+    }
+
+    [Event(EventIdFrameProcessingFailure, Message = "Failed to process incoming server frame. The frame was dropped: {0}", Level = EventLevel.Warning)]
+    public void FrameProcessingFailure(string exception)
+    {
+        this.WriteEvent(EventIdFrameProcessingFailure, exception);
     }
 
     [Event(EventIdHeartbeatServiceStart, Message = "Heartbeat service started.", Level = EventLevel.Informational)]

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/TransportConstants.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/TransportConstants.cs
@@ -10,5 +10,11 @@ internal static class TransportConstants
     /// Applies to both HTTP and WebSocket transports. Responses exceeding this limit
     /// are rejected to prevent uncontrolled memory allocation.
     /// </summary>
+    /// <remarks>
+    /// For WebSocket transport, the limit is enforced after each <c>ReceiveAsync</c> increment,
+    /// so the client may briefly buffer up to this many bytes plus at most one full receive
+    /// buffer worth of additional payload before the connection is closed. That tradeoff keeps
+    /// streaming reads bounded without requiring a length prefix on every frame.
+    /// </remarks>
     public const int MaxMessageSize = 128 * 1024;
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
@@ -8,18 +8,23 @@ using OpenTelemetry.OpAmp.Client.Internal.Utils;
 
 namespace OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 
+/// <summary>
+/// Reads OpAMP WebSocket messages from the server and dispatches them to the frame processor.
+/// </summary>
 internal sealed class WsReceiver : IDisposable
 {
     private const int RentalBufferSize = 4 * 1024; // 4 KB
     private const int ReceiveBufferSize = 8 * 1024; // 8 KB
 
     private readonly ClientWebSocket ws;
-    private readonly Thread receiveThread;
     private readonly FrameProcessor processor;
+    private readonly CancellationTokenSource disposeTokenSource = new();
 
     private readonly byte[] receiveBuffer = new byte[ReceiveBufferSize];
 
-    private CancellationToken token;
+    private CancellationTokenSource? linkedReceiveTokenSource;
+    private Task? receiveTask;
+    private bool disposed;
 
     public WsReceiver(ClientWebSocket ws, FrameProcessor processor)
     {
@@ -28,20 +33,75 @@ internal sealed class WsReceiver : IDisposable
 
         this.ws = ws;
         this.processor = processor;
-        this.receiveThread = new Thread(this.ReceiveLoop)
-        {
-            Name = "OpAmp WebSocket Receive Loop",
-        };
     }
 
     public void Start(CancellationToken token = default)
     {
-        this.token = token;
-        this.receiveThread.Start();
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+#else
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(WsReceiver));
+        }
+#endif
+
+        if (this.receiveTask != null)
+        {
+            throw new InvalidOperationException("The WebSocket receiver has already been started.");
+        }
+
+        this.linkedReceiveTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, this.disposeTokenSource.Token);
+        this.receiveTask = this.ReceiveLoopAsync(this.linkedReceiveTokenSource.Token);
     }
 
+    /// <summary>
+    /// Releases resources used by the receiver.
+    /// </summary>
+    /// <remarks>
+    /// This method blocks until the background receive task has finished so pooled receive buffers
+    /// are always returned and the <see cref="ClientWebSocket"/> is not used concurrently after
+    /// disposal. <see cref="WsTransport.Dispose"/> aborts the socket before calling this method, so
+    /// the wait is usually brief. For cooperative shutdown without blocking here, cancel the token
+    /// passed to <see cref="Start"/> and complete a graceful close on the transport before disposing.
+    /// </remarks>
     public void Dispose()
-        => this.receiveThread?.Join();
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.disposed = true;
+        this.disposeTokenSource.Cancel();
+
+        try
+        {
+            // Synchronous wait: see remarks on this method. WsTransport.Dispose aborts the socket
+            // before disposing the receiver, and the receive path uses ConfigureAwait(false).
+            this.receiveTask?.GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            // Swallow any other fault so Dispose() does not throw, per IDisposable contract.
+            // This can happen if, for example, the frame processor throws while handling a frame.
+            OpAmpClientEventSource.Log.TransportCloseException(ex);
+        }
+        finally
+        {
+            this.linkedReceiveTokenSource?.Dispose();
+            this.disposeTokenSource.Dispose();
+        }
+    }
+
+    private static void StopReading(out bool continueRead, out bool isClosed)
+    {
+        continueRead = false;
+        isClosed = true;
+    }
 
     private static void ReturnRentalBuffers(List<byte[]>? rentalBuffers)
     {
@@ -50,21 +110,22 @@ internal sealed class WsReceiver : IDisposable
             return;
         }
 
-        foreach (var rental in rentalBuffers)
+        // Skip index 0 because that is always the non-pooled receiveBuffer field.
+        for (var i = 1; i < rentalBuffers.Count; i++)
         {
-            ArrayPool<byte>.Shared.Return(rental);
+            ArrayPool<byte>.Shared.Return(rentalBuffers[i]);
         }
     }
 
-    private async void ReceiveLoop()
+    private async Task ReceiveLoopAsync(CancellationToken token)
     {
-        while (!this.token.IsCancellationRequested && this.ws.State == WebSocketState.Open)
+        while (!token.IsCancellationRequested && this.ws.State == WebSocketState.Open)
         {
-            await this.ReceiveAsync().ConfigureAwait(false);
+            await this.ReceiveAsync(token).ConfigureAwait(false);
         }
     }
 
-    private async Task ReceiveAsync()
+    private async Task ReceiveAsync(CancellationToken token)
     {
         var totalCount = 0;
         var workingCount = 0;
@@ -72,8 +133,8 @@ internal sealed class WsReceiver : IDisposable
         var workingBuffer = this.receiveBuffer;
 
         List<byte[]>? rentalBuffers = null;
-        bool continueRead;
-        bool isClosed;
+        bool continueRead = true;
+        bool isClosed = false;
 
         do
         {
@@ -99,7 +160,7 @@ internal sealed class WsReceiver : IDisposable
             try
             {
                 result = await this.ws
-                    .ReceiveAsync(segment1, this.token)
+                    .ReceiveAsync(segment1, token)
                     .ConfigureAwait(false);
 
                 continueRead = !result.EndOfMessage;
@@ -109,33 +170,57 @@ internal sealed class WsReceiver : IDisposable
             }
             catch (OperationCanceledException)
             {
-                continueRead = false;
-                isClosed = true;
+                StopReading(out continueRead, out isClosed);
+            }
+            catch (Exception ex) when (ex is WebSocketException || ex is ObjectDisposedException)
+            {
+                StopReading(out continueRead, out isClosed);
             }
 
+            // Reject only after a receive pushes past the limit (see TransportConstants.MaxMessageSize remarks).
             if (totalCount > TransportConstants.MaxMessageSize)
             {
+                OpAmpClientEventSource.Log.OversizedWebSocketMessageReceived(totalCount, TransportConstants.MaxMessageSize);
+
                 // Message too large, abort the connection.
-                await this.ws
-                    .CloseOutputAsync(WebSocketCloseStatus.MessageTooBig, "Message too large", CancellationToken.None)
-                    .ConfigureAwait(false);
+                try
+                {
+                    await this.ws
+                        .CloseOutputAsync(WebSocketCloseStatus.MessageTooBig, "Message too large", CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is WebSocketException || ex is ObjectDisposedException)
+                {
+                    OpAmpClientEventSource.Log.TransportCloseException(ex);
+                }
 
                 isClosed = true;
                 break;
             }
         }
-        while (continueRead && !this.token.IsCancellationRequested);
+        while (continueRead && !token.IsCancellationRequested);
 
-        if (!isClosed)
+        try
         {
-            var sequence =
-                rentalBuffers?.Count > 1
-                    ? rentalBuffers.CreateSequenceFromBuffers(workingCount + 1)
-                    : new ReadOnlySequence<byte>(this.receiveBuffer);
+            if (!isClosed)
+            {
+                var sequence =
+                    rentalBuffers?.Count > 1
+                        ? rentalBuffers.CreateSequenceFromBuffers(workingCount)
+                        : new ReadOnlySequence<byte>(this.receiveBuffer, 0, totalCount);
 
-            this.processor.OnServerFrame(sequence, totalCount, verifyHeader: true);
+                this.processor.OnServerFrame(sequence, totalCount, verifyHeader: true);
+            }
         }
-
-        ReturnRentalBuffers(rentalBuffers);
+        catch (Exception ex)
+        {
+            // Frame deserialization or listener dispatch failed. Log and continue the
+            // receive loop so a single bad frame does not kill the long-lived connection.
+            OpAmpClientEventSource.Log.FrameProcessingException(ex);
+        }
+        finally
+        {
+            ReturnRentalBuffers(rentalBuffers);
+        }
     }
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
@@ -1,87 +1,171 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NETFRAMEWORK
-using System.Net.Http;
-#endif
 using System.Net.WebSockets;
 using Google.Protobuf;
 using OpenTelemetry.Internal;
+using OpenTelemetry.OpAmp.Client.Settings;
 
 namespace OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 
+/// <summary>
+/// Represents an <see cref="IOpAmpTransport"/> implementation that exchanges OpAMP frames over a WebSocket connection.
+/// </summary>
 internal sealed class WsTransport : IOpAmpTransport, IDisposable
 {
     private readonly Uri uri;
-    private readonly HttpClientHandler handler = new();
-    private readonly ClientWebSocket ws = new();
+    private readonly ClientWebSocket webSocket;
     private readonly WsReceiver receiver;
     private readonly WsTransmitter transmitter;
-    private readonly FrameProcessor processor;
+    private int startState;
+    private bool disposed;
 
-    public WsTransport(Uri serverUrl, FrameProcessor processor)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WsTransport"/> class.
+    /// </summary>
+    /// <param name="settings">The client settings containing the target endpoint and WebSocket factory.</param>
+    /// <param name="processor">The frame processor used to handle server frames received on the connection.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="settings"/> or <paramref name="processor"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="OpAmpClientSettings.ClientWebSocketFactory"/> returns <see langword="null"/>.
+    /// </exception>
+    public WsTransport(OpAmpClientSettings settings, FrameProcessor processor)
     {
-        Guard.ThrowIfNull(serverUrl, nameof(serverUrl));
+        Guard.ThrowIfNull(settings, nameof(settings));
         Guard.ThrowIfNull(processor, nameof(processor));
 
-        // TODO: fix trust all certificates
-#if NET
-        this.handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-#endif
-        this.uri = serverUrl;
-        this.processor = processor;
-        this.receiver = new WsReceiver(this.ws, this.processor);
-        this.transmitter = new WsTransmitter(this.ws);
+        var webSocket = settings.ClientWebSocketFactory()
+            ?? throw new InvalidOperationException("ClientWebSocketFactory returned null. The factory must return a new, unconnected ClientWebSocket instance.");
+
+        this.uri = settings.ServerUrl;
+        this.webSocket = webSocket;
+        this.receiver = new WsReceiver(this.webSocket, processor);
+        this.transmitter = new WsTransmitter(this.webSocket);
     }
 
+    /// <summary>
+    /// Connects the WebSocket and starts receiving server frames.
+    /// </summary>
+    /// <param name="token">A cancellation token for the connect operation.</param>
+    /// <returns>A task that completes when the connection is established and the receive loop has started.</returns>
+    /// <remarks>
+    /// This method is not idempotent: a second call after a successful start throws
+    /// <see cref="InvalidOperationException"/>. If connection establishment or receive-loop startup fails,
+    /// the transport aborts the socket and the instance cannot be reused. A new <see cref="WsTransport"/>
+    /// instance (and therefore a new <see cref="ClientWebSocket"/>) is required to reconnect.
+    /// </remarks>
+    /// <exception cref=" ObjectDisposedException">
+    /// Thrown if the transport has already been started.
+    /// </exception>
     public async Task StartAsync(CancellationToken token = default)
     {
-#if NET
-        using var invoker = new HttpMessageInvoker(this.handler);
-#endif
+        this.ThrowIfDisposed();
 
-        await this.ws
-#if NET
-            .ConnectAsync(this.uri, invoker, token)
-#else
-            .ConnectAsync(this.uri, token)
-#endif
-            .ConfigureAwait(false);
+        if (Interlocked.CompareExchange(ref this.startState, 1, 0) != 0)
+        {
+            throw new InvalidOperationException("The WebSocket transport has already been started.");
+        }
 
-        this.receiver.Start(token);
+        try
+        {
+            await this.webSocket
+                .ConnectAsync(this.uri, token)
+                .ConfigureAwait(false);
+
+            this.receiver.Start(token);
+        }
+        catch
+        {
+            try
+            {
+                this.webSocket.Abort();
+            }
+            catch
+            {
+                // Best effort: Abort may throw if the socket is already in a terminal state.
+            }
+
+            Interlocked.Exchange(ref this.startState, 0);
+            throw;
+        }
     }
 
+    /// <summary>
+    /// Initiates a graceful shutdown of the WebSocket connection when the socket is open.
+    /// </summary>
+    /// <param name="token">A cancellation token for the close operation.</param>
+    /// <returns>A task that completes when the close frame has been sent or when no close was required.</returns>
+    /// <remarks>
+    /// If the socket is not currently open, this method returns without sending a close frame.
+    /// WebSocket close errors are logged and suppressed.
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown when the transport has been disposed.</exception>
     public async Task StopAsync(CancellationToken token = default)
     {
-        if (this.ws.State is not (WebSocketState.Open or WebSocketState.CloseReceived))
+        this.ThrowIfDisposed();
+
+        if (this.webSocket.State is not (WebSocketState.Open or WebSocketState.CloseReceived))
         {
             return;
         }
 
         try
         {
-            await this.ws
-                .CloseAsync(WebSocketCloseStatus.NormalClosure, "Client closed connection", token)
+            // Use CloseOutputAsync (send-only) rather than CloseAsync (send + wait for server
+            // close frame). CloseAsync also calls ReceiveAsync internally, which conflicts with
+            // the concurrent ReceiveAsync in WsReceiver and can hang on .NET Framework. The
+            // receive loop will consume the server's close response and exit naturally.
+            await this.webSocket
+                .CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Client closed connection", token)
                 .ConfigureAwait(false);
         }
         catch (WebSocketException ex)
         {
-            // The WsReceiver may consume the peer's close frame before
-            // CloseAsync sees it, causing a WebSocketException under load.
             OpAmpClientEventSource.Log.TransportCloseException(ex);
         }
     }
 
+    /// <summary>
+    /// Sends an OpAMP message over the active WebSocket connection.
+    /// </summary>
+    /// <typeparam name="T">The protobuf message type to send.</typeparam>
+    /// <param name="message">The message to serialize and transmit.</param>
+    /// <param name="token">A cancellation token for the send operation.</param>
+    /// <returns>A task that completes when the message has been serialized and written to the socket.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when the transport has been disposed.</exception>
     public Task SendAsync<T>(T message, CancellationToken token = default)
         where T : IMessage<T>
     {
+        this.ThrowIfDisposed();
+
         return this.transmitter.SendAsync(message, token);
     }
 
     public void Dispose()
     {
-        this.handler.Dispose();
-        this.ws.Dispose();
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.disposed = true;
+
+        this.webSocket.Abort();
         this.receiver.Dispose();
+        this.webSocket.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+#else
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(WsTransport));
+        }
+#endif
     }
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
@@ -56,9 +56,8 @@ internal sealed class WsTransport : IOpAmpTransport, IDisposable
     /// the transport aborts the socket and the instance cannot be reused. A new <see cref="WsTransport"/>
     /// instance (and therefore a new <see cref="ClientWebSocket"/>) is required to reconnect.
     /// </remarks>
-    /// <exception cref=" ObjectDisposedException">
-    /// Thrown if the transport has already been started.
-    /// </exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the transport has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the transport has already been started.</exception>
     public async Task StartAsync(CancellationToken token = default)
     {
         this.ThrowIfDisposed();

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsTransport.cs
@@ -13,6 +13,10 @@ namespace OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 /// </summary>
 internal sealed class WsTransport : IOpAmpTransport, IDisposable
 {
+    private const int NotStarted = 0;
+    private const int Running = 1;
+    private const int PermanentlyFailed = 2;
+
     private readonly Uri uri;
     private readonly ClientWebSocket webSocket;
     private readonly WsReceiver receiver;
@@ -48,23 +52,36 @@ internal sealed class WsTransport : IOpAmpTransport, IDisposable
     /// <summary>
     /// Connects the WebSocket and starts receiving server frames.
     /// </summary>
-    /// <param name="token">A cancellation token for the connect operation.</param>
+    /// <param name="token">A cancellation token scoped to the connect handshake only. It does not govern the receive loop lifetime.</param>
     /// <returns>A task that completes when the connection is established and the receive loop has started.</returns>
     /// <remarks>
-    /// This method is not idempotent: a second call after a successful start throws
-    /// <see cref="InvalidOperationException"/>. If connection establishment or receive-loop startup fails,
-    /// the transport aborts the socket and the instance cannot be reused. A new <see cref="WsTransport"/>
-    /// instance (and therefore a new <see cref="ClientWebSocket"/>) is required to reconnect.
+    /// This method is not idempotent: once called, any subsequent call throws
+    /// <see cref="InvalidOperationException"/> regardless of whether the first attempt succeeded or failed.
+    /// If connection establishment or receive-loop startup fails, the transport transitions to a permanently
+    /// failed state and aborts the socket. A new <see cref="WsTransport"/> instance (and therefore a new
+    /// <see cref="ClientWebSocket"/>) is required to reconnect.
+    /// <para>
+    /// The receive loop is long-lived and is not governed by this method's token.
+    /// Passing a short-lived token (e.g., a connection timeout) to this method does not affect the loop,
+    /// which typically ends when the WebSocket closes (for example after <see cref="StopAsync"/>).
+    /// Prefer <see cref="StopAsync"/> for graceful shutdown; <see cref="Dispose"/> performs
+    /// forceful cleanup and aborts the socket.
+    /// </para>
     /// </remarks>
     /// <exception cref="ObjectDisposedException">Thrown when the transport has been disposed.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when the transport has already been started.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the transport has already been started or has permanently failed after a previous start attempt.
+    /// </exception>
     public async Task StartAsync(CancellationToken token = default)
     {
         this.ThrowIfDisposed();
 
-        if (Interlocked.CompareExchange(ref this.startState, 1, 0) != 0)
+        var priorState = Interlocked.CompareExchange(ref this.startState, Running, NotStarted);
+        if (priorState != NotStarted)
         {
-            throw new InvalidOperationException("The WebSocket transport has already been started.");
+            throw new InvalidOperationException(priorState == PermanentlyFailed
+                ? "The WebSocket transport permanently failed during a previous start attempt and cannot be reused. Create a new WsTransport instance to reconnect."
+                : "The WebSocket transport has already been started.");
         }
 
         try
@@ -73,7 +90,9 @@ internal sealed class WsTransport : IOpAmpTransport, IDisposable
                 .ConnectAsync(this.uri, token)
                 .ConfigureAwait(false);
 
-            this.receiver.Start(token);
+            // Do not forward token: it scopes only the connect handshake. The receive loop
+            // is long-lived and exits on socket close (e.g., graceful shutdown) or disposal.
+            this.receiver.Start(CancellationToken.None);
         }
         catch
         {
@@ -86,7 +105,7 @@ internal sealed class WsTransport : IOpAmpTransport, IDisposable
                 // Best effort: Abort may throw if the socket is already in a terminal state.
             }
 
-            Interlocked.Exchange(ref this.startState, 0);
+            Interlocked.Exchange(ref this.startState, PermanentlyFailed);
             throw;
         }
     }
@@ -98,7 +117,8 @@ internal sealed class WsTransport : IOpAmpTransport, IDisposable
     /// <returns>A task that completes when the close frame has been sent or when no close was required.</returns>
     /// <remarks>
     /// If the socket is not currently open, this method returns without sending a close frame.
-    /// WebSocket close errors are logged and suppressed.
+    /// WebSocket close errors are logged and suppressed. This is the preferred shutdown path
+    /// before calling <see cref="Dispose"/>.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">Thrown when the transport has been disposed.</exception>
     public async Task StopAsync(CancellationToken token = default)
@@ -151,9 +171,23 @@ internal sealed class WsTransport : IOpAmpTransport, IDisposable
 
         this.disposed = true;
 
-        this.webSocket.Abort();
-        this.receiver.Dispose();
-        this.webSocket.Dispose();
+        try
+        {
+            this.webSocket.Abort();
+        }
+        catch
+        {
+            // Best effort: Abort may throw if the socket is already in a terminal state.
+        }
+
+        try
+        {
+            this.receiver.Dispose();
+        }
+        finally
+        {
+            this.webSocket.Dispose();
+        }
     }
 
     private void ThrowIfDisposed()

--- a/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
@@ -24,6 +24,7 @@ public sealed class OpAmpClient : IDisposable
     private readonly Dictionary<string, IBackgroundService> services = [];
     private readonly FrameDispatcher dispatcher;
     private readonly IOpAmpTransport transport;
+    private bool disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OpAmpClient"/> class.
@@ -46,6 +47,8 @@ public sealed class OpAmpClient : IDisposable
     /// <returns>A task that represents the asynchronous start operation.</returns>
     public async Task StartAsync(CancellationToken token = default)
     {
+        this.ThrowIfDisposed();
+
         if (this.transport is WsTransport wsTransport)
         {
             await wsTransport.StartAsync(token)
@@ -62,12 +65,19 @@ public sealed class OpAmpClient : IDisposable
     }
 
     /// <summary>
-    /// Stops the <see cref="OpAmpClient"/> instance, terminating the connection to the server and stopping all running services.
+    /// Stops the <see cref="OpAmpClient"/> instance gracefully, terminating the connection to the server and stopping all running services.
     /// </summary>
     /// <param name="token">Cancellation token.</param>
     /// <returns>A task that represents the asynchronous stop operation.</returns>
+    /// <remarks>
+    /// This method is the preferred shutdown path when the caller wants the client to notify the
+    /// server that it is disconnecting. In particular, for WebSocket transport this attempts a
+    /// graceful close handshake after sending the agent disconnect message.
+    /// </remarks>
     public async Task StopAsync(CancellationToken token = default)
     {
+        this.ThrowIfDisposed();
+
         await this.dispatcher.DispatchAgentDisconnectAsync(token)
             .ConfigureAwait(false);
 
@@ -91,6 +101,7 @@ public sealed class OpAmpClient : IDisposable
     public void Subscribe<T>(IOpAmpListener<T> listener)
         where T : OpAmpMessage
     {
+        this.ThrowIfDisposed();
         Guard.ThrowIfNull(listener, nameof(listener));
         this.processor.Subscribe(listener);
     }
@@ -103,6 +114,7 @@ public sealed class OpAmpClient : IDisposable
     public void Unsubscribe<T>(IOpAmpListener<T> listener)
         where T : OpAmpMessage
     {
+        this.ThrowIfDisposed();
         Guard.ThrowIfNull(listener, nameof(listener));
         this.processor.Unsubscribe(listener);
     }
@@ -122,6 +134,8 @@ public sealed class OpAmpClient : IDisposable
     /// </remarks>
     public Task SendEffectiveConfigAsync(IEnumerable<EffectiveConfigFile> files, CancellationToken cancellationToken = default)
     {
+        this.ThrowIfDisposed();
+
         if (!this.settings.EffectiveConfigurationReporting.EnableReporting)
         {
             throw new InvalidOperationException("Effective configuration reporting is not enabled in settings.");
@@ -138,6 +152,8 @@ public sealed class OpAmpClient : IDisposable
     /// <returns>A task that represents the asynchronous send operation.</returns>
     public Task SendCustomCapabilitiesAsync(IEnumerable<string> capabilities, CancellationToken cancellationToken = default)
     {
+        this.ThrowIfDisposed();
+
         return this.dispatcher.DispatchCustomCapabilitiesAsync(capabilities, cancellationToken);
     }
 
@@ -151,20 +167,60 @@ public sealed class OpAmpClient : IDisposable
     /// <returns>A task that represents the asynchronous send operation.</returns>
     public Task SendCustomMessageAsync(string capability, string type, ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
     {
+        this.ThrowIfDisposed();
+
         return this.dispatcher.DispatchCustomMessageAsync(capability, type, data, cancellationToken);
     }
 
     /// <summary>
-    /// Disposes the OpAmpClient instance and releases all associated resources.
+    /// Disposes the <see cref="OpAmpClient"/> instance and releases all associated resources.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Disposal performs synchronous, best-effort cleanup of background services and transport
+    /// resources.
+    /// </para>
+    /// <para>
+    /// This is not a graceful shutdown path and does not send the agent disconnect message. Call
+    /// <see cref="StopAsync(CancellationToken)"/> before disposal when the client
+    /// should unregister cleanly from the server.
+    /// </para>
+    /// </remarks>
     public void Dispose()
     {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.disposed = true;
+
+        foreach (var service in this.services.Values)
+        {
+            service.Stop();
+        }
+
+        foreach (var service in this.services.Values)
+        {
+            if (service is IDisposable disposableService)
+            {
+                disposableService.Dispose();
+            }
+        }
+
+        if (this.transport is IDisposable disposableTransport)
+        {
+            disposableTransport.Dispose();
+        }
+
         this.dispatcher.Dispose();
     }
 
     // Used for testing purposes only.
     internal Task SendHeartbeatAsync(HealthReport healthReport, CancellationToken cancellationToken = default)
     {
+        this.ThrowIfDisposed();
+
         return this.dispatcher.DispatchHeartbeatAsync(healthReport, cancellationToken);
     }
 
@@ -172,10 +228,22 @@ public sealed class OpAmpClient : IDisposable
     {
         return settings.ConnectionType switch
         {
-            ConnectionType.WebSocket => new WsTransport(settings.ServerUrl, processor),
+            ConnectionType.WebSocket => new WsTransport(settings, processor),
             ConnectionType.Http => new PlainHttpTransport(settings, processor),
             _ => throw new NotSupportedException("Unsupported transport type"),
         };
+    }
+
+    private void ThrowIfDisposed()
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+#else
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(OpAmpClient));
+        }
+#endif
     }
 
     private void ConfigureServices()

--- a/src/OpenTelemetry.OpAmp.Client/README.md
+++ b/src/OpenTelemetry.OpAmp.Client/README.md
@@ -27,7 +27,7 @@ dotnet add package --prerelease OpenTelemetry.OpAmp.Client
 using OpenTelemetry.OpAmp.Client;
 using OpenTelemetry.OpAmp.Client.Settings;
 
-var client = new OpAmpClient(opts =>
+using var client = new OpAmpClient(opts =>
 {
     // Set up the OpAMP server connection.
     // Supported options are HTTP (polling) and WebSocket connection.
@@ -59,6 +59,11 @@ redaction.
 - **Avoid sensitive files**: Do not report files that contain secrets such as
   passwords, API tokens, or private keys unless you fully trust the OpAMP server
   and the network path to it.
+
+Call `StopAsync()` before disposal when the client should unregister cleanly
+from the server. `Dispose()` performs synchronous, best-effort cleanup of
+services and transport resources, but it does not send the agent disconnect
+message.
 
 ## References
 

--- a/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
@@ -4,6 +4,7 @@
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
+using System.Net.WebSockets;
 
 using OpenTelemetry.Internal;
 
@@ -14,7 +15,8 @@ namespace OpenTelemetry.OpAmp.Client.Settings;
 /// </summary>
 public sealed class OpAmpClientSettings
 {
-    private readonly Func<HttpClient> defaultHttpClientFactory = () => new HttpClient();
+    private static readonly Func<ClientWebSocket> DefaultClientWebSocketFactory = static () => new();
+    private static readonly Func<HttpClient> DefaultHttpClientFactory = static () => new();
 
     /// <summary>
     /// Gets or sets the unique identifier for the current client instance.
@@ -99,20 +101,53 @@ public sealed class OpAmpClientSettings
 
     /// <summary>
     /// Gets or sets the factory function called to create the <see
+    /// cref="ClientWebSocket"/> instance used by the OpAmp client for
+    /// <see cref="ConnectionType.WebSocket"/> transport.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>This is only invoked for the <see
+    /// cref="ConnectionType.WebSocket"/> protocol.</item>
+    /// <item>The factory must return a new, unconnected <see
+    /// cref="ClientWebSocket"/> instance each time it is invoked.</item>
+    /// <item>The returned instance is owned and disposed by the OpAmp
+    /// client.</item>
+    /// <item>Available <see cref="ClientWebSocket.Options"/>
+    /// configuration varies by target framework.</item>
+    /// </list>
+    /// </remarks>
+    public Func<ClientWebSocket> ClientWebSocketFactory
+    {
+        get => field ?? DefaultClientWebSocketFactory;
+        set
+        {
+            Guard.ThrowIfNull(value);
+            field = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the factory function called to create the <see
     /// cref="HttpClient"/> instance that will be used at runtime to
-    /// transmit OpAmp messages over HTTP. The returned instance will
-    /// be reused for all communication.
+    /// transmit OpAmp messages over HTTP.
     /// </summary>
     /// <remarks>
     /// Notes:
     /// <list type="bullet">
     /// <item>This is only invoked for the <see
     /// cref="ConnectionType.Http"/> protocol.</item>
+    /// <item>The factory must return a new <see cref="HttpClient"/>
+    /// instance each time it is invoked.</item>
+    /// <item>The returned instance is owned and disposed by the OpAmp
+    /// client.</item>
+    /// <item>When not explicitly set, a default <see
+    /// cref="HttpClient"/> instance is created.</item>
     /// </list>
     /// </remarks>
     public Func<HttpClient> HttpClientFactory
     {
-        get => field ?? this.defaultHttpClientFactory;
+        get => field ?? DefaultHttpClientFactory;
         set
         {
             Guard.ThrowIfNull(value);

--- a/test/OpenTelemetry.OpAmp.Client.Tests/FrameProcessorTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/FrameProcessorTests.cs
@@ -29,7 +29,7 @@ public class FrameProcessorTests
             Encoding.UTF8.GetString([.. message.Data]);
 #endif
 
-        Assert.Equal(mockFrame.ExptectedContent, messageContent);
+        Assert.Equal(mockFrame.ExpectedContent, messageContent);
     }
 
     [Fact]

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockListener.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockListener.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
+
 using OpenTelemetry.OpAmp.Client.Listeners;
 using OpenTelemetry.OpAmp.Client.Messages;
 
@@ -19,9 +20,17 @@ internal class MockListener : IOpAmpListener<CustomMessageMessage>, IDisposable
         this.messageEvent.Set();
     }
 
+    public bool TryWaitForMessage(TimeSpan timeout)
+    {
+        return this.messageEvent.WaitOne(timeout);
+    }
+
     public void WaitForMessages(TimeSpan timeout)
     {
-        this.messageEvent.WaitOne(timeout);
+        if (!this.TryWaitForMessage(timeout))
+        {
+            throw new TimeoutException($"No message was received within {timeout}.");
+        }
     }
 
     public void Dispose()

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockServerFrame.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockServerFrame.cs
@@ -9,7 +9,7 @@ internal class MockServerFrame
 
     public bool HasHeader { get; set; }
 
-    public string? ExptectedContent { get; set; }
+    public string? ExpectedContent { get; set; }
 
     public int Size { get; internal set; }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -1,6 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+
+using System.Net;
 using System.Text;
 using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
@@ -15,6 +20,62 @@ namespace OpenTelemetry.OpAmp.Client.Tests;
 
 public class OpAmpClientTests
 {
+    [Fact]
+    public async Task OpAmpClient_PublicMethodsThrowAfterDispose()
+    {
+        using var listener = new MockListener();
+        var client = new OpAmpClient(o => o.Heartbeat.IsEnabled = false);
+        var configFile = new EffectiveConfigFile(Encoding.UTF8.GetBytes("test"), "plain/text", "config.txt");
+
+        client.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => client.Subscribe(listener));
+        Assert.Throws<ObjectDisposedException>(() => client.Unsubscribe(listener));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.StartAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.StopAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.SendEffectiveConfigAsync([configFile]));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.SendCustomCapabilitiesAsync(["capability"]));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.SendCustomMessageAsync("capability", "type", Encoding.UTF8.GetBytes("payload")));
+    }
+
+    [Fact]
+    public void OpAmpClient_DisposeDisposesHttpTransportCreatedByFactory()
+    {
+        var handler = new TrackingHttpMessageHandler();
+
+        var client = new OpAmpClient(o =>
+        {
+            o.ServerUrl = new Uri("http://localhost:4318");
+            o.Heartbeat.IsEnabled = false;
+            o.HttpClientFactory = () => new HttpClient(handler);
+        });
+
+        client.Dispose();
+
+        Assert.True(handler.Disposed);
+    }
+
+    [Fact]
+    public async Task OpAmpClient_DisposeDisposesWebSocketTransportWithoutStop()
+    {
+        using var opAmpServer = new OpAmpFakeWebSocketServer(useSmallPackets: false);
+
+        var client = new OpAmpClient(o =>
+        {
+            o.ConnectionType = ConnectionType.WebSocket;
+            o.ServerUrl = opAmpServer.Endpoint;
+            o.Heartbeat.IsEnabled = false;
+        });
+
+        await client.StartAsync();
+
+        var disposeTask = Task.Run(() => client.Dispose());
+        var completedTask = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.Same(disposeTask, completedTask);
+        await disposeTask;
+    }
+
     [Fact]
     public async Task OpAmpClient_SubscribeAndUnsubscribe()
     {
@@ -63,7 +124,9 @@ public class OpAmpClientTests
             Status = "OK",
         });
 
-        mockListener.WaitForMessages(TimeSpan.FromSeconds(1));
+        // Listener was unsubscribed; wait briefly to let the server process the frame,
+        // but do not assert a message arrives.
+        mockListener.TryWaitForMessage(TimeSpan.FromSeconds(1));
 
         var serverFrames = opAmpServer.GetFrames();
 
@@ -323,6 +386,31 @@ public class OpAmpClientTests
             this.Add(o => o.RemoteConfiguration.AcceptsRemoteConfig = false, [], [AgentCapabilities.AcceptsRemoteConfig]);
             this.Add(o => o.EffectiveConfigurationReporting.EnableReporting = true, [AgentCapabilities.ReportsEffectiveConfig], []);
             this.Add(o => o.EffectiveConfigurationReporting.EnableReporting = false, [], [AgentCapabilities.ReportsEffectiveConfig]);
+        }
+    }
+
+    private sealed class TrackingHttpMessageHandler : HttpMessageHandler
+    {
+        public bool Disposed { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([]),
+            };
+
+            return Task.FromResult(response);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.Disposed = true;
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpenTelemetry.OpAmp.Client.Tests.csproj
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpenTelemetry.OpAmp.Client.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestWebSocketServer.cs" Link="Includes\TestWebSocketServer.cs" />

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 #endif
 
 using System.IO.Compression;
+using System.Net;
 using System.Text;
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Transport;
@@ -101,7 +102,7 @@ public class PlainHttpTransportTests
         using var opAmpServer = TestHttpServer.RunServer(
             context =>
             {
-                context.Response.StatusCode = (int)System.Net.HttpStatusCode.OK;
+                context.Response.StatusCode = (int)HttpStatusCode.OK;
                 context.Response.ContentType = "application/x-protobuf";
                 context.Response.SendChunked = true;
                 context.Response.OutputStream.Write(oversizedBody, 0, oversizedBody.Length);
@@ -156,7 +157,7 @@ public class PlainHttpTransportTests
         using var opAmpServer = TestHttpServer.RunServer(
             context =>
             {
-                context.Response.StatusCode = (int)System.Net.HttpStatusCode.OK;
+                context.Response.StatusCode = (int)HttpStatusCode.OK;
                 context.Response.ContentType = "application/x-protobuf";
                 context.Response.Headers["Content-Encoding"] = "gzip";
                 context.Response.ContentLength64 = compressedBody.Length;
@@ -173,7 +174,7 @@ public class PlainHttpTransportTests
             {
                 var handler = new HttpClientHandler
                 {
-                    AutomaticDecompression = System.Net.DecompressionMethods.GZip,
+                    AutomaticDecompression = DecompressionMethods.GZip,
 #if NET
                     CheckCertificateRevocationList = true,
 #endif
@@ -203,7 +204,7 @@ public class PlainHttpTransportTests
             {
                 try
                 {
-                    context.Response.StatusCode = (int)System.Net.HttpStatusCode.OK;
+                    context.Response.StatusCode = (int)HttpStatusCode.OK;
                     context.Response.ContentType = "application/x-protobuf";
                     context.Response.SendChunked = true;
 
@@ -224,7 +225,7 @@ public class PlainHttpTransportTests
                     context.Response.OutputStream.WriteByte(0);
                     context.Response.Close();
                 }
-                catch (System.Net.HttpListenerException)
+                catch (HttpListenerException)
                 {
                     thresholdReached.Set();
                 }
@@ -265,17 +266,39 @@ public class PlainHttpTransportTests
     [Fact]
     public async Task PlainHttpTransport_RejectsResponseWithOversizedContentLength()
     {
-        // Arrange - server advertises and sends a Content-Length larger than the limit.
-        // The Content-Length pre-check in the transport should reject this before reading the body.
-        var oversizedBody = new byte[TransportConstants.MaxMessageSize + 1];
+        // Arrange - server advertises a Content-Length larger than the limit.
+        // The Content-Length pre-check in the transport should reject this before reading the body,
+        // so the client may disconnect immediately after the headers are flushed.
+        var oversizedLength = TransportConstants.MaxMessageSize + 1;
         using var opAmpServer = TestHttpServer.RunServer(
             context =>
             {
-                context.Response.StatusCode = (int)System.Net.HttpStatusCode.OK;
+                context.Response.StatusCode = (int)HttpStatusCode.OK;
                 context.Response.ContentType = "application/x-protobuf";
-                context.Response.ContentLength64 = oversizedBody.Length;
-                context.Response.OutputStream.Write(oversizedBody, 0, oversizedBody.Length);
-                context.Response.Close();
+                context.Response.ContentLength64 = oversizedLength;
+
+                try
+                {
+                    context.Response.OutputStream.WriteByte(0);
+                    context.Response.OutputStream.Flush();
+                }
+                catch (Exception ex) when (ex is HttpListenerException || ex is IOException || ex is ObjectDisposedException)
+                {
+                    // The client may close the connection as soon as it sees the oversized Content-Length.
+                }
+                finally
+                {
+                    try
+                    {
+                        context.Response.Close();
+                    }
+                    catch (HttpListenerException)
+                    {
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
+                }
             },
             out var host,
             out var port);
@@ -288,6 +311,7 @@ public class PlainHttpTransportTests
         var frameProcessor = new FrameProcessor();
         using var httpTransport = new PlainHttpTransport(settings, frameProcessor);
         var mockFrame = FrameGenerator.GenerateMockAgentFrame(true);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -303,7 +327,7 @@ public class PlainHttpTransportTests
         using var opAmpServer = TestHttpServer.RunServer(
             context =>
             {
-                context.Response.StatusCode = (int)System.Net.HttpStatusCode.OK;
+                context.Response.StatusCode = (int)HttpStatusCode.OK;
                 context.Response.ContentType = "application/x-protobuf";
                 context.Response.SendChunked = true;
                 context.Response.OutputStream.Write(body, 0, body.Length);

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
@@ -315,7 +315,7 @@ public class PlainHttpTransportTests
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => httpTransport.SendAsync(mockFrame.Frame, CancellationToken.None));
+            () => httpTransport.SendAsync(mockFrame.Frame, cts.Token));
     }
 
     [Fact]

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Tools/FrameGenerator.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Tools/FrameGenerator.cs
@@ -10,6 +10,8 @@ namespace OpenTelemetry.OpAmp.Client.Tests.Tools;
 
 internal class FrameGenerator
 {
+    private static readonly int WebSocketHeaderSize = OpAmpWsHeaderHelper.WriteHeader(new ArraySegment<byte>(new byte[OpAmpWsHeaderHelper.MaxHeaderLength]));
+
     public static MockAgentFrame GenerateMockAgentFrame(bool useSmallPackets = true)
     {
         var content = "This is a mock agent frame for testing purposes.";
@@ -53,10 +55,70 @@ internal class FrameGenerator
                 Type = "Utf8String",
             },
         };
-        var size = frame.CalculateSize();
 
+        var result = SerializeServerFrame(frame, addHeader);
+        result.ExpectedContent = content;
+        return result;
+    }
+
+    public static MockServerFrame GenerateMockServerFrameOfTotalSize(int totalSize, bool addHeader = false)
+    {
+        for (var typeLength = 1; typeLength <= 64; typeLength++)
+        {
+            var frame = TryGenerateMockServerFrameOfTotalSize(totalSize, addHeader, typeLength);
+            if (frame != null)
+            {
+                return frame;
+            }
+        }
+
+        throw new InvalidOperationException($"Unable to generate a valid server frame of total size {totalSize}.");
+    }
+
+    private static MockServerFrame? TryGenerateMockServerFrameOfTotalSize(int totalSize, bool addHeader, int typeLength)
+    {
+        var uid = ByteString.CopyFrom(Guid.NewGuid().ToByteArray());
+        var type = new string('T', typeLength);
+        var low = 0;
+        var high = totalSize;
+
+        while (low <= high)
+        {
+            var dataLength = low + ((high - low) / 2);
+            var frame = new ServerToAgent
+            {
+                InstanceUid = uid,
+                CustomMessage = new CustomMessage
+                {
+                    Data = ByteString.CopyFrom(new byte[dataLength]),
+                    Type = type,
+                },
+            };
+
+            var totalFrameSize = frame.CalculateSize() + (addHeader ? WebSocketHeaderSize : 0);
+            if (totalFrameSize == totalSize)
+            {
+                return SerializeServerFrame(frame, addHeader);
+            }
+
+            if (totalFrameSize < totalSize)
+            {
+                low = dataLength + 1;
+            }
+            else
+            {
+                high = dataLength - 1;
+            }
+        }
+
+        return null;
+    }
+
+    private static MockServerFrame SerializeServerFrame(ServerToAgent frame, bool addHeader)
+    {
+        var size = frame.CalculateSize();
         var responseBuffer = addHeader
-            ? new byte[size + OpAmpWsHeaderHelper.MaxHeaderLength]
+            ? new byte[size + WebSocketHeaderSize]
             : new byte[size];
         ArraySegment<byte> responseSegment;
 
@@ -78,7 +140,6 @@ internal class FrameGenerator
             Frame = responseSegment,
             Size = size,
             HasHeader = addHeader,
-            ExptectedContent = content,
         };
     }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeWebSocketServer.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeWebSocketServer.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Collections.Specialized;
 using System.Net.WebSockets;
 using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal.Utils;
@@ -14,13 +15,26 @@ internal class OpAmpFakeWebSocketServer : IDisposable
 {
     private readonly IDisposable httpServer;
     private readonly BlockingCollection<AgentToServer> frames = [];
+    private readonly BlockingCollection<NameValueCollection> requestHeaders = [];
+    private readonly BlockingCollection<WebSocketCloseStatus?> clientCloseStatuses = [];
     private readonly CancellationTokenSource cts = new();
 
     public OpAmpFakeWebSocketServer(bool useSmallPackets)
+        : this((frame, socket, token) =>
+        {
+            var response = GenerateResponse(frame, useSmallPackets);
+            return socket.SendAsync(response, WebSocketMessageType.Binary, true, token);
+        })
+    {
+    }
+
+    public OpAmpFakeWebSocketServer(Func<AgentToServer, WebSocket, CancellationToken, Task> responseHandler)
     {
         this.httpServer = TestWebSocketServer.RunServer(
-            async socket =>
+            async (context, socket) =>
             {
+                this.requestHeaders.Add(context.Request.Headers);
+
                 var buffer = new byte[8 * 1024];
                 using var ms = new MemoryStream();
 
@@ -32,7 +46,8 @@ internal class OpAmpFakeWebSocketServer : IDisposable
 
                         if (result.MessageType == WebSocketMessageType.Close)
                         {
-                            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by server", this.cts.Token);
+                            this.clientCloseStatuses.Add(result.CloseStatus);
+                            await socket.CloseAsync(result.CloseStatus ?? WebSocketCloseStatus.NormalClosure, result.CloseStatusDescription, this.cts.Token);
 
                             break;
                         }
@@ -47,16 +62,33 @@ internal class OpAmpFakeWebSocketServer : IDisposable
                             var frame = ProcessReceive(ms);
                             this.frames.Add(frame);
 
-                            var response = GenerateResponse(frame, useSmallPackets);
-                            await socket.SendAsync(response, WebSocketMessageType.Binary, true, this.cts.Token).ConfigureAwait(false);
+                            await responseHandler(frame, socket, this.cts.Token).ConfigureAwait(false);
                         }
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (WebSocketException)
+                {
+                    // The peer may abort the socket during disposal.
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The peer may abort the socket during disposal.
                 }
                 finally
                 {
                     if (socket.State is WebSocketState.Open or WebSocketState.CloseReceived)
                     {
-                        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server disposed", this.cts.Token);
+                        try
+                        {
+                            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server disposed", CancellationToken.None);
+                        }
+                        catch (WebSocketException)
+                        {
+                            // The peer may have already closed or aborted the connection.
+                        }
                     }
                 }
             },
@@ -70,6 +102,12 @@ internal class OpAmpFakeWebSocketServer : IDisposable
 
     public IReadOnlyCollection<AgentToServer> GetFrames()
         => [.. this.frames];
+
+    public IReadOnlyCollection<NameValueCollection> GetRequestHeaders()
+        => [.. this.requestHeaders];
+
+    public bool TryGetClientCloseStatus(TimeSpan timeout, out WebSocketCloseStatus? closeStatus)
+        => this.clientCloseStatuses.TryTake(out closeStatus, (int)timeout.TotalMilliseconds);
 
     public void Dispose()
     {

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -396,7 +396,7 @@ public class WsTransportTest
     [Fact]
     public async Task WsTransport_AfterFailedStart_SecondStartThrowsPermanentlyFailed()
     {
-        // Port 1 is reserved/unreachable on all platforms — ConnectAsync fails immediately.
+        // Port 1 is reserved/unreachable on all platforms - ConnectAsync fails immediately.
         var settings = new OpAmpClientSettings
         {
             ConnectionType = ConnectionType.WebSocket,

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -338,6 +338,83 @@ public class WsTransportTest
     }
 
     [Fact]
+    public async Task WsTransport_StartAsync_WhenCanceled_ThrowsAndTransitionsToPermanentlyFailed()
+    {
+        // Use a URI that accepts the TCP connection but never completes the WebSocket handshake
+        // so that ConnectAsync is still in-flight when we cancel.
+        var tcpListener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        Task acceptTask = Task.CompletedTask;
+        try
+        {
+            tcpListener.Start();
+            var port = ((System.Net.IPEndPoint)tcpListener.LocalEndpoint).Port;
+            var hangingUri = new Uri($"ws://127.0.0.1:{port}");
+
+            // Accept the TCP connection to prevent an immediate connection-refused, then do nothing
+            // so the WebSocket handshake never completes. Dispose the accepted client promptly
+            // to avoid unobserved-task noise when the listener stops.
+            acceptTask = tcpListener.AcceptTcpClientAsync().ContinueWith(
+                t =>
+                {
+                    if (t.Status == TaskStatus.RanToCompletion)
+                    {
+                        t.Result.Dispose();
+                    }
+                },
+                TaskContinuationOptions.ExecuteSynchronously);
+
+            var settings = new OpAmpClientSettings
+            {
+                ConnectionType = ConnectionType.WebSocket,
+                ServerUrl = hangingUri,
+            };
+            using var wsTransport = new WsTransport(settings, new FrameProcessor());
+
+            using var cts = new CancellationTokenSource();
+            var startTask = wsTransport.StartAsync(cts.Token);
+            cts.Cancel();
+
+            // .NET Framework throws WebSocketException instead of OperationCanceledException on cancellation.
+            var startException = await Record.ExceptionAsync(() => startTask);
+            Assert.True(
+                startException is OperationCanceledException || startException is WebSocketException,
+                $"Expected OperationCanceledException or WebSocketException, but got: {startException?.GetType().Name ?? "null"}");
+
+            // After a canceled start the transport is permanently failed; a second call must
+            // throw InvalidOperationException (not OperationCanceledException).
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => wsTransport.StartAsync(CancellationToken.None));
+            Assert.Contains("permanently failed", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            tcpListener.Stop();
+            await acceptTask;
+        }
+    }
+
+    [Fact]
+    public async Task WsTransport_AfterFailedStart_SecondStartThrowsPermanentlyFailed()
+    {
+        // Port 1 is reserved/unreachable on all platforms — ConnectAsync fails immediately.
+        var settings = new OpAmpClientSettings
+        {
+            ConnectionType = ConnectionType.WebSocket,
+            ServerUrl = new Uri("ws://127.0.0.1:1"),
+        };
+        using var wsTransport = new WsTransport(settings, new FrameProcessor());
+
+        // First call: ConnectAsync fails (connection refused or similar).
+        await Assert.ThrowsAnyAsync<Exception>(() => wsTransport.StartAsync(CancellationToken.None));
+
+        // Second call: must throw InvalidOperationException with the "permanently failed" message,
+        // not the "already started" message.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => wsTransport.StartAsync(CancellationToken.None));
+        Assert.Contains("permanently failed", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task WsTransport_MethodsThrowAfterDispose()
     {
         var settings = new OpAmpClientSettings

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -1,11 +1,16 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Tracing;
+using System.Net.WebSockets;
 using System.Text;
 using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Transport;
 using OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
+using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
+using OpenTelemetry.Tests;
 using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
@@ -26,7 +31,12 @@ public class WsTransportTest
         frameProcessor.Subscribe(mockListener);
 
         using var cts = new CancellationTokenSource();
-        using var wsTransport = new WsTransport(opAmpEndpoint, frameProcessor);
+        var settings = new OpAmpClientSettings
+        {
+            ConnectionType = ConnectionType.WebSocket,
+            ServerUrl = opAmpEndpoint,
+        };
+        using var wsTransport = new WsTransport(settings, frameProcessor);
         await wsTransport.StartAsync(cts.Token);
 
         var mockFrame = FrameGenerator.GenerateMockAgentFrame(useSmallPackets);
@@ -55,5 +65,473 @@ public class WsTransportTest
 
         Assert.Single(clientReceivedFrames);
         Assert.StartsWith("This is a mock server frame for testing purposes.", receivedTextData);
+    }
+
+    [Fact]
+    public async Task WsTransport_UsesConfiguredClientWebSocketFactory()
+    {
+        using var opAmpServer = new OpAmpFakeWebSocketServer(useSmallPackets: false);
+
+        var settings = new OpAmpClientSettings
+        {
+            ConnectionType = ConnectionType.WebSocket,
+            ServerUrl = opAmpServer.Endpoint,
+            ClientWebSocketFactory = () =>
+            {
+                var clientWebSocket = new ClientWebSocket();
+                clientWebSocket.Options.SetRequestHeader("X-Test-Header", "ConfiguredByFactory");
+                return clientWebSocket;
+            },
+        };
+
+        var frameProcessor = new FrameProcessor();
+
+        using var wsTransport = new WsTransport(settings, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.StopAsync(CancellationToken.None);
+
+        var requestHeaders = Assert.Single(opAmpServer.GetRequestHeaders());
+        Assert.Equal("ConfiguredByFactory", requestHeaders["X-Test-Header"]);
+    }
+
+    [Fact]
+    public async Task WsTransport_RejectsOversizedFragmentedResponseBeforeEndOfMessage()
+    {
+        using var thresholdReached = new ManualResetEventSlim();
+        var oversizedFrame = FrameGenerator.GenerateMockServerFrameOfTotalSize(TransportConstants.MaxMessageSize + 1, addHeader: true);
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            async (frame, socket, token) =>
+            {
+                var boundarySegment = new ArraySegment<byte>(oversizedFrame.Frame.Array!, oversizedFrame.Frame.Offset, TransportConstants.MaxMessageSize);
+                var overflowSegment = new ArraySegment<byte>(oversizedFrame.Frame.Array!, oversizedFrame.Frame.Offset + TransportConstants.MaxMessageSize, 1);
+
+                await socket.SendAsync(boundarySegment, WebSocketMessageType.Binary, false, token).ConfigureAwait(false);
+                await socket.SendAsync(overflowSegment, WebSocketMessageType.Binary, false, token).ConfigureAwait(false);
+                thresholdReached.Set();
+            });
+
+        var frameProcessor = new FrameProcessor();
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.True(thresholdReached.Wait(TimeSpan.FromSeconds(5)), "The server did not send enough bytes to exceed the transport limit.");
+        Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus));
+        Assert.Equal(WebSocketCloseStatus.MessageTooBig, closeStatus);
+    }
+
+    [Fact]
+    public async Task WsTransport_AcceptsLargeFragmentedMessageAcrossRentalBuffers()
+    {
+        var largeFrame = FrameGenerator.GenerateMockServerFrame(useSmallPackets: false, addHeader: true);
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => SendMessageInChunksAsync(socket, largeFrame.Frame, WebSocketMessageType.Binary, chunkSize: 1024, token));
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.True(mockListener.TryWaitForMessage(TimeSpan.FromSeconds(5)), "The client did not receive the large fragmented response.");
+
+#if NET
+        var receivedTextData = Encoding.UTF8.GetString(mockListener.Messages.Single().Data);
+#else
+        var receivedTextData = Encoding.UTF8.GetString([.. mockListener.Messages.Single().Data]);
+#endif
+
+        Assert.Equal(largeFrame.ExpectedContent, receivedTextData);
+
+        await wsTransport.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WsTransport_DropsInvalidBinaryFrameWithoutDispatchingMessage()
+    {
+        using var eventListener = new InMemoryEventListener(OpAmpClientEventSource.Log, EventLevel.Verbose);
+        var invalidFrame = new ArraySegment<byte>([0x01]);
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => socket.SendAsync(invalidFrame, WebSocketMessageType.Binary, true, token));
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.False(mockListener.TryWaitForMessage(TimeSpan.FromMilliseconds(500)));
+        Assert.Empty(mockListener.Messages);
+        await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.InvalidWsFrame), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WsTransport_ContinuesAfterInvalidBinaryFrame()
+    {
+        using var eventListener = new InMemoryEventListener(OpAmpClientEventSource.Log, EventLevel.Verbose);
+        var invalidFrame = new ArraySegment<byte>([0x01]);
+        var validFrame = FrameGenerator.GenerateMockServerFrame(addHeader: true);
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            async (frame, socket, token) =>
+            {
+                await socket.SendAsync(invalidFrame, WebSocketMessageType.Binary, true, token).ConfigureAwait(false);
+                await socket.SendAsync(validFrame.Frame, WebSocketMessageType.Binary, true, token).ConfigureAwait(false);
+            });
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.True(mockListener.TryWaitForMessage(TimeSpan.FromSeconds(5)), "The client did not receive the valid response after the invalid frame.");
+        await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.InvalidWsFrame), TimeSpan.FromSeconds(5));
+
+#if NET
+        var receivedTextData = Encoding.UTF8.GetString(mockListener.Messages.Single().Data);
+#else
+        var receivedTextData = Encoding.UTF8.GetString([.. mockListener.Messages.Single().Data]);
+#endif
+
+        Assert.Equal(validFrame.ExpectedContent, receivedTextData);
+
+        await wsTransport.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WsTransport_AcceptsResponseAtExactMaxSize()
+    {
+        var exactFrame = FrameGenerator.GenerateMockServerFrameOfTotalSize(TransportConstants.MaxMessageSize, addHeader: true);
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => socket.SendAsync(exactFrame.Frame, WebSocketMessageType.Binary, true, token));
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.True(mockListener.TryWaitForMessage(TimeSpan.FromSeconds(5)), "The client did not receive the exact-boundary response.");
+        Assert.Single(mockListener.Messages);
+
+        await wsTransport.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WsTransport_DropsOversizedResponseWithoutDispatchingFrame()
+    {
+        var oversizedFrame = FrameGenerator.GenerateMockServerFrameOfTotalSize(TransportConstants.MaxMessageSize + 1, addHeader: true);
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => socket.SendAsync(oversizedFrame.Frame, WebSocketMessageType.Binary, true, token));
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus));
+        Assert.Equal(WebSocketCloseStatus.MessageTooBig, closeStatus);
+        Assert.False(mockListener.TryWaitForMessage(TimeSpan.FromMilliseconds(500)));
+        Assert.Empty(mockListener.Messages);
+    }
+
+    [Fact]
+    public async Task WsTransport_DropsPartialMessageWhenServerClosesBeforeEndOfMessage()
+    {
+        var partialFrame = FrameGenerator.GenerateMockServerFrame(addHeader: true);
+        var partialLength = partialFrame.Frame.Count / 2;
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            async (frame, socket, token) =>
+            {
+                var partialSegment = Slice(partialFrame.Frame, 0, partialLength);
+                await socket.SendAsync(partialSegment, WebSocketMessageType.Binary, false, token).ConfigureAwait(false);
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed before end of message", token).ConfigureAwait(false);
+            });
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.False(mockListener.TryWaitForMessage(TimeSpan.FromMilliseconds(500)));
+        Assert.Empty(mockListener.Messages);
+    }
+
+    [Fact]
+    public async Task WsTransport_DropsTextFrameWithoutDispatchingMessage()
+    {
+        using var eventListener = new InMemoryEventListener(OpAmpClientEventSource.Log, EventLevel.Verbose);
+        var textFrame = new ArraySegment<byte>(Encoding.UTF8.GetBytes("not-opamp"));
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => socket.SendAsync(textFrame, WebSocketMessageType.Text, true, token));
+
+        using var mockListener = new MockListener();
+        var frameProcessor = new FrameProcessor();
+        frameProcessor.Subscribe(mockListener);
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, frameProcessor);
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.False(mockListener.TryWaitForMessage(TimeSpan.FromMilliseconds(500)));
+        Assert.Empty(mockListener.Messages);
+        await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.InvalidWsFrame), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WsTransport_LogsOversizedResponseWarning()
+    {
+        using var eventListener = new InMemoryEventListener(OpAmpClientEventSource.Log, EventLevel.Verbose);
+
+        var oversizedFrame = FrameGenerator.GenerateMockServerFrameOfTotalSize(TransportConstants.MaxMessageSize + 1, addHeader: true);
+
+        using var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => socket.SendAsync(oversizedFrame.Frame, WebSocketMessageType.Binary, true, token));
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, new FrameProcessor());
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+
+        Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus));
+        Assert.Equal(WebSocketCloseStatus.MessageTooBig, closeStatus);
+
+        var oversizedEvent = await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.OversizedWebSocketMessage), TimeSpan.FromSeconds(5));
+        Assert.Equal(EventLevel.Warning, oversizedEvent.Level);
+        Assert.Equal(TransportConstants.MaxMessageSize + 1, Assert.IsType<int>(oversizedEvent.Payload![0]));
+        Assert.Equal(TransportConstants.MaxMessageSize, Assert.IsType<int>(oversizedEvent.Payload![1]));
+    }
+
+    [Fact]
+    public async Task WsTransport_StartAsyncTwiceThrows()
+    {
+        using var opAmpServer = new OpAmpFakeWebSocketServer(useSmallPackets: false);
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, new FrameProcessor());
+
+        await wsTransport.StartAsync(CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => wsTransport.StartAsync(CancellationToken.None));
+
+        await wsTransport.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WsTransport_MethodsThrowAfterDispose()
+    {
+        var settings = new OpAmpClientSettings
+        {
+            ConnectionType = ConnectionType.WebSocket,
+            ServerUrl = new Uri("ws://localhost:1234"),
+        };
+
+        var wsTransport = new WsTransport(settings, new FrameProcessor());
+        wsTransport.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => wsTransport.StartAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => wsTransport.StopAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WsTransport_StopCompletesWhenReceiveIsPending()
+    {
+        var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => Task.CompletedTask);
+
+        var wsTransport = CreateTransport(opAmpServer.Endpoint, new FrameProcessor());
+
+        try
+        {
+            await wsTransport.StartAsync(CancellationToken.None);
+
+            var stopTask = wsTransport.StopAsync(CancellationToken.None);
+            var completedTask = await Task.WhenAny(stopTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+            Assert.Same(stopTask, completedTask);
+            await stopTask;
+
+            Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus), "The server did not observe the client close frame.");
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, closeStatus);
+        }
+        finally
+        {
+            wsTransport.Dispose();
+            opAmpServer.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WsTransport_DisposeCompletesWithoutStopWhenReceiveIsPending()
+    {
+        var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) => Task.CompletedTask);
+
+        // No `using` here so we can call Dispose in a separate task while the transport is still active.
+        var wsTransport = CreateTransport(opAmpServer.Endpoint, new FrameProcessor());
+        await wsTransport.StartAsync(CancellationToken.None);
+
+        var disposeTask = Task.Run(() => wsTransport.Dispose());
+        var completedTask = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        try
+        {
+            Assert.Same(disposeTask, completedTask);
+            await disposeTask;
+        }
+        finally
+        {
+            opAmpServer.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WsTransport_DisposeCompletesWithoutStopAfterOutstandingSend()
+    {
+        using var responseBlocked = new ManualResetEventSlim();
+        using var requestSeen = new ManualResetEventSlim();
+
+        var opAmpServer = new OpAmpFakeWebSocketServer(
+            (frame, socket, token) =>
+            {
+                requestSeen.Set();
+                responseBlocked.Wait(token);
+                return Task.CompletedTask;
+            });
+
+        using var wsTransport = CreateTransport(opAmpServer.Endpoint, new FrameProcessor());
+        await wsTransport.StartAsync(CancellationToken.None);
+        await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
+        Assert.True(requestSeen.Wait(TimeSpan.FromSeconds(5)), "The server did not receive the client request.");
+
+        var disposeTask = Task.Run(() => wsTransport.Dispose());
+        var completedTask = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        try
+        {
+            Assert.Same(disposeTask, completedTask);
+            await disposeTask;
+        }
+        finally
+        {
+            responseBlocked.Set();
+            opAmpServer.Dispose();
+        }
+    }
+
+    [Fact]
+    public void WsReceiver_StartTwiceThrows()
+    {
+        using var ws = new ClientWebSocket();
+        var receiver = new WsReceiver(ws, new FrameProcessor());
+
+        try
+        {
+            receiver.Start();
+
+            Assert.Throws<InvalidOperationException>(() => receiver.Start());
+        }
+        finally
+        {
+            receiver.Dispose();
+        }
+    }
+
+    [Fact]
+    public void WsReceiver_DisposeBeforeStartIsHarmless()
+    {
+        using var ws = new ClientWebSocket();
+        var receiver = new WsReceiver(ws, new FrameProcessor());
+
+        receiver.Dispose();
+        receiver.Dispose();
+    }
+
+    [Fact]
+    public void WsTransport_ThrowsWhenClientWebSocketFactoryReturnsNull()
+    {
+        var settings = new OpAmpClientSettings
+        {
+            ConnectionType = ConnectionType.WebSocket,
+            ServerUrl = new Uri("ws://localhost:1234"),
+            ClientWebSocketFactory = () => null!,
+        };
+
+        var frameProcessor = new FrameProcessor();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new WsTransport(settings, frameProcessor));
+
+        Assert.Equal("ClientWebSocketFactory returned null. The factory must return a new, unconnected ClientWebSocket instance.", exception.Message);
+    }
+
+    private static WsTransport CreateTransport(Uri endpoint, FrameProcessor frameProcessor)
+    {
+        var settings = new OpAmpClientSettings
+        {
+            ConnectionType = ConnectionType.WebSocket,
+            ServerUrl = endpoint,
+        };
+
+        return new WsTransport(settings, frameProcessor);
+    }
+
+    private static async Task SendMessageInChunksAsync(WebSocket socket, ArraySegment<byte> message, WebSocketMessageType messageType, int chunkSize, CancellationToken token)
+    {
+        var offset = 0;
+
+        while (offset < message.Count)
+        {
+            var count = Math.Min(chunkSize, message.Count - offset);
+            var segment = Slice(message, offset, count);
+            var endOfMessage = (offset + count) == message.Count;
+
+            await socket.SendAsync(segment, messageType, endOfMessage, token).ConfigureAwait(false);
+
+            offset += count;
+        }
+    }
+
+    private static ArraySegment<byte> Slice(ArraySegment<byte> segment, int offset, int count)
+        => new(segment.Array!, segment.Offset + offset, count);
+
+    private static async Task<EventWrittenEventArgs> WaitForEventAsync(InMemoryEventListener eventListener, string eventName, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            while (eventListener.Events.TryDequeue(out var candidate))
+            {
+                if (candidate.EventName == eventName)
+                {
+                    return candidate;
+                }
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(10)).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Timed out waiting for event '{eventName}'.");
     }
 }

--- a/test/Shared/TestHttpServer.cs
+++ b/test/Shared/TestHttpServer.cs
@@ -57,7 +57,7 @@ internal static class TestHttpServer
     {
         private readonly Task httpListenerTask;
         private readonly HttpListener listener;
-        private readonly AutoResetEvent initialized = new(false);
+        private readonly TaskCompletionSource<bool> initialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public RunningServer(Action<HttpListenerContext> action, string host, int port)
         {
@@ -66,38 +66,12 @@ internal static class TestHttpServer
             this.listener.Prefixes.Add($"http://{host}:{port}/");
             this.listener.Start();
 
-            this.httpListenerTask = new Task(async () =>
-            {
-                while (true)
-                {
-                    try
-                    {
-                        var ctxTask = this.listener.GetContextAsync();
-
-                        this.initialized.Set();
-
-                        action(await ctxTask.ConfigureAwait(false));
-                    }
-                    catch (Exception ex)
-                    {
-                        if (ex is ObjectDisposedException
-                            || (ex is HttpListenerException httpEx && httpEx.ErrorCode == 995))
-                        {
-                            // Listener was closed before we got into GetContextAsync or
-                            // Listener was closed while we were in GetContextAsync.
-                            break;
-                        }
-
-                        throw;
-                    }
-                }
-            });
+            this.httpListenerTask = Task.Run(() => this.ListenAsync(action));
         }
 
         public void Start()
         {
-            this.httpListenerTask.Start();
-            this.initialized.WaitOne();
+            this.initialized.Task.GetAwaiter().GetResult();
         }
 
         public void Dispose()
@@ -105,12 +79,43 @@ internal static class TestHttpServer
             try
             {
                 this.listener.Close();
-                this.httpListenerTask?.Wait();
-                this.initialized.Dispose();
+                this.httpListenerTask.GetAwaiter().GetResult();
             }
-            catch (ObjectDisposedException)
+            catch (Exception ex) when (this.IsListenerShutdownException(ex))
             {
-                // swallow this exception just in case
+                // Listener was already closed as part of disposal.
+            }
+        }
+
+        private bool IsListenerShutdownException(Exception ex)
+        {
+            return ex is ObjectDisposedException
+                || (ex is HttpListenerException httpEx && (httpEx.ErrorCode == 995 || httpEx.ErrorCode == 6))
+                || (ex is InvalidOperationException && !this.listener.IsListening);
+        }
+
+        private async Task ListenAsync(Action<HttpListenerContext> action)
+        {
+            this.initialized.TrySetResult(true);
+
+            while (true)
+            {
+                try
+                {
+                    var context = await this.listener.GetContextAsync().ConfigureAwait(false);
+                    action(context);
+                }
+                catch (Exception ex)
+                {
+                    if (this.IsListenerShutdownException(ex))
+                    {
+                        // Listener was closed before we got into GetContextAsync or
+                        // Listener was closed while we were in GetContextAsync.
+                        break;
+                    }
+
+                    throw;
+                }
             }
         }
     }

--- a/test/Shared/TestWebSocketServer.cs
+++ b/test/Shared/TestWebSocketServer.cs
@@ -91,8 +91,18 @@ internal static class TestWebSocketServer
 
         private bool IsListenerShutdownException(Exception ex)
         {
+            // Win32 error codes surfaced by HttpListener when the listener is closed while
+            // GetContextAsync is pending:
+            //   995 ERROR_OPERATION_ABORTED – normal abort when the listener is stopped
+            //   6   ERROR_INVALID_HANDLE    – listener handle was already closed
+            //   1   ERROR_INVALID_FUNCTION  – .NET Framework raises this instead of 995 for WebSocket
+            //                                 contexts; guarded by !IsListening to avoid swallowing a
+            //                                 genuine failure that happens to surface as code 1
             return ex is ObjectDisposedException
-                || (ex is HttpListenerException httpEx && (httpEx.ErrorCode == 995 || httpEx.ErrorCode == 6))
+                || (ex is HttpListenerException httpEx
+                    && (httpEx.ErrorCode == 995
+                        || httpEx.ErrorCode == 6
+                        || (httpEx.ErrorCode == 1 && !this.listener.IsListening)))
                 || (ex is InvalidOperationException && !this.listener.IsListening);
         }
 

--- a/test/Shared/TestWebSocketServer.cs
+++ b/test/Shared/TestWebSocketServer.cs
@@ -17,6 +17,11 @@ internal static class TestWebSocketServer
 
     public static IDisposable RunServer(Func<WebSocket, Task> handler, out string host, out int port)
     {
+        return RunServer((_, socket) => handler(socket), out host, out port);
+    }
+
+    public static IDisposable RunServer(Func<HttpListenerContext, WebSocket, Task> handler, out string host, out int port)
+    {
         host = "localhost";
         port = 0;
         RunningServer? server = null;
@@ -55,55 +60,20 @@ internal static class TestWebSocketServer
     {
         private readonly Task listenerTask;
         private readonly HttpListener listener;
-        private readonly AutoResetEvent initialized = new(false);
+        private readonly TaskCompletionSource<bool> initialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public RunningServer(Func<WebSocket, Task> handler, string host, int port)
+        public RunningServer(Func<HttpListenerContext, WebSocket, Task> handler, string host, int port)
         {
             this.listener = new HttpListener();
             this.listener.Prefixes.Add($"http://{host}:{port}/");
             this.listener.Start();
 
-            this.listenerTask = new Task(async () =>
-            {
-                while (true)
-                {
-                    try
-                    {
-                        var ctxTask = this.listener.GetContextAsync();
-
-                        this.initialized.Set();
-
-                        var ctx = await ctxTask.ConfigureAwait(false);
-
-                        if (ctx.Request.IsWebSocketRequest)
-                        {
-                            var wsContext = await ctx.AcceptWebSocketAsync(null).ConfigureAwait(false);
-                            await handler(wsContext.WebSocket);
-                        }
-                        else
-                        {
-                            ctx.Response.StatusCode = 400;
-                            ctx.Response.Close();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        if (ex is ObjectDisposedException
-                            || (ex is HttpListenerException httpEx && httpEx.ErrorCode == 995))
-                        {
-                            break; // listener closed
-                        }
-
-                        throw;
-                    }
-                }
-            });
+            this.listenerTask = Task.Run(() => this.ListenAsync(handler));
         }
 
         public void Start()
         {
-            this.listenerTask.Start();
-            this.initialized.WaitOne();
+            this.initialized.Task.GetAwaiter().GetResult();
         }
 
         public void Dispose()
@@ -111,12 +81,51 @@ internal static class TestWebSocketServer
             try
             {
                 this.listener.Close();
-                this.listenerTask?.Wait();
-                this.initialized.Dispose();
+                this.listenerTask.GetAwaiter().GetResult();
             }
-            catch (ObjectDisposedException)
+            catch (Exception ex) when (this.IsListenerShutdownException(ex))
             {
-                // swallow this exception just in case
+                // Listener was already closed as part of disposal.
+            }
+        }
+
+        private bool IsListenerShutdownException(Exception ex)
+        {
+            return ex is ObjectDisposedException
+                || (ex is HttpListenerException httpEx && (httpEx.ErrorCode == 995 || httpEx.ErrorCode == 6))
+                || (ex is InvalidOperationException && !this.listener.IsListening);
+        }
+
+        private async Task ListenAsync(Func<HttpListenerContext, WebSocket, Task> handler)
+        {
+            this.initialized.TrySetResult(true);
+
+            while (true)
+            {
+                try
+                {
+                    var ctx = await this.listener.GetContextAsync().ConfigureAwait(false);
+
+                    if (ctx.Request.IsWebSocketRequest)
+                    {
+                        var wsContext = await ctx.AcceptWebSocketAsync(null).ConfigureAwait(false);
+                        await handler(ctx, wsContext.WebSocket).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        ctx.Response.StatusCode = 400;
+                        ctx.Response.Close();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (this.IsListenerShutdownException(ex))
+                    {
+                        break;
+                    }
+
+                    throw;
+                }
             }
         }
     }

--- a/test/Shared/TestWebSocketServer.cs
+++ b/test/Shared/TestWebSocketServer.cs
@@ -93,9 +93,9 @@ internal static class TestWebSocketServer
         {
             // Win32 error codes surfaced by HttpListener when the listener is closed while
             // GetContextAsync is pending:
-            //   995 ERROR_OPERATION_ABORTED – normal abort when the listener is stopped
-            //   6   ERROR_INVALID_HANDLE    – listener handle was already closed
-            //   1   ERROR_INVALID_FUNCTION  – .NET Framework raises this instead of 995 for WebSocket
+            //   995 ERROR_OPERATION_ABORTED - normal abort when the listener is stopped
+            //   6   ERROR_INVALID_HANDLE    - listener handle was already closed
+            //   1   ERROR_INVALID_FUNCTION  - .NET Framework raises this instead of 995 for WebSocket
             //                                 contexts; guarded by !IsListening to avoid swallowing a
             //                                 genuine failure that happens to surface as code 1
             return ex is ObjectDisposedException


### PR DESCRIPTION
Async receive loop, max-message enforcement, ClientWebSocketFactory, and disposal fixes

## Changes

- Replace background Thread with async Task in WsReceiver so the receive loop is cancellable and disposal is deterministic (blocks until the task drains, prevents use-after-free on the socket)
- Remove the insecure DangerousAcceptAnyServerCertificateValidator default on .NET; users who need custom TLS can now set ClientWebSocketFactory
- Add OpAmpClientSettings.ClientWebSocketFactory (new public API) so callers control socket options (headers, TLS, etc.)
- Fix OpAmpClient.Dispose() to actually stop background services and dispose the transport (previously only dispatcher.Dispose() was called)
- Catch WebSocketException/ObjectDisposedException in the receive path so aborted-socket errors propagate cleanly rather than as unobserved faults
- Catch frame-processing exceptions and emit a FrameProcessingFailure event so a single bad frame cannot kill the long-lived connection
- Fix array-pool return bug: was returning the non-pooled receiveBuffer - Fix multi-buffer sequence construction (workingCount off-by-one) - Add OversizedWebSocketMessage and FrameProcessingFailure EventSource events - Add ThrowIfDisposed guards to all public OpAmpClient and WsTransport methods - Add new tests covering boundary conditions, disposal, factory config, invalid/text
  frames, fragmented oversized messages, and error resilience
- Switch StopAsync from CloseAsync to CloseOutputAsync so the graceful close handshake does not conflict with the concurrent ReceiveAsync in WsReceiver; also fixes a potential hang on .NET Framework where CloseAsync blocks waiting for the server close frame
- Fix single-buffer sequence construction: slice receiveBuffer to totalCount so the frame does not include uninitialised tail bytes

## Behaviour Notes

1. **Security fix (breaking for some users): TLS certificate validation is no longer bypassed**

   The .NET-only `DangerousAcceptAnyServerCertificateValidator` default has been removed. Any user
   connecting to an OpAMP server with a self-signed or non-standard TLS cert will need to configure
   `ClientWebSocketFactory` and set `ClientWebSocket.Options` appropriately. HTTP transport is
   unaffected.

2. **New public API: `OpAmpClientSettings.ClientWebSocketFactory`**

   Callers can now supply a factory that returns a pre-configured `ClientWebSocket`. This is the
   migration path for anyone who was relying on the removed TLS bypass, and it enables setting custom
   request headers, keep-alive settings, etc.

3. **`OpAmpClient.Dispose()` now releases transport and service resources**

   Previously `Dispose()` only called `dispatcher.Dispose()` and leaked the `IOpAmpTransport` and
   background services. `Dispose()` now stops all services and disposes the transport. Callers who
   were relying on `Dispose()` to be a no-op (e.g. GC-only cleanup) will now see that resources are
   actively released.

4. **`Dispose()` is not a graceful shutdown — `StopAsync()` should be called first**

   `Dispose()` aborts the `WebSocket` immediately without sending the agent disconnect message. The
   README and XML docs have been updated to make this explicit. Callers who previously called only
   `Dispose()` and expected a clean server-side unregister should switch to `await StopAsync()`
   followed by `Dispose()` (or `using`).

5. **`StopAsync` switches from `CloseAsync` to `CloseOutputAsync`**

   `CloseAsync` internally calls `ReceiveAsync`, which conflicts with the concurrent `ReceiveAsync`
   running in `WsReceiver` and can cause a deadlock or hang on .NET Framework. `CloseOutputAsync`
   only sends the close frame; the receive loop consumes the server's close response naturally and
   exits.

6. **Frame processing errors no longer crash the receive loop**

   A bad or unrecognisable server frame now logs a `FrameProcessingFailure` warning event and moves
   on to the next frame, rather than crashing the `async void` receive thread silently. This changes
   the failure mode from "connection dies silently" to "frame is dropped, warning is logged,
   connection stays up."

7. **Disposal of `WsReceiver` is now synchronous and deterministic**

   `Dispose()` cancels the receive task and blocks (via `GetAwaiter().GetResult()`) until it
   finishes, preventing the socket from being used concurrently after disposal. The previous
   implementation called `Thread.Join()` but never cancelled the cancellation token inside
   `Dispose()`, so if the caller had not cancelled externally the thread would block indefinitely on
   a live socket. The new path always has a cancellation route: `disposeTokenSource` is cancelled
   before the wait, and `WsTransport.Dispose()` calls `webSocket.Abort()` first, which unblocks
   `ReceiveAsync` almost immediately.

8. **Updated `TestHttpServer` and `TestWebSocketServer`**

   The original `RunningServer` used `new Task(async () => { ... })`, which is a known anti-pattern
   where the outer `Task` completes at the first `await` rather than when the async work finishes —
   meaning `Dispose()` was not actually waiting for the listener loop to complete. The fix replaces
   this with `Task.Run(() => this.ListenAsync(...))`, which correctly tracks the full async
   lifecycle. Initialization signalling is also improved: `AutoResetEvent` is replaced with
   `TaskCompletionSource<bool>` and the signal is set before the accept loop begins, so `Start()`
   returns only when the server is unambiguously ready. Shutdown exception handling is consolidated
   into a shared `IsListenerShutdownException` helper. `TestWebSocketServer.RunServer` also gains a
   new overload that exposes the `HttpListenerContext` alongside the `WebSocket`, enabling tests to
   inspect HTTP upgrade request headers (e.g. for verifying custom headers set via
   `ClientWebSocketFactory`); the existing single-argument overload delegates to the new one and is
   unaffected.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)