### PR TITLE
[Shared] Fix custom diagnostic events creating spans when instrumentation is suppressed

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Fixed instrumentation suppression handling so EF Core custom diagnostic events
   do not create spans when `SuppressInstrumentationScope` is active.
+  ([#4168](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4168))
 
 ## 1.15.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -12,6 +12,9 @@
   database Semantic Conventions, but not when both are used together.
   ([#4078](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4078))
 
+* Fixed instrumentation suppression handling so EF Core custom diagnostic events
+  do not create spans when `SuppressInstrumentationScope` is active.
+
 ## 1.15.0-beta.1
 
 Released 2026-Jan-21

--- a/src/Shared/DiagnosticSourceListener.cs
+++ b/src/Shared/DiagnosticSourceListener.cs
@@ -62,7 +62,7 @@ internal sealed class DiagnosticSourceListener : IObserver<KeyValuePair<string, 
             .GetMethod;
 
         return getter != null
-            ? getter.CreateDelegate<Func<bool>>()
+            ? (Func<bool>)Delegate.CreateDelegate(typeof(Func<bool>), getter)
             : static () => false;
     }
 }

--- a/src/Shared/DiagnosticSourceListener.cs
+++ b/src/Shared/DiagnosticSourceListener.cs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Reflection;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation;
 
 internal sealed class DiagnosticSourceListener : IObserver<KeyValuePair<string, object?>>
 {
+    private static readonly Func<bool> IsInstrumentationSuppressed = CreateIsInstrumentationSuppressed();
+
     private readonly ListenerHandler handler;
 
     private readonly Action<string, string, Exception>? logUnknownException;
@@ -35,6 +38,13 @@ internal sealed class DiagnosticSourceListener : IObserver<KeyValuePair<string, 
             return;
         }
 
+        if (IsInstrumentationSuppressed()
+            && !value.Key.EndsWith("Start", StringComparison.Ordinal)
+            && !value.Key.EndsWith("Stop", StringComparison.Ordinal))
+        {
+            return;
+        }
+
         try
         {
             this.handler.OnEventWritten(value.Key, value.Value);
@@ -43,5 +53,16 @@ internal sealed class DiagnosticSourceListener : IObserver<KeyValuePair<string, 
         {
             this.logUnknownException?.Invoke(this.handler.SourceName, value.Key, ex);
         }
+    }
+
+    private static Func<bool> CreateIsInstrumentationSuppressed()
+    {
+        var getter = Type.GetType("OpenTelemetry.Sdk, OpenTelemetry", throwOnError: false)?
+            .GetProperty("SuppressInstrumentation", BindingFlags.Public | BindingFlags.Static)?
+            .GetMethod;
+
+        return getter != null
+            ? getter.CreateDelegate<Func<bool>>()
+            : static () => false;
     }
 }

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -279,6 +279,32 @@ public class EntityFrameworkDiagnosticListenerTests : IDisposable
         VerifyActivityData(activity);
     }
 
+    [Fact]
+    public void EntityFrameworkContextEventsSuppressedTest()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (Sdk.CreateTracerProviderBuilder()
+                  .AddInMemoryExporter(exportedItems)
+                  .AddEntityFrameworkCoreInstrumentation()
+                  .Build())
+        {
+            using var context = new ItemsContext(this.contextOptions);
+
+            using (SuppressInstrumentationScope.Begin())
+            {
+                var items = context.Set<Item>().OrderBy(e => e.Name).ToList();
+
+                Assert.Equal(3, items.Count);
+                Assert.Equal("ItemOne", items[0].Name);
+                Assert.Equal("ItemThree", items[1].Name);
+                Assert.Equal("ItemTwo", items[2].Name);
+            }
+        }
+
+        Assert.Empty(exportedItems);
+    }
+
     [Theory]
     [InlineData(true, false)]
     [InlineData(false, true)]


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed instrumentation suppression handling so EF Core custom diagnostic events do not create spans when `SuppressInstrumentationScope` is active.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
