### PR TITLE
[Instrumentation.AWS] Fix suppression scope leakage

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -20,6 +20,10 @@
 * BREAKING: Update latest AWS Semantic Conventions to 1.40.0.
   ([#4043](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4043))
 
+* Fix suppression scope leakage when `SuppressDownstreamInstrumentation` is
+  enabled.
+  ([#4304](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4304))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -32,6 +32,7 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
 
     public override void InvokeSync(IExecutionContext executionContext)
     {
+        using var scope = this.SuppressDownstreamInstrumentation();
         var activity = this.ProcessBeginRequest(executionContext);
         base.InvokeSync(executionContext);
         this.ProcessEndRequest(activity, executionContext);
@@ -39,6 +40,7 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
 
     public override async Task<T> InvokeAsync<T>(IExecutionContext executionContext)
     {
+        using var scope = this.SuppressDownstreamInstrumentation();
         var activity = this.ProcessBeginRequest(executionContext);
         var ret = await base.InvokeAsync<T>(executionContext).ConfigureAwait(false);
 
@@ -298,11 +300,6 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
 
     private Activity? ProcessBeginRequest(IExecutionContext executionContext)
     {
-        if (this.options.SuppressDownstreamInstrumentation)
-        {
-            SuppressInstrumentationScope.Enter();
-        }
-
         var currentActivity = Activity.Current;
 
         if (currentActivity == null)
@@ -322,4 +319,9 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
 
         return currentActivity;
     }
+
+    private IDisposable? SuppressDownstreamInstrumentation() =>
+        this.options.SuppressDownstreamInstrumentation
+            ? SuppressInstrumentationScope.Begin()
+            : null;
 }

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -14,12 +14,14 @@ using Amazon.BedrockRuntime.Model;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Runtime;
+using Amazon.Runtime.Internal;
 using Amazon.SimpleNotificationService;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using OpenTelemetry.Instrumentation.AWS.Tests.Tools;
 using OpenTelemetry.Trace;
 using Xunit;
+using AWSTracingPipelineHandler = OpenTelemetry.Instrumentation.AWS.Implementation.AWSTracingPipelineHandler;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests;
 
@@ -749,6 +751,34 @@ public class TestAWSClientInstrumentation
         Assert.Equal(extendedRequestId, Utils.GetTagValue(awssdk_activity, "aws.extended_request_id"));
     }
 
+    [Fact]
+    public async Task SuppressDownstreamInstrumentation_RestoresSuppressionScope()
+    {
+        Assert.False(Sdk.SuppressInstrumentation);
+
+        var previousActivity = Activity.Current;
+        Activity.Current = null;
+
+        try
+        {
+            var handler = new AWSTracingPipelineHandler(
+                new AWSClientInstrumentationOptions { SuppressDownstreamInstrumentation = true })
+            {
+                InnerHandler = new SuppressionAssertPipelineHandler(),
+            };
+
+            handler.InvokeSync(null!);
+            Assert.False(Sdk.SuppressInstrumentation);
+
+            await handler.InvokeAsync<AmazonWebServiceResponse>(null!);
+            Assert.False(Sdk.SuppressInstrumentation);
+        }
+        finally
+        {
+            Activity.Current = previousActivity;
+        }
+    }
+
     private void ValidateAWSActivity(Activity aws_activity, Activity parent)
     {
         Assert.Equal(parent.SpanId, aws_activity.ParentSpanId);
@@ -878,5 +908,19 @@ public class TestAWSClientInstrumentation
         Assert.Equal("aws-api", Utils.GetTagValue(s3_activity, "rpc.system"));
         Assert.Equal("S3", Utils.GetTagValue(s3_activity, "rpc.service"));
         Assert.Equal("PutObject", Utils.GetTagValue(s3_activity, "rpc.method"));
+    }
+
+    private sealed class SuppressionAssertPipelineHandler : PipelineHandler
+    {
+        public override void InvokeSync(IExecutionContext executionContext)
+        {
+            Assert.True(Sdk.SuppressInstrumentation);
+        }
+
+        public override Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+        {
+            Assert.True(Sdk.SuppressInstrumentation);
+            return Task.FromResult(default(T)!);
+        }
     }
 }


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fix suppression scope leakage when `SuppressDownstreamInstrumentation` is enabled.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
