### PR TITLE
[Sampler.AWS] Fix flaky tests

### DIFF
--- a/test/OpenTelemetry.Sampler.AWS.Tests/MockServerRequestHandler.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/MockServerRequestHandler.cs
@@ -23,19 +23,29 @@ internal sealed class MockServerRequestHandler
 
     public void Handle(HttpListenerContext context)
     {
-        var path = context.Request.Url?.AbsolutePath;
-        if (path != null && this.responses.TryGetValue(path, out var responseBody))
+        try
         {
-            context.Response.StatusCode = 200;
-            context.Response.ContentType = "application/json";
-            using var writer = new StreamWriter(context.Response.OutputStream);
-            writer.Write(responseBody);
-        }
-        else
-        {
-            context.Response.StatusCode = 404;
-        }
+            var path = context.Request.Url?.AbsolutePath;
+            if (path != null && this.responses.TryGetValue(path, out var responseBody))
+            {
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "application/json";
 
-        context.Response.Close();
+#if NET
+                using var writer = new StreamWriter(context.Response.OutputStream, leaveOpen: true);
+#else
+                using var writer = new StreamWriter(context.Response.OutputStream, new System.Text.UTF8Encoding(false), 4096, leaveOpen: true);
+#endif
+                writer.Write(responseBody);
+            }
+            else
+            {
+                context.Response.StatusCode = 404;
+            }
+        }
+        finally
+        {
+            context.Response.Close();
+        }
     }
 }

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
@@ -47,12 +47,8 @@ public class TestAWSXRayRemoteSampler
         Assert.NotNull(xraySampler?.Client);
     }
 
-#if NETFRAMEWORK
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1219")]
-#else
     [Fact]
-#endif
-    public void TestSamplerUpdateAndSample()
+    public async Task TestSamplerUpdateAndSample()
     {
         // setup mock server
         var clock = new TestClock();
@@ -76,8 +72,7 @@ public class TestAWSXRayRemoteSampler
         // GetSamplingRules mock response
         requestHandler.SetResponse("/GetSamplingRules", File.ReadAllText("Data/GetSamplingRulesResponseOptionalFields.json"));
 
-        // rules will be polled in 10 milliseconds
-        Thread.Sleep(2000);
+        await Task.Delay(TimeSpan.FromSeconds(2));
 
         // sampler will drop because rule has 0 reservoir and 0 fixed rate
         Assert.Equal(SamplingDecision.Drop, this.DoSample(sampler, "cat-service"));
@@ -85,13 +80,29 @@ public class TestAWSXRayRemoteSampler
         // GetSamplingTargets mock response
         requestHandler.SetResponse("/SamplingTargets", File.ReadAllText("Data/GetSamplingTargetsResponseOptionalFields.json"));
 
-        // targets will be polled in 10 seconds
-        Thread.Sleep(13000);
+        var decision = SamplingDecision.Drop;
+        var expected = SamplingDecision.RecordAndSample;
+
+        // targets should be polled in 10 seconds
+        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                decision = this.DoSample(sampler, "cat-service");
+
+                if (decision == expected)
+                {
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
+            }
+        }
 
         // sampler will always sampler since target has 100% fixed rate
-        Assert.Equal(SamplingDecision.RecordAndSample, this.DoSample(sampler, "cat-service"));
-        Assert.Equal(SamplingDecision.RecordAndSample, this.DoSample(sampler, "cat-service"));
-        Assert.Equal(SamplingDecision.RecordAndSample, this.DoSample(sampler, "cat-service"));
+        Assert.Equal(expected, this.DoSample(sampler, "cat-service"));
+        Assert.Equal(expected, this.DoSample(sampler, "cat-service"));
+        Assert.Equal(expected, this.DoSample(sampler, "cat-service"));
     }
 
     private SamplingDecision DoSample(Trace.Sampler sampler, string serviceName)

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
@@ -16,7 +16,7 @@ public class TestAWSXRaySamplerClient : IDisposable
     {
         this.requestHandler = new MockServerRequestHandler();
         this.mockServer = TestHttpServer.RunServer(
-            ctx => this.requestHandler.Handle(ctx),
+            this.requestHandler.Handle,
             out var host,
             out var port);
         this.client = new AWSXRaySamplerClient($"http://{host}:{port}");


### PR DESCRIPTION
Fixes #1219

## Changes

- Refactor to avoid test flakiness on disposal.
- Enable test that now works on .NET Framework.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
