### PR TITLE
[Instrumentation.WCF] Fix null handling for AsyncCallback parameters

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -10,6 +10,10 @@
   and [GHSA-37gx-xxp4-5rgx](https://github.com/dotnet/runtime/security/advisories/GHSA-37gx-xxp4-5rgx).
   ([#4103](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4103))
 
+* Fixed an issue where instrumented WCF channel `Begin*` methods threw an
+  `ArgumentNullException` when `AsyncCallback` was `null`.
+  ([#4164](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4164))
+
 ## 1.15.0-beta.1
 
 Released 2026-Jan-21

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/AsyncResultWithTelemetryState.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/AsyncResultWithTelemetryState.cs
@@ -23,8 +23,13 @@ internal sealed class AsyncResultWithTelemetryState : IAsyncResult
 
     bool IAsyncResult.IsCompleted => this.Inner.IsCompleted;
 
-    public static AsyncCallback GetAsyncCallback(AsyncCallback innerCallback, RequestTelemetryState telemetryState) => ar =>
+    public static AsyncCallback? GetAsyncCallback(AsyncCallback? innerCallback, RequestTelemetryState telemetryState)
     {
-        innerCallback(new AsyncResultWithTelemetryState(ar, telemetryState));
-    };
+        if (innerCallback == null)
+        {
+            return null;
+        }
+
+        return ar => innerCallback(new AsyncResultWithTelemetryState(ar, telemetryState));
+    }
 }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
@@ -39,18 +39,16 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
         this.SendInternal(message, timeout, _ => this.Inner.Send(message, timeout));
     }
 
-    public IAsyncResult BeginSend(Message message, AsyncCallback callback, object? state)
+    public IAsyncResult BeginSend(Message message, AsyncCallback? callback, object? state)
     {
         Guard.ThrowIfNull(message);
-        Guard.ThrowIfNull(callback);
 
         return this.SendInternal(message, this.telemetryTimeout, (cb, s) => this.Inner.BeginSend(message, cb, s), callback, state);
     }
 
-    public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object? state)
+    public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback? callback, object? state)
     {
         Guard.ThrowIfNull(message);
-        Guard.ThrowIfNull(callback);
 
         return this.SendInternal(message, timeout, (cb, s) => this.Inner.BeginSend(message, timeout, cb, s), callback, state);
     }
@@ -85,17 +83,13 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
         return message;
     }
 
-    public IAsyncResult BeginReceive(AsyncCallback callback, object? state)
+    public IAsyncResult BeginReceive(AsyncCallback? callback, object? state)
     {
-        Guard.ThrowIfNull(callback);
-
         return this.Inner.BeginReceive(callback, state);
     }
 
-    public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object? state)
+    public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback? callback, object? state)
     {
-        Guard.ThrowIfNull(callback);
-
         return this.Inner.BeginReceive(timeout, callback, state);
     }
 
@@ -115,10 +109,8 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
         return returnValue;
     }
 
-    public IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object? state)
+    public IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback? callback, object? state)
     {
-        Guard.ThrowIfNull(callback);
-
         return this.Inner.BeginTryReceive(timeout, callback, state);
     }
 
@@ -136,10 +128,8 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
         return this.Inner.WaitForMessage(timeout);
     }
 
-    public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback callback, object? state)
+    public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback? callback, object? state)
     {
-        Guard.ThrowIfNull(callback);
-
         return this.Inner.BeginWaitForMessage(timeout, callback, state);
     }
 
@@ -164,7 +154,7 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
         ClientChannelInstrumentation.AfterRequestCompleted(null, telemetryState);
     }
 
-    private IAsyncResult SendInternal(Message message, TimeSpan timeout, Func<AsyncCallback, object?, IAsyncResult> executeSend, AsyncCallback callback, object? state)
+    private IAsyncResult SendInternal(Message message, TimeSpan timeout, Func<AsyncCallback?, object?, IAsyncResult> executeSend, AsyncCallback? callback, object? state)
     {
         IAsyncResult? result = null;
         this.SendInternal(message, timeout, telemetryState =>

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
@@ -60,18 +60,16 @@ internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestC
         return reply;
     }
 
-    IAsyncResult IRequestChannel.BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object? state)
+    IAsyncResult IRequestChannel.BeginRequest(Message message, TimeSpan timeout, AsyncCallback? callback, object? state)
     {
         Guard.ThrowIfNull(message);
-        Guard.ThrowIfNull(callback);
 
         return this.InternalBeginRequest(message, (cb, s) => this.Inner.BeginRequest(message, timeout, cb, s), callback, state);
     }
 
-    IAsyncResult IRequestChannel.BeginRequest(Message message, AsyncCallback callback, object? state)
+    IAsyncResult IRequestChannel.BeginRequest(Message message, AsyncCallback? callback, object? state)
     {
         Guard.ThrowIfNull(message);
-        Guard.ThrowIfNull(callback);
 
         return this.InternalBeginRequest(message, (cb, s) => this.Inner.BeginRequest(message, cb, s), callback, state);
     }
@@ -96,7 +94,7 @@ internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestC
         return reply;
     }
 
-    private IAsyncResult InternalBeginRequest(Message message, Func<AsyncCallback, object?, IAsyncResult> beginRequestDelegate, AsyncCallback callback, object? state)
+    private IAsyncResult InternalBeginRequest(Message message, Func<AsyncCallback?, object?, IAsyncResult> beginRequestDelegate, AsyncCallback? callback, object? state)
     {
         IAsyncResult? result = null;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
@@ -1,0 +1,295 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using OpenTelemetry.Instrumentation.Wcf.Implementation;
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Tests;
+
+public class InstrumentedChannelAsyncCallbackTests
+{
+    [Fact]
+    public void BeginRequest_AllowsNullAsyncCallback()
+    {
+        var inner = new RecordingRequestChannel();
+        var channel = (IRequestChannel)new InstrumentedRequestChannel(inner);
+        var state = new object();
+
+        var asyncResult = channel.BeginRequest(
+            Message.CreateMessage(MessageVersion.Soap11, "urn:test"),
+            callback: null,
+            state);
+
+        Assert.NotNull(asyncResult);
+        Assert.NotNull(inner.LastBeginRequestArgs);
+        Assert.Null(inner.LastBeginRequestArgs![1]);
+        Assert.Same(state, inner.LastBeginRequestArgs[2]);
+    }
+
+    [Fact]
+    public void BeginSend_AllowsNullAsyncCallback()
+    {
+        var inner = new RecordingDuplexChannel();
+        var channel = new InstrumentedDuplexChannel(inner, TimeSpan.FromSeconds(1));
+        var state = new object();
+
+        var asyncResult = channel.BeginSend(
+            Message.CreateMessage(MessageVersion.Soap11, "urn:test"),
+            callback: null,
+            state);
+
+        Assert.NotNull(asyncResult);
+        Assert.NotNull(inner.LastBeginSendArgs);
+        Assert.Null(inner.LastBeginSendArgs![1]);
+        Assert.Same(state, inner.LastBeginSendArgs[2]);
+    }
+
+    [Fact]
+    public void BeginReceive_AllowsNullAsyncCallback()
+    {
+        var inner = new RecordingDuplexChannel();
+        var channel = new InstrumentedDuplexChannel(inner, TimeSpan.FromSeconds(1));
+        var state = new object();
+
+        var asyncResult = channel.BeginReceive(callback: null, state);
+
+        Assert.NotNull(asyncResult);
+        Assert.NotNull(inner.LastBeginReceiveArgs);
+        Assert.Null(inner.LastBeginReceiveArgs![0]);
+        Assert.Same(state, inner.LastBeginReceiveArgs[1]);
+    }
+
+    private sealed class FakeAsyncResult : IAsyncResult
+    {
+        public FakeAsyncResult(object? asyncState)
+        {
+            this.AsyncState = asyncState;
+        }
+
+        public object? AsyncState { get; }
+
+        public WaitHandle AsyncWaitHandle { get; } = new ManualResetEvent(initialState: true);
+
+        public bool CompletedSynchronously => true;
+
+        public bool IsCompleted => true;
+    }
+
+    private abstract class RecordingChannel : IChannel
+    {
+        event EventHandler ICommunicationObject.Closed
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Closing
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Faulted
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Opened
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Opening
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        public CommunicationState State => CommunicationState.Opened;
+
+        public virtual T? GetProperty<T>()
+            where T : class
+            => default;
+
+        public void Abort()
+        {
+        }
+
+        public IAsyncResult BeginClose(AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public IAsyncResult BeginOpen(AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public void Close()
+        {
+        }
+
+        public void Close(TimeSpan timeout)
+        {
+        }
+
+        public void EndClose(IAsyncResult result)
+        {
+        }
+
+        public void EndOpen(IAsyncResult result)
+        {
+        }
+
+        public void Open()
+        {
+        }
+
+        public void Open(TimeSpan timeout)
+        {
+        }
+    }
+
+    private sealed class RecordingRequestChannel : RecordingChannel, IRequestChannel
+    {
+        public object?[]? LastBeginRequestArgs { get; private set; }
+
+        public EndpointAddress RemoteAddress { get; } = new("net.tcp://localhost/Service");
+
+        public Uri Via { get; } = new("net.tcp://localhost/Service");
+
+        public Message Request(Message message)
+            => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+
+        public Message Request(Message message, TimeSpan timeout)
+            => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+
+        public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)
+        {
+            this.LastBeginRequestArgs = [message, callback, state];
+            return new FakeAsyncResult(state);
+        }
+
+        public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            this.LastBeginRequestArgs = [message, timeout, callback, state];
+            return new FakeAsyncResult(state);
+        }
+
+        public Message EndRequest(IAsyncResult result)
+            => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+    }
+
+    private sealed class RecordingDuplexChannel : RecordingChannel, IDuplexChannel
+    {
+        public object?[]? LastBeginReceiveArgs { get; private set; }
+
+        public object?[]? LastBeginSendArgs { get; private set; }
+
+        public EndpointAddress LocalAddress { get; } = new("net.tcp://localhost/Local");
+
+        public EndpointAddress RemoteAddress { get; } = new("net.tcp://localhost/Service");
+
+        public Uri Via { get; } = new("net.tcp://localhost/Service");
+
+        public void Send(Message message)
+        {
+        }
+
+        public void Send(Message message, TimeSpan timeout)
+        {
+        }
+
+        public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state)
+        {
+            this.LastBeginSendArgs = [message, callback, state];
+            return new FakeAsyncResult(state);
+        }
+
+        public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            this.LastBeginSendArgs = [message, timeout, callback, state];
+            return new FakeAsyncResult(state);
+        }
+
+        public void EndSend(IAsyncResult result)
+        {
+        }
+
+        public Message Receive()
+            => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+
+        public Message Receive(TimeSpan timeout)
+            => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+
+        public IAsyncResult BeginReceive(AsyncCallback callback, object state)
+        {
+            this.LastBeginReceiveArgs = [callback, state];
+            return new FakeAsyncResult(state);
+        }
+
+        public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object state)
+        {
+            this.LastBeginReceiveArgs = [timeout, callback, state];
+            return new FakeAsyncResult(state);
+        }
+
+        public Message EndReceive(IAsyncResult result)
+            => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+
+        public bool TryReceive(TimeSpan timeout, out Message message)
+        {
+            message = Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+            return true;
+        }
+
+        public IAsyncResult BeginTryReceive(TimeSpan timeout, AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public bool EndTryReceive(IAsyncResult result, out Message message)
+        {
+            message = Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
+            return true;
+        }
+
+        public bool WaitForMessage(TimeSpan timeout)
+            => true;
+
+        public IAsyncResult BeginWaitForMessage(TimeSpan timeout, AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public bool EndWaitForMessage(IAsyncResult result)
+            => true;
+    }
+}


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed an issue where instrumented WCF channel `Begin*` methods threw an `ArgumentNullException` when `AsyncCallback` was `null`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
