### PR TITLE
[Infra] Skip netfx reference assemblies on Windows

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,8 +33,8 @@
 
   <ItemGroup Label="Packages referenced in all projects">
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.12.0-beta1.25218.8" PrivateAssets="All" />
-    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(SkipAnalysis)'!='true'" PrivateAssets="All" />
+    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" Condition="$(OS) != 'Windows_NT'" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" Condition="'$(SkipAnalysis)'!='true'" />
   </ItemGroup>
 
   <!-- Production packages are pinned so that any package updates are performed manually, not by any dependency automation -->


### PR DESCRIPTION
Relates to open-telemetry/opentelemetry-dotnet#7142

## Changes

Only reference `Microsoft.NETFramework.ReferenceAssemblies` on non-Windows OS.

I couldn't replicate the same failure here, but it makes sense to be consistent and skip restoring and referencing a redundant package on Windows.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
