### PR TITLE
[Infra] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -267,9 +267,9 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
             out string? lastItem)
         {
             lastItem = null;
-            bool result = false;
+            var result = false;
 
-            int index = value.LastIndexOf(delimiter);
+            var index = value.LastIndexOf(delimiter);
 
             if (index > -1 && index < value.Length - 1)
             {

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSHistogram.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSHistogram.cs
@@ -29,7 +29,7 @@ internal sealed class AWSHistogram<T> : Histogram<T>
 #if NET
         this.histogram = HistogramsDictionary.GetOrAdd(
             name,
-            static (histogramName, state) => CreateHistogram(histogramName, state),
+            static (histogramName, state) => state.meter.CreateHistogram<T>(histogramName, state.units, state.description),
             (meter, units, description));
 #else
         this.histogram = HistogramsDictionary.GetOrAdd(
@@ -55,9 +55,4 @@ internal sealed class AWSHistogram<T> : Histogram<T>
             this.histogram.Record(value);
         }
     }
-
-    private static System.Diagnostics.Metrics.Histogram<T> CreateHistogram(
-        string name,
-        (System.Diagnostics.Metrics.Meter Meter, string? Units, string? Description) state)
-        => state.Meter.CreateHistogram<T>(name, state.Units, state.Description);
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMonotonicCounter.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSMonotonicCounter.cs
@@ -29,7 +29,7 @@ internal sealed class AWSMonotonicCounter<T> : MonotonicCounter<T>
 #if NET
         this.monotonicCounter = MonotonicCountersDictionary.GetOrAdd(
             name,
-            static (counterName, state) => CreateCounter(counterName, state),
+            static (counterName, state) => state.meter.CreateCounter<T>(counterName, state.units, state.description),
             (meter, units, description));
 #else
         this.monotonicCounter = MonotonicCountersDictionary.GetOrAdd(
@@ -55,9 +55,4 @@ internal sealed class AWSMonotonicCounter<T> : MonotonicCounter<T>
             this.monotonicCounter.Add(value);
         }
     }
-
-    private static System.Diagnostics.Metrics.Counter<T> CreateCounter(
-        string name,
-        (System.Diagnostics.Metrics.Meter Meter, string? Units, string? Description) state)
-        => state.Meter.CreateCounter<T>(name, state.Units, state.Description);
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSUpDownCounter.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Metrics/AWSUpDownCounter.cs
@@ -29,7 +29,7 @@ internal sealed class AWSUpDownCounter<T> : UpDownCounter<T>
 #if NET
         this.upDownCounter = UpDownCountersDictionary.GetOrAdd(
             name,
-            static (counterName, state) => CreateUpDownCounter(counterName, state),
+            static (counterName, state) => state.meter.CreateUpDownCounter<T>(counterName, state.units, state.description),
             (meter, units, description));
 #else
         this.upDownCounter = UpDownCountersDictionary.GetOrAdd(
@@ -55,9 +55,4 @@ internal sealed class AWSUpDownCounter<T> : UpDownCounter<T>
             this.upDownCounter.Add(value);
         }
     }
-
-    private static System.Diagnostics.Metrics.UpDownCounter<T> CreateUpDownCounter(
-        string name,
-        (System.Diagnostics.Metrics.Meter Meter, string? Units, string? Description) state)
-        => state.Meter.CreateUpDownCounter<T>(name, state.Units, state.Description);
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Transport/WebSocket/WsReceiver.cs
@@ -133,8 +133,9 @@ internal sealed class WsReceiver : IDisposable
         var workingBuffer = this.receiveBuffer;
 
         List<byte[]>? rentalBuffers = null;
-        bool continueRead = true;
-        bool isClosed = false;
+
+        bool continueRead;
+        bool isClosed;
 
         do
         {
@@ -172,7 +173,7 @@ internal sealed class WsReceiver : IDisposable
             {
                 StopReading(out continueRead, out isClosed);
             }
-            catch (Exception ex) when (ex is WebSocketException || ex is ObjectDisposedException)
+            catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException)
             {
                 StopReading(out continueRead, out isClosed);
             }
@@ -189,7 +190,7 @@ internal sealed class WsReceiver : IDisposable
                         .CloseOutputAsync(WebSocketCloseStatus.MessageTooBig, "Message too large", CancellationToken.None)
                         .ConfigureAwait(false);
                 }
-                catch (Exception ex) when (ex is WebSocketException || ex is ObjectDisposedException)
+                catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException)
                 {
                     OpAmpClientEventSource.Log.TransportCloseException(ex);
                 }

--- a/test/OpenTelemetry.Extensions.Enrichment.Tests/OpenTelemetryEnrichmentServiceCollectionExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Tests/OpenTelemetryEnrichmentServiceCollectionExtensionsTests.cs
@@ -128,22 +128,20 @@ public sealed class OpenTelemetryEnrichmentServiceCollectionExtensionsTests
 
         await host.StartAsync();
 
-        using var source1 = new ActivitySource(SourceName);
+        using var source = new ActivitySource(SourceName);
+        using var activity = source.StartActivity(SourceName);
 
-        using (var activity = source1.StartActivity(SourceName))
-        {
-            Assert.NotNull(activity);
-            activity.Stop();
+        Assert.NotNull(activity);
+        activity.Stop();
 
-            Assert.Single(exportedItems);
+        Assert.Single(exportedItems);
 
-            var tagObjects = exportedItems[0].TagObjects;
-            var tagObject1 = tagObjects.Where(tag => tag.Key == testKey1);
-            Assert.Equal(testValue1, tagObject1.Single().Value);
+        var tagObjects = exportedItems[0].TagObjects;
+        var tagObject1 = tagObjects.Where(tag => tag.Key == testKey1);
+        Assert.Equal(testValue1, tagObject1.Single().Value);
 
-            var tagObject2 = tagObjects.Where(tag => tag.Key == testKey2);
-            Assert.Equal(testValue2, tagObject2.Single().Value);
-        }
+        var tagObject2 = tagObjects.Where(tag => tag.Key == testKey2);
+        Assert.Equal(testValue2, tagObject2.Single().Value);
     }
 
     [Fact]
@@ -204,7 +202,7 @@ public sealed class OpenTelemetryEnrichmentServiceCollectionExtensionsTests
                     .AddInMemoryExporter(exportedItems))
                 .Services
                 .AddTraceEnricher(ThrowingEnrichmentAction)
-                .AddTraceEnricher((Action<TraceEnrichmentBag>)(bag => bag.Add(testKey, testValue))))
+                .AddTraceEnricher(bag => bag.Add(testKey, testValue)))
             .Build();
 
         await host.StartAsync();
@@ -326,10 +324,17 @@ public sealed class OpenTelemetryEnrichmentServiceCollectionExtensionsTests
 
     private static EventSource GetEnrichmentEventSource()
     {
+#if NET
         var eventSourceType = typeof(TraceEnricher).Assembly.GetType("OpenTelemetry.Extensions.Enrichment.EnrichmentEventSource", throwOnError: true)!;
         return (EventSource)eventSourceType
             .GetField("Log", BindingFlags.Public | BindingFlags.Static)!
             .GetValue(null)!;
+#else
+        var eventSourceType = typeof(TraceEnricher).Assembly.GetType("OpenTelemetry.Extensions.Enrichment.EnrichmentEventSource", throwOnError: true);
+        return (EventSource)eventSourceType
+            .GetField("Log", BindingFlags.Public | BindingFlags.Static)
+            .GetValue(null);
+#endif
     }
 
     private sealed class ThrowingOnStartTraceEnricher : TraceEnricher

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
@@ -80,7 +80,7 @@ public class OpenTelemetryConsumeResultExtensionsTests
     {
         var consumeResult = new ConsumeResult<string, string>
         {
-            Message = new Message<string, string> { Value = "v", Headers = new Headers() },
+            Message = new Message<string, string> { Value = "v", Headers = [] },
         };
 
         var result = consumeResult.TryExtractPropagationContext(out var propagationContext);
@@ -361,11 +361,6 @@ public class OpenTelemetryConsumeResultExtensionsTests
 
         public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout) =>
             new(Offset.Unset, Offset.Unset);
-
-        public List<TopicPartitionOffset> OffsetsForTimes(
-            IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
-            TimeSpan timeout,
-            bool requireStableOffsets) => [];
 
         public void Close()
         {

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -18,80 +18,64 @@ public class GrpcCoreServerInterceptorTests
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task UnaryServerHandlerSuccess()
-    {
+    public async Task UnaryServerHandlerSuccess() =>
         await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest);
-    }
 
     /// <summary>
     /// Validates a failed UnaryServerHandler call.
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task UnaryServerHandlerFail()
-    {
+    public async Task UnaryServerHandlerFail() =>
         await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest);
-    }
 
     /// <summary>
     /// Validates a successful ClientStreamingServerHandler call.
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task ClientStreamingServerHandlerSuccess()
-    {
+    public async Task ClientStreamingServerHandlerSuccess() =>
         await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest);
-    }
 
     /// <summary>
     /// Validates a failed ClientStreamingServerHandler call.
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task ClientStreamingServerHandlerFail()
-    {
+    public async Task ClientStreamingServerHandlerFail() =>
         await TestHandlerFailure(FoobarService.MakeClientStreamingRequest);
-    }
 
     /// <summary>
     /// Validates a successful ServerStreamingServerHandler call.
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task ServerStreamingServerHandlerSuccess()
-    {
+    public async Task ServerStreamingServerHandlerSuccess() =>
         await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest);
-    }
 
     /// <summary>
     /// Validates a failed ServerStreamingServerHandler call.
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task ServerStreamingServerHandlerFail()
-    {
+    public async Task ServerStreamingServerHandlerFail() =>
         await TestHandlerFailure(FoobarService.MakeServerStreamingRequest);
-    }
 
     /// <summary>
     /// Validates a successful DuplexStreamingServerHandler call.
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task DuplexStreamingServerHandlerSuccess()
-    {
+    public async Task DuplexStreamingServerHandlerSuccess() =>
         await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest);
-    }
 
     /// <summary>
     /// Validates a failed DuplexStreamingServerHandler call.
     /// </summary>
     /// <returns>A task.</returns>
     [Fact]
-    public async Task DuplexStreamingServerHandlerFail()
-    {
+    public async Task DuplexStreamingServerHandlerFail() =>
         await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest);
-    }
 
     /// <summary>
     /// Validates that non protobuf payloads do not abort server RPCs when
@@ -108,8 +92,10 @@ public class GrpcCoreServerInterceptorTests
             AdditionalTags = testTags.Tags,
         };
 
-        static Task<NonProtobufPayload> HandleUnaryCall(NonProtobufPayload request, ServerCallContext context) =>
-            Task.FromResult(new NonProtobufPayload());
+        static Task<NonProtobufPayload> HandleUnaryCall(NonProtobufPayload request, ServerCallContext context)
+        {
+            return Task.FromResult(new NonProtobufPayload());
+        }
 
         var serviceDefinition = ServerServiceDefinition.CreateBuilder()
             .AddMethod(

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -69,11 +69,17 @@ public class OpAmpClientTests
 
         await client.StartAsync();
 
-        var disposeTask = Task.Run(() => client.Dispose());
-        var completedTask = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        var disposeTask = Task.Run(client.Dispose);
+        var timeout = TimeSpan.FromSeconds(5);
 
+#if NET
+        await disposeTask.WaitAsync(timeout);
+#else
+        using var cts = new CancellationTokenSource(timeout);
+        var completedTask = await Task.WhenAny(disposeTask, Task.Delay(timeout, cts.Token));
         Assert.Same(disposeTask, completedTask);
         await disposeTask;
+#endif
     }
 
     [Fact]
@@ -171,7 +177,9 @@ public class OpAmpClientTests
     }
 
     [Theory]
+#pragma warning disable xUnit1044 // Avoid using TheoryData type arguments that are not serializable
     [ClassData(typeof(CapabilityTestData))]
+#pragma warning restore xUnit1044 // Avoid using TheoryData type arguments that are not serializable
     internal async Task SendsExpectedCapabilities(
         Action<OpAmpClientSettings> configure,
         IEnumerable<AgentCapabilities> expectedCapabilities,

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
@@ -252,10 +252,17 @@ public class PlainHttpTransportTests
 
         try
         {
-            var completedTask = await Task.WhenAny(sendTask, Task.Delay(TimeSpan.FromSeconds(2)));
+            var timeout = TimeSpan.FromSeconds(2);
 
+#if NET
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await sendTask.WaitAsync(timeout));
+#else
+            using var cts = new CancellationTokenSource(timeout);
+            var completedTask = await Task.WhenAny(sendTask, Task.Delay(timeout, cts.Token));
             Assert.Same(sendTask, completedTask);
+
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await sendTask);
+#endif
         }
         finally
         {
@@ -282,7 +289,7 @@ public class PlainHttpTransportTests
                     context.Response.OutputStream.WriteByte(0);
                     context.Response.OutputStream.Flush();
                 }
-                catch (Exception ex) when (ex is HttpListenerException || ex is IOException || ex is ObjectDisposedException)
+                catch (Exception ex) when (ex is HttpListenerException or IOException or ObjectDisposedException)
                 {
                     // The client may close the connection as soon as it sees the oversized Content-Length.
                 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -451,14 +451,14 @@ public class WsTransportTest
             await wsTransport.StartAsync(CancellationToken.None);
 
             var stopTask = wsTransport.StopAsync(CancellationToken.None);
-            var timeout = TimeSpan.FromSeconds(5);
+            var timeout = TimeSpan.FromSeconds(10);
 
 #if NET
             await stopTask.WaitAsync(timeout);
 #else
             using var cts = new CancellationTokenSource(timeout);
             var completedTask = await Task.WhenAny(stopTask, Task.Delay(timeout, cts.Token));
-            Assert.Same(completedTask, completedTask);
+            Assert.Same(stopTask, completedTask);
             await stopTask;
 #endif
 
@@ -468,7 +468,15 @@ public class WsTransportTest
         finally
         {
             wsTransport.Dispose();
-            opAmpServer.Dispose();
+
+            try
+            {
+                opAmpServer.Dispose();
+            }
+            catch (ApplicationException)
+            {
+                // Ignore exceptions from the server when the client has already closed the connection
+            }
         }
     }
 
@@ -483,7 +491,7 @@ public class WsTransportTest
         await wsTransport.StartAsync(CancellationToken.None);
 
         var disposeTask = Task.Run(wsTransport.Dispose);
-        var timeout = TimeSpan.FromSeconds(5);
+        var timeout = TimeSpan.FromSeconds(10);
 
         try
         {
@@ -492,20 +500,27 @@ public class WsTransportTest
 #else
             using var cts = new CancellationTokenSource(timeout);
             var completedTask = await Task.WhenAny(disposeTask, Task.Delay(timeout, cts.Token));
-            Assert.Same(completedTask, completedTask);
+            Assert.Same(disposeTask, completedTask);
             await disposeTask;
 #endif
         }
         finally
         {
-            opAmpServer.Dispose();
+            try
+            {
+                opAmpServer.Dispose();
+            }
+            catch (ApplicationException)
+            {
+                // Ignore exceptions from the server when the client has already closed the connection
+            }
         }
     }
 
     [Fact]
     public async Task WsTransport_DisposeCompletesWithoutStopAfterOutstandingSend()
     {
-        var timeout = TimeSpan.FromSeconds(5);
+        var timeout = TimeSpan.FromSeconds(10);
 
         using var responseBlocked = new ManualResetEventSlim();
         using var requestSeen = new ManualResetEventSlim();
@@ -532,14 +547,22 @@ public class WsTransportTest
 #else
             using var cts = new CancellationTokenSource(timeout);
             var completedTask = await Task.WhenAny(disposeTask, Task.Delay(timeout, cts.Token));
-            Assert.Same(completedTask, completedTask);
+            Assert.Same(disposeTask, completedTask);
             await disposeTask;
 #endif
         }
         finally
         {
             responseBlocked.Set();
-            opAmpServer.Dispose();
+
+            try
+            {
+                opAmpServer.Dispose();
+            }
+            catch (ApplicationException)
+            {
+                // Ignore exceptions from the server when the client has already closed the connection
+            }
         }
     }
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -117,8 +117,10 @@ public class WsTransportTest
         await wsTransport.StartAsync(CancellationToken.None);
         await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
 
-        Assert.True(thresholdReached.Wait(TimeSpan.FromSeconds(5)), "The server did not send enough bytes to exceed the transport limit.");
-        Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus));
+        var timeout = TimeSpan.FromSeconds(5);
+
+        Assert.True(thresholdReached.Wait(timeout), "The server did not send enough bytes to exceed the transport limit.");
+        Assert.True(opAmpServer.TryGetClientCloseStatus(timeout, out var closeStatus));
         Assert.Equal(WebSocketCloseStatus.MessageTooBig, closeStatus);
     }
 
@@ -195,8 +197,10 @@ public class WsTransportTest
         await wsTransport.StartAsync(CancellationToken.None);
         await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
 
-        Assert.True(mockListener.TryWaitForMessage(TimeSpan.FromSeconds(5)), "The client did not receive the valid response after the invalid frame.");
-        await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.InvalidWsFrame), TimeSpan.FromSeconds(5));
+        var timeout = TimeSpan.FromSeconds(5);
+
+        Assert.True(mockListener.TryWaitForMessage(timeout), "The client did not receive the valid response after the invalid frame.");
+        await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.InvalidWsFrame), timeout);
 
 #if NET
         var receivedTextData = Encoding.UTF8.GetString(mockListener.Messages.Single().Data);
@@ -304,6 +308,8 @@ public class WsTransportTest
     [Fact]
     public async Task WsTransport_LogsOversizedResponseWarning()
     {
+        var timeout = TimeSpan.FromSeconds(5);
+
         using var eventListener = new InMemoryEventListener(OpAmpClientEventSource.Log, EventLevel.Verbose);
 
         var oversizedFrame = FrameGenerator.GenerateMockServerFrameOfTotalSize(TransportConstants.MaxMessageSize + 1, addHeader: true);
@@ -315,10 +321,10 @@ public class WsTransportTest
         await wsTransport.StartAsync(CancellationToken.None);
         await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
 
-        Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus));
+        Assert.True(opAmpServer.TryGetClientCloseStatus(timeout, out var closeStatus));
         Assert.Equal(WebSocketCloseStatus.MessageTooBig, closeStatus);
 
-        var oversizedEvent = await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.OversizedWebSocketMessage), TimeSpan.FromSeconds(5));
+        var oversizedEvent = await WaitForEventAsync(eventListener, nameof(OpAmpClientEventSource.OversizedWebSocketMessage), timeout);
         Assert.Equal(EventLevel.Warning, oversizedEvent.Level);
         Assert.Equal(TransportConstants.MaxMessageSize + 1, Assert.IsType<int>(oversizedEvent.Payload![0]));
         Assert.Equal(TransportConstants.MaxMessageSize, Assert.IsType<int>(oversizedEvent.Payload![1]));
@@ -343,7 +349,8 @@ public class WsTransportTest
         // Use a URI that accepts the TCP connection but never completes the WebSocket handshake
         // so that ConnectAsync is still in-flight when we cancel.
         var tcpListener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        Task acceptTask = Task.CompletedTask;
+        var acceptTask = Task.CompletedTask;
+
         try
         {
             tcpListener.Start();
@@ -377,7 +384,7 @@ public class WsTransportTest
             // .NET Framework throws WebSocketException instead of OperationCanceledException on cancellation.
             var startException = await Record.ExceptionAsync(() => startTask);
             Assert.True(
-                startException is OperationCanceledException || startException is WebSocketException,
+                startException is OperationCanceledException or WebSocketException,
                 $"Expected OperationCanceledException or WebSocketException, but got: {startException?.GetType().Name ?? "null"}");
 
             // After a canceled start the transport is permanently failed; a second call must
@@ -444,12 +451,18 @@ public class WsTransportTest
             await wsTransport.StartAsync(CancellationToken.None);
 
             var stopTask = wsTransport.StopAsync(CancellationToken.None);
-            var completedTask = await Task.WhenAny(stopTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            var timeout = TimeSpan.FromSeconds(5);
 
-            Assert.Same(stopTask, completedTask);
+#if NET
+            await stopTask.WaitAsync(timeout);
+#else
+            using var cts = new CancellationTokenSource(timeout);
+            var completedTask = await Task.WhenAny(stopTask, Task.Delay(timeout, cts.Token));
+            Assert.Same(completedTask, completedTask);
             await stopTask;
+#endif
 
-            Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus), "The server did not observe the client close frame.");
+            Assert.True(opAmpServer.TryGetClientCloseStatus(timeout, out var closeStatus), "The server did not observe the client close frame.");
             Assert.Equal(WebSocketCloseStatus.NormalClosure, closeStatus);
         }
         finally
@@ -469,13 +482,19 @@ public class WsTransportTest
         var wsTransport = CreateTransport(opAmpServer.Endpoint, new FrameProcessor());
         await wsTransport.StartAsync(CancellationToken.None);
 
-        var disposeTask = Task.Run(() => wsTransport.Dispose());
-        var completedTask = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        var disposeTask = Task.Run(wsTransport.Dispose);
+        var timeout = TimeSpan.FromSeconds(5);
 
         try
         {
-            Assert.Same(disposeTask, completedTask);
+#if NET
+            await disposeTask.WaitAsync(timeout);
+#else
+            using var cts = new CancellationTokenSource(timeout);
+            var completedTask = await Task.WhenAny(disposeTask, Task.Delay(timeout, cts.Token));
+            Assert.Same(completedTask, completedTask);
             await disposeTask;
+#endif
         }
         finally
         {
@@ -486,6 +505,8 @@ public class WsTransportTest
     [Fact]
     public async Task WsTransport_DisposeCompletesWithoutStopAfterOutstandingSend()
     {
+        var timeout = TimeSpan.FromSeconds(5);
+
         using var responseBlocked = new ManualResetEventSlim();
         using var requestSeen = new ManualResetEventSlim();
 
@@ -500,15 +521,20 @@ public class WsTransportTest
         using var wsTransport = CreateTransport(opAmpServer.Endpoint, new FrameProcessor());
         await wsTransport.StartAsync(CancellationToken.None);
         await wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None);
-        Assert.True(requestSeen.Wait(TimeSpan.FromSeconds(5)), "The server did not receive the client request.");
+        Assert.True(requestSeen.Wait(timeout), "The server did not receive the client request.");
 
-        var disposeTask = Task.Run(() => wsTransport.Dispose());
-        var completedTask = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        var disposeTask = Task.Run(wsTransport.Dispose);
 
         try
         {
-            Assert.Same(disposeTask, completedTask);
+#if NET
+            await disposeTask.WaitAsync(timeout);
+#else
+            using var cts = new CancellationTokenSource(timeout);
+            var completedTask = await Task.WhenAny(disposeTask, Task.Delay(timeout, cts.Token));
+            Assert.Same(completedTask, completedTask);
             await disposeTask;
+#endif
         }
         finally
         {
@@ -589,8 +615,12 @@ public class WsTransportTest
         }
     }
 
-    private static ArraySegment<byte> Slice(ArraySegment<byte> segment, int offset, int count)
-        => new(segment.Array!, segment.Offset + offset, count);
+    private static ArraySegment<byte> Slice(ArraySegment<byte> segment, int offset, int count) =>
+#if NET
+        new(segment.Array!, segment.Offset + offset, count);
+#else
+        new(segment.Array, segment.Offset + offset, count);
+#endif
 
     private static async Task<EventWrittenEventArgs> WaitForEventAsync(InMemoryEventListener eventListener, string eventName, TimeSpan timeout)
     {


### PR DESCRIPTION
## Changes

- Remove unused code for some TFMs introduced by https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4126.
- Fix new code analysis warnings flagged by https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3867.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
