### PR TITLE
[SqlClient] Polyfill Stopwatch.GetElapsedTime

### DIFF
--- a/opentelemetry-dotnet-contrib.slnx
+++ b/opentelemetry-dotnet-contrib.slnx
@@ -214,6 +214,7 @@
     <File Path="src/Shared/SqlParameterProcessor.cs" />
     <File Path="src/Shared/SqlProcessor.cs" />
     <File Path="src/Shared/SqlStatementInfo.cs" />
+    <File Path="src/Shared/StopwatchExtensions.cs" />
     <File Path="src/Shared/UriHelper.cs" />
   </Folder>
   <Folder Name="/src/Shared/AWS/">

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -93,17 +93,5 @@ internal sealed class SqlTelemetryHelper
     }
 
     internal static double CalculateDurationFromTimestamp(long begin)
-    {
-#if NET
-        var duration = Stopwatch.GetElapsedTime(begin);
-#else
-        var end = Stopwatch.GetTimestamp();
-        var timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
-        var delta = end - begin;
-        var ticks = (long)(timestampToTicks * delta);
-        var duration = new TimeSpan(ticks);
-#endif
-
-        return duration.TotalSeconds;
-    }
+        => Stopwatch.GetElapsedTime(begin).TotalSeconds;
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -38,6 +38,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\SqlParameterProcessor.cs" Link="Includes\SqlParameterProcessor.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlProcessor.cs" Link="Includes\SqlProcessor.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlStatementInfo.cs" Link="Includes\SqlStatementInfo.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/StopwatchExtensions.cs
+++ b/src/Shared/StopwatchExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if !NET
+
+using System.Diagnostics;
+
+internal static class StopwatchExtensions
+{
+    extension(Stopwatch)
+    {
+        public static TimeSpan GetElapsedTime(long begin)
+        {
+            var end = Stopwatch.GetTimestamp();
+
+            var timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+            var delta = end - begin;
+            var ticks = (long)(timestampToTicks * delta);
+
+            return new TimeSpan(ticks);
+        }
+    }
+}
+
+#endif

--- a/src/Shared/StopwatchExtensions.cs
+++ b/src/Shared/StopwatchExtensions.cs
@@ -3,7 +3,7 @@
 
 #if !NET
 
-using System.Diagnostics;
+namespace System.Diagnostics;
 
 internal static class StopwatchExtensions
 {


### PR DESCRIPTION
## Changes

Add a polyfill for `Stopwatch.GetElapsedTime()` for `netstandard2.0` and `net462` for reuse in other instrumentation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
