### PR TITLE
[Extensions] Use exception helper

### DIFF
--- a/src/OpenTelemetry.Extensions/Trace/RateLimitingSampler.cs
+++ b/src/OpenTelemetry.Extensions/Trace/RateLimitingSampler.cs
@@ -28,10 +28,14 @@ public class RateLimitingSampler : Sampler
     /// <param name="maxTracesPerSecond">The maximum number of traces that will be emitted each second.</param>
     public RateLimitingSampler(int maxTracesPerSecond)
     {
+#if NET
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxTracesPerSecond, 0, nameof(maxTracesPerSecond));
+#else
         if (maxTracesPerSecond <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(maxTracesPerSecond), maxTracesPerSecond, "Value must be greater than zero.");
         }
+#endif
 
         var maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
         this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);


### PR DESCRIPTION
Relates to #4127.

## Changes

Use `ArgumentOutOfRangeException.ThrowIfLessThanOrEqual` on .NET.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
