### PR TITLE
[Sampler.AWS] Handle missing SamplingTargetDocuments in target polling

### DIFF
--- a/src/OpenTelemetry.Sampler.AWS/AWSXRayRemoteSampler.cs
+++ b/src/OpenTelemetry.Sampler.AWS/AWSXRayRemoteSampler.cs
@@ -143,6 +143,11 @@ public sealed class AWSXRayRemoteSampler : Trace.Sampler, IDisposable
 
     private async void GetAndUpdateTargets(object? state)
     {
+        await this.GetAndUpdateTargetsAsync().ConfigureAwait(false);
+    }
+
+    private async Task GetAndUpdateTargetsAsync()
+    {
         var statistics = this.RulesCache.Snapshot(this.Clock.Now());
 
         var request = new GetSamplingTargetsRequest(statistics);

--- a/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
+++ b/src/OpenTelemetry.Sampler.AWS/AWSXRaySamplerClient.cs
@@ -98,7 +98,12 @@ internal class AWSXRaySamplerClient : IDisposable
                 .Deserialize<GetSamplingTargetsResponse>(responseJson);
 #endif
 
-            return getSamplingTargetsResponse;
+            return getSamplingTargetsResponse == null
+                ? null
+                : new GetSamplingTargetsResponse(
+                    getSamplingTargetsResponse.LastRuleModification,
+                    getSamplingTargetsResponse.SamplingTargetDocuments,
+                    getSamplingTargetsResponse.UnprocessedStatistics);
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Sampler.AWS/GetSamplingTargetsResponse.cs
+++ b/src/OpenTelemetry.Sampler.AWS/GetSamplingTargetsResponse.cs
@@ -9,12 +9,12 @@ internal sealed class GetSamplingTargetsResponse
 {
     public GetSamplingTargetsResponse(
         double lastRuleModification,
-        List<SamplingTargetDocument> samplingTargetDocuments,
-        List<UnprocessedStatistic> unprocessedStatistics)
+        List<SamplingTargetDocument>? samplingTargetDocuments,
+        List<UnprocessedStatistic>? unprocessedStatistics)
     {
         this.LastRuleModification = lastRuleModification;
-        this.SamplingTargetDocuments = samplingTargetDocuments;
-        this.UnprocessedStatistics = unprocessedStatistics;
+        this.SamplingTargetDocuments = samplingTargetDocuments ?? [];
+        this.UnprocessedStatistics = unprocessedStatistics ?? [];
     }
 
     // This is actually a time in unix seconds.
@@ -22,8 +22,8 @@ internal sealed class GetSamplingTargetsResponse
     public double LastRuleModification { get; set; }
 
     [JsonPropertyName("SamplingTargetDocuments")]
-    public List<SamplingTargetDocument> SamplingTargetDocuments { get; set; }
+    public List<SamplingTargetDocument> SamplingTargetDocuments { get; set; } = [];
 
     [JsonPropertyName("UnprocessedStatistics")]
-    public List<UnprocessedStatistic> UnprocessedStatistics { get; set; }
+    public List<UnprocessedStatistic> UnprocessedStatistics { get; set; } = [];
 }

--- a/src/OpenTelemetry.Sampler.AWS/GetSamplingTargetsResponse.cs
+++ b/src/OpenTelemetry.Sampler.AWS/GetSamplingTargetsResponse.cs
@@ -22,8 +22,8 @@ internal sealed class GetSamplingTargetsResponse
     public double LastRuleModification { get; set; }
 
     [JsonPropertyName("SamplingTargetDocuments")]
-    public List<SamplingTargetDocument> SamplingTargetDocuments { get; set; } = [];
+    public List<SamplingTargetDocument> SamplingTargetDocuments { get; set; }
 
     [JsonPropertyName("UnprocessedStatistics")]
-    public List<UnprocessedStatistic> UnprocessedStatistics { get; set; } = [];
+    public List<UnprocessedStatistic> UnprocessedStatistics { get; set; }
 }

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
@@ -140,7 +140,7 @@ public class TestAWSXRayRemoteSampler
         }
         finally
         {
-            sampler!.Dispose();
+            sampler.Dispose();
         }
     }
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
@@ -105,6 +105,45 @@ public class TestAWSXRayRemoteSampler
         Assert.Equal(expected, this.DoSample(sampler, "cat-service"));
     }
 
+    [Fact]
+    public async Task TestSamplerUpdateTargetsWithMissingTargetDocumentsDoesNotThrow()
+    {
+        var clock = new TestClock();
+        var requestHandler = new MockServerRequestHandler();
+
+        using var mockServer = TestHttpServer.RunServer(
+            requestHandler.Handle,
+            out var host,
+            out var port);
+
+        var parentBasedSampler = AWSXRayRemoteSampler.Builder(ResourceBuilder.CreateEmpty().Build())
+            .SetPollingInterval(TimeSpan.FromMilliseconds(10))
+            .SetEndpoint($"http://{host}:{port}")
+            .SetClock(clock)
+            .Build();
+
+        var rootSamplerFieldInfo = typeof(ParentBasedSampler).GetField("rootSampler", BindingFlags.NonPublic | BindingFlags.Instance);
+        var sampler = (AWSXRayRemoteSampler?)rootSamplerFieldInfo?.GetValue(parentBasedSampler);
+
+        Assert.NotNull(sampler);
+
+        requestHandler.SetResponse("/SamplingTargets", "{\"LastRuleModification\":1530920505.0}");
+
+        var getAndUpdateTargetsAsyncMethod = typeof(AWSXRayRemoteSampler).GetMethod("GetAndUpdateTargetsAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        var getAndUpdateTargetsAsyncTask = (Task?)getAndUpdateTargetsAsyncMethod?.Invoke(sampler, null);
+
+        Assert.NotNull(getAndUpdateTargetsAsyncTask);
+
+        try
+        {
+            await getAndUpdateTargetsAsyncTask!;
+        }
+        finally
+        {
+            sampler!.Dispose();
+        }
+    }
+
     private SamplingDecision DoSample(Trace.Sampler sampler, string serviceName)
     {
         var samplingParams = new SamplingParameters(

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
@@ -164,6 +164,30 @@ public class TestAWSXRaySamplerClient : IDisposable
     }
 
     [Fact]
+    public async Task TestGetSamplingTargetsWithMissingCollections()
+    {
+        var clock = new TestClock();
+        this.requestHandler.SetResponse("/SamplingTargets", "{\"LastRuleModification\":1530920505.0}");
+
+        var request = new GetSamplingTargetsRequest(
+        [
+            new(
+                "clientId",
+                "rule1",
+                100,
+                50,
+                10,
+                clock.ToDouble(clock.Now())),
+        ]);
+
+        var targetsResponse = await this.client.GetSamplingTargets(request);
+
+        Assert.NotNull(targetsResponse);
+        Assert.Empty(targetsResponse.SamplingTargetDocuments);
+        Assert.Empty(targetsResponse.UnprocessedStatistics);
+    }
+
+    [Fact]
     public async Task TestGetSamplingRulesWithOversizedResponse()
     {
         // Create a response larger than the 1 MB limit enforced by DoRequestAsync.


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Handle missing `SamplingTargetDocuments` and `UnprocessedStatistics` collections in `SamplingTargets` responses without crashing the remote sampler.


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~
