### PR TITLE
[OpAMP] Add missing null check for remote config

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add missing null check for remote config.
+  ([#4138](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4138))
+
 * Ensure heartbeat interval is bounded.
   ([#4136](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4136))
 

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## Unreleased
 
-* Add missing null check for remote config.
-  ([#4138](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4138))
-
-* Ensure heartbeat interval is bounded.
-  ([#4136](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4136))
-
 * Add agent effective config reporting.
   ([#3716](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3716))
 
@@ -19,6 +13,12 @@
 
 * Apply response size limits for oversized OpAMP responses.
   ([#4116](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4116))
+
+* Ensure heartbeat interval is bounded.
+  ([#4136](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4136))
+
+* Add missing null check for remote config.
+  ([#4138](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4138))
 
 ## 0.1.0-alpha.4
 

--- a/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/RemoteConfigMessage.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/RemoteConfigMessage.cs
@@ -16,15 +16,24 @@ public class RemoteConfigMessage : OpAmpMessage
 
     internal RemoteConfigMessage(AgentRemoteConfig agentRemoteConfig)
     {
-        this.agentConfigMap = new Dictionary<string, AgentConfigFile>(agentRemoteConfig.Config.ConfigMap.Count, StringComparer.Ordinal);
-
-        foreach (var config in agentRemoteConfig.Config.ConfigMap)
+        // Config may be absent per the OpAmp proto spec — it SHOULD NOT be set when
+        // the configuration has not changed since the last request.
+        if (agentRemoteConfig.Config is not null)
         {
-            // The value should never be null, but just in case...
-            if (config.Value is not null)
+            this.agentConfigMap = new Dictionary<string, AgentConfigFile>(agentRemoteConfig.Config.ConfigMap.Count, StringComparer.Ordinal);
+
+            foreach (var config in agentRemoteConfig.Config.ConfigMap)
             {
-                this.agentConfigMap[config.Key] = new AgentConfigFile(config.Key, config.Value);
+                // The value should never be null, but just in case...
+                if (config.Value is not null)
+                {
+                    this.agentConfigMap[config.Key] = new AgentConfigFile(config.Key, config.Value);
+                }
             }
+        }
+        else
+        {
+            this.agentConfigMap = new Dictionary<string, AgentConfigFile>(StringComparer.Ordinal);
         }
 
         this.configHash = agentRemoteConfig.ConfigHash;

--- a/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/RemoteConfigMessage.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/RemoteConfigMessage.cs
@@ -16,7 +16,7 @@ public class RemoteConfigMessage : OpAmpMessage
 
     internal RemoteConfigMessage(AgentRemoteConfig agentRemoteConfig)
     {
-        // Config may be absent per the OpAmp proto spec — it SHOULD NOT be set when
+        // Config may be absent per the OpAmp proto spec - it SHOULD NOT be set when
         // the configuration has not changed since the last request.
         if (agentRemoteConfig.Config is not null)
         {

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/RemoteConfigMessageTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/RemoteConfigMessageTests.cs
@@ -33,6 +33,23 @@ public class RemoteConfigMessageTests
     }
 
     [Fact]
+    public void Constructor_WithNullConfig_InitializesEmptyDictionary()
+    {
+        // Arrange — the OpAmp proto says Config SHOULD NOT be set when unchanged,
+        // so a valid server response may omit it entirely.
+        var agentRemoteConfig = new global::OpAmp.Proto.V1.AgentRemoteConfig
+        {
+            ConfigHash = ByteString.CopyFromUtf8(HashString),
+        };
+
+        // Act
+        var remoteConfigMessage = new Client.Messages.RemoteConfigMessage(agentRemoteConfig);
+
+        // Assert
+        Assert.Empty(remoteConfigMessage.AgentConfigMap);
+    }
+
+    [Fact]
     public void Constructor_WithEmptyConfigMap_InitializesEmptyDictionary()
     {
         // Arrange

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/RemoteConfigMessageTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/RemoteConfigMessageTests.cs
@@ -35,8 +35,7 @@ public class RemoteConfigMessageTests
     [Fact]
     public void Constructor_WithNullConfig_InitializesEmptyDictionary()
     {
-        // Arrange — the OpAmp proto says Config SHOULD NOT be set when unchanged,
-        // so a valid server response may omit it entirely.
+        // Arrange
         var agentRemoteConfig = new global::OpAmp.Proto.V1.AgentRemoteConfig
         {
             ConfigHash = ByteString.CopyFromUtf8(HashString),


### PR DESCRIPTION
## Changes

Ensures that in cases where the remote config message has no config (which the spec permits) that we handle that scenario.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
