### PR TITLE
[Instrumentation.SqlClient] Refactor to prevent option leaks across tracer providers

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fix `SqlClientTraceInstrumentationOptions` leaking across multiple tracer
+  provider registrations.
+  ([#4267](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4267))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -60,7 +60,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
             return;
         }
 
-        var options = SqlClientInstrumentation.TracingOptions;
+        var options = SqlClientInstrumentation.Instance.GetTracingOptions();
         var activity = Activity.Current;
         switch (name)
         {

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -130,8 +130,6 @@ internal sealed class SqlEventSourceListener : EventListener
             return;
         }
 
-        var options = SqlClientInstrumentation.TracingOptions;
-
         if (eventData.Payload.Count < 4)
         {
             SqlClientInstrumentationEventSource.Log.InvalidPayload(nameof(SqlEventSourceListener), nameof(this.OnBeginExecute));

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -31,6 +31,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\InstrumentationHandleManager.cs" Link="Includes\InstrumentationHandleManager.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -148,17 +148,17 @@ internal sealed class SqlClientInstrumentation : IDisposable
             0 => null,
             1 => filters[0],
             _ => command =>
+            {
+                foreach (var filter in filters)
                 {
-                    foreach (var filter in filters)
+                    if (!filter(command))
                     {
-                        if (!filter(command))
-                        {
-                            return false;
-                        }
+                        return false;
                     }
+                }
 
-                    return true;
-                },
+                return true;
+            },
         };
         snapshot.EnrichWithSqlCommand = enrichWithSqlCommand;
 #endif

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -143,23 +143,32 @@ internal sealed class SqlClientInstrumentation : IDisposable
         }
 
 #if !NETFRAMEWORK
-        snapshot.Filter = filters.Count switch
+        switch (filters.Count)
         {
-            0 => null,
-            1 => filters[0],
-            _ => command =>
-            {
-                foreach (var filter in filters)
-                {
-                    if (!filter(command))
-                    {
-                        return false;
-                    }
-                }
+            case 0:
+                snapshot.Filter = null;
+                break;
 
-                return true;
-            },
-        };
+            case 1:
+                snapshot.Filter = filters[0];
+                break;
+
+            default:
+                snapshot.Filter = command =>
+                {
+                    foreach (var filter in filters)
+                    {
+                        if (!filter(command))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                };
+                break;
+        }
+
         snapshot.EnrichWithSqlCommand = enrichWithSqlCommand;
 #endif
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -72,7 +72,7 @@ internal sealed class SqlClientInstrumentation : IDisposable
 #if NETFRAMEWORK
         this.sqlEventSourceListener?.Dispose();
 #else
-    this.diagnosticSourceSubscriber?.Dispose();
+        this.diagnosticSourceSubscriber?.Dispose();
 #endif
 
     internal SqlClientTraceInstrumentationOptions GetTracingOptions() => Volatile.Read(ref this.tracingOptions);
@@ -106,15 +106,17 @@ internal sealed class SqlClientInstrumentation : IDisposable
             return snapshot;
         }
 
+        var firstActiveTracingOption = activeTracingOptions[0];
+
 #if !NETFRAMEWORK
         var filters = new List<Func<object, bool>>();
-        Action<Activity, object>? enrichWithSqlCommand = activeTracingOptions[0].EnrichWithSqlCommand;
+        Action<Activity, object>? enrichWithSqlCommand = firstActiveTracingOption.EnrichWithSqlCommand;
 
-        snapshot.RecordException = activeTracingOptions[0].RecordException;
-        snapshot.SetDbQueryParameters = activeTracingOptions[0].SetDbQueryParameters;
+        snapshot.RecordException = firstActiveTracingOption.RecordException;
+        snapshot.SetDbQueryParameters = firstActiveTracingOption.SetDbQueryParameters;
 #endif
 #if NET
-        snapshot.EnableTraceContextPropagation = activeTracingOptions[0].EnableTraceContextPropagation;
+        snapshot.EnableTraceContextPropagation = firstActiveTracingOption.EnableTraceContextPropagation;
 #endif
 
         for (var i = 0; i < activeTracingOptions.Count; i++)

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if !NETFRAMEWORK
+using System.Diagnostics;
+#endif
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -16,17 +19,12 @@ namespace OpenTelemetry.Instrumentation.SqlClient;
 #endif
 internal sealed class SqlClientInstrumentation : IDisposable
 {
-    public static readonly SqlClientInstrumentation Instance = new();
-
-    public readonly InstrumentationHandleManager HandleManager = new();
-
     internal const string SqlClientDiagnosticListenerName = "SqlClientDiagnosticListener";
 #if NET
     internal const string SqlClientTrimmingUnsupportedMessage = "Trimming is not yet supported with SqlClient instrumentation.";
 #endif
-#if NETFRAMEWORK
-    private readonly SqlEventSourceListener sqlEventSourceListener;
-#else
+    internal static readonly SqlClientInstrumentation Instance = new();
+#if !NETFRAMEWORK
     private static readonly HashSet<string> DiagnosticSourceEvents =
     [
         "System.Data.SqlClient.WriteCommandBefore",
@@ -36,11 +34,39 @@ internal sealed class SqlClientInstrumentation : IDisposable
         "System.Data.SqlClient.WriteCommandError",
         "Microsoft.Data.SqlClient.WriteCommandError"
     ];
+#endif
 
+    internal readonly InstrumentationHandleManager HandleManager = new();
+    private readonly object tracingOptionsSync = new();
+    private readonly List<SqlClientTraceInstrumentationOptions> activeTracingOptions = [];
+#if NETFRAMEWORK
+    private readonly SqlEventSourceListener sqlEventSourceListener;
+#else
     private readonly Func<string, object?, object?, bool> isEnabled = (eventName, _, _)
         => DiagnosticSourceEvents.Contains(eventName);
 
     private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
+#endif
+    private SqlClientTraceInstrumentationOptions tracingOptions = CreateTracingOptionsSnapshot([]);
+
+    internal SqlClientTraceInstrumentationOptions GetTracingOptions() => Volatile.Read(ref this.tracingOptions);
+
+    internal IDisposable AddTracingHandle(SqlClientTraceInstrumentationOptions options)
+    {
+        lock (this.tracingOptionsSync)
+        {
+            this.activeTracingOptions.Add(options);
+            Volatile.Write(ref this.tracingOptions, CreateTracingOptionsSnapshot(this.activeTracingOptions));
+        }
+
+        return new TracingHandle(this, this.HandleManager.AddTracingHandle(), options);
+    }
+
+    void IDisposable.Dispose() =>
+#if NETFRAMEWORK
+        this.sqlEventSourceListener?.Dispose();
+#else
+        this.diagnosticSourceSubscriber?.Dispose();
 #endif
 
     /// <summary>
@@ -60,13 +86,116 @@ internal sealed class SqlClientInstrumentation : IDisposable
 #endif
     }
 
-    public static SqlClientTraceInstrumentationOptions TracingOptions { get; set; } = new SqlClientTraceInstrumentationOptions();
+    private static SqlClientTraceInstrumentationOptions CreateTracingOptionsSnapshot(
+        List<SqlClientTraceInstrumentationOptions> activeTracingOptions)
+    {
+        var snapshot = new SqlClientTraceInstrumentationOptions();
 
-    /// <inheritdoc/>
-    public void Dispose() =>
-#if NETFRAMEWORK
-        this.sqlEventSourceListener?.Dispose();
-#else
-        this.diagnosticSourceSubscriber?.Dispose();
+#if !NETFRAMEWORK
+        snapshot.RecordException = false;
+        snapshot.SetDbQueryParameters = false;
 #endif
+#if NET
+        snapshot.EnableTraceContextPropagation = false;
+#endif
+
+        if (activeTracingOptions.Count == 0)
+        {
+            return snapshot;
+        }
+
+#if !NETFRAMEWORK
+        var filters = new List<Func<object, bool>>();
+        Action<Activity, object>? enrichWithSqlCommand = activeTracingOptions[0].EnrichWithSqlCommand;
+
+        snapshot.RecordException = activeTracingOptions[0].RecordException;
+        snapshot.SetDbQueryParameters = activeTracingOptions[0].SetDbQueryParameters;
+#endif
+#if NET
+        snapshot.EnableTraceContextPropagation = activeTracingOptions[0].EnableTraceContextPropagation;
+#endif
+
+        for (var i = 0; i < activeTracingOptions.Count; i++)
+        {
+            var options = activeTracingOptions[i];
+
+#if !NETFRAMEWORK
+            if (options.Filter != null)
+            {
+                filters.Add(options.Filter);
+            }
+
+            if (!Equals(enrichWithSqlCommand, options.EnrichWithSqlCommand))
+            {
+                enrichWithSqlCommand = null;
+            }
+
+            snapshot.RecordException &= options.RecordException;
+            snapshot.SetDbQueryParameters &= options.SetDbQueryParameters;
+#endif
+#if NET
+            snapshot.EnableTraceContextPropagation &= options.EnableTraceContextPropagation;
+#endif
+        }
+
+#if !NETFRAMEWORK
+        snapshot.Filter = filters.Count switch
+        {
+            0 => null,
+            1 => filters[0],
+            _ => command =>
+            {
+                foreach (var filter in filters)
+                {
+                    if (!filter(command))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            },
+        };
+        snapshot.EnrichWithSqlCommand = enrichWithSqlCommand;
+#endif
+
+        return snapshot;
+    }
+
+    private void RemoveTracingHandle(SqlClientTraceInstrumentationOptions options)
+    {
+        lock (this.tracingOptionsSync)
+        {
+            _ = this.activeTracingOptions.Remove(options);
+            Volatile.Write(ref this.tracingOptions, CreateTracingOptionsSnapshot(this.activeTracingOptions));
+        }
+    }
+
+    private sealed class TracingHandle : IDisposable
+    {
+        private readonly SqlClientInstrumentation instrumentation;
+        private readonly IDisposable handle;
+        private readonly SqlClientTraceInstrumentationOptions options;
+        private bool disposed;
+
+        public TracingHandle(
+            SqlClientInstrumentation instrumentation,
+            IDisposable handle,
+            SqlClientTraceInstrumentationOptions options)
+        {
+            this.instrumentation = instrumentation;
+            this.handle = handle;
+            this.options = options;
+        }
+
+        public void Dispose()
+        {
+            if (!this.disposed)
+            {
+                this.instrumentation.RemoveTracingHandle(this.options);
+                this.handle.Dispose();
+                this.disposed = true;
+            }
+        }
+    }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -39,7 +39,7 @@ internal sealed class SqlClientInstrumentation : IDisposable
     ];
 #endif
 
-    private readonly object tracingOptionsSync = new();
+    private readonly Lock tracingOptionsSync = new();
     private readonly List<SqlClientTraceInstrumentationOptions> activeTracingOptions = [];
 #if NETFRAMEWORK
     private readonly SqlEventSourceListener sqlEventSourceListener;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -148,17 +148,17 @@ internal sealed class SqlClientInstrumentation : IDisposable
             0 => null,
             1 => filters[0],
             _ => command =>
-            {
-                foreach (var filter in filters)
                 {
-                    if (!filter(command))
+                    foreach (var filter in filters)
                     {
-                        return false;
+                        if (!filter(command))
+                        {
+                            return false;
+                        }
                     }
-                }
 
-                return true;
-            },
+                    return true;
+                },
         };
         snapshot.EnrichWithSqlCommand = enrichWithSqlCommand;
 #endif

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -24,6 +24,9 @@ internal sealed class SqlClientInstrumentation : IDisposable
     internal const string SqlClientTrimmingUnsupportedMessage = "Trimming is not yet supported with SqlClient instrumentation.";
 #endif
     internal static readonly SqlClientInstrumentation Instance = new();
+
+    internal readonly InstrumentationHandleManager HandleManager = new();
+
 #if !NETFRAMEWORK
     private static readonly HashSet<string> DiagnosticSourceEvents =
     [
@@ -36,7 +39,6 @@ internal sealed class SqlClientInstrumentation : IDisposable
     ];
 #endif
 
-    internal readonly InstrumentationHandleManager HandleManager = new();
     private readonly object tracingOptionsSync = new();
     private readonly List<SqlClientTraceInstrumentationOptions> activeTracingOptions = [];
 #if NETFRAMEWORK
@@ -48,26 +50,6 @@ internal sealed class SqlClientInstrumentation : IDisposable
     private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 #endif
     private SqlClientTraceInstrumentationOptions tracingOptions = CreateTracingOptionsSnapshot([]);
-
-    internal SqlClientTraceInstrumentationOptions GetTracingOptions() => Volatile.Read(ref this.tracingOptions);
-
-    internal IDisposable AddTracingHandle(SqlClientTraceInstrumentationOptions options)
-    {
-        lock (this.tracingOptionsSync)
-        {
-            this.activeTracingOptions.Add(options);
-            Volatile.Write(ref this.tracingOptions, CreateTracingOptionsSnapshot(this.activeTracingOptions));
-        }
-
-        return new TracingHandle(this, this.HandleManager.AddTracingHandle(), options);
-    }
-
-    void IDisposable.Dispose() =>
-#if NETFRAMEWORK
-        this.sqlEventSourceListener?.Dispose();
-#else
-        this.diagnosticSourceSubscriber?.Dispose();
-#endif
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlClientInstrumentation"/> class.
@@ -84,6 +66,26 @@ internal sealed class SqlClientInstrumentation : IDisposable
            SqlClientInstrumentationEventSource.Log.UnknownErrorProcessingEvent);
         this.diagnosticSourceSubscriber.Subscribe();
 #endif
+    }
+
+    void IDisposable.Dispose() =>
+#if NETFRAMEWORK
+        this.sqlEventSourceListener?.Dispose();
+#else
+    this.diagnosticSourceSubscriber?.Dispose();
+#endif
+
+    internal SqlClientTraceInstrumentationOptions GetTracingOptions() => Volatile.Read(ref this.tracingOptions);
+
+    internal IDisposable AddTracingHandle(SqlClientTraceInstrumentationOptions options)
+    {
+        lock (this.tracingOptionsSync)
+        {
+            this.activeTracingOptions.Add(options);
+            Volatile.Write(ref this.tracingOptions, CreateTracingOptionsSnapshot(this.activeTracingOptions));
+        }
+
+        return new TracingHandle(this, this.HandleManager.AddTracingHandle(), options);
     }
 
     private static SqlClientTraceInstrumentationOptions CreateTracingOptionsSnapshot(

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -69,8 +69,7 @@ public static class TracerProviderBuilderExtensions
         builder.AddInstrumentation(sp =>
         {
             var sqlOptions = sp.GetRequiredService<IOptionsMonitor<SqlClientTraceInstrumentationOptions>>().Get(name);
-            SqlClientInstrumentation.TracingOptions = sqlOptions;
-            return SqlClientInstrumentation.Instance.HandleManager.AddTracingHandle();
+            return SqlClientInstrumentation.Instance.AddTracingHandle(sqlOptions);
         });
 
         builder.AddSource(SqlTelemetryHelper.ActivitySource.Name);

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
@@ -61,6 +61,59 @@ public class SqlClientTraceInstrumentationOptionsTests
     }
 
 #if !NETFRAMEWORK
+    [Fact]
+    public void MultipleTracerProviders_DoNotLeakFilterConfiguration()
+    {
+        var filteredActivities = new List<Activity>();
+        var defaultActivities = new List<Activity>();
+
+        using var filteredProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation(options => options.Filter = _ => false)
+            .AddInMemoryExporter(filteredActivities)
+            .Build();
+
+        using var defaultProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation()
+            .AddInMemoryExporter(defaultActivities)
+            .Build();
+
+        MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, "SELECT * FROM Foo", false, SqlClientLibrary.MicrosoftDataSqlClient);
+
+        filteredProvider.ForceFlush();
+        defaultProvider.ForceFlush();
+
+        Assert.Empty(filteredActivities);
+        Assert.Empty(defaultActivities);
+    }
+
+    [Fact]
+    public void MultipleTracerProviders_DoNotLeakEnrichmentConfiguration()
+    {
+        var defaultActivities = new List<Activity>();
+        var enrichedActivities = new List<Activity>();
+
+        using var defaultProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation()
+            .AddInMemoryExporter(defaultActivities)
+            .Build();
+
+        using var enrichedProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation(options => options.EnrichWithSqlCommand = ActivityEnrichment)
+            .AddInMemoryExporter(enrichedActivities)
+            .Build();
+
+        MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, "SELECT * FROM Foo", false, SqlClientLibrary.MicrosoftDataSqlClient);
+
+        defaultProvider.ForceFlush();
+        enrichedProvider.ForceFlush();
+
+        var defaultActivity = Assert.Single(defaultActivities);
+        var enrichedActivity = Assert.Single(enrichedActivities);
+
+        Assert.DoesNotContain(defaultActivity.Tags, tag => tag.Key == "enriched");
+        Assert.DoesNotContain(enrichedActivity.Tags, tag => tag.Key == "enriched");
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
@@ -67,20 +67,20 @@ public class SqlClientTraceInstrumentationOptionsTests
         var filteredActivities = new List<Activity>();
         var defaultActivities = new List<Activity>();
 
-        using var filteredProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSqlClientInstrumentation(options => options.Filter = _ => false)
-            .AddInMemoryExporter(filteredActivities)
-            .Build();
+        using (var filteredProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddSqlClientInstrumentation(options => options.Filter = _ => false)
+                   .AddInMemoryExporter(filteredActivities)
+                   .Build())
+        using (var defaultProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddSqlClientInstrumentation()
+                   .AddInMemoryExporter(defaultActivities)
+                   .Build())
+        {
+            MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, "SELECT * FROM Foo", false, SqlClientLibrary.MicrosoftDataSqlClient);
 
-        using var defaultProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSqlClientInstrumentation()
-            .AddInMemoryExporter(defaultActivities)
-            .Build();
-
-        MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, "SELECT * FROM Foo", false, SqlClientLibrary.MicrosoftDataSqlClient);
-
-        filteredProvider.ForceFlush();
-        defaultProvider.ForceFlush();
+            filteredProvider.ForceFlush();
+            defaultProvider.ForceFlush();
+        }
 
         Assert.Empty(filteredActivities);
         Assert.Empty(defaultActivities);
@@ -92,20 +92,20 @@ public class SqlClientTraceInstrumentationOptionsTests
         var defaultActivities = new List<Activity>();
         var enrichedActivities = new List<Activity>();
 
-        using var defaultProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSqlClientInstrumentation()
-            .AddInMemoryExporter(defaultActivities)
-            .Build();
+        using (var defaultProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddSqlClientInstrumentation()
+                   .AddInMemoryExporter(defaultActivities)
+                   .Build())
+        using (var enrichedProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddSqlClientInstrumentation(options => options.EnrichWithSqlCommand = ActivityEnrichment)
+                   .AddInMemoryExporter(enrichedActivities)
+                   .Build())
+        {
+            MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, "SELECT * FROM Foo", false, SqlClientLibrary.MicrosoftDataSqlClient);
 
-        using var enrichedProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSqlClientInstrumentation(options => options.EnrichWithSqlCommand = ActivityEnrichment)
-            .AddInMemoryExporter(enrichedActivities)
-            .Build();
-
-        MockCommandExecutor.ExecuteCommand(TestConnectionString, CommandType.Text, "SELECT * FROM Foo", false, SqlClientLibrary.MicrosoftDataSqlClient);
-
-        defaultProvider.ForceFlush();
-        enrichedProvider.ForceFlush();
+            defaultProvider.ForceFlush();
+            enrichedProvider.ForceFlush();
+        }
 
         var defaultActivity = Assert.Single(defaultActivities);
         var enrichedActivity = Assert.Single(enrichedActivities);


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Updated the `SqlClient` tracing path to prevent registrations from overwriting a single global options object. In `SqlClientInstrumentation.cs`, each tracer registration now manages its own active options handle, while the singleton listener reads a recomputed snapshot instead of relying on “last registration wins.” In `TracerProviderBuilderExtensions.cs`, we register this per-provider handle rather than assigning a static `TracingOptions`. The listener in `SqlClientDiagnosticListener.cs` now consumes the aggregated options snapshot.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
