### PR TITLE
[Resources.AWS] Ensure ECS cluster ARN is always in correct ARN format

### DIFF
--- a/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
@@ -129,7 +129,14 @@ internal sealed partial class AWSECSDetector : IResourceDetector
 
         if (!clusterArn.StartsWith("arn:", StringComparison.Ordinal))
         {
-            var baseArn = containerArn.Substring(0, containerArn.LastIndexOf(':'));
+            var containerArnSeparatorIndex = containerArn.LastIndexOf(':');
+            if (containerArnSeparatorIndex < 0)
+            {
+                AWSResourcesEventSource.Log.ResourceAttributesExtractException(nameof(AWSECSDetector), new ArgumentException("The ECS Metadata V4 response contained an invalid 'ContainerARN' field"));
+                return;
+            }
+
+            var baseArn = containerArn.Substring(0, containerArnSeparatorIndex);
             clusterArn = $"{baseArn}:cluster/{clusterArn}";
         }
 

--- a/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
@@ -127,6 +127,12 @@ internal sealed partial class AWSECSDetector : IResourceDetector
             return;
         }
 
+        if (!clusterArn.StartsWith("arn:", StringComparison.Ordinal))
+        {
+            var baseArn = containerArn.Substring(0, containerArn.LastIndexOf(':'));
+            clusterArn = $"{baseArn}:cluster/{clusterArn}";
+        }
+
         resourceAttributes
             .AddAttributeCloudResourceId(containerArn)
             .AddAttributeEcsContainerArn(containerArn)

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Limit how much of the response body is consumed from metadata service HTTP responses.
   ([#4122](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4122))
 
+* Fix ECS Metadata V4 cluster ARN normalization when the `Cluster` field returns
+  a cluster name instead of an ARN.
+  ([#4160](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4160))
+
 ## 1.15.0
 
 Released 2026-Jan-21

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
@@ -143,6 +143,29 @@ public class AWSECSDetectorTests
     }
 
     [Fact]
+    public async Task TestEcsMetadataV4Ec2WithInvalidContainerArn()
+    {
+        await using var metadataEndpoint = new MockEcsMetadataEndpoint(
+            "ecs_metadata/metadatav4-response-container-ec2-invalid-container-arn.json",
+            "ecs_metadata/metadatav4-response-task-ec2.json");
+
+        using (EnvironmentVariableScope.Create(AWSECSMetadataURLV4Key, metadataEndpoint.Address.ToString()))
+        {
+            var ecsResourceDetector = new AWSECSDetector(
+                new OpenTelemetry.AWS.AWSSemanticConventions(
+                    SemanticConventionVersion.Latest));
+
+            var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
+
+            Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudProvider], "aws");
+            Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudPlatform], "aws_ecs");
+            Assert.DoesNotContain(ExpectedSemanticConventions.AttributeCloudResourceId, resourceAttributes.Keys);
+            Assert.DoesNotContain(ExpectedSemanticConventions.AttributeEcsClusterArn, resourceAttributes.Keys);
+            Assert.DoesNotContain(ExpectedSemanticConventions.AttributeEcsContainerArn, resourceAttributes.Keys);
+        }
+    }
+
+    [Fact]
     public async Task TestResponseBodyIsBeyondSizeLimit()
     {
         var source = new CancellationTokenSource();

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
@@ -78,6 +78,7 @@ public class AWSECSDetectorTests
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudAvailabilityZone], "us-west-2d");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudRegion], "us-west-2");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudResourceId], "arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9");
+            Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsClusterArn], "arn:aws:ecs:us-west-2:111122223333:cluster/default");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsContainerArn], "arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsLaunchtype], "ec2");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsTaskArn], "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c");
@@ -121,6 +122,7 @@ public class AWSECSDetectorTests
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudAvailabilityZone], "us-west-2a");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudRegion], "us-west-2");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudResourceId], "arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1");
+            Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsClusterArn], "arn:aws:ecs:us-west-2:111122223333:cluster/default");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsContainerArn], "arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsLaunchtype], "fargate");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeEcsTaskArn], "arn:aws:ecs:us-west-2:111122223333:task/default/e9028f8d5d8e4f258373e7b93ce9a3c3");
@@ -236,6 +238,7 @@ public class AWSECSDetectorTests
         public const string AttributeCloudRegion = "cloud.region";
         public const string AttributeCloudResourceId = "cloud.resource_id";
         public const string AttributeContainerId = "container.id";
+        public const string AttributeEcsClusterArn = "aws.ecs.cluster.arn";
         public const string AttributeEcsContainerArn = "aws.ecs.container.arn";
         public const string AttributeEcsLaunchtype = "aws.ecs.launchtype";
         public const string AttributeEcsTaskArn = "aws.ecs.task.arn";

--- a/test/OpenTelemetry.Resources.AWS.Tests/ecs_metadata/metadatav4-response-container-ec2-invalid-container-arn.json
+++ b/test/OpenTelemetry.Resources.AWS.Tests/ecs_metadata/metadatav4-response-container-ec2-invalid-container-arn.json
@@ -1,0 +1,44 @@
+{
+    "DockerId": "ea32192c8553fbff06c9340478a2ff089b2bb5646fb718b4ee206641c9086d66",
+    "Name": "curl",
+    "DockerName": "ecs-curltest-24-curl-cca48e8dcadd97805600",
+    "Image": "111122223333.dkr.ecr.us-west-2.amazonaws.com/curltest:latest",
+    "ImageID": "sha256:d691691e9652791a60114e67b365688d20d19940dde7c4736ea30e660d8d3553",
+    "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "curl",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/8f03e41243824aea923aca126495f665",
+        "com.amazonaws.ecs.task-definition-family": "curltest",
+        "com.amazonaws.ecs.task-definition-version": "24"
+    },
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "Limits": {
+        "CPU": 10,
+        "Memory": 128
+    },
+    "CreatedAt": "2020-10-02T00:15:07.620912337Z",
+    "StartedAt": "2020-10-02T00:15:08.062559351Z",
+    "Type": "NORMAL",
+    "LogDriver": "awslogs",
+    "LogOptions": {
+        "awslogs-create-group": "true",
+        "awslogs-group": "/ecs/metadata",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream": "ecs/curl/8f03e41243824aea923aca126495f665"
+    },
+    "ContainerARN": "invalid-container-arn",
+    "Networks": [
+        {
+            "NetworkMode": "awsvpc",
+            "IPv4Addresses": [
+                "10.0.2.100"
+            ],
+            "AttachmentIndex": 0,
+            "MACAddress": "0e:9e:32:c7:48:85",
+            "IPv4SubnetCIDRBlock": "10.0.2.0/24",
+            "PrivateDNSName": "ip-10-0-2-100.us-west-2.compute.internal",
+            "SubnetGatewayIpv4Address": "10.0.2.1/24"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fix ECS Metadata V4 cluster ARN normalization when the `Cluster` field returns a cluster name instead of an ARN.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
