### PR TITLE
[WCF] Add test for .NET Framework

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryEndpointBehaviorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryEndpointBehaviorTests.cs
@@ -34,6 +34,31 @@ public class TelemetryEndpointBehaviorTests
         }
     }
 
+#if NETFRAMEWORK
+    [Fact]
+    public void ApplyDispatchBehaviorToEndpoint_WithNullActionOperation_DoesNotThrow()
+    {
+        // Arrange
+        var endpointDispatcher = new EndpointDispatcher(
+            new EndpointAddress("http://localhost/something"),
+            contractName: "Service",
+            contractNamespace: "http://opentelemetry.io/");
+
+        endpointDispatcher.DispatchRuntime.Operations.Add(
+            new DispatchOperation(
+                endpointDispatcher.DispatchRuntime,
+                name: "NullActionOperation",
+                action: null));
+
+        // Act
+        var exception = Record.Exception(() => TelemetryEndpointBehavior.ApplyDispatchBehaviorToEndpoint(endpointDispatcher));
+
+        // Assert
+        Assert.Null(exception);
+        Assert.Single(endpointDispatcher.DispatchRuntime.MessageInspectors);
+    }
+#endif
+
     private sealed class InjectNullActionOperationBehavior : IEndpointBehavior
     {
         public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4026#discussion_r3001833571

## Changes

Add test missed from #4026.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
