### PR TITLE
[ServiceFabricRemoting] Respect TransportSettings

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Updated OpenTelemetry core component version(s) to `1.15.2`.
   ([#4080](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4080))
 
+* Ensure that `TransportSettings` configuration is applied to created
+  instances of `IServiceRemotingClientFactory`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.0-beta.1
 
 Released 2026-Jan-21

--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * Ensure that `TransportSettings` configuration is applied to created
   instances of `IServiceRemotingClientFactory`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4148](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4148))
 
 ## 1.15.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/ServiceRemoting/TraceContextEnrichedServiceRemotingProviderAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/ServiceRemoting/TraceContextEnrichedServiceRemotingProviderAttribute.cs
@@ -20,6 +20,7 @@ namespace OpenTelemetry.Instrumentation.ServiceFabricRemoting;
 public sealed class TraceContextEnrichedServiceRemotingProviderAttribute : FabricTransportServiceRemotingProviderAttribute
 {
     private const string DefaultV2listenerName = "V2Listener";
+    private const string DefaultTransportSettingsSectionName = "TransportSettings";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TraceContextEnrichedServiceRemotingProviderAttribute"/> class.
@@ -29,6 +30,10 @@ public sealed class TraceContextEnrichedServiceRemotingProviderAttribute : Fabri
         this.RemotingClientVersion = RemotingClientVersion.V2;
         this.RemotingListenerVersion = RemotingListenerVersion.V2;
     }
+
+    internal static Func<FabricTransportRemotingSettings?> RemotingSettingsLoader { get; set; } = LoadRemotingSettings;
+
+    internal static Func<FabricTransportRemotingListenerSettings?> ListenerSettingsLoader { get; set; } = LoadListenerSettings;
 
     /// <summary>
     /// Creates a V2 service remoting listener for remoting the service interface.
@@ -66,11 +71,7 @@ public sealed class TraceContextEnrichedServiceRemotingProviderAttribute : Fabri
     /// </returns>
     public override IServiceRemotingClientFactory CreateServiceRemotingClientFactoryV2(IServiceRemotingCallbackMessageHandler? callbackMessageHandler)
     {
-        var fabricTransportRemotingSettings = new FabricTransportRemotingSettings();
-        fabricTransportRemotingSettings.MaxMessageSize = this.GetAndValidateMaxMessageSize(fabricTransportRemotingSettings.MaxMessageSize);
-        fabricTransportRemotingSettings.OperationTimeout = this.GetAndValidateOperationTimeout(fabricTransportRemotingSettings.OperationTimeout);
-        fabricTransportRemotingSettings.KeepAliveTimeout = this.GetAndValidateKeepAliveTimeout(fabricTransportRemotingSettings.KeepAliveTimeout);
-        fabricTransportRemotingSettings.ConnectTimeout = this.GetConnectTimeout(fabricTransportRemotingSettings.ConnectTimeout);
+        var fabricTransportRemotingSettings = this.GetRemotingSettings();
 
         var fabricTransportServiceRemotingClientFactory = new FabricTransportServiceRemotingClientFactory(
             fabricTransportRemotingSettings,
@@ -82,15 +83,56 @@ public sealed class TraceContextEnrichedServiceRemotingProviderAttribute : Fabri
         return new TraceContextEnrichedServiceRemotingClientFactoryAdapter(fabricTransportServiceRemotingClientFactory);
     }
 
-    private FabricTransportRemotingListenerSettings GetListenerSettings()
+    internal FabricTransportRemotingListenerSettings GetListenerSettings()
     {
-        var listenerSettings = new FabricTransportRemotingListenerSettings();
+        var settings = ListenerSettingsLoader() ?? new FabricTransportRemotingListenerSettings();
 
-        listenerSettings.MaxMessageSize = this.GetAndValidateMaxMessageSize(listenerSettings.MaxMessageSize);
-        listenerSettings.OperationTimeout = this.GetAndValidateOperationTimeout(listenerSettings.OperationTimeout);
-        listenerSettings.KeepAliveTimeout = this.GetAndValidateKeepAliveTimeout(listenerSettings.KeepAliveTimeout);
+        settings.MaxMessageSize = this.GetAndValidateMaxMessageSize(settings.MaxMessageSize);
+        settings.OperationTimeout = this.GetAndValidateOperationTimeout(settings.OperationTimeout);
+        settings.KeepAliveTimeout = this.GetAndValidateKeepAliveTimeout(settings.KeepAliveTimeout);
 
-        return listenerSettings;
+        return settings;
+    }
+
+    internal FabricTransportRemotingSettings GetRemotingSettings()
+    {
+        var settings = RemotingSettingsLoader() ?? new FabricTransportRemotingSettings();
+
+        settings.MaxMessageSize = this.GetAndValidateMaxMessageSize(settings.MaxMessageSize);
+        settings.OperationTimeout = this.GetAndValidateOperationTimeout(settings.OperationTimeout);
+        settings.KeepAliveTimeout = this.GetAndValidateKeepAliveTimeout(settings.KeepAliveTimeout);
+        settings.ConnectTimeout = this.GetConnectTimeout(settings.ConnectTimeout);
+
+        return settings;
+    }
+
+    private static FabricTransportRemotingSettings? LoadRemotingSettings() =>
+        TryLoadSettings(() =>
+            FabricTransportRemotingSettings.TryLoadFrom(DefaultTransportSettingsSectionName, out var settings, filepath: null, configPackageName: null)
+                ? settings
+                : null);
+
+    private static FabricTransportRemotingListenerSettings? LoadListenerSettings() =>
+        TryLoadSettings(() =>
+            FabricTransportRemotingListenerSettings.TryLoadFrom(DefaultTransportSettingsSectionName, out var settings, configPackageName: null)
+                ? settings
+                : null);
+
+    private static T? TryLoadSettings<T>(Func<T?> loader)
+        where T : class
+    {
+        try
+        {
+            return loader();
+        }
+        catch (DllNotFoundException)
+        {
+            return null;
+        }
+        catch (TypeInitializationException ex) when (ex.InnerException is DllNotFoundException)
+        {
+            return null;
+        }
     }
 
     private long GetAndValidateMaxMessageSize(long maxMessageSizeDefault)

--- a/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Include must be the fully qualified .NET type name of the Attribute to create. -->
     <AssemblyAttribute Include="OpenTelemetry.Instrumentation.ServiceFabricRemoting.TraceContextEnrichedServiceRemotingProviderAttribute" />
     <AssemblyAttribute Include="OpenTelemetry.Instrumentation.ServiceFabricRemoting.TraceContextEnrichedActorRemotingProviderAttribute" />

--- a/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/ServiceFabricRemotingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/ServiceFabricRemotingTests.cs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Fabric;
 using System.Text;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting.V2;
 using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
 using OpenTelemetry.Context.Propagation;
@@ -22,6 +25,7 @@ public class ServiceFabricRemotingTests
     private const string BaggageKey = "SomeBaggageKey";
     private const string BaggageValue = "SomeBaggageValue";
     private static readonly ActivitySource ActivitySource = new("ServiceFabricRemotingTests");
+    private static readonly Lock TransportSettingsLock = new();
 
     [Fact]
     public async Task TestStatefulServiceContextPropagation_ShouldExtractActivityContextAndBaggage()
@@ -142,6 +146,74 @@ public class ServiceFabricRemotingTests
 
         Assert.Equal(activity.TraceId, propagationContext.ActivityContext.TraceId);
         Assert.Equal(BaggageValue, propagationContext.Baggage.GetBaggage(BaggageKey));
+    }
+
+    [Fact]
+    public void ServiceRemotingProviderListenerSettings_LoadConfiguredTransportDefaults()
+    {
+        lock (TransportSettingsLock)
+        {
+            var originalLoader = TraceContextEnrichedServiceRemotingProviderAttribute.ListenerSettingsLoader;
+
+            try
+            {
+                TraceContextEnrichedServiceRemotingProviderAttribute.ListenerSettingsLoader = () => new FabricTransportRemotingListenerSettings
+                {
+                    MaxQueueSize = 35,
+                    SecurityCredentials = new X509Credentials(),
+                };
+
+                var provider = new TraceContextEnrichedServiceRemotingProviderAttribute
+                {
+                    MaxMessageSize = 17,
+                };
+
+                var actual = provider.GetListenerSettings();
+
+                Assert.Equal(35, actual.MaxQueueSize);
+                Assert.Equal(CredentialType.X509, actual.SecurityCredentials.CredentialType);
+                Assert.Equal(17, actual.MaxMessageSize);
+            }
+            finally
+            {
+                TraceContextEnrichedServiceRemotingProviderAttribute.ListenerSettingsLoader = originalLoader;
+            }
+        }
+    }
+
+    [Fact]
+    public void ServiceRemotingProviderClientFactory_LoadsConfiguredTransportDefaults()
+    {
+        lock (TransportSettingsLock)
+        {
+            var originalLoader = TraceContextEnrichedServiceRemotingProviderAttribute.RemotingSettingsLoader;
+
+            try
+            {
+                TraceContextEnrichedServiceRemotingProviderAttribute.RemotingSettingsLoader = () => new FabricTransportRemotingSettings
+                {
+                    MaxQueueSize = 35,
+                    ConnectTimeout = TimeSpan.FromMilliseconds(7),
+                    SecurityCredentials = new X509Credentials(),
+                };
+
+                var provider = new TraceContextEnrichedServiceRemotingProviderAttribute
+                {
+                    MaxMessageSize = 17,
+                };
+
+                var actual = provider.GetRemotingSettings();
+
+                Assert.Equal(35, actual.MaxQueueSize);
+                Assert.Equal(CredentialType.X509, actual.SecurityCredentials.CredentialType);
+                Assert.Equal(TimeSpan.FromMilliseconds(7), actual.ConnectTimeout);
+                Assert.Equal(17, actual.MaxMessageSize);
+            }
+            finally
+            {
+                TraceContextEnrichedServiceRemotingProviderAttribute.RemotingSettingsLoader = originalLoader;
+            }
+        }
     }
 
     private ServiceRemotingRequestMessageHeaderMock CreateServiceRemotingRequestMessageHeader(Type interfaceType, string methodName)

--- a/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/ServiceFabricRemotingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/ServiceFabricRemotingTests.cs
@@ -182,7 +182,7 @@ public class ServiceFabricRemotingTests
     }
 
     [Fact]
-    public void ServiceRemotingProviderClientFactory_LoadsConfiguredTransportDefaults()
+    public void ServiceRemotingProviderListenerSettings_LoadConfiguredRemotingSettings()
     {
         lock (TransportSettingsLock)
         {


### PR DESCRIPTION
## Changes

Respect any user-configured `TransportSettings` options that are used.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
