### PR TITLE
[Infra] Update deprecated action input

### DIFF
--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -121,7 +121,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write
@@ -171,7 +171,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: read
         permission-pull-requests: write
@@ -214,7 +214,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write
@@ -264,7 +264,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write
@@ -319,7 +319,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-issues: write

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -210,7 +210,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/sync-sql-tests.yml
+++ b/.github/workflows/sync-sql-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
## Changes

`app-id` was deprecated in 3.1.0 in favour of `client-id`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
