### PR TITLE
[Infra] Disallow instance string.Equals methods

### DIFF
--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -44,6 +44,8 @@ M:System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.SByte@); Use ove
 M:System.SByte.TryParse(System.String,System.SByte@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.String,System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
+M:System.String.Equals(System.String); Use the static string.Equals(string, string) method instead.
+M:System.String.Equals(System.String,System.StringComparison); Use the static string.Equals(string, string, StringComparison) method instead.
 M:System.TimeOnly.TryParse(System.ReadOnlySpan{System.Char},System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeOnly.TryParse(System.String,System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeSpan.TryParse(System.ReadOnlySpan{System.Char},System.TimeSpan@); Use overloads that specify CultureInfo.InvariantCulture.

--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -44,8 +44,8 @@ M:System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.SByte@); Use ove
 M:System.SByte.TryParse(System.String,System.SByte@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.String,System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
-M:System.String.Equals(System.String); Use the static string.Equals(string, string) method instead.
-M:System.String.Equals(System.String,System.StringComparison); Use the static string.Equals(string, string, StringComparison) method instead.
+M:System.String.Equals(System.String); Use the static string.Equals(string, string) method instead to avoid potential NullReferenceException.
+M:System.String.Equals(System.String,System.StringComparison); Use the static string.Equals(string, string, StringComparison) method instead to avoid potential NullReferenceException.
 M:System.TimeOnly.TryParse(System.ReadOnlySpan{System.Char},System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeOnly.TryParse(System.String,System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeSpan.TryParse(System.ReadOnlySpan{System.Char},System.TimeSpan@); Use overloads that specify CultureInfo.InvariantCulture.

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/ConnectionStringBuilder.cs
@@ -71,16 +71,16 @@ internal sealed class ConnectionStringBuilder
     }
 
     public bool PrivatePreviewEnableTraceLoggingDynamic => this.parts.TryGetValue(nameof(this.PrivatePreviewEnableTraceLoggingDynamic), out var value)
-                && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+                && string.Equals(bool.TrueString, value, StringComparison.OrdinalIgnoreCase);
 
     public bool PrivatePreviewEnableOtlpProtobufEncoding => this.parts.TryGetValue(nameof(this.PrivatePreviewEnableOtlpProtobufEncoding), out var value)
-                && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+                && string.Equals(bool.TrueString, value, StringComparison.OrdinalIgnoreCase);
 
     public bool PrivatePreviewEnableUserEvents => this.parts.TryGetValue(nameof(this.PrivatePreviewEnableUserEvents), out var value)
-                && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+                && string.Equals(bool.TrueString, value, StringComparison.OrdinalIgnoreCase);
 
     public bool PrivatePreviewEnableAFDCorrelationIdEnrichment => this.parts.TryGetValue(nameof(this.PrivatePreviewEnableAFDCorrelationIdEnrichment), out var value)
-                && bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+                && string.Equals(bool.TrueString, value, StringComparison.OrdinalIgnoreCase);
 
     public int PrivatePreviewLogMessagePackStringSizeLimit =>
         !this.parts.TryGetValue(nameof(this.PrivatePreviewLogMessagePackStringSizeLimit), out var value)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
@@ -50,8 +50,8 @@ public class GenevaMetricExporterOptions
 
             foreach (var entry in value)
             {
-                if (entry.Key.Equals(GenevaMetricExporter.DimensionKeyForCustomMonitoringAccount, StringComparison.OrdinalIgnoreCase) ||
-                    entry.Key.Equals(GenevaMetricExporter.DimensionKeyForCustomMetricsNamespace, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(entry.Key, GenevaMetricExporter.DimensionKeyForCustomMonitoringAccount, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(entry.Key, GenevaMetricExporter.DimensionKeyForCustomMetricsNamespace, StringComparison.OrdinalIgnoreCase))
                 {
                     throw new ArgumentException($"The dimension: {entry.Key} is reserved and cannot be used as a prepopulated dimension.");
                 }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
@@ -646,8 +646,8 @@ internal sealed class TlvMetricExporter : IDisposable
                 // TODO: Data Validation
             }
 
-            if (tag.Key.Equals(GenevaMetricExporter.DimensionKeyForCustomMonitoringAccount, StringComparison.OrdinalIgnoreCase) ||
-                tag.Key.Equals(GenevaMetricExporter.DimensionKeyForCustomMetricsNamespace, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(tag.Key, GenevaMetricExporter.DimensionKeyForCustomMonitoringAccount, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(tag.Key, GenevaMetricExporter.DimensionKeyForCustomMetricsNamespace, StringComparison.OrdinalIgnoreCase))
             {
                 reservedTags++;
                 continue;
@@ -667,7 +667,7 @@ internal sealed class TlvMetricExporter : IDisposable
         // Serialize MetricPoint Dimension values
         foreach (var tag in tags)
         {
-            if (tag.Key.Equals(GenevaMetricExporter.DimensionKeyForCustomMonitoringAccount, StringComparison.OrdinalIgnoreCase) && tag.Value is string metricsAccount)
+            if (string.Equals(tag.Key, GenevaMetricExporter.DimensionKeyForCustomMonitoringAccount, StringComparison.OrdinalIgnoreCase) && tag.Value is string metricsAccount)
             {
                 if (!string.IsNullOrWhiteSpace(metricsAccount))
                 {
@@ -677,7 +677,7 @@ internal sealed class TlvMetricExporter : IDisposable
                 continue;
             }
 
-            if (tag.Key.Equals(GenevaMetricExporter.DimensionKeyForCustomMetricsNamespace, StringComparison.OrdinalIgnoreCase) && tag.Value is string metricsNamespace)
+            if (string.Equals(tag.Key, GenevaMetricExporter.DimensionKeyForCustomMetricsNamespace, StringComparison.OrdinalIgnoreCase) && tag.Value is string metricsNamespace)
             {
                 if (!string.IsNullOrWhiteSpace(metricsNamespace))
                 {

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
@@ -15,23 +15,23 @@ internal class AWSServiceType
     internal const string BedrockRuntimeService = "Bedrock Runtime";
 
     internal static bool IsDynamoDbService(string service)
-        => DynamoDbService.Equals(service, StringComparison.OrdinalIgnoreCase);
+        => string.Equals(DynamoDbService, service, StringComparison.OrdinalIgnoreCase);
 
     internal static bool IsSqsService(string service)
-        => SQSService.Equals(service, StringComparison.OrdinalIgnoreCase);
+        => string.Equals(SQSService, service, StringComparison.OrdinalIgnoreCase);
 
     internal static bool IsSnsService(string service)
-        => SNSService.Equals(service, StringComparison.OrdinalIgnoreCase);
+        => string.Equals(SNSService, service, StringComparison.OrdinalIgnoreCase);
 
     internal static bool IsBedrockService(string service)
-        => BedrockService.Equals(service, StringComparison.OrdinalIgnoreCase);
+        => string.Equals(BedrockService, service, StringComparison.OrdinalIgnoreCase);
 
     internal static bool IsBedrockAgentService(string service)
-        => BedrockAgentService.Equals(service, StringComparison.OrdinalIgnoreCase);
+        => string.Equals(BedrockAgentService, service, StringComparison.OrdinalIgnoreCase);
 
     internal static bool IsBedrockAgentRuntimeService(string service)
-        => BedrockAgentRuntimeService.Equals(service, StringComparison.OrdinalIgnoreCase);
+        => string.Equals(BedrockAgentRuntimeService, service, StringComparison.OrdinalIgnoreCase);
 
     internal static bool IsBedrockRuntimeService(string service)
-        => BedrockRuntimeService.Equals(service, StringComparison.OrdinalIgnoreCase);
+        => string.Equals(BedrockRuntimeService, service, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/Utils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/Utils.cs
@@ -11,7 +11,7 @@ internal class Utils
     {
         foreach (var tag in activity.TagObjects)
         {
-            if (tag.Key.Equals(tagName, StringComparison.Ordinal))
+            if (string.Equals(tag.Key, tagName, StringComparison.Ordinal))
             {
                 return tag.Value;
             }
@@ -20,15 +20,13 @@ internal class Utils
         return null;
     }
 
-    internal static string RemoveSuffix(string originalString, string suffix)
-    {
-        return string.IsNullOrEmpty(originalString)
+    internal static string RemoveSuffix(string originalString, string suffix) =>
+        string.IsNullOrEmpty(originalString)
             ? string.Empty
             : originalString.EndsWith(suffix, StringComparison.Ordinal)
                 ?
                 originalString.Substring(0, originalString.Length - suffix.Length)
                 : originalString;
-    }
 
     /// <summary>
     /// Removes amazon prefix from service name. There are two type of service name.
@@ -39,14 +37,10 @@ internal class Utils
     /// <param name="serviceName">Name of the service.</param>
     /// <returns>String after removing Amazon prefix.</returns>
     internal static string RemoveAmazonPrefixFromServiceName(string serviceName)
-    {
-        return RemovePrefix(RemovePrefix(serviceName, "Amazon"), ".");
-    }
+        => RemovePrefix(RemovePrefix(serviceName, "Amazon"), ".");
 
-    private static string RemovePrefix(string originalString, string prefix)
-    {
-        return string.IsNullOrEmpty(originalString) ? string.Empty :
+    private static string RemovePrefix(string originalString, string prefix) =>
+        string.IsNullOrEmpty(originalString) ? string.Empty :
             originalString.StartsWith(prefix, StringComparison.Ordinal) ? originalString.Substring(prefix.Length) :
             originalString;
-    }
 }

--- a/src/OpenTelemetry.Sampler.AWS/SamplingRuleApplier.cs
+++ b/src/OpenTelemetry.Sampler.AWS/SamplingRuleApplier.cs
@@ -94,19 +94,19 @@ internal class SamplingRuleApplier
         {
             foreach (var tag in samplingParameters.Tags)
             {
-                if (tag.Key.Equals(SemanticConventions.AttributeUrlPath, StringComparison.Ordinal))
+                if (string.Equals(tag.Key, SemanticConventions.AttributeUrlPath, StringComparison.Ordinal))
                 {
                     httpTarget = (string?)tag.Value;
                 }
-                else if (tag.Key.Equals(SemanticConventions.AttributeUrlFull, StringComparison.Ordinal))
+                else if (string.Equals(tag.Key, SemanticConventions.AttributeUrlFull, StringComparison.Ordinal))
                 {
                     httpUrl = (string?)tag.Value;
                 }
-                else if (tag.Key.Equals(SemanticConventions.AttributeHttpRequestMethod, StringComparison.Ordinal))
+                else if (string.Equals(tag.Key, SemanticConventions.AttributeHttpRequestMethod, StringComparison.Ordinal))
                 {
                     httpMethod = (string?)tag.Value;
                 }
-                else if (tag.Key.Equals(SemanticConventions.AttributeHttpHost, StringComparison.Ordinal))
+                else if (string.Equals(tag.Key, SemanticConventions.AttributeHttpHost, StringComparison.Ordinal))
                 {
                     httpHost = (string?)tag.Value;
                 }
@@ -128,7 +128,7 @@ internal class SamplingRuleApplier
         }
 
         var serviceName = (string)resource.Attributes.FirstOrDefault(kvp =>
-                kvp.Key.Equals("service.name", StringComparison.Ordinal)).Value;
+                string.Equals(kvp.Key, "service.name", StringComparison.Ordinal)).Value;
 
         return Matcher.AttributeMatch(samplingParameters.Tags, this.Rule.Attributes) &&
                Matcher.WildcardMatch(httpTarget, this.Rule.UrlPath) &&
@@ -224,7 +224,7 @@ internal class SamplingRuleApplier
     private static string GetServiceType(Resource resource)
     {
         var cloudPlatform = (string)resource.Attributes.FirstOrDefault(kvp =>
-            kvp.Key.Equals("cloud.platform", StringComparison.Ordinal)).Value;
+            string.Equals(kvp.Key, "cloud.platform", StringComparison.Ordinal)).Value;
 
         return cloudPlatform == null ? string.Empty :
             Matcher.XRayCloudPlatform.TryGetValue(cloudPlatform, out var value) ? value : string.Empty;
@@ -234,16 +234,16 @@ internal class SamplingRuleApplier
     {
         // currently the aws resource detectors only capture ARNs for ECS and Lambda environments.
         var arn = (string?)resource.Attributes.FirstOrDefault(kvp =>
-            kvp.Key.Equals("aws.ecs.container.arn", StringComparison.Ordinal)).Value;
+            string.Equals(kvp.Key, "aws.ecs.container.arn", StringComparison.Ordinal)).Value;
 
         if (arn != null)
         {
             return arn;
         }
 
-        if (GetServiceType(resource).Equals("AWS::Lambda::Function", StringComparison.Ordinal))
+        if (string.Equals(GetServiceType(resource), "AWS::Lambda::Function", StringComparison.Ordinal))
         {
-            arn = (string?)samplingParameters.Tags?.FirstOrDefault(kvp => kvp.Key.Equals("faas.id", StringComparison.Ordinal)).Value;
+            arn = (string?)samplingParameters.Tags?.FirstOrDefault(kvp => string.Equals(kvp.Key, "faas.id", StringComparison.Ordinal)).Value;
 
             if (arn != null)
             {


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-dotnet/pull/7210.

## Changes

- Disallow use of string instance `Equals()` methods and require the static versions be used instead.
- Apply minor refactoring suggested by Visual Studio in files touched.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
