### PR TITLE
[Infra] Bump OpenTelemetry.Extensions.Enrichment

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>1.15.2</OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>
     <OpenTelemetryInstrumentationHttpLatestStableVersion>1.15.1</OpenTelemetryInstrumentationHttpLatestStableVersion>
     <OpenTelemetryInstrumentationRuntimeLatestStableVersion>1.15.1</OpenTelemetryInstrumentationRuntimeLatestStableVersion>
-    <OpenTelemetryEnrichmentUnstableLatestVersion>1.15.0-beta.1</OpenTelemetryEnrichmentUnstableLatestVersion>
+    <OpenTelemetryExtensionsEnrichmentUnstableLatestVersion>1.15.1-beta.1</OpenTelemetryExtensionsEnrichmentUnstableLatestVersion>
   </PropertyGroup>
 
   <ItemGroup Label="OpenTelemetry packages">
@@ -25,7 +25,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="[$(OpenTelemetryCoreUnstableLatestVersion),2.0)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="[$(OpenTelemetryCoreLatestVersion),2.0)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="[$(OpenTelemetryCoreLatestVersion),2.0)" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Enrichment" Version="[$(OpenTelemetryEnrichmentUnstableLatestVersion),2.0)" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Enrichment" Version="[$(OpenTelemetryExtensionsEnrichmentUnstableLatestVersion),2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[$(OpenTelemetryInstrumentationAspNetCoreLatestStableVersion),2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[$(OpenTelemetryInstrumentationHttpLatestStableVersion),2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[$(OpenTelemetryInstrumentationRuntimeLatestStableVersion),2.0)" />

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -274,16 +274,6 @@ Merge once packages are available on NuGet and the build passes.
     $body += "`n* Sets ``OpenTelemetryInstrumentationAspNetCoreLatestStableVersion`` in Common.props to version ``$version``."
   }
 
-  if ($tagPrefix -eq 'Instrumentation.Http-' -and $version -match '^[01]\.')
-  {
-    $body += "`n* Sets ``OpenTelemetryInstrumentationHttpLatestStableVersion`` in Common.props to version ``$version``."
-  }
-
-  if ($tagPrefix -eq 'Instrumentation.Runtime-' -and $version -match '^[01]\.')
-  {
-    $body += "`n* Sets ``OpenTelemetryInstrumentationRuntimeLatestStableVersion`` in Common.props to version ``$version``."
-  }
-
   gh pr create `
     --title "[release] $tagPrefix stable release $version updates" `
     --body $body `

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -251,7 +251,6 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
   UpdateCommonPropsVersion -tagPrefix $tagPrefix -version $version -propertyName 'Instrumentation.AspNetCore-' -propertyDisplayName 'OpenTelemetryInstrumentationAspNetCoreLatestStableVersion'
   UpdateCommonPropsVersion -tagPrefix $tagPrefix -version $version -propertyName 'Instrumentation.Http-' -propertyDisplayName 'OpenTelemetryInstrumentationHttpLatestStableVersion'
   UpdateCommonPropsVersion -tagPrefix $tagPrefix -version $version -propertyName 'Instrumentation.Runtime-' -propertyDisplayName 'OpenTelemetryInstrumentationRuntimeLatestStableVersion'
-  UpdateCommonPropsVersion -tagPrefix $tagPrefix -version $version -propertyName 'Extensions.Enrichment-' -propertyDisplayName 'OpenTelemetryEnrichmentUnstableLatestVersion'
 
   git push -u origin $branch 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
@@ -273,6 +272,16 @@ Merge once packages are available on NuGet and the build passes.
   if ($tagPrefix -eq 'Instrumentation.AspNetCore-' -and $version -match '^[01]\.')
   {
     $body += "`n* Sets ``OpenTelemetryInstrumentationAspNetCoreLatestStableVersion`` in Common.props to version ``$version``."
+  }
+
+  if ($tagPrefix -eq 'Instrumentation.Http-' -and $version -match '^[01]\.')
+  {
+    $body += "`n* Sets ``OpenTelemetryInstrumentationHttpLatestStableVersion`` in Common.props to version ``$version``."
+  }
+
+  if ($tagPrefix -eq 'Instrumentation.Runtime-' -and $version -match '^[01]\.')
+  {
+    $body += "`n* Sets ``OpenTelemetryInstrumentationRuntimeLatestStableVersion`` in Common.props to version ``$version``."
   }
 
   gh pr create `


### PR DESCRIPTION
## Changes

- Bump OpenTelemetry.Extensions.Enrichment to the latest prerelease version and update property name.
- Remove redundant property set.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
