### PR TITLE
[Instrumentation.StackExchangeRedis] `db.query.text` respect `SetVerboseDatabaseStatements`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updated OpenTelemetry core component version(s) to `1.15.3`.
   ([#4166](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4166))
 
-* Fixed `db.query.text` emission to respect `SetVerboseDatabaseStatements` when
+* Fixed `db.query.text` not respecting `SetVerboseDatabaseStatements` when
   the new database semantic conventions are enabled.
   ([#4245](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4245))
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Updated OpenTelemetry core component version(s) to `1.15.3`.
   ([#4166](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4166))
 
+* Fixed `db.query.text` emission to respect `SetVerboseDatabaseStatements` when
+  the new database semantic conventions are enabled.
+  ([#4245](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4245))
+
 ## 1.15.0-beta.1
 
 Released 2026-Jan-21

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Unreleased
 
+* Fixed `db.query.text` not respecting `SetVerboseDatabaseStatements` when
+  the new database semantic conventions are enabled.
+  ([#4245](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4245))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21
 
 * Updated OpenTelemetry core component version(s) to `1.15.3`.
   ([#4166](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4166))
-
-* Fixed `db.query.text` not respecting `SetVerboseDatabaseStatements` when
-  the new database semantic conventions are enabled.
-  ([#4245](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4245))
 
 ## 1.15.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -126,6 +126,14 @@ internal static class RedisProfilerEntryToActivityConverter
             // Total:
             // command.ElapsedTime;             // 00:00:32.4988020
 
+            string? commandAndKey = null;
+            string? script = null;
+            if (options.SetVerboseDatabaseStatements
+                && (options.EmitOldAttributes || options.EmitNewAttributes))
+            {
+                (commandAndKey, script) = MessageDataGetter.Value.Invoke(command);
+            }
+
             if (options.EmitOldAttributes)
             {
                 activity.SetTag(StackExchangeRedisConnectionInstrumentation.RedisDatabaseIndexKeyName, command.Db);
@@ -133,8 +141,6 @@ internal static class RedisProfilerEntryToActivityConverter
 
                 if (options.SetVerboseDatabaseStatements)
                 {
-                    var (commandAndKey, script) = MessageDataGetter.Value.Invoke(command);
-
                     if (!string.IsNullOrEmpty(commandAndKey))
                     {
                         statement = commandAndKey;
@@ -157,10 +163,13 @@ internal static class RedisProfilerEntryToActivityConverter
 
             if (options.EmitNewAttributes)
             {
-                var (commandAndKey, script) = MessageDataGetter.Value.Invoke(command);
+                var queryText = options.SetVerboseDatabaseStatements && !string.IsNullOrEmpty(commandAndKey)
+                    ? commandAndKey
+                    : command.Command;
+
                 activity.SetTag(SemanticConventions.AttributeDbOperationName, command.Command);
                 activity.SetTag(SemanticConventions.AttributeDbNamespace, command.Db.ToString(CultureInfo.InvariantCulture));
-                activity.SetTag(SemanticConventions.AttributeDbQueryText, commandAndKey);
+                activity.SetTag(SemanticConventions.AttributeDbQueryText, queryText);
             }
 
             if (command.EndPoint != null)

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -128,8 +128,7 @@ internal static class RedisProfilerEntryToActivityConverter
 
             string? commandAndKey = null;
             string? script = null;
-            if (options.SetVerboseDatabaseStatements
-                && (options.EmitOldAttributes || options.EmitNewAttributes))
+            if (options.SetVerboseDatabaseStatements)
             {
                 (commandAndKey, script) = MessageDataGetter.Value.Invoke(command);
             }

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -163,9 +163,16 @@ internal static class RedisProfilerEntryToActivityConverter
 
             if (options.EmitNewAttributes)
             {
-                var queryText = options.SetVerboseDatabaseStatements && !string.IsNullOrEmpty(commandAndKey)
-                    ? commandAndKey
-                    : command.Command;
+                string? queryText = command.Command;
+                if (options.SetVerboseDatabaseStatements && !string.IsNullOrEmpty(commandAndKey))
+                {
+                    queryText = commandAndKey;
+
+                    if (!string.IsNullOrEmpty(script))
+                    {
+                        queryText += " " + script;
+                    }
+                }
 
                 activity.SetTag(SemanticConventions.AttributeDbOperationName, command.Command);
                 activity.SetTag(SemanticConventions.AttributeDbNamespace, command.Db.ToString(CultureInfo.InvariantCulture));

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -34,7 +34,9 @@ public class StackExchangeRedisInstrumentationOptions
     public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// Gets or sets a value indicating whether the <see cref="StackExchangeRedisConnectionInstrumentation"/> should use reflection to get more detailed <see cref="SemanticConventions.AttributeDbStatement"/> tag values. Default value: <see langword="false"/>.
+    /// Gets or sets a value indicating whether the <see cref="StackExchangeRedisConnectionInstrumentation"/> should use reflection to get more detailed
+    /// <see cref="SemanticConventions.AttributeDbStatement"/> and <see cref="SemanticConventions.AttributeDbQueryText"/> tag values. Default value:
+    /// <see langword="false"/>.
     /// </summary>
     public bool SetVerboseDatabaseStatements { get; set; }
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -157,11 +157,60 @@ public class StackExchangeRedisCallsInstrumentationTests(RedisXunitFixture fixtu
 
         if (emitNewAttributes)
         {
-            VerifyNewActivityData(exportedItems[0], true, endpoint);
-            VerifyNewActivityData(exportedItems[1], false, endpoint);
+            VerifyNewActivityData(exportedItems[0], true, endpoint, setCommandKey: false);
+            VerifyNewActivityData(exportedItems[1], false, endpoint, setCommandKey: false);
 
             // TODO VerifySamplingParameters(sampler.LatestSamplingParameters);
         }
+    }
+
+    [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
+    public void SuccessfulCommandWithVerboseStatementsEmitsDetailedNewAttributes()
+    {
+        using var scope = SemanticConventionScope.Get(DatabaseSemanticConventionHelper.DatabaseSemanticConvention.New);
+
+        var connectionOptions = new ConfigurationOptions
+        {
+            AbortOnConnectFail = true,
+        };
+        connectionOptions.EndPoints.Add(this.connectionString);
+
+        ConnectionMultiplexer? connection = null;
+        var exportedItems = new List<Activity>();
+        using (Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
+            {
+                services.TryAddSingleton<IConnectionMultiplexer>(sp =>
+                {
+                    return connection = ConnectionMultiplexer.Connect(connectionOptions);
+                });
+            })
+            .AddInMemoryExporter(exportedItems)
+            .AddRedisInstrumentation(options =>
+            {
+                options.SetVerboseDatabaseStatements = true;
+            })
+            .Build())
+        {
+            Assert.NotNull(connection);
+
+            var db = connection.GetDatabase();
+
+            var set = db.StringSet("key1", "value1", TimeSpan.FromSeconds(60));
+
+            Assert.True(set);
+
+            var redisValue = db.StringGet("key1");
+
+            Assert.True(redisValue.HasValue);
+            Assert.Equal("value1", redisValue.ToString());
+        }
+
+        Assert.Equal(2, exportedItems.Count);
+
+        var endpoint = connection.GetEndPoints()[0];
+        VerifyNewActivityData(exportedItems[0], true, endpoint, setCommandKey: true);
+        VerifyNewActivityData(exportedItems[1], false, endpoint, setCommandKey: true);
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -482,17 +531,17 @@ public class StackExchangeRedisCallsInstrumentationTests(RedisXunitFixture fixtu
         VerifyEndPoint(activity, endPoint);
     }
 
-    private static void VerifyNewActivityData(Activity activity, bool isSet, EndPoint endPoint)
+    private static void VerifyNewActivityData(Activity activity, bool isSet, EndPoint endPoint, bool setCommandKey)
     {
         var displayName = "SETEX";
         var dbOperationName = "SETEX";
-        var dbQueryText = "SETEX key1";
+        var dbQueryText = setCommandKey ? "SETEX key1" : "SETEX";
 
         if (!isSet)
         {
             displayName = "GET";
             dbOperationName = "GET";
-            dbQueryText = "GET key1";
+            dbQueryText = setCommandKey ? "GET key1" : "GET";
         }
 
         Assert.Equal(displayName, activity.DisplayName);


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed `db.query.text` omission to respect `SetVerboseDatabaseStatements` when the new database semantic conventions are enabled.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
