### PR TITLE
[Shared] Fix flaky tests and avoid deadlock

### DIFF
--- a/test/Shared/TestHttpServer.cs
+++ b/test/Shared/TestHttpServer.cs
@@ -58,6 +58,7 @@ internal static class TestHttpServer
         private readonly Task httpListenerTask;
         private readonly HttpListener listener;
         private readonly TaskCompletionSource<bool> initialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly CancellationTokenSource cancellationTokenSource = new();
 
         public RunningServer(Action<HttpListenerContext> action, string host, int port)
         {
@@ -66,18 +67,21 @@ internal static class TestHttpServer
             this.listener.Prefixes.Add($"http://{host}:{port}/");
             this.listener.Start();
 
-            this.httpListenerTask = Task.Run(() => this.ListenAsync(action));
+            this.httpListenerTask = Task.Factory.StartNew(
+                () => this.ListenAsync(action),
+                this.cancellationTokenSource.Token,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
         }
 
-        public void Start()
-        {
-            this.initialized.Task.GetAwaiter().GetResult();
-        }
+        public void Start() => this.initialized.Task.GetAwaiter().GetResult();
 
         public void Dispose()
         {
             try
             {
+                this.cancellationTokenSource.Cancel();
+                this.cancellationTokenSource.Dispose();
                 this.listener.Close();
                 this.httpListenerTask.GetAwaiter().GetResult();
             }
@@ -87,20 +91,25 @@ internal static class TestHttpServer
             }
         }
 
-        private bool IsListenerShutdownException(Exception ex) =>
+        private static bool IsResponseAlreadyClosedException(Exception ex) =>
             ex is ObjectDisposedException ||
-            (ex is HttpListenerException httpEx && (httpEx.ErrorCode is 6 or 995 or 10057)) ||
+            (ex is HttpListenerException httpEx && (httpEx.ErrorCode is 1 or 6 or 995 or 10057));
+
+        private bool IsListenerShutdownException(Exception ex) =>
+            IsResponseAlreadyClosedException(ex) ||
             (ex is InvalidOperationException && !this.listener.IsListening);
 
         private async Task ListenAsync(Action<HttpListenerContext> action)
         {
             this.initialized.TrySetResult(true);
 
-            while (true)
+            while (!this.cancellationTokenSource.IsCancellationRequested)
             {
+                HttpListenerContext? context = null;
+
                 try
                 {
-                    var context = await this.listener.GetContextAsync().ConfigureAwait(false);
+                    context = await this.listener.GetContextAsync().ConfigureAwait(false);
                     action(context);
                 }
                 catch (Exception ex)
@@ -114,6 +123,27 @@ internal static class TestHttpServer
 
                     throw;
                 }
+                finally
+                {
+                    if (context is not null)
+                    {
+                        this.TryCloseResponse(context.Response);
+                    }
+                }
+
+                await Task.Yield();
+            }
+        }
+
+        private void TryCloseResponse(HttpListenerResponse response)
+        {
+            try
+            {
+                response.Close();
+            }
+            catch (Exception ex) when (IsResponseAlreadyClosedException(ex))
+            {
+                // The handler completed the response explicitly.
             }
         }
     }

--- a/test/Shared/TestHttpServer.cs
+++ b/test/Shared/TestHttpServer.cs
@@ -91,9 +91,23 @@ internal static class TestHttpServer
             }
         }
 
-        private static bool IsResponseAlreadyClosedException(Exception ex) =>
-            ex is ObjectDisposedException ||
-            (ex is HttpListenerException httpEx && (httpEx.ErrorCode is 1 or 6 or 995 or 10057));
+        private static bool IsResponseAlreadyClosedException(Exception exception)
+        {
+            for (var ex = exception; ex is not null; ex = ex.InnerException)
+            {
+                if (ex is ObjectDisposedException)
+                {
+                    return true;
+                }
+
+                if (ex is HttpListenerException httpEx && (httpEx.ErrorCode is 1 or 6 or 995 or 10057))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private bool IsListenerShutdownException(Exception ex) =>
             IsResponseAlreadyClosedException(ex) ||
@@ -110,7 +124,17 @@ internal static class TestHttpServer
                 try
                 {
                     context = await this.listener.GetContextAsync().ConfigureAwait(false);
-                    action(context);
+
+                    try
+                    {
+                        action(context);
+                    }
+                    catch (Exception ex) when (IsResponseAlreadyClosedException(ex))
+                    {
+                        // Client disconnected / response stream already torn down while the handler
+                        // was writing the response or disposing response writer/stream.
+                        // Treat as non-fatal and continue accepting new requests.
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -143,7 +167,7 @@ internal static class TestHttpServer
             }
             catch (Exception ex) when (IsResponseAlreadyClosedException(ex))
             {
-                // The handler completed the response explicitly.
+                // The handler completed the response explicitly or the client disconnected.
             }
         }
     }

--- a/test/Shared/TestHttpServer.cs
+++ b/test/Shared/TestHttpServer.cs
@@ -71,7 +71,7 @@ internal static class TestHttpServer
                 () => this.ListenAsync(action),
                 this.cancellationTokenSource.Token,
                 TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
+                TaskScheduler.Default).Unwrap();
         }
 
         public void Start() => this.initialized.Task.GetAwaiter().GetResult();


### PR DESCRIPTION
## Changes

- Attempt to fix flaky test shutdown.
- Avoid deadlock when used with `HttpClient.Send()` (found in #4153).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
