### PR TITLE
[Instrumentation.Hangfire] Fix undisposed activities in filter

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentationJobFilterAttribute.cs
@@ -57,15 +57,13 @@ internal sealed class HangfireInstrumentationJobFilterAttribute : JobFilterAttri
                 {
                     if (this.options.Filter?.Invoke(performingContext.BackgroundJob) == false)
                     {
-                        activity.IsAllDataRequested = false;
-                        activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+                        SuppressAndDisposeActivity(activity);
                         return;
                     }
                 }
                 catch (Exception)
                 {
-                    activity.IsAllDataRequested = false;
-                    activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+                    SuppressAndDisposeActivity(activity);
                     return;
                 }
 
@@ -134,6 +132,13 @@ internal sealed class HangfireInstrumentationJobFilterAttribute : JobFilterAttri
     private static IEnumerable<string> ExtractActivityProperties(Dictionary<string, string> telemetryData, string key)
     {
         return telemetryData.TryGetValue(key, out var value) ? [value] : [];
+    }
+
+    private static void SuppressAndDisposeActivity(Activity activity)
+    {
+        activity.IsAllDataRequested = false;
+        activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+        activity.Dispose();
     }
 
     private void SetStatusAndRecordException(Activity activity, Exception exception)

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
@@ -230,6 +230,57 @@ public class HangfireInstrumentationJobFilterAttributeTests
         Assert.Equal(shouldRecord, activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void OnPerforming_When_Filter_Suppresses_Activity_Should_Dispose_Activity_And_Restore_Parent(bool throwInFilter)
+    {
+        var startedActivities = 0;
+        var stoppedActivities = 0;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = activity =>
+            {
+                if (activity.Source.Name == HangfireInstrumentation.ActivitySourceName)
+                {
+                    startedActivities++;
+                }
+            },
+            ActivityStopped = activity =>
+            {
+                if (activity.Source.Name == HangfireInstrumentation.ActivitySourceName)
+                {
+                    stoppedActivities++;
+                }
+            },
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var parentSource = new ActivitySource(nameof(HangfireInstrumentationJobFilterAttributeTests));
+        using var parentActivity = parentSource.StartActivity("parent");
+        Assert.NotNull(parentActivity);
+
+        var storage = new MemoryStorage();
+        using var connection = storage.GetConnection();
+
+        var filter = new HangfireInstrumentationJobFilterAttribute(new HangfireInstrumentationOptions
+        {
+            Filter = throwInFilter ? _ => throw new InvalidOperationException("Filter throws exception") : _ => false,
+        });
+        var performingContext = CreatePerformingContext(storage, connection);
+
+        filter.OnPerforming(performingContext);
+
+        Assert.Same(parentActivity, Activity.Current);
+        Assert.False(performingContext.Items.ContainsKey(HangfireInstrumentationConstants.ActivityKey));
+        Assert.Equal(1, startedActivities);
+        Assert.Equal(1, stoppedActivities);
+    }
+
     [Fact]
     public async Task Should_Not_Inject_Invalid_Context()
     {


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fix issue where filter leaves activities undisposed

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~
