### PR TITLE
[Geneva] Fix fuzz tests

### DIFF
--- a/test/OpenTelemetry.Exporter.Geneva.FuzzTests/MetricSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.FuzzTests/MetricSerializerTests.cs
@@ -456,14 +456,28 @@ public static class MetricSerializerTests
     public static void SerializeString_Buffer_Too_Small_Throws(NonEmptyString input)
     {
         // Arrange
-        var str = input.Get.Substring(0, Math.Min(input.Get.Length, 10)); // Limit string size
-        var requiredSize = System.Text.Encoding.UTF8.GetByteCount(str) + sizeof(short);
+        var value = input.Get.Substring(0, Math.Min(input.Get.Length, 10)); // Limit string size
+        var requiredSize = System.Text.Encoding.UTF8.GetByteCount(value) + sizeof(short);
         var bufferSize = Math.Max(1, requiredSize / 2); // Intentionally too small
         var buffer = new byte[bufferSize];
         var offset = 0;
 
         // Act
-        var ex = Assert.ThrowsAny<Exception>(() => MetricSerializer.SerializeString(buffer, ref offset, str));
+        var ex = Assert.ThrowsAny<Exception>(() => MetricSerializer.SerializeString(buffer, ref offset, value));
+
+        // Assert
+        Assert.True(ex is ArgumentException or IndexOutOfRangeException, $"Unexpected exception type {ex.GetType()}.");
+    }
+
+    [Property(MaxTest = MaxValue, Replay = "(11934653490780154147,14955749465213992389,100)")]
+    public static void SerializeString_Buffer_Too_Small_Throws_Repro(NonEmptyString input, PositiveInt nearEnd)
+    {
+        // Arrange
+        var buffer = new byte[100];
+        var offset = Math.Min(nearEnd.Get % 100, 47); // Start near or at the end
+
+        // Act
+        var ex = Assert.ThrowsAny<Exception>(() => MetricSerializer.SerializeString(buffer, ref offset, input.Get));
 
         // Assert
         Assert.True(ex is ArgumentException or IndexOutOfRangeException, $"Unexpected exception type {ex.GetType()}.");
@@ -475,6 +489,12 @@ public static class MetricSerializerTests
         // Arrange
         var buffer = new byte[100];
         var offset = Math.Min(nearEnd.Get % 100, 99); // Start near or at the end
+        var encodedLength = System.Text.Encoding.UTF8.GetByteCount(input.Get);
+
+        if (encodedLength > (buffer.Length - offset - sizeof(short)))
+        {
+            return;
+        }
 
         // Act
         MetricSerializer.SerializeString(buffer, ref offset, input.Get);


### PR DESCRIPTION
## Changes

Handle case where `SerializeString_Offset_Near_Buffer_End_Does_Not_Throw` would generate inputs that would throw an exception as the encoded string is too large for the buffer.

[Example](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/24669440730/job/72135844853?pr=4161#step:8:1711)

```text
[xUnit.net 00:00:04.56]     OpenTelemetry.Exporter.Geneva.MetricSerializerTests.SerializeString_Offset_Near_Buffer_End_Does_Not_Throw [FAIL]
[xUnit.net 00:00:04.56]       FsCheck.Xunit.PropertyFailedException : 
[xUnit.net 00:00:04.56]       Falsifiable, after 1000 tests (52 shrinks) (10253591241543748838,13012710626530032541). 
[xUnit.net 00:00:04.56]       Last step was invoked with size of 100 and seed of (11934653490780154147,14955749465213992389).
[xUnit.net 00:00:04.56]       Replay directly at failing step with (11934653490780154147,14955749465213992389,100).
[xUnit.net 00:00:04.56]       Original:
[xUnit.net 00:00:04.56]       (NonEmptyString "IDB\017^^\014]%Y
du\0188\008vl>\011=\028s\0163vm&U3\127F\023dC.v\1275\002\016d
bh{EO].q\027",
 PositiveInt 47) (At least one control character has been escaped as a char code, e.g. \023)
[xUnit.net 00:00:04.56]       Shrunk:
[xUnit.net 00:00:04.56]       (NonEmptyString "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 PositiveInt 47)
[xUnit.net 00:00:04.56]       
[xUnit.net 00:00:04.56]       ---- System.ArgumentException : The output byte buffer is too small to contain the encoded data, encoding codepage '65001' and fallback 'System.Text.EncoderReplacementFallback'. (Parameter 'bytes')
[xUnit.net 00:00:04.56]       Stack Trace:
[xUnit.net 00:00:04.57]         
[xUnit.net 00:00:04.57]         ----- Inner Stack Trace -----
[xUnit.net 00:00:04.57]            at System.Text.Encoding.ThrowBytesOverflow()
[xUnit.net 00:00:04.57]            at System.Text.Encoding.ThrowBytesOverflow(EncoderNLS encoder, Boolean nothingEncoded)
[xUnit.net 00:00:04.57]            at System.Text.Encoding.GetBytesWithFallback(ReadOnlySpan`1 chars, Int32 originalCharsLength, Span`1 bytes, Int32 originalBytesLength, EncoderNLS encoder, Boolean throwForDestinationOverflow)
[xUnit.net 00:00:04.57]            at System.Text.Encoding.GetBytesWithFallback(Char* pOriginalChars, Int32 originalCharCount, Byte* pOriginalBytes, Int32 originalByteCount, Int32 charsConsumedSoFar, Int32 bytesWrittenSoFar, Boolean throwForDestinationOverflow)
[xUnit.net 00:00:04.57]            at System.Text.UTF8Encoding.GetBytes(ReadOnlySpan`1 chars, Span`1 bytes)
[xUnit.net 00:00:04.57]         /_/test/OpenTelemetry.Exporter.Geneva.FuzzTests/MetricSerializerTests.cs(480,0): at OpenTelemetry.Exporter.Geneva.MetricSerializerTests.SerializeString_Offset_Near_Buffer_End_Does_Not_Throw(NonEmptyString input, PositiveInt nearEnd)
[xUnit.net 00:00:04.57]            at InvokeStub_MetricSerializerTests.SerializeString_Offset_Near_Buffer_End_Does_Not_Throw(Object, Span`1)
[xUnit.net 00:00:04.57]            at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
[xUnit.net 00:00:04.57]         --- End of stack trace from previous location ---
[xUnit.net 00:00:04.57]         C:\Users\kurts\Projects\FsCheck\src\FsCheck\Runner.fs(595,0): at FsCheck.Runner.invokeAndThrowInner@592-1.Invoke(Object[] o)
[xUnit.net 00:00:04.57]         D:\workspace\_work\1\s\src\fsharp\FSharp.Core\reflect.fs(986,0): at <StartupCode$FSharp-Core>.$Reflect.Invoke@986-4.Invoke(T1 inp)
[xUnit.net 00:00:04.57]            at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
[xUnit.net 00:00:04.57]            at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
[xUnit.net 00:00:04.57]            at System.Lazy`1.CreateValue()
[xUnit.net 00:00:04.57]         C:\Users\kurts\Projects\FsCheck\src\FsCheck\Testable.fs(156,0): at FsCheck.Testable.Prop.safeForce[a](Lazy`1 body)
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
