### PR TITLE
[Shared.SqlProcessor] Add support for handling unterminated escaped identifiers in sanitization

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fix SQL query text sanitization for malformed bracketed identifiers in `FROM`
+  clauses to avoid leaking following literal values.
+  ([#4317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4317))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Add support for native AoT on .NET 8+.
   ([#4062](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4062))
 
+* Fix SQL query text sanitization for malformed bracketed identifiers in `FROM`
+  clauses to avoid leaking following literal values.
+  ([#4317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4317))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -228,18 +228,17 @@ internal static class SqlProcessor
     {
         for (var i = start + 1; i < sql.Length; i++)
         {
-            if (sql[i] != CloseSquareBracketChar)
+            if (sql[i] == CloseSquareBracketChar)
             {
-                continue;
+                if (i + 1 < sql.Length && sql[i + 1] == CloseSquareBracketChar)
+                {
+                    i++;
+                }
+                else
+                {
+                    return true;
+                }
             }
-
-            if (i + 1 < sql.Length && sql[i + 1] == CloseSquareBracketChar)
-            {
-                i++;
-                continue;
-            }
-
-            return true;
         }
 
         return false;

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -223,6 +223,28 @@ internal static class SqlProcessor
         return (currentChar != DotChar || indexInToken != 0) && IsUnescapedIdentifierChar(currentChar);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool HasTerminatingEscapedIdentifier(ReadOnlySpan<char> sql, int start)
+    {
+        for (var i = start + 1; i < sql.Length; i++)
+        {
+            if (sql[i] != CloseSquareBracketChar)
+            {
+                continue;
+            }
+
+            if (i + 1 < sql.Length && sql[i + 1] == CloseSquareBracketChar)
+            {
+                i++;
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     private static SqlStatementInfo SanitizeSql(string sql)
     {
         var sqlSpan = sql.AsSpan();
@@ -611,7 +633,9 @@ internal static class SqlProcessor
             // Brackets may occur when using schema-qualified or delimited identifiers.
             state.CaptureNextNonKeywordTokenAsIdentifier = state.InFromClause && (currentChar is CommaChar or OpenSquareBracketChar or DotChar);
 
-            if (state.CaptureNextNonKeywordTokenAsIdentifier && currentChar is OpenSquareBracketChar)
+            if (state.CaptureNextNonKeywordTokenAsIdentifier
+                && currentChar is OpenSquareBracketChar
+                && HasTerminatingEscapedIdentifier(sql, state.ParsePosition))
             {
                 state.InEscapedIdentifier = true;
                 AppendSummaryChar(OpenSquareBracketChar, ref state);

--- a/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Globalization;
 using FsCheck;
 using FsCheck.Xunit;
 using Xunit;
@@ -392,6 +393,7 @@ public static class SqlProcessorTests
         }
 
         var numericLiteral = number.Get + 100_000;
+        var numericLiteralString = numericLiteral.ToString(CultureInfo.InvariantCulture);
         var sqlPrefix = (variant.Get % 3) switch
         {
             0 => "SELECT * FROM [Orders",
@@ -399,7 +401,7 @@ public static class SqlProcessorTests
             _ => "SELECT * FROM Customers, [Orders",
         };
 
-        var sql = $"{sqlPrefix} WHERE Name = '{secret}' AND Id = {numericLiteral} AND Token = 0xDEADBEEF";
+        var sql = $"{sqlPrefix} WHERE Name = '{secret}' AND Id = {numericLiteralString} AND Token = 0xDEADBEEF";
 
         // Act
         var result = SqlProcessor.GetSanitizedSql(sql);
@@ -407,7 +409,7 @@ public static class SqlProcessorTests
         // Assert
         Assert.Contains("?", result.SanitizedSql);
         Assert.DoesNotContain(secret, result.SanitizedSql);
-        Assert.DoesNotContain(numericLiteral.ToString(), result.SanitizedSql);
+        Assert.DoesNotContain(numericLiteralString, result.SanitizedSql);
         Assert.DoesNotContain("DEADBEEF", result.SanitizedSql);
     }
 }

--- a/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
@@ -377,4 +377,37 @@ public static class SqlProcessorTests
         var questionMarkCount = result.SanitizedSql.Count((p) => p == '?');
         Assert.Equal(1, questionMarkCount);
     }
+
+    [Property(MaxTest = MaxValue)]
+    public static void GetSanitizedSql_Unterminated_Escaped_Identifier_In_From_Clause_Sanitizes_Following_Literals(
+        NonEmptyString input,
+        PositiveInt number,
+        NonNegativeInt variant)
+    {
+        // Arrange
+        var secret = "secret_" + new string([.. input.Get.Where(char.IsLetterOrDigit).Take(32)]);
+        if (secret.Length == "secret_".Length)
+        {
+            secret += "value";
+        }
+
+        var numericLiteral = number.Get + 100_000;
+        var sqlPrefix = (variant.Get % 3) switch
+        {
+            0 => "SELECT * FROM [Orders",
+            1 => "SELECT * FROM dbo.[Orders",
+            _ => "SELECT * FROM Customers, [Orders",
+        };
+
+        var sql = $"{sqlPrefix} WHERE Name = '{secret}' AND Id = {numericLiteral} AND Token = 0xDEADBEEF";
+
+        // Act
+        var result = SqlProcessor.GetSanitizedSql(sql);
+
+        // Assert
+        Assert.Contains("?", result.SanitizedSql);
+        Assert.DoesNotContain(secret, result.SanitizedSql);
+        Assert.DoesNotContain(numericLiteral.ToString(), result.SanitizedSql);
+        Assert.DoesNotContain("DEADBEEF", result.SanitizedSql);
+    }
 }

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
@@ -36,9 +36,6 @@ public class SqlProcessorTests
         var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
 
         Assert.Equal("SELECT * FROM [Orders WHERE CustomerName = ? AND Id = ? AND Token = ?", sqlStatementInfo.SanitizedSql);
-        Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
-        Assert.DoesNotContain("123", sqlStatementInfo.SanitizedSql);
-        Assert.DoesNotContain("DEADBEEF", sqlStatementInfo.SanitizedSql);
     }
 
     [SkippableTheory]

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
@@ -28,6 +28,19 @@ public class SqlProcessorTests
         Assert.Equal(sql, sqlStatementInfo.DbQuerySummary);
     }
 
+    [Fact]
+    public void GetSanitizedSql_UnterminatedEscapedIdentifierInFromClause_SanitizesLiterals()
+    {
+        var sql = "SELECT * FROM [Orders WHERE CustomerName = 'secret-name' AND Id = 123 AND Token = 0xDEADBEEF";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        Assert.Equal("SELECT * FROM [Orders WHERE CustomerName = ? AND Id = ? AND Token = ?", sqlStatementInfo.SanitizedSql);
+        Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
+        Assert.DoesNotContain("123", sqlStatementInfo.SanitizedSql);
+        Assert.DoesNotContain("DEADBEEF", sqlStatementInfo.SanitizedSql);
+    }
+
     [SkippableTheory]
     [MemberData(nameof(TestData))]
     public void TestGetSanitizedSql(SqlProcessorTestCases.TestCase testCase)


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Add support for handling unterminated escaped identifiers in sanitization

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
