### PR TITLE
[OpAMP] Ensure heartbeat interval is bounded

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Ensure heartbeat interval is bounded.
+  ([#4136](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4136))
+
 * Add agent effective config reporting.
   ([#3716](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3716))
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -11,6 +11,9 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
 {
     public const string Name = "heartbeat-service";
 
+    // Safe upper bound.
+    private static readonly ulong MaxHeartbeatIntervalSeconds = (ulong)TimeSpan.MaxValue.TotalSeconds;
+
     private readonly FrameDispatcher dispatcher;
     private readonly FrameProcessor processor;
     private readonly CancellationTokenSource cts;
@@ -56,9 +59,15 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
         var newInterval = message.ConnectionSettings.Opamp?.HeartbeatIntervalSeconds ?? 0;
         if (newInterval > 0)
         {
+            // Clamp to TimeSpan.MaxValue to avoid OverflowException from server-supplied values
+            // that exceed the representable range.
+            var interval = newInterval > MaxHeartbeatIntervalSeconds
+                ? TimeSpan.MaxValue
+                : TimeSpan.FromSeconds(newInterval);
+
             OpAmpClientEventSource.Log.HeartbeatServiceTimerUpdateReceived(newInterval);
 
-            this.CreateOrUpdateTimer(TimeSpan.FromSeconds(newInterval));
+            this.CreateOrUpdateTimer(interval);
         }
     }
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
@@ -1,7 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Internal.Listeners.Messages;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
@@ -11,6 +13,26 @@ namespace OpenTelemetry.OpAmp.Client.Tests;
 
 public class HeartbeatServiceTests
 {
+    [Theory]
+    [InlineData(ulong.MaxValue)] // far beyond TimeSpan.MaxValue
+    [InlineData(922_337_203_686ul)] // just above TimeSpan.MaxValue.TotalSeconds (~922337203685)
+    public void HeartbeatService_HandleMessage_OversizedInterval_DoesNotThrow(ulong intervalSeconds)
+    {
+        var settings = new OpAmpClientSettings();
+        using var transport = new MockTransport(expectedCount: 0);
+        using var dispatcher = new FrameDispatcher(transport, settings);
+        using var service = new HeartbeatService(dispatcher, new FrameProcessor());
+        service.Configure(settings);
+
+        var message = new ConnectionSettingsMessage(new ConnectionSettingsOffers
+        {
+            Opamp = new OpAMPConnectionSettings { HeartbeatIntervalSeconds = intervalSeconds },
+        });
+
+        // Must not throw OverflowException.
+        service.HandleMessage(message);
+    }
+
     [Fact]
     public void HeartbeatService_EmitsHeartbeats()
     {


### PR DESCRIPTION
## Changes

Ensures that a interval larger than `TimeSpan.MaxValue.TotalSeconds` returned by the server is not used when configuring the heartbeat service.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
