### PR TITLE
[Instrumentation.WCF] Fixed server-side exception recording could bypass `IncomingRequestFilter`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed an issue where server-side exception recording could bypass
+  `IncomingRequestFilter` for filtered faulting requests.
+  ([#4306](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4306))
+
 ## 1.15.1-beta.2
 
 Released 2026-Apr-22

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
@@ -105,15 +105,15 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
                 }
             }
 
-            if (WcfInstrumentationActivitySource.Options.RecordException)
-            {
-                OperationContext.Current?.Extensions.Add(new WcfOperationContext(activity));
-            }
-
             if (textMapPropagator is not TraceContextPropagator)
             {
                 Baggage.Current = ctx.Baggage;
             }
+        }
+
+        if (WcfInstrumentationActivitySource.Options.RecordException)
+        {
+            OperationContext.Current?.Extensions.Add(new WcfOperationContext(activity));
         }
 
         return activity;

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TracingErrorHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TracingErrorHandler.cs
@@ -43,11 +43,14 @@ internal class TracingErrorHandler : IErrorHandler
 
         var activity = context.Activity ?? WcfInstrumentationActivitySource.ActivitySource.StartActivity(WcfInstrumentationActivitySource.UnassociatedExceptionActivityName, ActivityKind.Internal);
 
-        activity?.AddException(error);
-
-        if (activity != context.Activity)
+        if (activity != null)
         {
-            activity?.Stop();
+            activity.AddException(error);
+
+            if (activity != context.Activity)
+            {
+                activity.Stop();
+            }
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TracingErrorHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TracingErrorHandler.cs
@@ -27,19 +27,25 @@ internal class TracingErrorHandler : IErrorHandler
         // Also it becomes very difficult to unit-test, because there is no easy `ErrorsHandled`
         // event to listen for before checking to see whether the error was logged.
 
-        if (!WcfInstrumentationActivitySource.Options?.RecordException ?? false)
+        if (WcfInstrumentationActivitySource.Options?.RecordException != true)
         {
             return;
         }
 
-        // OperationContext.Current *should* be reliable even in async calls at .NET 4.6.2+.
-        // In older versions it may not be.
+        // TelemetryDispatchMessageInspector adds WcfOperationContext only after a request
+        // has passed filtering. Without it, exception recording must not create telemetry
+        // for requests that were intentionally filtered out.
         var context = OperationContext.Current?.Extensions.Find<WcfOperationContext>();
-        var activity = context?.Activity ?? WcfInstrumentationActivitySource.ActivitySource.StartActivity(WcfInstrumentationActivitySource.UnassociatedExceptionActivityName, ActivityKind.Internal);
+        if (context == null)
+        {
+            return;
+        }
+
+        var activity = context.Activity ?? WcfInstrumentationActivitySource.ActivitySource.StartActivity(WcfInstrumentationActivitySource.UnassociatedExceptionActivityName, ActivityKind.Internal);
 
         activity?.AddException(error);
 
-        if (activity != context?.Activity)
+        if (activity != context.Activity)
         {
             activity?.Stop();
         }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfOperationContext.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfOperationContext.cs
@@ -9,12 +9,12 @@ namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
 
 internal class WcfOperationContext : IExtension<OperationContext>
 {
-    public WcfOperationContext(Activity activity)
+    public WcfOperationContext(Activity? activity)
     {
         this.Activity = activity;
     }
 
-    public Activity Activity { get; }
+    public Activity? Activity { get; }
 
     public void Attach(OperationContext owner)
     {

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfOperationContext.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/WcfOperationContext.cs
@@ -7,7 +7,7 @@ using System.ServiceModel;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
 
-internal class WcfOperationContext : IExtension<OperationContext>
+internal sealed class WcfOperationContext : IExtension<OperationContext>
 {
     public WcfOperationContext(Activity? activity)
     {

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
@@ -329,6 +329,7 @@ public class TelemetryDispatchMessageInspectorTests : IDisposable
         }
         catch (Exception)
         {
+            // Ignore
         }
         finally
         {

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
@@ -286,6 +286,63 @@ public class TelemetryDispatchMessageInspectorTests : IDisposable
             Assert.Empty(recordedExceptions);
         }
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FilteredIncomingRequestDoesNotRecordException(bool throwFromFilter)
+    {
+        List<Activity> startedActivities = [];
+        List<Activity> stoppedActivities = [];
+        List<Exception> recordedExceptions = [];
+
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            ActivityStarted = startedActivities.Add,
+            ActivityStopped = stoppedActivities.Add,
+        };
+
+        activityListener.ExceptionRecorder += (activity, ex, ref tags) =>
+        {
+            recordedExceptions.Add(ex);
+        };
+
+        ActivitySource.AddActivityListener(activityListener);
+
+        var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddWcfInstrumentation(options =>
+            {
+                options.RecordException = true;
+                options.IncomingRequestFilter = throwFromFilter
+                    ? _ => throw new InvalidOperationException("Failure whilst filtering activity")
+                    : _ => false;
+            })
+            .Build();
+
+        var client = new ServiceClient(
+            new NetTcpBinding(),
+            new EndpointAddress(new Uri(this.serviceBaseUri, "/Service")));
+        try
+        {
+            await client.ErrorAsync();
+        }
+        catch (Exception)
+        {
+        }
+        finally
+        {
+            client.AbortOrClose();
+            tracerProvider?.Shutdown();
+            tracerProvider?.Dispose();
+
+            WcfInstrumentationActivitySource.Options = null;
+        }
+
+        Assert.Empty(startedActivities);
+        Assert.Empty(stoppedActivities);
+        Assert.Empty(recordedExceptions);
+    }
 }
 
 #endif


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis
## Changes

Fixed an issue where server-side exception recording could bypass `IncomingRequestFilter` for filtered faulting requests.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
