### PR TITLE
[AspNetCore] Fix server.address

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -404,7 +404,6 @@ internal class HttpInListener : ListenerHandler
     // the optimal path if the user has explicitly opted-out of suppressing the OpenTelemetry data.
     private static bool AspNetCoreHasNativeOpenTelemetryTags()
     {
-#if NET10_0_OR_GREATER
         bool? suppressed = null;
 
         if (AppContext.TryGetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", out var configuredValue))
@@ -417,14 +416,11 @@ internal class HttpInListener : ListenerHandler
             return !suppressedValue;
         }
 
+        // In ASP.NET Core 8 and 9 the feature switch does not exist and there are no native OpenTelemetry tags.
         // In ASP.NET Core 10 OpenTelemetry tags are suppressed by default,
         // see https://github.com/dotnet/aspnetcore/blob/7387de91234d3ef751fa50b3d1bfede4130213ff/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs#L59-L67.
         // In ASP.NET Core 11+ OpenTelemetry tags are emitted by default,
         // see https://github.com/dotnet/aspnetcore/blob/655f41d52f2fc75992eac41496b8e9cc119e1b54/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs#L59-L67.
         return Net11OrGreater;
-#else
-        // In ASP.NET Core 8 and 9 the feature switch does not exist and there are no native OpenTelemetry tags
-        return false;
-#endif
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -400,12 +400,13 @@ internal class HttpInListener : ListenerHandler
         }
     }
 
-    // ASP.NET Core 10 does not generate OpenTelemetry tags by default so we can only take
-    // the optimal path if the user has explicitly opted-out of suppressing the OpenTelemetry data.
     private static bool AspNetCoreHasNativeOpenTelemetryTags()
     {
         bool? suppressed = null;
 
+        // ASP.NET Core 10 added a feature switch to specify whether to suppress OpenTelemetry
+        // tags being added natively by default, so we can take an optimal path if the user has
+        // not explicitly opted-out of suppressing the OpenTelemetry data.
         if (AppContext.TryGetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", out var configuredValue))
         {
             suppressed = configuredValue;

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -31,6 +31,7 @@ internal class HttpInListener : ListenerHandler
     internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
     internal static readonly bool Net7OrGreater = Environment.Version.Major >= 7;
     internal static readonly bool Net10OrGreater = Environment.Version.Major >= 10;
+    internal static readonly bool Net11OrGreater = Environment.Version.Major >= 11;
 
     private const string DiagnosticSourceName = "Microsoft.AspNetCore";
 
@@ -173,20 +174,18 @@ internal class HttpInListener : ListenerHandler
                 ActivityInstrumentationHelper.SetKindProperty(activity, ActivityKind.Server);
             }
 
-            // See the spec: https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/http/http-spans.md
-            var path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
-
             TelemetryHelper.RequestDataHelper.SetActivityDisplayName(activity, request.Method);
 
             // ASP.NET Core 10 does not support OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS so we
             // still need to set the HTTP method tag so that any override by the user is honoured.
+            // See https://github.com/dotnet/aspnetcore/issues/65873.
             TelemetryHelper.RequestDataHelper.SetHttpMethodTag(activity, request.Method);
 
             if (!Net10OrGreater || !this.nativeAspNetCoreOpenTelemetryEnabled)
             {
                 if (request.Host.HasValue)
                 {
-                    activity.SetTag(SemanticConventions.AttributeServerAddress, request.Host.Value);
+                    activity.SetTag(SemanticConventions.AttributeServerAddress, request.Host.Host);
 
                     if (request.Host.Port is { } port)
                     {
@@ -204,6 +203,9 @@ internal class HttpInListener : ListenerHandler
                 }
 
                 activity.SetTag(SemanticConventions.AttributeUrlScheme, request.Scheme);
+
+                // See the spec: https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/http/http-spans.md
+                var path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
                 activity.SetTag(SemanticConventions.AttributeUrlPath, path);
             }
 
@@ -403,19 +405,23 @@ internal class HttpInListener : ListenerHandler
     private static bool AspNetCoreHasNativeOpenTelemetryTags()
     {
 #if NET10_0_OR_GREATER
-        if (AppContext.TryGetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", out var suppressed))
+        bool? suppressed = null;
+
+        if (AppContext.TryGetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", out var configuredValue))
         {
-            return !suppressed;
+            suppressed = configuredValue;
         }
-#endif
-#if NET10_0
+
+        if (suppressed is { } suppressedValue)
+        {
+            return !suppressedValue;
+        }
+
         // In ASP.NET Core 10 OpenTelemetry tags are suppressed by default,
         // see https://github.com/dotnet/aspnetcore/blob/7387de91234d3ef751fa50b3d1bfede4130213ff/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs#L59-L67.
-        return false;
-#elif NET11_0_OR_GREATER
         // In ASP.NET Core 11+ OpenTelemetry tags are emitted by default,
         // see https://github.com/dotnet/aspnetcore/blob/655f41d52f2fc75992eac41496b8e9cc119e1b54/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs#L59-L67.
-        return true;
+        return Net11OrGreater;
 #else
         // In ASP.NET Core 8 and 9 the feature switch does not exist and there are no native OpenTelemetry tags
         return false;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EndToEndTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EndToEndTests.cs
@@ -30,14 +30,10 @@ public sealed class EndToEndTests
     [InlineData(true)]
     public async Task HttpRequestActivityIsCorrectWithFeatureSwitch(bool isEnabled)
     {
-        bool? originalValue = null;
+        const string SwitchName = "Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData";
 
-        if (AppContext.TryGetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", out var existingValue))
-        {
-            originalValue = existingValue;
-        }
-
-        AppContext.SetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", isEnabled);
+        var wasConfigured = AppContext.TryGetSwitch(SwitchName, out var originalValue);
+        AppContext.SetSwitch(SwitchName, isEnabled);
 
         try
         {
@@ -58,7 +54,7 @@ public sealed class EndToEndTests
                     builder.ConfigureTestServices(ConfigureTestServices);
                     builder.ConfigureLogging(loggingBuilder => loggingBuilder.ClearProviders());
                 })
-                .CreateClient();
+                .CreateClient(new() { BaseAddress = new Uri("http://localhost:12345") });
 
             client.DefaultRequestHeaders.UserAgent.Add(new("OpenTelemetry.Instrumentation.AspNetCore.Tests", "1.0"));
 
@@ -73,16 +69,15 @@ public sealed class EndToEndTests
             Assert.Equal("GET /ping", activity.DisplayName);
             Assert.Equal("GET", activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethod));
             Assert.Equal("localhost", activity.GetTagValue(SemanticConventions.AttributeServerAddress));
+            Assert.Equal(12345, activity.GetTagValue(SemanticConventions.AttributeServerPort));
             Assert.Equal("OpenTelemetry.Instrumentation.AspNetCore.Tests/1.0", activity.GetTagValue(SemanticConventions.AttributeUserAgentOriginal));
             Assert.Equal("http", activity.GetTagValue(SemanticConventions.AttributeUrlScheme));
             Assert.Equal("/ping", activity.GetTagValue(SemanticConventions.AttributeUrlPath));
         }
         finally
         {
-            if (originalValue is { } previousValue)
-            {
-                AppContext.SetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", previousValue);
-            }
+            var resetValue = wasConfigured ? originalValue : Environment.Version.Major < 11;
+            AppContext.SetSwitch(SwitchName, resetValue);
         }
     }
 


### PR DESCRIPTION
https://github.com/martincostello/opentelemetry-dotnet-contrib/pull/2#pullrequestreview-4205856581

## Changes

- Fix mistake from #3993 and set the right `server.address` value.
- Apply some Copilot refactoring suggestions for feature switch handling.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
