### PR TITLE
[OpAMP] Enhance EffectiveConfigFile: stream APIs, size limits, tests

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -11,9 +11,9 @@ OpenTelemetry.OpAmp.Client.Messages.CustomMessageMessage.Capability.get -> strin
 OpenTelemetry.OpAmp.Client.Messages.CustomMessageMessage.Data.get -> System.ReadOnlySpan<byte>
 OpenTelemetry.OpAmp.Client.Messages.CustomMessageMessage.Type.get -> string!
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile
-OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.Content.get -> System.Memory<byte>
+OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.Content.get -> System.ReadOnlyMemory<byte>
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.ContentType.get -> string!
-OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.EffectiveConfigFile(System.Memory<byte> content, string! contentType, string! fileName) -> void
+OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.EffectiveConfigFile(System.ReadOnlyMemory<byte> content, string! contentType = "", string! fileName = "") -> void
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.FileName.get -> string!
 OpenTelemetry.OpAmp.Client.Messages.OpAmpMessage
 OpenTelemetry.OpAmp.Client.Messages.OpAmpMessage.OpAmpMessage() -> void
@@ -88,6 +88,7 @@ OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings.AcceptsRemoteConfig.set
 OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings.RemoteConfigSettings() -> void
 override OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.Equals(object? obj) -> bool
 override OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.GetHashCode() -> int
-static OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.CreateFromFilePath(string! filePath, string! contentType, string? filename = null) -> OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!
+static OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.CreateFromStream(System.IO.Stream! stream, string! contentType = "", string! fileName = "", int maxBytes = 524288) -> OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!
+static OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.CreateFromStreamAsync(System.IO.Stream! stream, string! contentType = "", string! fileName = "", int maxBytes = 524288, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>!
 static OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.operator !=(OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion left, OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion right) -> bool
 static OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.operator ==(OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion left, OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion right) -> bool

--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -13,7 +13,7 @@ OpenTelemetry.OpAmp.Client.Messages.CustomMessageMessage.Type.get -> string!
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.Content.get -> System.ReadOnlyMemory<byte>
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.ContentType.get -> string!
-OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.EffectiveConfigFile(System.ReadOnlyMemory<byte> content, string! contentType = "", string! fileName = "") -> void
+OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.EffectiveConfigFile(System.ReadOnlyMemory<byte> content, string! contentType, string! fileName) -> void
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.FileName.get -> string!
 OpenTelemetry.OpAmp.Client.Messages.OpAmpMessage
 OpenTelemetry.OpAmp.Client.Messages.OpAmpMessage.OpAmpMessage() -> void
@@ -88,7 +88,7 @@ OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings.AcceptsRemoteConfig.set
 OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings.RemoteConfigSettings() -> void
 override OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.Equals(object? obj) -> bool
 override OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.GetHashCode() -> int
-static OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.CreateFromStream(System.IO.Stream! stream, string! contentType = "", string! fileName = "", int maxBytes = 524288) -> OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!
-static OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.CreateFromStreamAsync(System.IO.Stream! stream, string! contentType = "", string! fileName = "", int maxBytes = 524288, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>!
+static OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.CreateFromStream(System.IO.Stream! stream, string! contentType, string! fileName, int maxBytes) -> OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!
+static OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.CreateFromStreamAsync(System.IO.Stream! stream, string! contentType, string! fileName, int maxBytes, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>!
 static OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.operator !=(OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion left, OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion right) -> bool
 static OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion.operator ==(OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion left, OpenTelemetry.OpAmp.Client.Settings.AnyValueUnion right) -> bool

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Enhance EffectiveConfigFile:
+  * Remove `CreateFromFilePath` factory method.
+  * Add `CreateFromSteam` and `CreateFromStreamAsync` methods which enforce max size limits.
+  * Content property is now `ReadOnlyMemory`.
+  ([#4285](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4285))
+
 ## 0.2.0-alpha.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Enhance EffectiveConfigFile:
   * Remove `CreateFromFilePath` factory method.
   * Add `CreateFromSteam` and `CreateFromStreamAsync` methods which enforce max
-  size limits.
+    size limits.
   * Content property is now `ReadOnlyMemory`.
   ([#4285](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4285))
 

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Enhance EffectiveConfigFile:
   * Remove `CreateFromFilePath` factory method.
-  * Add `CreateFromSteam` and `CreateFromStreamAsync` methods which enforce max size limits.
+  * Add `CreateFromSteam` and `CreateFromStreamAsync` methods which enforce max
+  size limits.
   * Content property is now `ReadOnlyMemory`.
   ([#4285](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4285))
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
@@ -188,6 +188,7 @@ internal sealed class FrameBuilder : IFrameBuilder
         var fileMap = new Dictionary<string, global::OpAmp.Proto.V1.AgentConfigFile>(StringComparer.Ordinal);
         foreach (var file in files)
         {
+            // Dictionary.Add throws if multiple files share the same FileName (including the empty-string default).
             fileMap.Add(file.FileName, new global::OpAmp.Proto.V1.AgentConfigFile()
             {
                 Body = ByteString.CopyFrom(file.Content.Span),

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameBuilder.cs
@@ -188,7 +188,11 @@ internal sealed class FrameBuilder : IFrameBuilder
         var fileMap = new Dictionary<string, global::OpAmp.Proto.V1.AgentConfigFile>(StringComparer.Ordinal);
         foreach (var file in files)
         {
-            // Dictionary.Add throws if multiple files share the same FileName (including the empty-string default).
+            if (fileMap.ContainsKey(file.FileName))
+            {
+                throw new ArgumentException($"Multiple config files share the same FileName '{file.FileName}'. FileNames must be unique.", nameof(files));
+            }
+
             fileMap.Add(file.FileName, new global::OpAmp.Proto.V1.AgentConfigFile()
             {
                 Body = ByteString.CopyFrom(file.Content.Span),

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
@@ -17,6 +17,7 @@ internal sealed class OpAmpClientEventSource : EventSource
     private const int EventIdHttpResponseReceived = 3;
     private const int EventIdOversizedWebSocketMessage = 4;
     private const int EventIdFrameProcessingFailure = 5;
+    private const int EventIdEffectiveConfigSizeLimitViolation = 6;
 
     // Service events 500-999
     private const int EventIdHeartbeatServiceStart = 500;
@@ -105,6 +106,21 @@ internal sealed class OpAmpClientEventSource : EventSource
     public void FrameProcessingFailure(string exception)
     {
         this.WriteEvent(EventIdFrameProcessingFailure, exception);
+    }
+
+    [NonEvent]
+    public void EffectiveConfigSizeLimitExceeded(int maxBytes)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.EffectiveConfigSizeLimitViolation(maxBytes);
+        }
+    }
+
+    [Event(EventIdEffectiveConfigSizeLimitViolation, Message = "Configuration file exceeds maximum allowed size of {0} bytes.", Level = EventLevel.Warning)]
+    public void EffectiveConfigSizeLimitViolation(int maxBytes)
+    {
+        this.WriteEvent(EventIdEffectiveConfigSizeLimitViolation, maxBytes);
     }
 
     [Event(EventIdHeartbeatServiceStart, Message = "Heartbeat service started.", Level = EventLevel.Informational)]

--- a/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/EffectiveConfigFile.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/EffectiveConfigFile.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Buffers;
+using OpenTelemetry.Internal;
 using OpenTelemetry.OpAmp.Client.Internal;
 
 namespace OpenTelemetry.OpAmp.Client.Messages;
@@ -11,8 +12,6 @@ namespace OpenTelemetry.OpAmp.Client.Messages;
 /// </summary>
 public sealed class EffectiveConfigFile
 {
-    private const int DefaultMaxSize = 512 * 1024; // 512 KB
-
     /// <summary>
     /// Initializes a new instance of the <see cref="EffectiveConfigFile"/> class.
     /// </summary>
@@ -22,24 +21,12 @@ public sealed class EffectiveConfigFile
     /// <remarks>
     /// This constructor does not enforce a maximum content size. Callers must bound <paramref name="content"/> themselves.
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contentType"/> or <paramref name="fileName"/> is null.</exception>
-    public EffectiveConfigFile(ReadOnlyMemory<byte> content, string contentType = "", string fileName = "")
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="content"/>, <paramref name="contentType"/> or <paramref name="fileName"/> are null.</exception>
+    public EffectiveConfigFile(ReadOnlyMemory<byte> content, string contentType, string fileName)
     {
-        // Protect against null here because these are optional in the OpAMP spec, but can only be empty, not null.
-#if NET
-        ArgumentNullException.ThrowIfNull(contentType);
-        ArgumentNullException.ThrowIfNull(fileName);
-#else
-        if (contentType == null)
-        {
-            throw new ArgumentNullException(nameof(contentType));
-        }
-
-        if (fileName == null)
-        {
-            throw new ArgumentNullException(nameof(fileName));
-        }
-#endif
+        Guard.ThrowIfNull(content);
+        Guard.ThrowIfNull(contentType);
+        Guard.ThrowIfNull(fileName);
 
         this.Content = content;
         this.ContentType = contentType;
@@ -84,7 +71,7 @@ public sealed class EffectiveConfigFile
     /// <exception cref="ArgumentException">Thrown when <paramref name="stream"/> does not support reading.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is less than zero.</exception>
     /// <exception cref="InvalidDataException">Thrown when the stream length exceeds the specified <paramref name="maxBytes"/>.</exception>
-    public static EffectiveConfigFile CreateFromStream(Stream stream, string contentType = "", string fileName = "", int maxBytes = DefaultMaxSize)
+    public static EffectiveConfigFile CreateFromStream(Stream stream, string contentType, string fileName, int maxBytes)
     {
         ValidateArguments(stream, contentType, fileName, maxBytes);
         CheckSeekableSize(stream, maxBytes);
@@ -154,7 +141,7 @@ public sealed class EffectiveConfigFile
     /// <exception cref="ArgumentException">Thrown when <paramref name="stream"/> does not support reading.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is less than zero.</exception>
     /// <exception cref="InvalidDataException">Thrown when the stream length exceeds the specified <paramref name="maxBytes"/>.</exception>
-    public static async Task<EffectiveConfigFile> CreateFromStreamAsync(Stream stream, string contentType = "", string fileName = "", int maxBytes = DefaultMaxSize, CancellationToken cancellationToken = default)
+    public static async Task<EffectiveConfigFile> CreateFromStreamAsync(Stream stream, string contentType, string fileName, int maxBytes, CancellationToken cancellationToken = default)
     {
         ValidateArguments(stream, contentType, fileName, maxBytes);
         CheckSeekableSize(stream, maxBytes);
@@ -228,32 +215,10 @@ public sealed class EffectiveConfigFile
 
     private static void ValidateArguments(Stream stream, string contentType, string fileName, int maxBytes)
     {
-#if NET
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentNullException.ThrowIfNull(contentType);
-        ArgumentNullException.ThrowIfNull(fileName);
-        ArgumentOutOfRangeException.ThrowIfNegative(maxBytes);
-#else
-        if (stream == null)
-        {
-            throw new ArgumentNullException(nameof(stream));
-        }
-
-        if (contentType == null)
-        {
-            throw new ArgumentNullException(nameof(contentType));
-        }
-
-        if (fileName == null)
-        {
-            throw new ArgumentNullException(nameof(fileName));
-        }
-
-        if (maxBytes < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxBytes));
-        }
-#endif
+        Guard.ThrowIfNull(stream);
+        Guard.ThrowIfNull(contentType);
+        Guard.ThrowIfNull(fileName);
+        Guard.ThrowIfNegative(maxBytes);
 
         if (!stream.CanRead)
         {

--- a/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/EffectiveConfigFile.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Messages/RemoteConfiguration/EffectiveConfigFile.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Buffers;
+using OpenTelemetry.OpAmp.Client.Internal;
+
 namespace OpenTelemetry.OpAmp.Client.Messages;
 
 /// <summary>
@@ -8,14 +11,36 @@ namespace OpenTelemetry.OpAmp.Client.Messages;
 /// </summary>
 public sealed class EffectiveConfigFile
 {
+    private const int DefaultMaxSize = 512 * 1024; // 512 KB
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EffectiveConfigFile"/> class.
     /// </summary>
     /// <param name="content">File content.</param>
-    /// <param name="contentType">File content type.</param>
+    /// <param name="contentType">File MIME Content-Type.</param>
     /// <param name="fileName">File name.</param>
-    public EffectiveConfigFile(Memory<byte> content, string contentType, string fileName)
+    /// <remarks>
+    /// This constructor does not enforce a maximum content size. Callers must bound <paramref name="content"/> themselves.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contentType"/> or <paramref name="fileName"/> is null.</exception>
+    public EffectiveConfigFile(ReadOnlyMemory<byte> content, string contentType = "", string fileName = "")
     {
+        // Protect against null here because these are optional in the OpAMP spec, but can only be empty, not null.
+#if NET
+        ArgumentNullException.ThrowIfNull(contentType);
+        ArgumentNullException.ThrowIfNull(fileName);
+#else
+        if (contentType == null)
+        {
+            throw new ArgumentNullException(nameof(contentType));
+        }
+
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+#endif
+
         this.Content = content;
         this.ContentType = contentType;
         this.FileName = fileName;
@@ -24,44 +49,250 @@ public sealed class EffectiveConfigFile
     /// <summary>
     /// Gets the file content.
     /// </summary>
-    public Memory<byte> Content { get; private set; }
+    public ReadOnlyMemory<byte> Content { get; }
 
     /// <summary>
-    /// Gets the file content type.
+    /// Gets the MIME Content-Type of the file.
     /// </summary>
-    public string ContentType { get; private set; }
+    public string ContentType { get; }
 
     /// <summary>
     /// Gets the file name.
     /// </summary>
-    public string FileName { get; private set; }
+    public string FileName { get; }
 
     /// <summary>
-    /// Creates a configuration reference from the file path.
+    /// Creates an <see cref="EffectiveConfigFile"/> instance from a <see cref="Stream"/>.
     /// </summary>
-    /// <param name="filePath">Path of the configuration file.</param>
-    /// <param name="contentType">The content type of the configuration file.</param>
-    /// <param name="filename">The reported filename.</param>
-    /// <returns>Effective config object.</returns>
+    /// <param name="stream">A <see cref="Stream"/> containing the effective configuration file content.</param>
+    /// <param name="contentType">The MIME Content-Type of the configuration file.</param>
+    /// <param name="fileName">The reported file name.</param>
+    /// <param name="maxBytes">Maximum allowed file size in bytes. Default is 512 KB.</param>
+    /// <returns>An instance of <see cref="EffectiveConfigFile"/>.</returns>
     /// <remarks>
     /// <para>
-    /// The entire file is read into memory and transmitted as-is to the OpAMP server.
-    /// Do not include files that contain secrets (passwords, tokens, private keys) unless
+    /// The entire content is transmitted as-is to the OpAMP server.
+    /// Do not include file content that contains secrets (passwords, tokens, private keys) unless
     /// the transport is secure (e.g. with TLS) and the OpAMP server is fully trusted.
     /// </para>
+    /// <para>
+    /// When validating stream size for non-seekable streams, this method may consume up to one byte
+    /// beyond <paramref name="maxBytes"/> before throwing an exception.
+    /// </para>
     /// </remarks>
-    public static EffectiveConfigFile CreateFromFilePath(string filePath, string contentType, string? filename = null)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="stream"/>, <paramref name="contentType"/>, or <paramref name="fileName"/> are null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="stream"/> does not support reading.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is less than zero.</exception>
+    /// <exception cref="InvalidDataException">Thrown when the stream length exceeds the specified <paramref name="maxBytes"/>.</exception>
+    public static EffectiveConfigFile CreateFromStream(Stream stream, string contentType = "", string fileName = "", int maxBytes = DefaultMaxSize)
     {
+        ValidateArguments(stream, contentType, fileName, maxBytes);
+        CheckSeekableSize(stream, maxBytes);
+
+        if (maxBytes == 0)
+        {
+            // For non-seekable streams that CheckSeekableSize skips, we must peek one byte to verify emptiness.
+            // For seekable streams, CheckSeekableSize already confirmed remaining length is zero.
+            if (!stream.CanSeek && stream.ReadByte() != -1)
+            {
+                ThrowSizeLimitExceeded(maxBytes);
+            }
+
+            return new EffectiveConfigFile(ReadOnlyMemory<byte>.Empty, contentType, fileName);
+        }
+
+        var buffer = ArrayPool<byte>.Shared.Rent(maxBytes);
         try
         {
-            var content = File.ReadAllBytes(filePath);
-            var fileName = filename ?? Path.GetFileName(filePath);
+            var totalBytesRead = 0;
 
-            return new EffectiveConfigFile(content, contentType, fileName);
+            while (totalBytesRead < maxBytes)
+            {
+                var bytesRead = stream.Read(buffer, totalBytesRead, maxBytes - totalBytesRead);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                totalBytesRead += bytesRead;
+            }
+
+            if (totalBytesRead == maxBytes && stream.ReadByte() != -1)
+            {
+                ThrowSizeLimitExceeded(maxBytes);
+            }
+
+            return BuildResult(buffer, totalBytesRead, contentType, fileName);
         }
-        catch (Exception ex)
+        finally
         {
-            throw new InvalidOperationException("Could not read configuration file.", ex);
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
         }
+    }
+
+    /// <summary>
+    /// Creates an <see cref="EffectiveConfigFile"/> instance from a <see cref="Stream"/> asynchronously.
+    /// </summary>
+    /// <param name="stream">A <see cref="Stream"/> containing the effective configuration file content.</param>
+    /// <param name="contentType">The MIME Content-Type of the configuration file.</param>
+    /// <param name="fileName">The reported file name.</param>
+    /// <param name="maxBytes">Maximum allowed file size in bytes. Default is 512 KB.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous read, containing the resulting <see cref="EffectiveConfigFile"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The entire content is transmitted as-is to the OpAMP server.
+    /// Do not include file content that contains secrets (passwords, tokens, private keys) unless
+    /// the transport is secure (e.g. with TLS) and the OpAMP server is fully trusted.
+    /// </para>
+    /// <para>
+    /// When validating stream size for non-seekable streams, this method may consume up to one byte
+    /// beyond <paramref name="maxBytes"/> before throwing an exception.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="stream"/>, <paramref name="contentType"/>, or <paramref name="fileName"/> are null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="stream"/> does not support reading.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is less than zero.</exception>
+    /// <exception cref="InvalidDataException">Thrown when the stream length exceeds the specified <paramref name="maxBytes"/>.</exception>
+    public static async Task<EffectiveConfigFile> CreateFromStreamAsync(Stream stream, string contentType = "", string fileName = "", int maxBytes = DefaultMaxSize, CancellationToken cancellationToken = default)
+    {
+        ValidateArguments(stream, contentType, fileName, maxBytes);
+        CheckSeekableSize(stream, maxBytes);
+
+        if (maxBytes == 0)
+        {
+            // For non-seekable streams that CheckSeekableSize skips, we must peek one byte to verify emptiness.
+            // For seekable streams, CheckSeekableSize already confirmed remaining length is zero.
+            if (!stream.CanSeek)
+            {
+                // Zero maxBytes is extremely unlikely to be used, so the cost of this extra allocation is acceptable as an edge case.
+                var peekBuffer = new byte[1];
+#if NET
+                var peeked = await stream.ReadAsync(peekBuffer.AsMemory(0, 1), cancellationToken).ConfigureAwait(false);
+#else
+                var peeked = await stream.ReadAsync(peekBuffer, 0, 1, cancellationToken).ConfigureAwait(false);
+#endif
+                if (peeked > 0)
+                {
+                    ThrowSizeLimitExceeded(maxBytes);
+                }
+            }
+
+            return new EffectiveConfigFile(ReadOnlyMemory<byte>.Empty, contentType, fileName);
+        }
+
+        var buffer = ArrayPool<byte>.Shared.Rent(maxBytes);
+        try
+        {
+            var totalBytesRead = 0;
+
+            while (totalBytesRead < maxBytes)
+            {
+#if NET
+                var bytesRead = await stream.ReadAsync(buffer.AsMemory(totalBytesRead, maxBytes - totalBytesRead), cancellationToken).ConfigureAwait(false);
+#else
+                var bytesRead = await stream.ReadAsync(buffer, totalBytesRead, maxBytes - totalBytesRead, cancellationToken).ConfigureAwait(false);
+#endif
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                totalBytesRead += bytesRead;
+            }
+
+            if (totalBytesRead == maxBytes)
+            {
+                // Peek for overflow by reusing buffer[0] to avoid extra allocation.
+                // Safety: if 0 bytes are returned (EOF) buffer[0] is not written and BuildResult
+                // proceeds with intact content. If 1 byte is returned we throw immediately and
+                // never call BuildResult, so the corrupted slot is irrelevant.
+#if NET
+                var extra = await stream.ReadAsync(buffer.AsMemory(0, 1), cancellationToken).ConfigureAwait(false);
+#else
+                var extra = await stream.ReadAsync(buffer, 0, 1, cancellationToken).ConfigureAwait(false);
+#endif
+                if (extra > 0)
+                {
+                    ThrowSizeLimitExceeded(maxBytes);
+                }
+            }
+
+            return BuildResult(buffer, totalBytesRead, contentType, fileName);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+        }
+    }
+
+    private static void ValidateArguments(Stream stream, string contentType, string fileName, int maxBytes)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(contentType);
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxBytes);
+#else
+        if (stream == null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        if (contentType == null)
+        {
+            throw new ArgumentNullException(nameof(contentType));
+        }
+
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        if (maxBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxBytes));
+        }
+#endif
+
+        if (!stream.CanRead)
+        {
+            throw new ArgumentException("Stream must support reading.", nameof(stream));
+        }
+    }
+
+    private static void CheckSeekableSize(Stream stream, int maxBytes)
+    {
+        if (!stream.CanSeek)
+        {
+            return;
+        }
+
+        // Clamp to zero: Position > Length is legal for seekable streams (e.g. after an explicit
+        // Seek past EOF). Without the clamp, remainingBytes would be negative and the comparison
+        // remainingBytes > maxBytes would silently pass even for custom Stream implementations
+        // that return data beyond their declared Length.
+        var remainingBytes = Math.Max(0L, stream.Length - stream.Position);
+        if (remainingBytes > maxBytes)
+        {
+            ThrowSizeLimitExceeded(maxBytes);
+        }
+    }
+
+    private static EffectiveConfigFile BuildResult(byte[] buffer, int length, string contentType, string fileName)
+    {
+        var content = new byte[length];
+        if (length > 0)
+        {
+            Buffer.BlockCopy(buffer, 0, content, 0, length);
+        }
+
+        return new EffectiveConfigFile(content, contentType, fileName);
+    }
+
+    private static void ThrowSizeLimitExceeded(int maxBytes)
+    {
+        OpAmpClientEventSource.Log.EffectiveConfigSizeLimitExceeded(maxBytes);
+        throw new InvalidDataException($"Configuration file exceeds maximum allowed size of {maxBytes} bytes.");
     }
 }

--- a/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
@@ -45,6 +45,7 @@ public sealed class OpAmpClient : IDisposable
     /// </summary>
     /// <param name="token">Cancellation token.</param>
     /// <returns>A task that represents the asynchronous start operation.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
     public async Task StartAsync(CancellationToken token = default)
     {
         this.ThrowIfDisposed();
@@ -74,6 +75,7 @@ public sealed class OpAmpClient : IDisposable
     /// server that it is disconnecting. In particular, for WebSocket transport this attempts a
     /// graceful close handshake after sending the agent disconnect message.
     /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
     public async Task StopAsync(CancellationToken token = default)
     {
         this.ThrowIfDisposed();
@@ -98,6 +100,8 @@ public sealed class OpAmpClient : IDisposable
     /// </summary>
     /// <typeparam name="T">The <see cref="OpAmpMessage"/> to subscribe to.</typeparam>
     /// <param name="listener">A listener capable of handling messages of type <typeparamref name="T"/>.</param>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="listener"/> is null.</exception>
     public void Subscribe<T>(IOpAmpListener<T> listener)
         where T : OpAmpMessage
     {
@@ -111,6 +115,8 @@ public sealed class OpAmpClient : IDisposable
     /// </summary>
     /// <typeparam name="T">The <see cref="OpAmpMessage"/> to unsubscribe from.</typeparam>
     /// <param name="listener">A listener capable of handling messages of type <typeparamref name="T"/>.</param>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="listener"/> is null.</exception>
     public void Unsubscribe<T>(IOpAmpListener<T> listener)
         where T : OpAmpMessage
     {
@@ -132,6 +138,9 @@ public sealed class OpAmpClient : IDisposable
     /// before reporting files that may contain sensitive data such as passwords or tokens.
     /// </para>
     /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown if effective configuration reporting is not enabled in settings.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="files"/> contains two or more files with the same filename.</exception>
     public Task SendEffectiveConfigAsync(IEnumerable<EffectiveConfigFile> files, CancellationToken cancellationToken = default)
     {
         this.ThrowIfDisposed();
@@ -150,6 +159,7 @@ public sealed class OpAmpClient : IDisposable
     /// <param name="capabilities">Capabilities list.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that represents the asynchronous send operation.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
     public Task SendCustomCapabilitiesAsync(IEnumerable<string> capabilities, CancellationToken cancellationToken = default)
     {
         this.ThrowIfDisposed();
@@ -165,6 +175,7 @@ public sealed class OpAmpClient : IDisposable
     /// <param name="data">Contents of the message.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that represents the asynchronous send operation.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
     public Task SendCustomMessageAsync(string capability, string type, ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
     {
         this.ThrowIfDisposed();

--- a/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
@@ -140,7 +140,7 @@ public sealed class OpAmpClient : IDisposable
     /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown if effective configuration reporting is not enabled in settings.</exception>
     /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="files"/> contains two or more files with the same filename.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="files"/> contains two or more files with the same file name.</exception>
     public Task SendEffectiveConfigAsync(IEnumerable<EffectiveConfigFile> files, CancellationToken cancellationToken = default)
     {
         this.ThrowIfDisposed();

--- a/src/Shared/Guard.cs
+++ b/src/Shared/Guard.cs
@@ -116,6 +116,22 @@ namespace OpenTelemetry.Internal
         }
 
         /// <summary>
+        /// Throw an exception if the value is negative.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <param name="message">The message to use in the thrown exception.</param>
+        /// <param name="paramName">The parameter name to use in the thrown exception.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNegative(int value, string message = "Must not be negative", [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, message);
+            }
+        }
+
+        /// <summary>
         /// Throw an exception if the value is not considered a valid timeout.
         /// </summary>
         /// <param name="value">The value to check.</param>

--- a/test/OpenTelemetry.OpAmp.Client.Tests/DataGenerators/TempFile.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/DataGenerators/TempFile.cs
@@ -41,7 +41,7 @@ internal class TempFile : IDisposable
 
         try
         {
-            if (!File.Exists(this.FilePath))
+            if (File.Exists(this.FilePath))
             {
                 File.Delete(this.FilePath);
             }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/FrameBuilderTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/FrameBuilderTests.cs
@@ -3,6 +3,7 @@
 
 using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.OpAmp.Client.Messages;
 using OpenTelemetry.OpAmp.Client.Tests.DataGenerators;
 using Xunit;
 
@@ -53,6 +54,34 @@ public class FrameBuilderTests
         frameBuilder.StartBaseMessage();
 
         Assert.Throws<InvalidOperationException>(frameBuilder.StartBaseMessage);
+    }
+
+    [Fact]
+    public void AddEffectiveConfig_DuplicateFileName_ThrowsArgumentException()
+    {
+        var frameBuilder = new FrameBuilder(new());
+        var files = new[]
+        {
+            new EffectiveConfigFile(Array.Empty<byte>(), fileName: "config.yaml"),
+            new EffectiveConfigFile(Array.Empty<byte>(), fileName: "config.yaml"),
+        };
+
+        Assert.Throws<ArgumentException>(() =>
+            frameBuilder.StartBaseMessage().AddEffectiveConfig(files));
+    }
+
+    [Fact]
+    public void AddEffectiveConfig_DuplicateDefaultFileName_ThrowsArgumentException()
+    {
+        var frameBuilder = new FrameBuilder(new());
+        var files = new[]
+        {
+            new EffectiveConfigFile(Array.Empty<byte>()),
+            new EffectiveConfigFile(Array.Empty<byte>()),
+        };
+
+        Assert.Throws<ArgumentException>(() =>
+            frameBuilder.StartBaseMessage().AddEffectiveConfig(files));
     }
 
     [Theory]

--- a/test/OpenTelemetry.OpAmp.Client.Tests/FrameBuilderTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/FrameBuilderTests.cs
@@ -62,22 +62,8 @@ public class FrameBuilderTests
         var frameBuilder = new FrameBuilder(new());
         var files = new[]
         {
-            new EffectiveConfigFile(Array.Empty<byte>(), fileName: "config.yaml"),
-            new EffectiveConfigFile(Array.Empty<byte>(), fileName: "config.yaml"),
-        };
-
-        Assert.Throws<ArgumentException>(() =>
-            frameBuilder.StartBaseMessage().AddEffectiveConfig(files));
-    }
-
-    [Fact]
-    public void AddEffectiveConfig_DuplicateDefaultFileName_ThrowsArgumentException()
-    {
-        var frameBuilder = new FrameBuilder(new());
-        var files = new[]
-        {
-            new EffectiveConfigFile(Array.Empty<byte>()),
-            new EffectiveConfigFile(Array.Empty<byte>()),
+            new EffectiveConfigFile(Array.Empty<byte>(), string.Empty, "config.yaml"),
+            new EffectiveConfigFile(Array.Empty<byte>(), string.Empty, "config.yaml"),
         };
 
         Assert.Throws<ArgumentException>(() =>

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
@@ -11,31 +11,22 @@ public class EffectiveConfigFileTests
 {
     [Fact]
     public void Constructor_NullContentType_ThrowsArgumentNullException() =>
-        Assert.Throws<ArgumentNullException>(() => new EffectiveConfigFile(Array.Empty<byte>(), null!));
+        Assert.Throws<ArgumentNullException>(() => new EffectiveConfigFile(Array.Empty<byte>(), null!, "filename.yml"));
 
     [Fact]
     public void Constructor_NullFileName_ThrowsArgumentNullException() =>
         Assert.Throws<ArgumentNullException>(() => new EffectiveConfigFile(Array.Empty<byte>(), "application/octet-stream", null!));
 
     [Fact]
-    public void Constructor_DefaultOptionalParameters_UsesEmptyStrings()
-    {
-        var config = new EffectiveConfigFile(Array.Empty<byte>());
-
-        Assert.Equal(string.Empty, config.ContentType);
-        Assert.Equal(string.Empty, config.FileName);
-    }
-
-    [Fact]
     public void CreateFromStream_NullStream_ThrowsArgumentNullException() =>
-        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(null!, "application/octet-stream"));
+        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(null!, "application/octet-stream", "filename.yml", 1_024));
 
     [Fact]
     public void CreateFromStream_NullContentType_ThrowsArgumentNullException()
     {
         using var stream = new MemoryStream([]);
 
-        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(stream, null!));
+        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(stream, null!, "filename.yml", 1_024));
     }
 
     [Fact]
@@ -43,18 +34,7 @@ public class EffectiveConfigFileTests
     {
         using var stream = new MemoryStream([]);
 
-        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", null!));
-    }
-
-    [Fact]
-    public void CreateFromStream_DefaultOptionalParameters_UsesEmptyStrings()
-    {
-        using var stream = new MemoryStream([]);
-
-        var config = EffectiveConfigFile.CreateFromStream(stream);
-
-        Assert.Equal(string.Empty, config.ContentType);
-        Assert.Equal(string.Empty, config.FileName);
+        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", null!, 1_024));
     }
 
     [Fact]
@@ -63,7 +43,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([]);
 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: -1));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", -1));
     }
 
     [Fact]
@@ -72,7 +52,7 @@ public class EffectiveConfigFileTests
         using var stream = new NonReadableStream();
 
         var exception = Assert.Throws<ArgumentException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream"));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 1_024));
 
         Assert.Equal("stream", exception.ParamName);
     }
@@ -84,11 +64,11 @@ public class EffectiveConfigFileTests
 
         using var stream = new MemoryStream(content);
 
-        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length + 1);
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", content.Length + 1);
 
         Assert.Equal(content, config.Content.ToArray());
         Assert.Equal("application/octet-stream", config.ContentType);
-        Assert.Equal(string.Empty, config.FileName);
+        Assert.Equal("filename.yml", config.FileName);
     }
 
     [Fact]
@@ -99,7 +79,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream(content);
         stream.Position = 2;
 
-        var config = EffectiveConfigFile.CreateFromStream(stream, "application/json", maxBytes: 3, fileName: "config.json");
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/json", "config.json", 3);
 
         Assert.Equal([3, 4, 5], config.Content.ToArray());
         Assert.Equal("application/json", config.ContentType);
@@ -113,7 +93,7 @@ public class EffectiveConfigFileTests
 
         using var stream = new MemoryStream(content);
 
-        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length);
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", content.Length);
 
         Assert.Equal(content, config.Content.ToArray());
     }
@@ -127,7 +107,7 @@ public class EffectiveConfigFileTests
         stream.Position = 1;
 
         Assert.Throws<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 3));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 3));
     }
 
     [Fact]
@@ -139,7 +119,7 @@ public class EffectiveConfigFileTests
         stream.Position = 1;
 
         Assert.Throws<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 3));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 3));
 
         Assert.Equal(1, stream.Position);
     }
@@ -149,7 +129,7 @@ public class EffectiveConfigFileTests
     {
         using var stream = new MemoryStream([]);
 
-        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0);
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 0);
 
         Assert.Empty(config.Content.ToArray());
     }
@@ -160,7 +140,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([1]);
 
         Assert.Throws<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 0));
     }
 
     [Fact]
@@ -169,7 +149,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([1, 2]);
 
         Assert.Throws<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 0));
 
         Assert.Equal(0, stream.Position);
     }
@@ -179,7 +159,7 @@ public class EffectiveConfigFileTests
     {
         using var stream = new MemoryStream([]);
 
-        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 4);
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 4);
 
         Assert.Empty(config.Content.ToArray());
     }
@@ -191,7 +171,7 @@ public class EffectiveConfigFileTests
 
         using var stream = new NonSeekableReadStream(content, maxReadSize: 1);
 
-        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length);
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", content.Length);
 
         Assert.Equal(content, config.Content.ToArray());
     }
@@ -203,7 +183,7 @@ public class EffectiveConfigFileTests
 
         using var stream = new NonSeekableReadStream(content);
 
-        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length);
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", content.Length);
 
         Assert.Equal(content, config.Content.ToArray());
     }
@@ -216,7 +196,7 @@ public class EffectiveConfigFileTests
         using var stream = new NonSeekableReadStream(content);
 
         Assert.Throws<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length - 1));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", content.Length - 1));
     }
 
     [Fact]
@@ -225,7 +205,7 @@ public class EffectiveConfigFileTests
         using var stream = new NonSeekableReadStream([1, 2]);
 
         Assert.Throws<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 0));
 
         Assert.Equal(1, stream.BytesConsumed);
     }
@@ -243,7 +223,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream(content);
 
         Assert.Throws<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 3));
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 3));
 
         var @event = Assert.Single(listener.Events);
         Assert.Equal("EffectiveConfigSizeLimitViolation", @event.EventName);
@@ -254,7 +234,7 @@ public class EffectiveConfigFileTests
     [Fact]
     public async Task CreateFromStreamAsync_NullStream_ThrowsArgumentNullException() =>
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(null!, "application/octet-stream"));
+            EffectiveConfigFile.CreateFromStreamAsync(null!, "application/octet-stream", "filename.yml", 1_024));
 
     [Fact]
     public async Task CreateFromStreamAsync_NullContentType_ThrowsArgumentNullException()
@@ -262,7 +242,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([]);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, null!));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, null!, "filename.yml", 1_024));
     }
 
     [Fact]
@@ -271,18 +251,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([]);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", null!));
-    }
-
-    [Fact]
-    public async Task CreateFromStreamAsync_DefaultOptionalParameters_UsesEmptyStrings()
-    {
-        using var stream = new MemoryStream([]);
-
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream);
-
-        Assert.Equal(string.Empty, config.ContentType);
-        Assert.Equal(string.Empty, config.FileName);
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", null!, 1_024));
     }
 
     [Fact]
@@ -291,7 +260,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([]);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: -1));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", -1));
     }
 
     [Fact]
@@ -300,7 +269,7 @@ public class EffectiveConfigFileTests
         using var stream = new NonReadableStream();
 
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream"));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 1_024));
 
         Assert.Equal("stream", exception.ParamName);
     }
@@ -312,11 +281,11 @@ public class EffectiveConfigFileTests
 
         using var stream = new MemoryStream(content);
 
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length + 1);
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", content.Length + 1);
 
         Assert.Equal(content, config.Content.ToArray());
         Assert.Equal("application/octet-stream", config.ContentType);
-        Assert.Equal(string.Empty, config.FileName);
+        Assert.Equal("filename.yml", config.FileName);
     }
 
     [Fact]
@@ -327,7 +296,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream(content);
         stream.Position = 2;
 
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/json", maxBytes: 3, fileName: "config.json");
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/json", "config.json", 3);
 
         Assert.Equal([3, 4, 5], config.Content.ToArray());
         Assert.Equal("application/json", config.ContentType);
@@ -341,7 +310,7 @@ public class EffectiveConfigFileTests
 
         using var stream = new MemoryStream(content);
 
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length);
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", content.Length);
 
         Assert.Equal(content, config.Content.ToArray());
     }
@@ -355,7 +324,7 @@ public class EffectiveConfigFileTests
         stream.Position = 1;
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 3));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 3));
     }
 
     [Fact]
@@ -367,7 +336,7 @@ public class EffectiveConfigFileTests
         stream.Position = 1;
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 3));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 3));
 
         Assert.Equal(1, stream.Position);
     }
@@ -377,7 +346,7 @@ public class EffectiveConfigFileTests
     {
         using var stream = new MemoryStream([]);
 
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0);
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 0);
 
         Assert.Empty(config.Content.ToArray());
     }
@@ -388,7 +357,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([1]);
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 0));
     }
 
     [Fact]
@@ -397,7 +366,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream([1, 2]);
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 0));
 
         Assert.Equal(0, stream.Position);
     }
@@ -407,7 +376,7 @@ public class EffectiveConfigFileTests
     {
         using var stream = new MemoryStream([]);
 
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 4);
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 4);
 
         Assert.Empty(config.Content.ToArray());
     }
@@ -419,7 +388,7 @@ public class EffectiveConfigFileTests
 
         using var stream = new NonSeekableReadStream(content, maxReadSize: 1);
 
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length);
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", content.Length);
 
         Assert.Equal(content, config.Content.ToArray());
     }
@@ -431,7 +400,7 @@ public class EffectiveConfigFileTests
 
         using var stream = new NonSeekableReadStream(content);
 
-        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length);
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", content.Length);
 
         Assert.Equal(content, config.Content.ToArray());
     }
@@ -444,7 +413,7 @@ public class EffectiveConfigFileTests
         using var stream = new NonSeekableReadStream(content);
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length - 1));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", content.Length - 1));
     }
 
     [Fact]
@@ -453,7 +422,7 @@ public class EffectiveConfigFileTests
         using var stream = new NonSeekableReadStream([1, 2]);
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 0));
 
         Assert.Equal(1, stream.BytesConsumed);
     }
@@ -468,7 +437,7 @@ public class EffectiveConfigFileTests
         using var stream = new NonSeekableReadStream(content);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, maxBytes: content.Length, cancellationToken: cts.Token));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", content.Length, cancellationToken: cts.Token));
     }
 
     // EventListener on .NET Framework uses the ETW stack whose initialization timing
@@ -484,7 +453,7 @@ public class EffectiveConfigFileTests
         using var stream = new MemoryStream(content);
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>
-            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 3));
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 3));
 
         var @event = Assert.Single(listener.Events);
         Assert.Equal("EffectiveConfigSizeLimitViolation", @event.EventName);

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
@@ -229,8 +229,7 @@ public class EffectiveConfigFileTests
         Assert.Throws<InvalidDataException>(() =>
             EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", "filename.yml", 3));
 
-        var @event = Assert.Single(listener.Events);
-        Assert.Equal("EffectiveConfigSizeLimitViolation", @event.EventName);
+        var @event = Assert.Single(listener.Events, e => e.EventName == "EffectiveConfigSizeLimitViolation");
         Assert.Equal(3, (int)@event.Payload![0]!);
     }
 #endif
@@ -459,8 +458,7 @@ public class EffectiveConfigFileTests
         await Assert.ThrowsAsync<InvalidDataException>(() =>
             EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", "filename.yml", 3));
 
-        var @event = Assert.Single(listener.Events);
-        Assert.Equal("EffectiveConfigSizeLimitViolation", @event.EventName);
+        var @event = Assert.Single(listener.Events, e => e.EventName == "EffectiveConfigSizeLimitViolation");
         Assert.Equal(3, (int)@event.Payload![0]!);
     }
 #endif

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
@@ -1,9 +1,13 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics.Tracing;
 using OpenTelemetry.OpAmp.Client.Messages;
 using Xunit;
+
+#if NET
+using OpenTelemetry.OpAmp.Client.Internal;
+using OpenTelemetry.Tests;
+#endif
 
 namespace OpenTelemetry.OpAmp.Client.Tests.Messages;
 
@@ -217,7 +221,7 @@ public class EffectiveConfigFileTests
     [Fact]
     public void CreateFromStream_WhenExceedsMaxBytes_LogsEvent()
     {
-        using var listener = new CapturingEventListener("OpenTelemetry-OpAmp-Client");
+        using var listener = new InMemoryEventListener(OpAmpClientEventSource.Log);
 
         var content = new byte[] { 1, 2, 3, 4, 5 };
         using var stream = new MemoryStream(content);
@@ -447,7 +451,7 @@ public class EffectiveConfigFileTests
     [Fact]
     public async Task CreateFromStreamAsync_WhenExceedsMaxBytes_LogsEvent()
     {
-        using var listener = new CapturingEventListener("OpenTelemetry-OpAmp-Client");
+        using var listener = new InMemoryEventListener(OpAmpClientEventSource.Log);
 
         var content = new byte[] { 1, 2, 3, 4, 5 };
         using var stream = new MemoryStream(content);
@@ -569,44 +573,5 @@ public class EffectiveConfigFileTests
 
         public override void Write(byte[] buffer, int offset, int count)
             => throw new NotSupportedException();
-    }
-
-    private sealed class CapturingEventListener : EventListener
-    {
-        private readonly string sourceName;
-        private readonly List<EventWrittenEventArgs> capturedEvents = new();
-
-        public CapturingEventListener(string sourceName)
-        {
-            this.sourceName = sourceName;
-
-            // On some runtime versions, EnableEvents called from OnEventSourceCreated during
-            // the EventSource constructor is deferred and may not take effect immediately.
-            // Re-enable explicitly after the base constructor has finished.
-#if NET
-            foreach (var source in EventSource.GetSources())
-            {
-                this.OnEventSourceCreated(source);
-            }
-#endif
-        }
-
-        public IReadOnlyList<EventWrittenEventArgs> Events => this.capturedEvents;
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name == this.sourceName)
-            {
-                this.EnableEvents(eventSource, EventLevel.Warning);
-            }
-        }
-
-        protected override void OnEventWritten(EventWrittenEventArgs eventData)
-        {
-            if (eventData.EventName == "EffectiveConfigSizeLimitViolation")
-            {
-                this.capturedEvents.Add(eventData);
-            }
-        }
     }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
@@ -1,0 +1,643 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Tracing;
+using OpenTelemetry.OpAmp.Client.Messages;
+using Xunit;
+
+namespace OpenTelemetry.OpAmp.Client.Tests.Messages;
+
+public class EffectiveConfigFileTests
+{
+    [Fact]
+    public void Constructor_NullContentType_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => new EffectiveConfigFile(Array.Empty<byte>(), null!));
+
+    [Fact]
+    public void Constructor_NullFileName_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => new EffectiveConfigFile(Array.Empty<byte>(), "application/octet-stream", null!));
+
+    [Fact]
+    public void Constructor_DefaultOptionalParameters_UsesEmptyStrings()
+    {
+        var config = new EffectiveConfigFile(Array.Empty<byte>());
+
+        Assert.Equal(string.Empty, config.ContentType);
+        Assert.Equal(string.Empty, config.FileName);
+    }
+
+    [Fact]
+    public void CreateFromStream_NullStream_ThrowsArgumentNullException() =>
+        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(null!, "application/octet-stream"));
+
+    [Fact]
+    public void CreateFromStream_NullContentType_ThrowsArgumentNullException()
+    {
+        using var stream = new MemoryStream([]);
+
+        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(stream, null!));
+    }
+
+    [Fact]
+    public void CreateFromStream_NullFileName_ThrowsArgumentNullException()
+    {
+        using var stream = new MemoryStream([]);
+
+        Assert.Throws<ArgumentNullException>(() => EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", null!));
+    }
+
+    [Fact]
+    public void CreateFromStream_DefaultOptionalParameters_UsesEmptyStrings()
+    {
+        using var stream = new MemoryStream([]);
+
+        var config = EffectiveConfigFile.CreateFromStream(stream);
+
+        Assert.Equal(string.Empty, config.ContentType);
+        Assert.Equal(string.Empty, config.FileName);
+    }
+
+    [Fact]
+    public void CreateFromStream_NegativeMaxBytes_ThrowsArgumentOutOfRangeException()
+    {
+        using var stream = new MemoryStream([]);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: -1));
+    }
+
+    [Fact]
+    public void CreateFromStream_UnreadableStream_ThrowsArgumentException()
+    {
+        using var stream = new NonReadableStream();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream"));
+
+        Assert.Equal("stream", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateFromStream_SeekableStream_WithContentUnderMaxBytes_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new MemoryStream(content);
+
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length + 1);
+
+        Assert.Equal(content, config.Content.ToArray());
+        Assert.Equal("application/octet-stream", config.ContentType);
+        Assert.Equal(string.Empty, config.FileName);
+    }
+
+    [Fact]
+    public void CreateFromStream_SeekableStream_WithCurrentPosition_UsesRemainingBytesAndPreservesMetadata()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new MemoryStream(content);
+        stream.Position = 2;
+
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/json", maxBytes: 3, fileName: "config.json");
+
+        Assert.Equal([3, 4, 5], config.Content.ToArray());
+        Assert.Equal("application/json", config.ContentType);
+        Assert.Equal("config.json", config.FileName);
+    }
+
+    [Fact]
+    public void CreateFromStream_SeekableStream_WithContentAtMaxBytes_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new MemoryStream(content);
+
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length);
+
+        Assert.Equal(content, config.Content.ToArray());
+    }
+
+    [Fact]
+    public void CreateFromStream_SeekableStream_WithRemainingContentOverMaxBytes_Throws()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new MemoryStream(content);
+        stream.Position = 1;
+
+        Assert.Throws<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 3));
+    }
+
+    [Fact]
+    public void CreateFromStream_SeekableStream_WithRemainingContentOverMaxBytes_DoesNotAdvancePosition()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new MemoryStream(content);
+        stream.Position = 1;
+
+        Assert.Throws<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 3));
+
+        Assert.Equal(1, stream.Position);
+    }
+
+    [Fact]
+    public void CreateFromStream_ZeroMaxBytes_WithEmptyStream_Succeeds()
+    {
+        using var stream = new MemoryStream([]);
+
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0);
+
+        Assert.Empty(config.Content.ToArray());
+    }
+
+    [Fact]
+    public void CreateFromStream_ZeroMaxBytes_WithContent_Throws()
+    {
+        using var stream = new MemoryStream([1]);
+
+        Assert.Throws<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0));
+    }
+
+    [Fact]
+    public void CreateFromStream_ZeroMaxBytes_WithContent_DoesNotAdvancePosition()
+    {
+        using var stream = new MemoryStream([1, 2]);
+
+        Assert.Throws<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0));
+
+        Assert.Equal(0, stream.Position);
+    }
+
+    [Fact]
+    public void CreateFromStream_EmptyStream_WithPositiveMaxBytes_Succeeds()
+    {
+        using var stream = new MemoryStream([]);
+
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 4);
+
+        Assert.Empty(config.Content.ToArray());
+    }
+
+    [Fact]
+    public void CreateFromStream_NonSeekableStream_WithPartialReads_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new NonSeekableReadStream(content, maxReadSize: 1);
+
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length);
+
+        Assert.Equal(content, config.Content.ToArray());
+    }
+
+    [Fact]
+    public void CreateFromStream_NonSeekableStream_WithContentAtMaxBytes_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new NonSeekableReadStream(content);
+
+        var config = EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length);
+
+        Assert.Equal(content, config.Content.ToArray());
+    }
+
+    [Fact]
+    public void CreateFromStream_NonSeekableStream_WithContentOverMaxBytes_Throws()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new NonSeekableReadStream(content);
+
+        Assert.Throws<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: content.Length - 1));
+    }
+
+    [Fact]
+    public void CreateFromStream_NonSeekableStream_ZeroMaxBytes_WithContent_ConsumesOneByteBeforeThrow()
+    {
+        using var stream = new NonSeekableReadStream([1, 2]);
+
+        Assert.Throws<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 0));
+
+        Assert.Equal(1, stream.BytesConsumed);
+    }
+
+    // EventListener on .NET Framework uses the ETW stack whose initialization timing
+    // differs from the in-process model on modern .NET, making this test unreliable
+    // when test classes run in parallel. The test is therefore NET-only.
+#if NET
+    [Fact]
+    public void CreateFromStream_WhenExceedsMaxBytes_LogsEvent()
+    {
+        using var listener = new CapturingEventListener("OpenTelemetry-OpAmp-Client");
+
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        using var stream = new MemoryStream(content);
+
+        Assert.Throws<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStream(stream, "application/octet-stream", maxBytes: 3));
+
+        var @event = Assert.Single(listener.Events);
+        Assert.Equal("EffectiveConfigSizeLimitViolation", @event.EventName);
+        Assert.Equal(3, (int)@event.Payload![0]!);
+    }
+#endif
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NullStream_ThrowsArgumentNullException() =>
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(null!, "application/octet-stream"));
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NullContentType_ThrowsArgumentNullException()
+    {
+        using var stream = new MemoryStream([]);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, null!));
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NullFileName_ThrowsArgumentNullException()
+    {
+        using var stream = new MemoryStream([]);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", null!));
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_DefaultOptionalParameters_UsesEmptyStrings()
+    {
+        using var stream = new MemoryStream([]);
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream);
+
+        Assert.Equal(string.Empty, config.ContentType);
+        Assert.Equal(string.Empty, config.FileName);
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NegativeMaxBytes_ThrowsArgumentOutOfRangeException()
+    {
+        using var stream = new MemoryStream([]);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: -1));
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_UnreadableStream_ThrowsArgumentException()
+    {
+        using var stream = new NonReadableStream();
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream"));
+
+        Assert.Equal("stream", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_SeekableStream_WithContentUnderMaxBytes_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new MemoryStream(content);
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length + 1);
+
+        Assert.Equal(content, config.Content.ToArray());
+        Assert.Equal("application/octet-stream", config.ContentType);
+        Assert.Equal(string.Empty, config.FileName);
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_SeekableStream_WithCurrentPosition_UsesRemainingBytesAndPreservesMetadata()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new MemoryStream(content);
+        stream.Position = 2;
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/json", maxBytes: 3, fileName: "config.json");
+
+        Assert.Equal([3, 4, 5], config.Content.ToArray());
+        Assert.Equal("application/json", config.ContentType);
+        Assert.Equal("config.json", config.FileName);
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_SeekableStream_WithContentAtMaxBytes_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new MemoryStream(content);
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length);
+
+        Assert.Equal(content, config.Content.ToArray());
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_SeekableStream_WithRemainingContentOverMaxBytes_Throws()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new MemoryStream(content);
+        stream.Position = 1;
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 3));
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_SeekableStream_WithRemainingContentOverMaxBytes_DoesNotAdvancePosition()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new MemoryStream(content);
+        stream.Position = 1;
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 3));
+
+        Assert.Equal(1, stream.Position);
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_ZeroMaxBytes_WithEmptyStream_Succeeds()
+    {
+        using var stream = new MemoryStream([]);
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0);
+
+        Assert.Empty(config.Content.ToArray());
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_ZeroMaxBytes_WithContent_Throws()
+    {
+        using var stream = new MemoryStream([1]);
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0));
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_ZeroMaxBytes_WithContent_DoesNotAdvancePosition()
+    {
+        using var stream = new MemoryStream([1, 2]);
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0));
+
+        Assert.Equal(0, stream.Position);
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_EmptyStream_WithPositiveMaxBytes_Succeeds()
+    {
+        using var stream = new MemoryStream([]);
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 4);
+
+        Assert.Empty(config.Content.ToArray());
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NonSeekableStream_WithPartialReads_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new NonSeekableReadStream(content, maxReadSize: 1);
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length);
+
+        Assert.Equal(content, config.Content.ToArray());
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NonSeekableStream_WithContentAtMaxBytes_Succeeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4 };
+
+        using var stream = new NonSeekableReadStream(content);
+
+        var config = await EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length);
+
+        Assert.Equal(content, config.Content.ToArray());
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NonSeekableStream_WithContentOverMaxBytes_Throws()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        using var stream = new NonSeekableReadStream(content);
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: content.Length - 1));
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_NonSeekableStream_ZeroMaxBytes_WithContent_ConsumesOneByteBeforeThrow()
+    {
+        using var stream = new NonSeekableReadStream([1, 2]);
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 0));
+
+        Assert.Equal(1, stream.BytesConsumed);
+    }
+
+    [Fact]
+    public async Task CreateFromStreamAsync_WithCancelledToken_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var content = new byte[] { 1, 2, 3, 4 };
+        using var stream = new NonSeekableReadStream(content);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, maxBytes: content.Length, cancellationToken: cts.Token));
+    }
+
+    // EventListener on .NET Framework uses the ETW stack whose initialization timing
+    // differs from the in-process model on modern .NET, making this test unreliable
+    // when test classes run in parallel. The test is therefore NET-only.
+#if NET
+    [Fact]
+    public async Task CreateFromStreamAsync_WhenExceedsMaxBytes_LogsEvent()
+    {
+        using var listener = new CapturingEventListener("OpenTelemetry-OpAmp-Client");
+
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        using var stream = new MemoryStream(content);
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            EffectiveConfigFile.CreateFromStreamAsync(stream, "application/octet-stream", maxBytes: 3));
+
+        var @event = Assert.Single(listener.Events);
+        Assert.Equal("EffectiveConfigSizeLimitViolation", @event.EventName);
+        Assert.Equal(3, (int)@event.Payload![0]!);
+    }
+#endif
+
+    private sealed class NonSeekableReadStream : Stream
+    {
+        private readonly MemoryStream innerStream;
+        private readonly int maxReadSize;
+
+        public NonSeekableReadStream(byte[] content, int maxReadSize = int.MaxValue)
+        {
+            this.innerStream = new MemoryStream(content);
+            this.maxReadSize = maxReadSize;
+        }
+
+        public int BytesConsumed => checked((int)this.innerStream.Position);
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => this.innerStream.Read(buffer, offset, Math.Min(count, this.maxReadSize));
+
+        public override int ReadByte()
+            => this.innerStream.ReadByte();
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled<int>(cancellationToken)
+                : Task.FromResult(this.innerStream.Read(buffer, offset, Math.Min(count, this.maxReadSize)));
+
+#if NET
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return ValueTask.FromCanceled<int>(cancellationToken);
+            }
+
+            var count = Math.Min(buffer.Length, this.maxReadSize);
+            return new ValueTask<int>(this.innerStream.Read(buffer.Span[..count]));
+        }
+#endif
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class NonReadableStream : Stream
+    {
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+            => throw new NotSupportedException();
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override int ReadByte()
+            => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class CapturingEventListener : EventListener
+    {
+        private readonly string sourceName;
+        private readonly List<EventWrittenEventArgs> capturedEvents = new();
+
+        public CapturingEventListener(string sourceName)
+        {
+            this.sourceName = sourceName;
+
+            // On some runtime versions, EnableEvents called from OnEventSourceCreated during
+            // the EventSource constructor is deferred and may not take effect immediately.
+            // Re-enable explicitly after the base constructor has finished.
+#if NET
+            foreach (var source in EventSource.GetSources())
+            {
+                this.OnEventSourceCreated(source);
+            }
+#endif
+        }
+
+        public IReadOnlyList<EventWrittenEventArgs> Events => this.capturedEvents;
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == this.sourceName)
+            {
+                this.EnableEvents(eventSource, EventLevel.Warning);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName == "EffectiveConfigSizeLimitViolation")
+            {
+                this.capturedEvents.Add(eventData);
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -296,7 +296,7 @@ public class OpAmpClientTests
             """;
         using var tempConfigFile = TempFile.Create(fileContent);
         using var stream = File.OpenRead(tempConfigFile.FilePath);
-        var configFile = EffectiveConfigFile.CreateFromStream(stream, fileContentType, fileName: tempConfigFile.FileName);
+        var configFile = EffectiveConfigFile.CreateFromStream(stream, fileContentType, tempConfigFile.FileName, 512 * 1024);
 
         // Act
         await client.StartAsync();

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -295,7 +295,8 @@ public class OpAmpClientTests
             }
             """;
         using var tempConfigFile = TempFile.Create(fileContent);
-        var configFile = EffectiveConfigFile.CreateFromFilePath(tempConfigFile.FilePath, fileContentType);
+        using var stream = File.OpenRead(tempConfigFile.FilePath);
+        var configFile = EffectiveConfigFile.CreateFromStream(stream, fileContentType, fileName: tempConfigFile.FileName);
 
         // Act
         await client.StartAsync();


### PR DESCRIPTION
Fixes #4151

## Changes

- Add CreateFromStream and CreateFromStreamAsync to EffectiveConfigFile for safe, size-limited config loading from streams (sync/async) with enforced max byte length.
- Remove CreateFromFilePath.
- Content is now ReadOnlyMemory<byte>.
- Enforce non-null contentType and fileName (default to empty string).
- Improve OpAmpClient API docs with thrown exception details.
- Add comprehensive EffectiveConfigFile tests (validation, limits, event logging).
- Update FrameBuilderTests and OpAmpClientTests for new APIs.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)