### PR TITLE
[Remoting] Apply limit to cache size

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
+++ b/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.Remoting.Contexts;
 using System.Runtime.Remoting.Messaging;
@@ -28,21 +27,18 @@ internal sealed class TelemetryDynamicSink : IDynamicMessageSink
     private readonly string activityInName;
     private readonly string activityOutName;
     private readonly string savedAspnetActivityPropertyName;
-    private readonly ConcurrentDictionary<string, string> serviceNameCache;
 
     private readonly TelemetryDynamicSinkProvider optionsProvider;
 
     public TelemetryDynamicSink(
         TelemetryDynamicSinkProvider optionsProvider,
-        ActivitySource activitySource,
-        ConcurrentDictionary<string, string> serviceNameCache)
+        ActivitySource activitySource)
     {
         this.optionsProvider = optionsProvider;
         this.remotingActivitySource = activitySource;
         this.activityOutName = activitySource.Name + ".RequestOut";
         this.activityInName = activitySource.Name + ".RequestIn";
         this.savedAspnetActivityPropertyName = activitySource.Name + ".SavedAspnetActivity";
-        this.serviceNameCache = serviceNameCache;
     }
 
     public void ProcessMessageStart(IMessage reqMsg, bool bCliSide, bool bAsync)
@@ -318,17 +314,7 @@ internal sealed class TelemetryDynamicSink : IDynamicMessageSink
     private string GetServiceName(string typeName)
     {
         // typeName will be a full .NET type name as a string "SharedLib.IHelloServer, SharedLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
-        return this.serviceNameCache.GetOrAdd(typeName, assemblyQualifiedTypeName =>
-        {
-            int index = assemblyQualifiedTypeName.IndexOf(",", StringComparison.OrdinalIgnoreCase);
-            if (index >= 0)
-            {
-                // Trim to just the type's full name
-                return assemblyQualifiedTypeName.Substring(0, index);
-            }
-
-            return assemblyQualifiedTypeName;
-        });
+        return this.optionsProvider.GetServiceName(typeName);
     }
 
     private void SetPostCreationAttributes(Activity activity, IMethodMessage? msg)

--- a/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSinkProvider.cs
+++ b/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSinkProvider.cs
@@ -17,11 +17,13 @@ internal sealed class TelemetryDynamicSinkProvider : IDynamicProperty, IContribu
 {
     internal const string ActivitySourceName = "OpenTelemetry.Instrumentation.Remoting";
     internal const string DynamicPropertyName = "TelemetryDynamicSinkProvider";
+    internal const int MaxCachedServiceNames = 1024;
     internal static readonly Version SemanticConventionsVersion = new(1, 40, 0);
 
     private readonly ActivitySource activitySource = ActivitySourceFactory.Create<TelemetryDynamicSinkProvider>(SemanticConventionsVersion);
     private readonly ConcurrentDictionary<string, string> serviceNameCache = new();
     private readonly IDisposable? optionsChangeRegistration;
+    private int approximateServiceNameCacheCount;
 
     private volatile RemotingInstrumentationOptions options;
 
@@ -36,16 +38,47 @@ internal sealed class TelemetryDynamicSinkProvider : IDynamicProperty, IContribu
 
     internal RemotingInstrumentationOptions Options => this.options;
 
+    internal int CachedServiceNameCount => Volatile.Read(ref this.approximateServiceNameCacheCount);
+
     /// <summary>
     /// Creates and returns a <see cref="TelemetryDynamicSink"/> to be used for instrumentation.
     /// </summary>
     /// <returns>A new instance of <see cref="TelemetryDynamicSink"/>.</returns>
-    public IDynamicMessageSink GetDynamicSink() => new TelemetryDynamicSink(this, this.activitySource, this.serviceNameCache);
+    public IDynamicMessageSink GetDynamicSink() => new TelemetryDynamicSink(this, this.activitySource);
 
     /// <inheritdoc />
     public void Dispose()
     {
         this.optionsChangeRegistration?.Dispose();
         this.activitySource.Dispose();
+    }
+
+    internal static string ExtractServiceName(string assemblyQualifiedTypeName)
+    {
+        int index = assemblyQualifiedTypeName.IndexOf(',');
+        return index >= 0 ? assemblyQualifiedTypeName.Substring(0, index) : assemblyQualifiedTypeName;
+    }
+
+    internal string GetServiceName(string typeName)
+    {
+        if (this.serviceNameCache.TryGetValue(typeName, out var serviceName))
+        {
+            return serviceName;
+        }
+
+        serviceName = ExtractServiceName(typeName);
+
+        if (Volatile.Read(ref this.approximateServiceNameCacheCount) >= MaxCachedServiceNames)
+        {
+            return serviceName;
+        }
+
+        if (this.serviceNameCache.TryAdd(typeName, serviceName))
+        {
+            Interlocked.Increment(ref this.approximateServiceNameCacheCount);
+            return serviceName;
+        }
+
+        return this.serviceNameCache.TryGetValue(typeName, out var existing) ? existing : serviceName;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSinkProvider.cs
+++ b/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSinkProvider.cs
@@ -55,7 +55,7 @@ internal sealed class TelemetryDynamicSinkProvider : IDynamicProperty, IContribu
 
     internal static string ExtractServiceName(string assemblyQualifiedTypeName)
     {
-        int index = assemblyQualifiedTypeName.IndexOf(',');
+        int index = FindAssemblySeparatorIndex(assemblyQualifiedTypeName);
         return index >= 0 ? assemblyQualifiedTypeName.Substring(0, index) : assemblyQualifiedTypeName;
     }
 
@@ -80,5 +80,33 @@ internal sealed class TelemetryDynamicSinkProvider : IDynamicProperty, IContribu
         }
 
         return this.serviceNameCache.TryGetValue(typeName, out var existing) ? existing : serviceName;
+    }
+
+    private static int FindAssemblySeparatorIndex(string assemblyQualifiedTypeName)
+    {
+        int depth = 0;
+
+        for (int i = 0; i < assemblyQualifiedTypeName.Length; i++)
+        {
+            char c = assemblyQualifiedTypeName[i];
+
+            if (c == '[')
+            {
+                depth++;
+            }
+            else if (c == ']')
+            {
+                if (depth > 0)
+                {
+                    depth--;
+                }
+            }
+            else if (c == ',' && depth == 0)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
@@ -171,6 +171,30 @@ public class RemotingInstrumentationTests
         Assert.Equal("DoStuff", activity.GetTagItem("remoting.finish.method"));
     }
 
+    [Theory]
+    [InlineData("SharedLib.IHelloServer, SharedLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", "SharedLib.IHelloServer")]
+    [InlineData("SharedLib.IHelloServer", "SharedLib.IHelloServer")]
+    public void TelemetryDynamicSinkProvider_ExtractServiceName_HandlesQualifiedAndPlainTypeNames(string typeName, string expectedServiceName)
+    {
+        Assert.Equal(expectedServiceName, TelemetryDynamicSinkProvider.ExtractServiceName(typeName));
+    }
+
+    [Fact]
+    public void TelemetryDynamicSinkProvider_BoundsServiceNameCache()
+    {
+        var provider = new TelemetryDynamicSinkProvider(new TestOptionsMonitor<RemotingInstrumentationOptions>(new RemotingInstrumentationOptions()));
+
+        string? lastResolvedServiceName = null;
+
+        for (int i = 0; i < TelemetryDynamicSinkProvider.MaxCachedServiceNames + 32; i++)
+        {
+            lastResolvedServiceName = provider.GetServiceName($"Namespace.Type{i}, Assembly{i}, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+        }
+
+        Assert.Equal($"Namespace.Type{TelemetryDynamicSinkProvider.MaxCachedServiceNames + 31}", lastResolvedServiceName);
+        Assert.Equal(TelemetryDynamicSinkProvider.MaxCachedServiceNames, provider.CachedServiceNameCount);
+    }
+
     private static void InvokeRemoteObject()
     {
         var domainSetup = AppDomain.CurrentDomain.SetupInformation;

--- a/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
@@ -24,18 +24,10 @@ public class RemotingInstrumentationTests
             .AddRemotingInstrumentation(
                 options =>
                 {
-                    options.Filter = msg =>
-                    {
-                        // xUnit runner uses AppDomains to execute tests.
-                        // Without the Filter, we would start instrumenting all cross-domain messages, including the xUnit runner ones.
-                        // We don't want this obviously, instead just inspect calls to our test object only.
-                        if (msg is IMethodMessage methodMsg)
-                        {
-                            return methodMsg.TypeName.Contains("RemoteObject");
-                        }
-
-                        return false;
-                    };
+                    // xUnit runner uses AppDomains to execute tests.
+                    // Without the Filter, we would start instrumenting all cross-domain messages, including the xUnit runner ones.
+                    // We don't want this obviously, instead just inspect calls to our test object only.
+                    options.Filter = message => message is IMethodMessage methodMsg && methodMsg.TypeName.Contains("RemoteObject");
                 })
             .Build();
 
@@ -124,15 +116,7 @@ public class RemotingInstrumentationTests
 
         optionsMonitor.Set(new RemotingInstrumentationOptions
         {
-            Filter = message =>
-            {
-                if (message is IMethodMessage methodMessage)
-                {
-                    return methodMessage.TypeName.Contains("RemoteObject");
-                }
-
-                return false;
-            },
+            Filter = message => message is IMethodMessage methodMessage && methodMessage.TypeName.Contains("RemoteObject"),
         });
 
         InvokeRemoteObject();
@@ -149,15 +133,7 @@ public class RemotingInstrumentationTests
             .AddInMemoryExporter(activities)
             .AddRemotingInstrumentation(options =>
             {
-                options.Filter = message =>
-                {
-                    if (message is IMethodMessage methodMessage)
-                    {
-                        return methodMessage.TypeName.Contains("RemoteObject");
-                    }
-
-                    return false;
-                };
+                options.Filter = message => message is IMethodMessage methodMessage && methodMessage.TypeName.Contains("RemoteObject");
                 options.EnrichWithMethodMessage = (activity, message) => activity.SetTag("remoting.start.method", message.MethodName);
                 options.EnrichWithMethodReturnMessage = (activity, message) => activity.SetTag("remoting.finish.method", message.MethodName);
             })
@@ -174,15 +150,21 @@ public class RemotingInstrumentationTests
     [Theory]
     [InlineData("SharedLib.IHelloServer, SharedLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", "SharedLib.IHelloServer")]
     [InlineData("SharedLib.IHelloServer", "SharedLib.IHelloServer")]
-    public void TelemetryDynamicSinkProvider_ExtractServiceName_HandlesQualifiedAndPlainTypeNames(string typeName, string expectedServiceName)
-    {
+    [InlineData("Company.Division.Library.MyClass", "Company.Division.Library.MyClass")]
+    [InlineData("Company.Division.Library.MyClass, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c", "Company.Division.Library.MyClass")]
+    [InlineData("Company.Division.Library.MyClass+AnotherNestedClass", "Company.Division.Library.MyClass+AnotherNestedClass")]
+    [InlineData("Company.Division.Library.MyClass+AnotherNestedClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c", "Company.Division.Library.MyClass+AnotherNestedClass")]
+    [InlineData("Company.Division.Library.MyClass+MyNestedClass`2+MyInnerNestedClass`2[[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass+AnotherNestedClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c]]", "Company.Division.Library.MyClass+MyNestedClass`2+MyInnerNestedClass`2[[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass+AnotherNestedClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c]]")]
+    [InlineData("Company.Division.Library.MyClass+MyNestedClass`2+MyInnerNestedClass`2[[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass+AnotherNestedClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c]], Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c", "Company.Division.Library.MyClass+MyNestedClass`2+MyInnerNestedClass`2[[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass+AnotherNestedClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c],[Company.Division.Library.MyClass, Company.Division.Library, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c]]")]
+    public void TelemetryDynamicSinkProvider_ExtractServiceName_HandlesQualifiedAndPlainTypeNames(string typeName, string expectedServiceName) =>
         Assert.Equal(expectedServiceName, TelemetryDynamicSinkProvider.ExtractServiceName(typeName));
-    }
 
     [Fact]
     public void TelemetryDynamicSinkProvider_BoundsServiceNameCache()
     {
-        var provider = new TelemetryDynamicSinkProvider(new TestOptionsMonitor<RemotingInstrumentationOptions>(new RemotingInstrumentationOptions()));
+        using var provider = new TelemetryDynamicSinkProvider(
+            new TestOptionsMonitor<RemotingInstrumentationOptions>(
+                new RemotingInstrumentationOptions()));
 
         string? lastResolvedServiceName = null;
 
@@ -232,17 +214,16 @@ public class RemotingInstrumentationTests
     {
         private readonly List<Action<TOptions, string?>> listeners = [];
         private readonly bool updateCurrentValueOnSet;
-        private TOptions currentValue;
 
         public TestOptionsMonitor(TOptions currentValue, bool updateCurrentValueOnSet = true)
         {
-            this.currentValue = currentValue;
+            this.CurrentValue = currentValue;
             this.updateCurrentValueOnSet = updateCurrentValueOnSet;
         }
 
-        public TOptions CurrentValue => this.currentValue;
+        public TOptions CurrentValue { get; private set; }
 
-        public TOptions Get(string? name) => this.currentValue;
+        public TOptions Get(string? name) => this.CurrentValue;
 
         public IDisposable OnChange(Action<TOptions, string?> listener)
         {
@@ -254,7 +235,7 @@ public class RemotingInstrumentationTests
         {
             if (this.updateCurrentValueOnSet)
             {
-                this.currentValue = value;
+                this.CurrentValue = value;
             }
 
             foreach (var listener in this.listeners)
@@ -273,9 +254,6 @@ public class RemotingInstrumentationTests
             this.callback = callback;
         }
 
-        public void Dispose()
-        {
-            this.callback();
-        }
+        public void Dispose() => this.callback();
     }
 }


### PR DESCRIPTION
Fixes #4132.

## Changes

Apply a maximum size to the cache of type to service name mappings.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
