### PR TITLE
[SqlClient] Fix IndexOutOfRangeException 

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 
 * Fix `IndexOutOfRangeException` when parsing SQL statements.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4139](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4139))
 
 ## 1.15.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 
+* Fix `IndexOutOfRangeException` when parsing SQL statements.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.0-beta.1
 
 Released 2026-Jan-21

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);INCLUDE_SQL_QUERY_PARSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\DatabaseSemanticConventionHelper.cs" Link="Includes\DatabaseSemanticConventionHelper.cs" />

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 
+* Fix `IndexOutOfRangeException` when parsing SQL statements.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1
 
 Released 2026-Mar-04

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 
 * Fix `IndexOutOfRangeException` when parsing SQL statements.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4139](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4139))
 
 ## 1.15.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -15,6 +15,10 @@
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);INCLUDE_SQL_QUERY_PARSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -25,8 +25,6 @@
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\SqlProcessor.cs" Link="Includes\SqlProcessor.cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\SqlStatementInfo.cs" Link="Includes\SqlStatementInfo.cs" />
 
   </ItemGroup>
 

--- a/src/Shared/DatabaseSemanticConventionHelper.cs
+++ b/src/Shared/DatabaseSemanticConventionHelper.cs
@@ -1,11 +1,15 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if INCLUDE_SQL_QUERY_PARSER
 using System.Diagnostics;
+#endif
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
+#if INCLUDE_SQL_QUERY_PARSER
 using OpenTelemetry.Instrumentation;
 using OpenTelemetry.Trace;
+#endif
 
 namespace OpenTelemetry.Internal;
 
@@ -59,6 +63,7 @@ internal static class DatabaseSemanticConventionHelper
         return DatabaseSemanticConvention.Old;
     }
 
+#if INCLUDE_SQL_QUERY_PARSER
     public static void ApplyConventionsForQueryText(
         Activity activity,
         string? commandText,
@@ -151,6 +156,7 @@ internal static class DatabaseSemanticConventionHelper
         tagsList.Add(SemanticConventions.AttributeDbQuerySummary, dbQuerySummary);
         activityName = dbQuerySummary;
     }
+#endif
 
     private static bool TryGetConfiguredValues(IConfiguration configuration, [NotNullWhen(true)] out HashSet<string>? values)
     {

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -306,10 +306,57 @@ internal static class SqlProcessor
             sanitizedSql,
             summary.Slice(0, summaryLength).ToString());
 
+        if (state.RentedSummaryBuffer != null)
+        {
+            ArrayPool<char>.Shared.Return(state.RentedSummaryBuffer);
+        }
+
         // We don't clear the buffer as we know the content has been sanitized
         ArrayPool<char>.Shared.Return(rentedBuffer);
 
         return sqlStatementInfo;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendSummaryChar(char value, ref ParseState state)
+    {
+        EnsureSummaryCapacity(checked(state.SummaryPosition + 1), ref state);
+
+        state.SummaryBuffer[state.SummaryPosition++] = value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AppendSummaryToken(ReadOnlySpan<char> value, ref ParseState state)
+    {
+        EnsureSummaryCapacity(checked(state.SummaryPosition + value.Length), ref state);
+
+        value.CopyTo(state.SummaryBuffer.Slice(state.SummaryPosition));
+
+        state.SummaryPosition += value.Length;
+    }
+
+    private static void EnsureSummaryCapacity(int requiredCapacity, ref ParseState state)
+    {
+        if (requiredCapacity <= state.SummaryBuffer.Length)
+        {
+            return;
+        }
+
+        var doubledCapacity = state.SummaryBuffer.Length <= (int.MaxValue / 2)
+            ? state.SummaryBuffer.Length * 2
+            : int.MaxValue;
+
+        var newBuffer = ArrayPool<char>.Shared.Rent(Math.Max(requiredCapacity, doubledCapacity));
+
+        state.SummaryBuffer.Slice(0, state.SummaryPosition).CopyTo(newBuffer);
+
+        if (state.RentedSummaryBuffer != null)
+        {
+            ArrayPool<char>.Shared.Return(state.RentedSummaryBuffer);
+        }
+
+        state.RentedSummaryBuffer = newBuffer;
+        state.SummaryBuffer = newBuffer.AsSpan();
     }
 
     private static void ParseNextTokenFast(
@@ -436,11 +483,10 @@ internal static class SqlProcessor
                             state.FirstSummaryKeyword = potentialKeywordInfo.SqlKeyword;
                         }
 
-                        sql.Slice(start, keywordLength).CopyTo(state.SummaryBuffer.Slice(state.SummaryPosition));
-                        state.SummaryPosition += keywordLength;
+                        AppendSummaryToken(sql.Slice(start, keywordLength), ref state);
 
                         // Add a space after the keyword. The trailing space will be trimmed later.
-                        state.SummaryBuffer[state.SummaryPosition++] = ' ';
+                        AppendSummaryChar(SpaceChar, ref state);
 
                         state.PreviousSummaryKeyword = potentialKeywordInfo.SqlKeyword;
                     }
@@ -521,11 +567,10 @@ internal static class SqlProcessor
                 // Optionally copy to summary buffer.
                 if (state.CaptureNextNonKeywordTokenAsIdentifier)
                 {
-                    sql.Slice(start, length).CopyTo(state.SummaryBuffer.Slice(state.SummaryPosition));
-                    state.SummaryPosition += length;
+                    AppendSummaryToken(sql.Slice(start, length), ref state);
 
                     // Add a space after the identifier. The trailing space will be trimmed later.
-                    state.SummaryBuffer[state.SummaryPosition++] = SpaceChar;
+                    AppendSummaryChar(SpaceChar, ref state);
                 }
             }
 
@@ -548,16 +593,16 @@ internal static class SqlProcessor
                 // Remove the space we added after the identifier in the summary buffer before we write the closing bracket.
                 state.SummaryPosition--;
 
-                state.SummaryBuffer[state.SummaryPosition++] = CloseSquareBracketChar;
+                AppendSummaryChar(CloseSquareBracketChar, ref state);
 
                 var nextPos = state.ParsePosition + 1;
                 if (nextPos >= sql.Length || sql[nextPos] != DotChar)
                 {
-                    state.SummaryBuffer[state.SummaryPosition++] = SpaceChar;
+                    AppendSummaryChar(SpaceChar, ref state);
                 }
                 else
                 {
-                    state.SummaryBuffer[state.SummaryPosition++] = DotChar; // write the dot to summary
+                    AppendSummaryChar(DotChar, ref state); // write the dot to summary
                 }
             }
 
@@ -569,7 +614,7 @@ internal static class SqlProcessor
             if (state.CaptureNextNonKeywordTokenAsIdentifier && currentChar is OpenSquareBracketChar)
             {
                 state.InEscapedIdentifier = true;
-                state.SummaryBuffer[state.SummaryPosition++] = OpenSquareBracketChar;
+                AppendSummaryChar(OpenSquareBracketChar, ref state);
             }
 
             buffer[state.SanitizedPosition++] = currentChar;
@@ -908,6 +953,7 @@ internal static class SqlProcessor
 
         // Stored in state to avoid slicing repeatedly.
         public Span<char> SummaryBuffer;
+        public char[]? RentedSummaryBuffer;
 
         /// <summary>
         /// Will be set if a keyword has been matched by the parser.

--- a/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
@@ -153,6 +153,21 @@ public static class SqlProcessorTests
     }
 
     [Property(MaxTest = MaxValue)]
+    public static void GetSanitizedSql_SqlStatement_AlignedToArrayPoolBuckets_DoesNotThrow(PositiveInt seed)
+    {
+        // Choose statement lengths that align with common ArrayPool buckets. Before the fix,
+        // these lengths can make the initial summary slice exactly as long as the SQL text.
+        var sqlLength = 1 << ((seed.Get % 5) + 4);
+        var prefix = "CREATE TABLE ";
+        var identifier = new string('X', sqlLength - prefix.Length);
+        var sql = prefix + identifier;
+
+        var exception = Record.Exception(() => SqlProcessor.GetSanitizedSql(sql));
+
+        Assert.Null(exception);
+    }
+
+    [Property(MaxTest = MaxValue)]
     public static void GetSanitizedSql_In_Clause_Optimizes_Sanitization(PositiveInt input)
     {
         // Arrange

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
@@ -17,6 +17,17 @@ public class SqlProcessorTests
 
     public static TheoryData<SqlProcessorTestCases.TestCase> TestData => SqlProcessorTestCases.GetSemanticConventionsTestCases();
 
+    [Fact]
+    public void GetSanitizedSql_CreateTableWithTrailingIdentifier_DoesNotThrow()
+    {
+        var sql = "CREATE TABLE XXX";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        Assert.Equal(sql, sqlStatementInfo.SanitizedSql);
+        Assert.Equal(sql, sqlStatementInfo.DbQuerySummary);
+    }
+
     [SkippableTheory]
     [MemberData(nameof(TestData))]
     public void TestGetSanitizedSql(SqlProcessorTestCases.TestCase testCase)


### PR DESCRIPTION
## Changes

- Fix `IndexOutOfRangeException` if trailing whitespace in an SQL statement aligns with an `ArrayPool` bucket boundary.
- Remove unused code related to parsing SQL queries from OpenTelemetry.Instrumentation.StackExchangeRedis.

I ran the benchmarks locally, and the differences are basically statistical noise.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
