### PR TITLE
[Instrumentation.GrpcCore] Fix message event recording for non-Protobuf payloads

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 
+* Fixed `RecordMessageEvents` to skip message-event emission for custom-marshalled
+  payloads that do not implement `Google.Protobuf.IMessage`.
+  ([#4141](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4141))
+
 ## 1.0.0-beta.10
 
 Released 2026-Feb-16

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -82,7 +82,10 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
             return;
         }
 
-        this.AddMessageEvent(typeof(TRequest).Name, (request as IMessage)!, request: true);
+        if (request is IMessage message)
+        {
+            this.AddMessageEvent(typeof(TRequest).Name, message, request: true);
+        }
     }
 
     /// <summary>
@@ -100,7 +103,10 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
             return;
         }
 
-        this.AddMessageEvent(typeof(TResponse).Name, (response as IMessage)!, request: false);
+        if (response is IMessage message)
+        {
+            this.AddMessageEvent(typeof(TResponse).Name, message, request: false);
+        }
     }
 
     /// <summary>
@@ -239,8 +245,13 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// <param name="eventName">Name of the event.</param>
     /// <param name="message">The message.</param>
     /// <param name="request">if true this is a request message.</param>
-    private void AddMessageEvent(string eventName, IMessage message, bool request)
+    private void AddMessageEvent(string eventName, IMessage? message, bool request)
     {
+        if (message == null)
+        {
+            return;
+        }
+
         var messageSize = message.CalculateSize();
 
         var attributes = new ActivityTagsCollection(

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -281,6 +281,40 @@ public class GrpcCoreClientInterceptorTests
     }
 
     /// <summary>
+    /// Validates that non protobuf payloads do not cause interceptor failures
+    /// when message event recording is enabled.
+    /// </summary>
+    [Fact]
+    public void BlockingUnaryCallWithNonProtobufPayloadDoesNotThrowWhenRecordingMessageEvents()
+    {
+        var testTags = new TestActivityTags();
+        var interceptorOptions = new ClientTracingInterceptorOptions
+        {
+            Propagator = new TraceContextPropagator(),
+            RecordMessageEvents = true,
+            AdditionalTags = testTags.Tags,
+        };
+        var interceptor = new ClientTracingInterceptor(interceptorOptions);
+        var context = new ClientInterceptorContext<NonProtobufPayload, NonProtobufPayload>(
+            NonProtobufGrpcTestHelpers.UnaryMethod,
+            "localhost",
+            default);
+
+        using var activityListener = new InterceptorActivityListener(testTags);
+
+        var response = interceptor.BlockingUnaryCall(
+            new NonProtobufPayload(),
+            context,
+            static (request, _) => request);
+
+        Assert.NotNull(response);
+
+        var activity = activityListener.Activity;
+        ValidateCommonActivityTags(activity);
+        Assert.Empty(activity!.Events);
+    }
+
+    /// <summary>
     /// Validates the common activity tags.
     /// </summary>
     /// <param name="activity">The activity.</param>

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Grpc.Core;
+using Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
 using Xunit;
 
@@ -90,6 +91,70 @@ public class GrpcCoreServerInterceptorTests
     public async Task DuplexStreamingServerHandlerFail()
     {
         await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest);
+    }
+
+    /// <summary>
+    /// Validates that non protobuf payloads do not abort server RPCs when
+    /// message event recording is enabled.
+    /// </summary>
+    [Fact]
+    public async Task UnaryServerHandlerWithNonProtobufPayloadDoesNotThrowWhenRecordingMessageEvents()
+    {
+        var testTags = new TestActivityTags();
+        var interceptorOptions = new ServerTracingInterceptorOptions
+        {
+            Propagator = new TraceContextPropagator(),
+            RecordMessageEvents = true,
+            AdditionalTags = testTags.Tags,
+        };
+
+        static Task<NonProtobufPayload> HandleUnaryCall(NonProtobufPayload request, ServerCallContext context) =>
+            Task.FromResult(new NonProtobufPayload());
+
+        var serviceDefinition = ServerServiceDefinition.CreateBuilder()
+            .AddMethod(
+                NonProtobufGrpcTestHelpers.UnaryMethod,
+                HandleUnaryCall)
+            .Build()
+            .Intercept(new ServerTracingInterceptor(interceptorOptions));
+
+        var server = new Server
+        {
+            Ports = { { "localhost", ServerPort.PickUnused, ServerCredentials.Insecure } },
+            Services = { serviceDefinition },
+        };
+
+        server.Start();
+        var serverUriString = new Uri("dns:localhost:" + server.Ports.Single().BoundPort).ToString();
+
+        try
+        {
+            using var activityListener = new InterceptorActivityListener(testTags);
+            var channel = new Channel(serverUriString, ChannelCredentials.Insecure);
+
+            try
+            {
+                var response = channel.CreateCallInvoker().BlockingUnaryCall(
+                    NonProtobufGrpcTestHelpers.UnaryMethod,
+                    null,
+                    default,
+                    new NonProtobufPayload());
+
+                Assert.NotNull(response);
+
+                var activity = activityListener.Activity;
+                GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity);
+                Assert.Empty(activity!.Events);
+            }
+            finally
+            {
+                await channel.ShutdownAsync();
+            }
+        }
+        finally
+        {
+            await server.ShutdownAsync();
+        }
     }
 
     /// <summary>

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufGrpcTestHelpers.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufGrpcTestHelpers.cs
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Grpc.Core;
+
+namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
+
+internal static class NonProtobufGrpcTestHelpers
+{
+    internal static readonly Marshaller<NonProtobufPayload> PayloadMarshaller =
+        new(static _ => [], static _ => new NonProtobufPayload());
+
+    internal static readonly Method<NonProtobufPayload, NonProtobufPayload> UnaryMethod =
+        new(
+            MethodType.Unary,
+            "OpenTelemetry.Instrumentation.GrpcCore.Tests.Foobar",
+            "Unary",
+            PayloadMarshaller,
+            PayloadMarshaller);
+}

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufPayload.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufPayload.cs
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
+
+internal sealed class NonProtobufPayload
+{
+}

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufPayload.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufPayload.cs
@@ -3,6 +3,4 @@
 
 namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
 
-internal sealed class NonProtobufPayload
-{
-}
+internal sealed class NonProtobufPayload;


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed `RecordMessageEvents` to skip message-event emission for custom-marshalled payloads that do not implement `Google.Protobuf.IMessage`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
