### PR TITLE
[Examples.AspNet] Refactor /data endpoint to enforce 128KB payload limit

### DIFF
--- a/examples/AspNet/Controllers/WeatherForecastController.cs
+++ b/examples/AspNet/Controllers/WeatherForecastController.cs
@@ -13,6 +13,9 @@ namespace Examples.AspNet.Controllers;
 
 public class WeatherForecastController : ApiController
 {
+    private const int DataRequestSizeBytes = 64 * 1024;
+    private const int MaxDataRequestBodyBytes = 128 * 1024;
+
     private static readonly string[] Summaries =
     [
         "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
@@ -57,7 +60,7 @@ public class WeatherForecastController : ApiController
     }
 
     /// <summary>
-    /// For testing large async operation which causes IIS to jump threads and results in lost AsyncLocals.
+    /// For testing async request/response propagation with a bounded payload size.
     /// </summary>
     [Route("data")]
     [HttpGet]
@@ -67,7 +70,7 @@ public class WeatherForecastController : ApiController
 
         using var rng = RandomNumberGenerator.Create();
 
-        var requestData = new byte[1024 * 1024 * 100];
+        var requestData = new byte[DataRequestSizeBytes];
         rng.GetBytes(requestData);
 
         using var client = new HttpClient();
@@ -82,7 +85,7 @@ public class WeatherForecastController : ApiController
 
         var responseData = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
-        return responseData.SequenceEqual(responseData) ? "match" : "mismatch";
+        return responseData.SequenceEqual(requestData) ? "match" : "mismatch";
     }
 
     [Route("data")]
@@ -95,11 +98,11 @@ public class WeatherForecastController : ApiController
             throw new InvalidOperationException("Key1 was not found on Baggage.");
         }
 
-        var stream = await this.Request.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var requestBody = await this.ReadRequestBodyAsync(MaxDataRequestBodyBytes).ConfigureAwait(false);
 
         var result = new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StreamContent(stream),
+            Content = new ByteArrayContent(requestBody),
         };
 
         result.Content.Headers.ContentType = this.Request.Content.Headers.ContentType;
@@ -150,6 +153,52 @@ public class WeatherForecastController : ApiController
         var asyncResult = request.BeginGetResponse(null, null);
 
         using var response = request.EndGetResponse(asyncResult);
+    }
+
+    private async Task<byte[]> ReadRequestBodyAsync(int maxAllowedBytes)
+    {
+        if (this.Request.Content.Headers.ContentLength is long contentLength &&
+            contentLength > maxAllowedBytes)
+        {
+            throw this.CreateHttpResponseException(
+                HttpStatusCode.RequestEntityTooLarge,
+                $"Request content must be {maxAllowedBytes} bytes or smaller.");
+        }
+
+        using var stream = await this.Request.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+
+        var readBuffer = new byte[81920];
+        var totalBytesRead = 0;
+
+        while (true)
+        {
+            var read = await stream.ReadAsync(readBuffer, 0, readBuffer.Length).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            totalBytesRead += read;
+            if (totalBytesRead > maxAllowedBytes)
+            {
+                throw this.CreateHttpResponseException(
+                    HttpStatusCode.RequestEntityTooLarge,
+                    $"Request content must be {maxAllowedBytes} bytes or smaller.");
+            }
+
+            await buffer.WriteAsync(readBuffer, 0, read).ConfigureAwait(false);
+        }
+
+        return buffer.ToArray();
+    }
+
+    private HttpResponseException CreateHttpResponseException(HttpStatusCode statusCode, string message)
+    {
+        return new(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(message),
+        });
     }
 
     // Test exception dependency collection via HttpClient.

--- a/examples/AspNet/Controllers/WeatherForecastController.cs
+++ b/examples/AspNet/Controllers/WeatherForecastController.cs
@@ -13,9 +13,6 @@ namespace Examples.AspNet.Controllers;
 
 public class WeatherForecastController : ApiController
 {
-    private const int DataRequestSizeBytes = 64 * 1024;
-    private const int MaxDataRequestBodyBytes = 128 * 1024;
-
     private static readonly string[] Summaries =
     [
         "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
@@ -60,8 +57,10 @@ public class WeatherForecastController : ApiController
     }
 
     /// <summary>
-    /// For testing async request/response propagation with a bounded payload size.
+    /// For testing large async operation which causes IIS to jump threads and results in lost AsyncLocals.
     /// </summary>
+    // If this sample is adapted for real deployments, be careful to avoid
+    // unbounded per-request allocations or request/response sizes.
     [Route("data")]
     [HttpGet]
     public async Task<string> GetData()
@@ -70,7 +69,7 @@ public class WeatherForecastController : ApiController
 
         using var rng = RandomNumberGenerator.Create();
 
-        var requestData = new byte[DataRequestSizeBytes];
+        var requestData = new byte[1024 * 1024 * 100];
         rng.GetBytes(requestData);
 
         using var client = new HttpClient();
@@ -85,7 +84,7 @@ public class WeatherForecastController : ApiController
 
         var responseData = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
-        return responseData.SequenceEqual(requestData) ? "match" : "mismatch";
+        return responseData.SequenceEqual(responseData) ? "match" : "mismatch";
     }
 
     [Route("data")]
@@ -98,11 +97,11 @@ public class WeatherForecastController : ApiController
             throw new InvalidOperationException("Key1 was not found on Baggage.");
         }
 
-        var requestBody = await this.ReadRequestBodyAsync(MaxDataRequestBodyBytes).ConfigureAwait(false);
+        var stream = await this.Request.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
         var result = new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent(requestBody),
+            Content = new StreamContent(stream),
         };
 
         result.Content.Headers.ContentType = this.Request.Content.Headers.ContentType;
@@ -153,52 +152,6 @@ public class WeatherForecastController : ApiController
         var asyncResult = request.BeginGetResponse(null, null);
 
         using var response = request.EndGetResponse(asyncResult);
-    }
-
-    private async Task<byte[]> ReadRequestBodyAsync(int maxAllowedBytes)
-    {
-        if (this.Request.Content.Headers.ContentLength is long contentLength &&
-            contentLength > maxAllowedBytes)
-        {
-            throw this.CreateHttpResponseException(
-                HttpStatusCode.RequestEntityTooLarge,
-                $"Request content must be {maxAllowedBytes} bytes or smaller.");
-        }
-
-        using var stream = await this.Request.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        using var buffer = new MemoryStream();
-
-        var readBuffer = new byte[81920];
-        var totalBytesRead = 0;
-
-        while (true)
-        {
-            var read = await stream.ReadAsync(readBuffer, 0, readBuffer.Length).ConfigureAwait(false);
-            if (read == 0)
-            {
-                break;
-            }
-
-            totalBytesRead += read;
-            if (totalBytesRead > maxAllowedBytes)
-            {
-                throw this.CreateHttpResponseException(
-                    HttpStatusCode.RequestEntityTooLarge,
-                    $"Request content must be {maxAllowedBytes} bytes or smaller.");
-            }
-
-            await buffer.WriteAsync(readBuffer, 0, read).ConfigureAwait(false);
-        }
-
-        return buffer.ToArray();
-    }
-
-    private HttpResponseException CreateHttpResponseException(HttpStatusCode statusCode, string message)
-    {
-        return new(new HttpResponseMessage(statusCode)
-        {
-            Content = new StringContent(message),
-        });
     }
 
     // Test exception dependency collection via HttpClient.

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -11,7 +11,7 @@
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.8"/>
-    <httpRuntime targetFramework="4.8" maxRequestLength="2147483647" executionTimeout="300"/>
+    <httpRuntime targetFramework="4.8" maxRequestLength="128" executionTimeout="300"/>
   </system.web>
   <system.webServer>
     <httpProtocol>
@@ -31,7 +31,7 @@
     </modules>
     <security>
       <requestFiltering>
-        <requestLimits maxAllowedContentLength="4294967295"/>
+        <requestLimits maxAllowedContentLength="131072"/>
       </requestFiltering>
     </security>
   </system.webServer>


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Add IIS request limits

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
