### PR TITLE
[Instrumentation.AspNet] Handle exceptions in `onRequestStoppedCallback`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -21,6 +21,8 @@ internal static class ActivityHelper
 
     internal static readonly object StartedButNotSampledObj = new();
 
+    private const string StopInstrumentationCallbackContextKey = "__AspnetOpenTelemetryInstrumentationStopCallback__";
+
     private const string BaggageSlotName = "otel.baggage";
     private static readonly Func<HttpRequestBase, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers.GetValues(name);
 
@@ -97,23 +99,22 @@ internal static class ActivityHelper
     /// <param name="context"><see cref="HttpContextBase"/>.</param>
     /// <param name="onRequestStoppedCallback">Callback action.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void StopAspNetActivity(TextMapPropagator textMapPropagator, Activity? aspNetActivity, HttpContextBase context, Action<Activity?, HttpContextBase>? onRequestStoppedCallback)
+    public static void StopAspNetActivity(
+        TextMapPropagator textMapPropagator,
+        Activity? aspNetActivity,
+        HttpContextBase context,
+        Action<Activity?, HttpContextBase>? onRequestStoppedCallback)
     {
+        var onRequestStoppedInstrumentationCallback = context.Items[StopInstrumentationCallbackContextKey] as Action<Activity?, HttpContextBase>;
+        context.Items[StopInstrumentationCallbackContextKey] = null;
+
         if (aspNetActivity == null)
         {
             Debug.Assert(context.Items[ContextKey] == StartedButNotSampledObj, "Context item is not StartedButNotSampledObj.");
 
             // This is the case where a start was called but no activity was
             // created due to a sampling decision.
-            try
-            {
-                onRequestStoppedCallback?.Invoke(aspNetActivity, context);
-            }
-            catch (Exception callbackEx)
-            {
-                AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, "OnStopped", callbackEx);
-            }
-
+            onRequestStoppedInstrumentationCallback?.Invoke(aspNetActivity, context);
             context.Items[ContextKey] = null;
             return;
         }
@@ -129,6 +130,8 @@ internal static class ActivityHelper
         {
             aspNetActivity.SetEndTime(ActivityDateTimeHelper.GetUtcNow());
         }
+
+        onRequestStoppedInstrumentationCallback?.Invoke(aspNetActivity, context);
 
         try
         {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -105,7 +105,15 @@ internal static class ActivityHelper
 
             // This is the case where a start was called but no activity was
             // created due to a sampling decision.
-            onRequestStoppedCallback?.Invoke(aspNetActivity, context);
+            try
+            {
+                onRequestStoppedCallback?.Invoke(aspNetActivity, context);
+            }
+            catch (Exception callbackEx)
+            {
+                AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, "OnStopped", callbackEx);
+            }
+
             context.Items[ContextKey] = null;
             return;
         }

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed `OnRequestStoppedCallback` exception handling when no root `Activity`
+  was created.
+  ([#4307](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4307))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Fixed `OnRequestStoppedCallback` exception handling when no root `Activity`
-  was created.
+* Fixed `OnRequestStoppedCallback` invocation when no root `Activity` was
+  created.
   ([#4307](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4307))
 
 ## 1.15.2

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -11,24 +11,27 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation;
 
 internal sealed class HttpInListener : IDisposable
 {
+    private const string StopInstrumentationCallbackContextKey = "__AspnetOpenTelemetryInstrumentationStopCallback__";
     private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
     private readonly HttpRequestRouteHelper routeHelper = new();
     private readonly RequestDataHelper requestDataHelper = new(configureByHttpKnownMethodsEnvironmentalVariable: true);
     private readonly AsyncLocal<long> beginTimestamp = new();
+    private readonly Action<Activity?, HttpContextBase> onStopActivityCallback;
 
     public HttpInListener()
     {
+        this.onStopActivityCallback = this.OnStopActivity;
+
         TelemetryHttpModule.Options.TextMapPropagator = Propagators.DefaultTextMapPropagator;
 
         TelemetryHttpModule.Options.OnRequestStartedCallback += this.StartActivity;
-        TelemetryHttpModule.Options.OnRequestStoppedCallback += this.OnStopActivity;
         TelemetryHttpModule.Options.OnExceptionCallback += this.OnException;
     }
 
     public void Dispose()
     {
         TelemetryHttpModule.Options.OnRequestStartedCallback -= this.StartActivity;
-        TelemetryHttpModule.Options.OnRequestStoppedCallback -= this.OnStopActivity;
         TelemetryHttpModule.Options.OnExceptionCallback -= this.OnException;
     }
 
@@ -113,15 +116,15 @@ internal sealed class HttpInListener : IDisposable
 
     private Activity? StartActivity(HttpContextBase context, ActivityContext activityContext)
     {
+        context.Items[StopInstrumentationCallbackContextKey] = this.onStopActivityCallback;
+
+        if (AspNetInstrumentation.Instance.HandleManager.MetricHandles > 0)
+        {
+            this.beginTimestamp.Value = Stopwatch.GetTimestamp();
+        }
+
         if (AspNetInstrumentation.Instance.HandleManager.TracingHandles == 0)
         {
-            if (AspNetInstrumentation.Instance.HandleManager.MetricHandles > 0)
-            {
-                // If we are not tracing, but we are collecting metrics, we still
-                // need to set the activity name and tags.
-                this.beginTimestamp.Value = Stopwatch.GetTimestamp();
-            }
-
             return null;
         }
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -16,6 +16,7 @@ public class ActivityHelperTest : IDisposable
     private const string BaggageInHeader = "TestKey1=123,TestKey2=456,TestKey1=789";
     private const string TestActivityName = "Activity.Test";
     private const string TestActivitySourceName = "TestActivitySource";
+    private const string StopInstrumentationCallbackContextKey = "__AspnetOpenTelemetryInstrumentationStopCallback__";
 
     private readonly ActivitySource testActivitySource = new(TestActivitySourceName);
     private readonly TextMapPropagator noopTextMapPropagator = new NoopTextMapPropagator();
@@ -320,7 +321,7 @@ public class ActivityHelperTest : IDisposable
     }
 
     [Fact]
-    public void Should_Not_Throw_When_Stop_Callback_Throws_Without_RootActivity()
+    public void Should_Not_Fire_Stop_Callback_Without_RootActivity()
     {
         var context = HttpContextHelper.GetFakeHttpContextBase();
         using var rootActivity = ActivityHelper.StartAspNetActivity(this.noopTextMapPropagator, context, null);
@@ -328,18 +329,51 @@ public class ActivityHelperTest : IDisposable
         Assert.Null(rootActivity);
         Assert.Equal(ActivityHelper.StartedButNotSampledObj, context.Items[ActivityHelper.ContextKey]);
 
-        var exception = Record.Exception(() => ActivityHelper.StopAspNetActivity(
+        var instrumentationCallbackFired = false;
+        var callbackFired = false;
+        context.Items[StopInstrumentationCallbackContextKey] = (Action<Activity?, HttpContextBase>)((activity, _) =>
+        {
+            Assert.Null(activity);
+            instrumentationCallbackFired = true;
+        });
+
+        ActivityHelper.StopAspNetActivity(
             this.noopTextMapPropagator,
             rootActivity,
             context,
-            (activity, _) =>
-            {
-                Assert.Null(activity);
-                throw new InvalidOperationException("Callback failed.");
-            }));
+            (_, _) => callbackFired = true);
 
-        Assert.Null(exception);
+        Assert.True(instrumentationCallbackFired);
+        Assert.False(callbackFired);
         Assert.Null(context.Items[ActivityHelper.ContextKey]);
+        Assert.Null(context.Items[StopInstrumentationCallbackContextKey]);
+    }
+
+    [Fact]
+    public void Should_Fire_Instrumentation_Stop_Callback_Without_RootActivity()
+    {
+        var context = HttpContextHelper.GetFakeHttpContextBase();
+        using var rootActivity = ActivityHelper.StartAspNetActivity(this.noopTextMapPropagator, context, null);
+
+        Assert.Null(rootActivity);
+        Assert.Equal(ActivityHelper.StartedButNotSampledObj, context.Items[ActivityHelper.ContextKey]);
+
+        var callbackFired = false;
+        context.Items[StopInstrumentationCallbackContextKey] = (Action<Activity?, HttpContextBase>)((activity, _) =>
+        {
+            Assert.Null(activity);
+            callbackFired = true;
+        });
+
+        ActivityHelper.StopAspNetActivity(
+            this.noopTextMapPropagator,
+            rootActivity,
+            context,
+            onRequestStoppedCallback: null);
+
+        Assert.True(callbackFired);
+        Assert.Null(context.Items[ActivityHelper.ContextKey]);
+        Assert.Null(context.Items[StopInstrumentationCallbackContextKey]);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -320,6 +320,29 @@ public class ActivityHelperTest : IDisposable
     }
 
     [Fact]
+    public void Should_Not_Throw_When_Stop_Callback_Throws_Without_RootActivity()
+    {
+        var context = HttpContextHelper.GetFakeHttpContextBase();
+        using var rootActivity = ActivityHelper.StartAspNetActivity(this.noopTextMapPropagator, context, null);
+
+        Assert.Null(rootActivity);
+        Assert.Equal(ActivityHelper.StartedButNotSampledObj, context.Items[ActivityHelper.ContextKey]);
+
+        var exception = Record.Exception(() => ActivityHelper.StopAspNetActivity(
+            this.noopTextMapPropagator,
+            rootActivity,
+            context,
+            (activity, _) =>
+            {
+                Assert.Null(activity);
+                throw new InvalidOperationException("Callback failed.");
+            }));
+
+        Assert.Null(exception);
+        Assert.Null(context.Items[ActivityHelper.ContextKey]);
+    }
+
+    [Fact]
     public void Can_Create_RootActivity_From_W3C_Traceparent()
     {
         this.EnableListener();


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed `OnRequestStoppedCallback` invocation when no root `Activity` was created.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
