### PR TITLE
[gRPC] Update Semantic Conventions for client instrumentations

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add instrumentation scope version and schema URL to traces.
   ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
-* Add `net10.0` target framework.
+* Add `net8.0` and `net10.0` target frameworks.
   ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
 ## 1.0.0-beta.11

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -8,9 +8,6 @@
 * Add instrumentation scope version and schema URL to traces.
   ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
-* Add `net8.0` and `net10.0` target frameworks.
-  ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
-
 ## 1.0.0-beta.11
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* **BREAKING**: Update to version 1.41.0 of the Semantic Conventions.
+  ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
+
+* Add instrumentation scope version and schema URL to traces.
+  ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
+
+* Add `net10.0` target framework.
+  ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
+
 ## 1.0.0-beta.11
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
@@ -292,11 +292,6 @@ public class ClientTracingInterceptor : Interceptor
         private static readonly Action<Metadata?, string, string> MetadataSetter = (metadata, key, value) => { metadata?.Add(new Metadata.Entry(key, value)); };
 
         /// <summary>
-        /// The context.
-        /// </summary>
-        private readonly ClientInterceptorContext<TRequest, TResponse> context;
-
-        /// <summary>
         /// The parent activity.
         /// </summary>
         private readonly Activity? parentActivity;
@@ -307,9 +302,9 @@ public class ClientTracingInterceptor : Interceptor
         /// <param name="context">The context.</param>
         /// <param name="options">The options.</param>
         public ClientRpcScope(ClientInterceptorContext<TRequest, TResponse> context, ClientTracingInterceptorOptions options)
-            : base(context.Method?.FullName, options.RecordMessageEvents, options.RecordException)
+            : base(context.Host, context.Method?.FullName, options.RecordMessageEvents, options.RecordException)
         {
-            this.context = context;
+            this.Context = context;
 
             // Capture the current activity.
             this.parentActivity = Activity.Current;
@@ -355,20 +350,18 @@ public class ClientTracingInterceptor : Interceptor
 
             this.SetActivity(rpcActivity);
             options.Propagator.Inject(new PropagationContext(rpcActivity.Context, Baggage.Current), callOptions.Headers, MetadataSetter);
-            this.context = new ClientInterceptorContext<TRequest, TResponse>(context.Method!, context.Host, callOptions);
+            this.Context = new ClientInterceptorContext<TRequest, TResponse>(context.Method!, context.Host, callOptions);
         }
 
         /// <summary>
         /// Gets the context.
         /// </summary>
-        public ClientInterceptorContext<TRequest, TResponse> Context => this.context;
+        public ClientInterceptorContext<TRequest, TResponse> Context { get; }
 
         /// <summary>
         /// Restores the parent activity.
         /// </summary>
         public void RestoreParentActivity()
-        {
-            Activity.Current = this.parentActivity;
-        }
+            => Activity.Current = this.parentActivity;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ClientTracingInterceptor.cs
@@ -321,16 +321,24 @@ public class ClientTracingInterceptor : Interceptor
             // the callers current Activity which isn't what we want. We need to restore the original immediately after doing this.
             // If this call happened after some kind of async context await then a restore wouldn't be necessary.
             // gRPC Core just doesn't have the hooks to do this as far as I can tell.
-            var rpcActivity = GrpcCoreInstrumentation.ActivitySource.StartActivity(
+            var parentContext = this.parentActivity?.Context ?? default;
+            var rpcActivity = GrpcCoreInstrumentation.ActivitySource.CreateActivity(
                 this.FullServiceName,
                 ActivityKind.Client,
-                this.parentActivity == default ? default : this.parentActivity.Context,
+                parentContext,
                 tags: options.AdditionalTags);
 
             if (rpcActivity == null)
             {
                 return;
             }
+
+            if (!parentContext.IsValid())
+            {
+                rpcActivity.SetIdFormat(ActivityIdFormat.W3C);
+            }
+
+            rpcActivity.Start();
 
             var callOptions = context.Options;
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/Extensions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/Extensions.cs
@@ -14,18 +14,15 @@ internal static class Extensions
     /// <param name="first">The first.</param>
     /// <param name="second">The second.</param>
     /// <returns>An Action.</returns>
-    internal static Action WithBestEffortDispose(this IDisposable first, IDisposable second)
+    internal static Action WithBestEffortDispose(this IDisposable first, IDisposable second) => () =>
     {
-        return () =>
+        try
         {
-            try
-            {
-                first.Dispose();
-            }
-            finally
-            {
-                second.Dispose();
-            }
-        };
-    }
+            first.Dispose();
+        }
+        finally
+        {
+            second.Dispose();
+        }
+    };
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/GrpcCoreInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/GrpcCoreInstrumentation.cs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using System.Reflection;
-using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.GrpcCore;
 
@@ -13,22 +12,12 @@ namespace OpenTelemetry.Instrumentation.GrpcCore;
 internal static class GrpcCoreInstrumentation
 {
     /// <summary>
-    /// The assembly.
+    /// Gets the version of the RPC Semantic Conventions used by the instrumentation.
     /// </summary>
-    internal static readonly Assembly Assembly = typeof(GrpcCoreInstrumentation).Assembly;
+    internal static readonly Version SemanticConventionsVersion = new(1, 41, 0);
 
     /// <summary>
-    /// The assembly name.
+    /// Gets the activity source for the instrumentation.
     /// </summary>
-    internal static readonly AssemblyName AssemblyName = Assembly.GetName();
-
-    /// <summary>
-    /// The activity source name.
-    /// </summary>
-    internal static readonly string ActivitySourceName = AssemblyName.Name;
-
-    /// <summary>
-    /// The activity source.
-    /// </summary>
-    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Assembly.GetPackageVersion());
+    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create(typeof(GrpcCoreInstrumentation), SemanticConventionsVersion);
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
+    <TargetFrameworks>net10.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <Description>.NET gRPC Core based client and server interceptors for OpenTelemetry.</Description>
     <PackageTags>$(PackageTags);gRPC Core;interceptors</PackageTags>
     <MinVerTagPrefix>Instrumentation.GrpcCore-</MinVerTagPrefix>
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksForLibraries);$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksForLibraries)</TargetFrameworks>
     <Description>.NET gRPC Core based client and server interceptors for OpenTelemetry.</Description>
     <PackageTags>$(PackageTags);gRPC Core;interceptors</PackageTags>
     <MinVerTagPrefix>Instrumentation.GrpcCore-</MinVerTagPrefix>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworksForLibraries)</TargetFrameworks>
+    <TargetFrameworks>$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <Description>.NET gRPC Core based client and server interceptors for OpenTelemetry.</Description>
     <PackageTags>$(PackageTags);gRPC Core;interceptors</PackageTags>
     <MinVerTagPrefix>Instrumentation.GrpcCore-</MinVerTagPrefix>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworksForLibraries);$(NetStandardMinimumSupportedVersion)</TargetFrameworks>
     <Description>.NET gRPC Core based client and server interceptors for OpenTelemetry.</Description>
     <PackageTags>$(PackageTags);gRPC Core;interceptors</PackageTags>
     <MinVerTagPrefix>Instrumentation.GrpcCore-</MinVerTagPrefix>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -20,6 +20,11 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     where TResponse : class
 {
     /// <summary>
+    /// The host.
+    /// </summary>
+    private readonly string? host;
+
+    /// <summary>
     /// The record message events flag.
     /// </summary>
     private readonly bool recordMessageEvents;
@@ -52,11 +57,17 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="RpcScope{TRequest, TResponse}" /> class.
     /// </summary>
+    /// <param name="host">The host that the currect invocation will be dispatched to.</param>
     /// <param name="fullServiceName">Full name of the service.</param>
     /// <param name="recordMessageEvents">if set to <c>true</c> [record message events].</param>
     /// <param name="recordException">If set to <c>true</c> [record exception].</param>
-    protected RpcScope(string? fullServiceName, bool recordMessageEvents, bool recordException)
+    protected RpcScope(
+        string? host,
+        string? fullServiceName,
+        bool recordMessageEvents,
+        bool recordException)
     {
+        this.host = host;
         this.FullServiceName = fullServiceName?.TrimStart('/') ?? "unknownservice/unknownmethod";
         this.recordMessageEvents = recordMessageEvents;
         this.recordException = recordException;
@@ -164,11 +175,11 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
             return;
         }
 
-        // assign some reasonable defaults
+        // Assign some reasonable defaults
         var rpcService = this.FullServiceName;
         var rpcMethod = this.FullServiceName;
 
-        // split the full service name by the slash
+        // Split the full service name by the slash
         var parts = this.FullServiceName.Split('/');
         if (parts.Length == 2)
         {
@@ -176,9 +187,16 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
             rpcMethod = parts[1];
         }
 
-        this.activity.SetTag(SemanticConventions.AttributeRpcSystem, "grpc");
+        this.activity.SetTag(SemanticConventions.AttributeRpcSystemName, "grpc");
         this.activity.SetTag(SemanticConventions.AttributeRpcService, rpcService);
         this.activity.SetTag(SemanticConventions.AttributeRpcMethod, rpcMethod);
+
+        if (this.host is { Length: > 0 } host)
+        {
+            this.activity.SetTag(SemanticConventions.AttributeServerAddress, host);
+        }
+
+        this.activity.DisplayName = rpcMethod.Trim('/');
     }
 
     /// <summary>
@@ -188,12 +206,12 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// <param name="markAsCompleted">If set to <c>true</c> [mark as completed].</param>
     private void StopActivity(int statusCode, bool markAsCompleted = true)
     {
-        if (markAsCompleted && !this.TryMarkAsCompleted())
+        if ((markAsCompleted && !this.TryMarkAsCompleted()) || this.activity is null)
         {
             return;
         }
 
-        this.activity!.SetTag(SemanticConventions.AttributeRpcGrpcStatusCode, statusCode);
+        this.activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, statusCode);
         this.activity.Stop();
     }
 
@@ -203,7 +221,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// <param name="exception">The exception.</param>
     private void StopActivity(Exception exception)
     {
-        if (!this.TryMarkAsCompleted())
+        if (!this.TryMarkAsCompleted() || this.activity is null)
         {
             return;
         }
@@ -219,10 +237,10 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
 
         if (!string.IsNullOrEmpty(description))
         {
-            this.activity!.SetStatus(ActivityStatusCode.Error, description);
+            this.activity.SetStatus(ActivityStatusCode.Error, description);
         }
 
-        if (this.activity!.IsAllDataRequested && this.recordException)
+        if (this.activity.IsAllDataRequested && this.recordException)
         {
             this.activity.AddException(exception);
         }
@@ -235,9 +253,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// </summary>
     /// <returns>Returns <c>true</c> if marked as completed successfully.</returns>
     private bool TryMarkAsCompleted()
-    {
-        return Interlocked.CompareExchange(ref this.complete, 1, 0) == 0;
-    }
+        => Interlocked.CompareExchange(ref this.complete, 1, 0) == 0;
 
     /// <summary>
     /// Adds a message event.
@@ -247,7 +263,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// <param name="request">if true this is a request message.</param>
     private void AddMessageEvent(string eventName, IMessage? message, bool request)
     {
-        if (message == null)
+        if (message == null || this.activity is null)
         {
             return;
         }
@@ -265,6 +281,6 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
             new(SemanticConventions.AttributeMessageUncompressedSize, messageSize),
         ]);
 
-        this.activity!.AddEvent(new ActivityEvent(eventName, default, attributes));
+        this.activity.AddEvent(new ActivityEvent(eventName, default, attributes));
     }
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using Google.Protobuf;
 using Grpc.Core;
 using OpenTelemetry.Internal;
@@ -193,7 +194,18 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
 
         if (this.host is { Length: > 0 } host)
         {
-            this.activity.SetTag(SemanticConventions.AttributeServerAddress, host);
+            parts = host.Split(':');
+
+            if (parts.Length > 0)
+            {
+                this.activity.SetTag(SemanticConventions.AttributeServerAddress, parts[0]);
+
+                if (parts.Length > 1 &&
+                    int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+                {
+                    this.activity.SetTag(SemanticConventions.AttributeServerPort, port);
+                }
+            }
         }
 
         this.activity.DisplayName = rpcMethod.Trim('/');

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using System.Globalization;
 using Google.Protobuf;
 using Grpc.Core;
 using OpenTelemetry.Internal;
@@ -194,21 +193,26 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
 
         if (this.host is { Length: > 0 } host)
         {
-            parts = host.Split(':');
-
-            if (parts.Length > 0)
-            {
-                this.activity.SetTag(SemanticConventions.AttributeServerAddress, parts[0]);
-
-                if (parts.Length > 1 &&
-                    int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out var port))
-                {
-                    this.activity.SetTag(SemanticConventions.AttributeServerPort, port);
-                }
-            }
+            TrySetServerAttributes(this.activity, host);
         }
 
         this.activity.DisplayName = rpcMethod.Trim('/');
+    }
+
+    private static void TrySetServerAttributes(Activity activity, string host)
+    {
+        // Add a placeholder for the scheme so the parse succeeds. The value is not important.
+        if (!Uri.TryCreate($"http://{host}", UriKind.Absolute, out var uri))
+        {
+            return;
+        }
+
+        activity.SetTag(SemanticConventions.AttributeServerAddress, uri.Host);
+
+        if (!uri.IsDefaultPort)
+        {
+            activity.SetTag(SemanticConventions.AttributeServerPort, uri.Port);
+        }
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -57,7 +57,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="RpcScope{TRequest, TResponse}" /> class.
     /// </summary>
-    /// <param name="host">The host that the currect invocation will be dispatched to.</param>
+    /// <param name="host">The host that the current invocation will be dispatched to.</param>
     /// <param name="fullServiceName">Full name of the service.</param>
     /// <param name="recordMessageEvents">if set to <c>true</c> [record message events].</param>
     /// <param name="recordException">If set to <c>true</c> [record exception].</param>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/ServerTracingInterceptor.cs
@@ -176,7 +176,7 @@ public class ServerTracingInterceptor : Interceptor
         /// <param name="context">The context.</param>
         /// <param name="options">The options.</param>
         public ServerRpcScope(ServerCallContext context, ServerTracingInterceptorOptions options)
-            : base(context.Method, options.RecordMessageEvents, options.RecordException)
+            : base(context.Host, context.Method, options.RecordMessageEvents, options.RecordException)
         {
             if (!GrpcCoreInstrumentation.ActivitySource.HasListeners())
             {

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/TracerProviderBuilderExtensions.cs
@@ -21,6 +21,6 @@ public static class TracerProviderBuilderExtensions
     {
         Guard.ThrowIfNull(builder);
 
-        return builder.AddSource(GrpcCoreInstrumentation.ActivitySourceName);
+        return builder.AddSource(GrpcCoreInstrumentation.ActivitySource.Name);
     }
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* **BREAKING**: Update to version 1.41.0 of the Semantic Conventions.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
+* Add instrumentation scope version and schema URL to traces.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## Unreleased
 
 * **BREAKING**: Update to version 1.41.0 of the Semantic Conventions.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
 * Add instrumentation scope version and schema URL to traces.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -109,10 +109,10 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
 
             var grpcMethod = GrpcTagHelper.GetGrpcMethodFromActivity(activity);
 
+            activity.DisplayName = grpcMethod?.Trim('/') ?? GrpcTagHelper.RpcSystemGrpc;
+
             if (grpcMethod != null)
             {
-                activity.DisplayName = grpcMethod.Trim('/');
-
                 if (GrpcTagHelper.TryParseRpcServiceAndRpcMethod(grpcMethod, out var rpcService, out var rpcMethod))
                 {
                     activity.SetTag(SemanticConventions.AttributeRpcService, rpcService);

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -3,22 +3,15 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using OpenTelemetry.Context.Propagation;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation;
 
 internal sealed class GrpcClientDiagnosticListener : ListenerHandler
 {
-    internal static readonly Assembly Assembly = typeof(GrpcClientDiagnosticListener).Assembly;
-    internal static readonly AssemblyName AssemblyName = Assembly.GetName();
-#pragma warning disable IDE0370 // Suppression is unnecessary
-    internal static readonly string ActivitySourceName = AssemblyName.Name!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
-    internal static readonly string Version = Assembly.GetPackageVersion();
-    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version);
+    internal static readonly Version SemanticConventionsVersion = new(1, 41, 0);
+    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<GrpcClientDiagnosticListener>(SemanticConventionsVersion);
 
     private const string OnStartEvent = "Grpc.Net.Client.GrpcOut.Start";
     private const string OnStopEvent = "Grpc.Net.Client.GrpcOut.Stop";
@@ -36,21 +29,21 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
 
     public override void OnEventWritten(string name, object? payload)
     {
-        var activity = Activity.Current!;
+        if (Activity.Current is not { } activity)
+        {
+            return;
+        }
+
         switch (name)
         {
             case OnStartEvent:
-                {
-                    this.OnStartActivity(activity, payload);
-                }
-
+                this.OnStartActivity(activity, payload);
                 break;
+
             case OnStopEvent:
-                {
-                    this.OnStopActivity(activity, payload);
-                }
-
+                this.OnStopActivity(activity, payload);
                 break;
+
             default:
                 break;
         }
@@ -130,33 +123,34 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
                 }
             }
 
-            activity.SetTag(SemanticConventions.AttributeRpcSystem, GrpcTagHelper.RpcSystemGrpc);
+            activity.SetTag(SemanticConventions.AttributeRpcSystemName, GrpcTagHelper.RpcSystemGrpc);
 
             var requestUri = request.RequestUri;
 
             if (requestUri != null)
             {
+                activity.SetTag(SemanticConventions.AttributeServerAddress, requestUri.Host);
+                activity.SetTag(SemanticConventions.AttributeServerPort, requestUri.Port);
+
                 var uriHostNameType = Uri.CheckHostName(requestUri.Host);
 
                 if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                 {
-                    activity.SetTag(SemanticConventions.AttributeServerSocketAddress, requestUri.Host);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, requestUri.Host);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, requestUri.Port);
                 }
-                else
+            }
+
+            if (this.options.EnrichWithHttpRequestMessage is { } enrich)
+            {
+                try
                 {
-                    activity.SetTag(SemanticConventions.AttributeServerAddress, requestUri.Host);
+                    enrich(activity, request);
                 }
-
-                activity.SetTag(SemanticConventions.AttributeServerPort, requestUri.Port);
-            }
-
-            try
-            {
-                this.options.EnrichWithHttpRequestMessage?.Invoke(activity, request);
-            }
-            catch (Exception ex)
-            {
-                GrpcInstrumentationEventSource.Log.EnrichmentException(ex);
+                catch (Exception ex)
+                {
+                    GrpcInstrumentationEventSource.Log.EnrichmentException(ex);
+                }
             }
         }
 
@@ -173,28 +167,43 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
 
     public void OnStopActivity(Activity activity, object? payload)
     {
-        if (activity.IsAllDataRequested)
+        if (!activity.IsAllDataRequested)
         {
-            var validConversion = GrpcTagHelper.TryGetGrpcStatusCodeFromActivity(activity, out var status);
-            if (validConversion)
-            {
-                if (activity.Status == ActivityStatusCode.Unset)
-                {
-                    activity.SetStatus(GrpcTagHelper.ResolveSpanStatusForGrpcStatusCodeOnClient(status));
-                }
+            return;
+        }
 
-                // setting rpc.grpc.status_code
-                activity.SetTag(SemanticConventions.AttributeRpcGrpcStatusCode, status);
+        var validConversion = GrpcTagHelper.TryGetGrpcStatusCodeFromActivity(activity, out var status);
+        if (validConversion)
+        {
+            if (activity.Status == ActivityStatusCode.Unset)
+            {
+                activity.SetStatus(GrpcTagHelper.ResolveSpanStatusForGrpcStatusCodeOnClient(status));
             }
 
-            // Remove the grpc.status_code tag added by the gRPC .NET library
-            activity.SetTag(GrpcTagHelper.GrpcStatusCodeTagName, null);
+            activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, status);
+        }
 
-            if (TryFetchResponse(payload, out var response))
+        // Remove the grpc.status_code tag added by the gRPC .NET library
+        activity.SetTag(GrpcTagHelper.GrpcStatusCodeTagName, null);
+
+        if (TryFetchResponse(payload, out var response))
+        {
+            if (response.RequestMessage?.RequestUri is { } requestUri)
+            {
+                var uriHostNameType = Uri.CheckHostName(requestUri.Host);
+
+                if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
+                {
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, requestUri.Host);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, requestUri.Port);
+                }
+            }
+
+            if (this.options.EnrichWithHttpResponseMessage is { } enrich)
             {
                 try
                 {
-                    this.options.EnrichWithHttpResponseMessage?.Invoke(activity, response);
+                    enrich(activity, response);
                 }
                 catch (Exception ex)
                 {

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ActivityInstrumentationHelper.cs" Link="Includes\ActivityInstrumentationHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\DiagnosticSourceListener.cs" Link="Includes\DiagnosticSourceListener.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\DiagnosticSourceSubscriber.cs" Link="Includes\DiagnosticSourceSubscriber.cs" />

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
@@ -25,9 +25,9 @@ is released, there can be breaking changes.
 
 ## Supported .NET Versions
 
-This package targets
-[`NETSTANDARD2.1`](https://docs.microsoft.com/dotnet/standard/net-standard#net-implementation-support)
-and hence can be used in any .NET versions implementing `NETSTANDARD2.1`.
+This package targets all supported versions of .NET and
+[`netstandard2.1`](https://docs.microsoft.com/dotnet/standard/net-standard#net-implementation-support)
+and hence can be used in any .NET versions implementing `netstandard2.1`.
 
 ## Steps to enable OpenTelemetry.Instrumentation.GrpcNetClient
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
@@ -55,7 +55,7 @@ public static class TracerProviderBuilderExtensions
             builder.ConfigureServices(services => services.Configure(name, configure));
         }
 
-        builder.AddSource(GrpcClientDiagnosticListener.ActivitySourceName);
+        builder.AddSource(GrpcClientDiagnosticListener.ActivitySource.Name);
         builder.AddLegacySource("Grpc.Net.Client.GrpcOut");
 
         return builder.AddInstrumentation(sp =>

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -60,6 +60,7 @@ internal static class SemanticConventions
     public const string AttributeRpcService = "rpc.service";
     public const string AttributeRpcMethod = "rpc.method";
     public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
+    public const string AttributeRpcResponseStatusCode = "rpc.response.status_code";
 
     public const string AttributeMessageType = "message.type";
     public const string AttributeMessageId = "message.id";

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
@@ -176,7 +176,7 @@ internal class FoobarService : Foobar.FoobarBase
     }
 
     /// <inheritdoc/>
-    public async override Task<FoobarResponse> Unary(FoobarRequest request, ServerCallContext context)
+    public override async Task<FoobarResponse> Unary(FoobarRequest request, ServerCallContext context)
     {
         this.CheckForFailure(context);
 
@@ -267,8 +267,6 @@ internal class FoobarService : Foobar.FoobarBase
 
         /// <inheritdoc/>
         public void Dispose()
-        {
-            this.server.ShutdownAsync().Wait();
-        }
+            => this.server.ShutdownAsync().Wait();
     }
 }

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
@@ -73,9 +73,8 @@ internal class FoobarService : Foobar.FoobarBase
         };
 
         server.Start();
-        var serverUriString = new Uri("dns:localhost:" + server.Ports.Single().BoundPort).ToString();
 
-        return new DisposableServer(server, serverUriString);
+        return new DisposableServer(server);
     }
 
     /// <summary>
@@ -253,17 +252,22 @@ internal class FoobarService : Foobar.FoobarBase
         /// Initializes a new instance of the <see cref="DisposableServer" /> class.
         /// </summary>
         /// <param name="server">The server.</param>
-        /// <param name="uriString">The URI string.</param>
-        public DisposableServer(Server server, string uriString)
+        public DisposableServer(Server server)
         {
+            var serverPort = server.Ports.Single();
+
             this.server = server;
-            this.UriString = uriString;
+            this.HostName = serverPort.Host;
+            this.Port = serverPort.BoundPort;
         }
 
-        /// <summary>
-        /// Gets the URI string.
-        /// </summary>
-        public string UriString { get; }
+        public string Host => $"{this.HostName}:{this.Port}";
+
+        public string HostName { get; }
+
+        public int Port { get; }
+
+        public string Target => $"dns:{this.Host}";
 
         /// <inheritdoc/>
         public void Dispose()

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/FoobarService.cs
@@ -12,6 +12,14 @@ namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
 /// </summary>
 internal class FoobarService : Foobar.FoobarBase
 {
+    public const string UnaryMethod = nameof(Foobar.FoobarClient.Unary);
+
+    public const string ClientStreamingMethod = nameof(Foobar.FoobarClient.ClientStreaming);
+
+    public const string ServerStreamingMethod = nameof(Foobar.FoobarClient.ServerStreaming);
+
+    public const string DuplexStreamingMethod = nameof(Foobar.FoobarClient.DuplexStreaming);
+
     /// <summary>
     /// Default traceparent header value with the sampling bit on.
     /// </summary>

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -33,7 +33,10 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task AsyncUnarySuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest, DefaultMetadataFunc());
+        await TestHandlerSuccess(
+            FoobarService.MakeUnaryAsyncRequest,
+            "Unary",
+            DefaultMetadataFunc());
 
     /// <summary>
     /// Validates a failed AsyncUnary call because the endpoint isn't there.
@@ -43,6 +46,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task AsyncUnaryUnavailable() =>
         await TestHandlerFailure(
             FoobarService.MakeUnaryAsyncRequest,
+            "Unary",
             StatusCode.Unavailable,
             validateErrorDescription: false,
             BogusServerUri);
@@ -53,7 +57,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task AsyncUnaryFail() =>
-        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest);
+        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest, "Unary");
 
     /// <summary>
     /// Validates a failed AsyncUnary call because the client is disposed before completing the RPC.
@@ -66,7 +70,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.UnaryAsync(FoobarService.DefaultRequestMessage);
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest);
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "Unary");
     }
 
     /// <summary>
@@ -75,7 +79,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, DefaultMetadataFunc());
+        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, "ClientStreaming", DefaultMetadataFunc());
 
     /// <summary>
     /// Validates a failed ClientStreaming call when the service is unavailable.
@@ -85,6 +89,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task ClientStreamingUnavailable() =>
         await TestHandlerFailure(
             FoobarService.MakeClientStreamingRequest,
+            "ClientStreaming",
             StatusCode.Unavailable,
             validateErrorDescription: false,
             BogusServerUri);
@@ -95,7 +100,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingFail() =>
-        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest);
+        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest, "ClientStreaming");
 
     /// <summary>
     /// Validates a failed ClientStreaming call because the client is disposed before completing the RPC.
@@ -108,7 +113,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.ClientStreaming();
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest);
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "ClientStreaming");
     }
 
     /// <summary>
@@ -117,7 +122,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, DefaultMetadataFunc());
+        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, "ServerStreaming", DefaultMetadataFunc());
 
     /// <summary>
     /// Validates a failed ServerStreaming call.
@@ -125,7 +130,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingFail() =>
-        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest);
+        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest, "ServerStreaming");
 
     /// <summary>
     /// Validates a failed ServerStreaming call because the client is disposed before completing the RPC.
@@ -138,7 +143,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.ServerStreaming(FoobarService.DefaultRequestMessage);
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest);
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "ServerStreaming");
     }
 
     /// <summary>
@@ -147,7 +152,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, DefaultMetadataFunc());
+        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming", DefaultMetadataFunc());
 
     /// <summary>
     /// Validates a failed DuplexStreaming call when the service is unavailable.
@@ -157,6 +162,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task DuplexStreamingUnavailable() =>
         await TestHandlerFailure(
             FoobarService.MakeDuplexStreamingRequest,
+            "DuplexStreaming",
             StatusCode.Unavailable,
             validateErrorDescription: false,
             BogusServerUri);
@@ -167,7 +173,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingFail() =>
-        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest);
+        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming");
 
     /// <summary>
     /// Validates a failed DuplexStreaming call because the client is disposed before completing the RPC.
@@ -180,7 +186,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.DuplexStreaming();
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest);
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "DuplexStreaming");
     }
 
     /// <summary>
@@ -310,7 +316,7 @@ public class GrpcCoreClientInterceptorTests
         Assert.NotNull(response);
 
         var activity = activityListener.Activity;
-        ValidateCommonActivityTags(activity);
+        ValidateCommonActivityTags(activity, "Unary");
         Assert.Empty(activity!.Events);
     }
 
@@ -318,11 +324,13 @@ public class GrpcCoreClientInterceptorTests
     /// Validates the common activity tags.
     /// </summary>
     /// <param name="activity">The activity.</param>
+    /// <param name="expectedMethodName">The expected gRPC method name.</param>
     /// <param name="expectedStatusCode">The expected status code.</param>
     /// <param name="recordedMessages">if set to <c>true</c> [recorded messages].</param>
     /// <param name="recordedExceptions">if set to <c>true</c> [recorded exceptions].</param>
     internal static void ValidateCommonActivityTags(
         Activity? activity,
+        string expectedMethodName,
         StatusCode expectedStatusCode = StatusCode.OK,
         bool recordedMessages = false,
         bool recordedExceptions = false)
@@ -332,12 +340,14 @@ public class GrpcCoreClientInterceptorTests
 
         Assert.True(activity.IsStopped, "The activity has not been stopped.");
 
+        Assert.Equal(expectedMethodName, activity.DisplayName);
+
         // TagObjects contain non string values
         // Tags contains only string values
-        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcSystem && (string?)t.Value == "grpc");
+        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcSystemName && (string?)t.Value == "grpc");
         Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcService && (string?)t.Value == "OpenTelemetry.Instrumentation.GrpcCore.Tests.Foobar");
-        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcMethod);
-        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcGrpcStatusCode && (int?)t.Value == (int)expectedStatusCode);
+        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcMethod && (string?)t.Value == expectedMethodName);
+        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcResponseStatusCode && (int?)t.Value == (int)expectedStatusCode);
 
         // Cancelled is not an error.
         if (expectedStatusCode is not StatusCode.OK and not StatusCode.Cancelled)
@@ -388,9 +398,13 @@ public class GrpcCoreClientInterceptorTests
     /// Tests basic handler success.
     /// </summary>
     /// <param name="clientRequestFunc">The client request function.</param>
+    /// <param name="expectedMethodName">The expected gRPC method name.</param>
     /// <param name="additionalMetadata">The additional metadata, if any.</param>
     /// <returns>A Task.</returns>
-    private static async Task TestHandlerSuccess(Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc, Metadata additionalMetadata)
+    private static async Task TestHandlerSuccess(
+        Func<Foobar.FoobarClient, Metadata, Task> clientRequestFunc,
+        string expectedMethodName,
+        Metadata additionalMetadata)
     {
         var propagator = new TestTextMapPropagator();
         PropagationContext capturedPropagationContext = default;
@@ -454,7 +468,11 @@ public class GrpcCoreClientInterceptorTests
             Assert.NotNull(capturedCarrier);
             Assert.NotEmpty(capturedCarrier);
 
-            ValidateCommonActivityTags(activity, StatusCode.OK, interceptorOptions.RecordMessageEvents);
+            ValidateCommonActivityTags(
+                activity,
+                expectedMethodName,
+                StatusCode.OK,
+                interceptorOptions.RecordMessageEvents);
 
             Assert.Equal(default, activity.ParentSpanId);
         }
@@ -482,7 +500,11 @@ public class GrpcCoreClientInterceptorTests
 
             var activity = activityListener.Activity;
 
-            ValidateCommonActivityTags(activity, StatusCode.OK, interceptorOptions.RecordMessageEvents);
+            ValidateCommonActivityTags(
+                activity,
+                expectedMethodName,
+                StatusCode.OK,
+                interceptorOptions.RecordMessageEvents);
 
             Assert.NotNull(activity);
             Assert.Equal(parentActivity.Id, activity.ParentId);
@@ -493,6 +515,7 @@ public class GrpcCoreClientInterceptorTests
     /// Tests basic handler failure. Instructs the server to fail with resources exhausted and validates the created Activity.
     /// </summary>
     /// <param name="clientRequestFunc">The client request function.</param>
+    /// <param name="expectedMethodName">The expected gRPC method name.</param>
     /// <param name="statusCode">The status code to use for the failure. Defaults to ResourceExhausted.</param>
     /// <param name="validateErrorDescription">if set to <c>true</c> [validate error description].</param>
     /// <param name="serverUriString">An alternate server URI string.</param>
@@ -501,12 +524,18 @@ public class GrpcCoreClientInterceptorTests
     /// </returns>
     private static async Task TestHandlerFailure(
         Func<Foobar.FoobarClient, Metadata?, Task> clientRequestFunc,
+        string expectedMethodName,
         StatusCode statusCode = StatusCode.ResourceExhausted,
         bool validateErrorDescription = true,
         string? serverUriString = null)
     {
         var testTags = new TestActivityTags();
-        var interceptorOptions = new ClientTracingInterceptorOptions { Propagator = new TraceContextPropagator(), AdditionalTags = testTags.Tags, RecordException = true };
+        var interceptorOptions = new ClientTracingInterceptorOptions
+        {
+            Propagator = new TraceContextPropagator(),
+            AdditionalTags = testTags.Tags,
+            RecordException = true,
+        };
 
         using var activityListener = new InterceptorActivityListener(testTags);
 
@@ -525,7 +554,12 @@ public class GrpcCoreClientInterceptorTests
 
         var activity = activityListener.Activity;
 
-        ValidateCommonActivityTags(activity, statusCode, interceptorOptions.RecordMessageEvents, interceptorOptions.RecordException);
+        ValidateCommonActivityTags(
+            activity,
+            expectedMethodName,
+            statusCode,
+            interceptorOptions.RecordMessageEvents,
+            interceptorOptions.RecordException);
 
         if (validateErrorDescription)
         {
@@ -538,18 +572,30 @@ public class GrpcCoreClientInterceptorTests
     /// Tests for Activity cancellation when the handler is disposed before completing the RPC.
     /// </summary>
     /// <param name="clientRequestAction">The client request action.</param>
-    private void TestActivityIsCancelledWhenHandlerDisposed(Action<Foobar.FoobarClient> clientRequestAction)
+    /// <param name="expectedMethodName">The expected gRPC method name.</param>
+    private void TestActivityIsCancelledWhenHandlerDisposed(
+        Action<Foobar.FoobarClient> clientRequestAction,
+        string expectedMethodName)
     {
         var testTags = new TestActivityTags();
         using var activityListener = new InterceptorActivityListener(testTags);
 
         using (var server = FoobarService.Start())
         {
-            var clientInterceptorOptions = new ClientTracingInterceptorOptions { Propagator = new TraceContextPropagator(), AdditionalTags = testTags.Tags };
+            var clientInterceptorOptions = new ClientTracingInterceptorOptions
+            {
+                Propagator = new TraceContextPropagator(),
+                AdditionalTags = testTags.Tags,
+            };
+
             var client = FoobarService.ConstructRpcClient(server.UriString, new ClientTracingInterceptor(clientInterceptorOptions));
             clientRequestAction(client);
         }
 
-        ValidateCommonActivityTags(activityListener.Activity, StatusCode.Cancelled, false);
+        ValidateCommonActivityTags(
+            activityListener.Activity,
+            expectedMethodName,
+            StatusCode.Cancelled,
+            false);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -198,7 +198,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task DownstreamInterceptorActivityAccess()
     {
         using var server = FoobarService.Start();
-        var channel = new Channel(server.UriString, ChannelCredentials.Insecure);
+        var channel = new Channel(server.Target, ChannelCredentials.Insecure);
         var callInvoker = channel.CreateCallInvoker();
 
         // Activity has a parent
@@ -441,7 +441,10 @@ public class GrpcCoreClientInterceptorTests
         // No Activity parent
         using (var activityListener = new InterceptorActivityListener(testTags))
         {
-            var client = FoobarService.ConstructRpcClient(server.UriString, new ClientTracingInterceptor(interceptorOptions));
+            var client = FoobarService
+                .ConstructRpcClient(server.Target, new ClientTracingInterceptor(interceptorOptions))
+                .WithHost(server.Host);
+
             await clientRequestFunc(client, additionalMetadata).ConfigureAwait(false);
 
             Assert.Equal(default, Activity.Current);
@@ -475,6 +478,9 @@ public class GrpcCoreClientInterceptorTests
                 interceptorOptions.RecordMessageEvents);
 
             Assert.Equal(default, activity.ParentSpanId);
+
+            Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeServerAddress && (string?)t.Value == server.HostName);
+            Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeServerPort && (int?)t.Value == server.Port);
         }
 
         propagatorCalled = 0;
@@ -486,7 +492,11 @@ public class GrpcCoreClientInterceptorTests
             using var parentActivity = new Activity("foo");
             parentActivity.SetIdFormat(ActivityIdFormat.W3C);
             parentActivity.Start();
-            var client = FoobarService.ConstructRpcClient(server.UriString, new ClientTracingInterceptor(interceptorOptions));
+
+            var client = FoobarService
+                .ConstructRpcClient(server.Target, new ClientTracingInterceptor(interceptorOptions))
+                .WithHost(server.Host);
+
             await clientRequestFunc(client, additionalMetadata).ConfigureAwait(false);
 
             Assert.Equal(parentActivity, Activity.Current);
@@ -508,6 +518,8 @@ public class GrpcCoreClientInterceptorTests
 
             Assert.NotNull(activity);
             Assert.Equal(parentActivity.Id, activity.ParentId);
+            Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeServerAddress && (string?)t.Value == server.HostName);
+            Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeServerPort && (int?)t.Value == server.Port);
         }
     }
 
@@ -542,7 +554,7 @@ public class GrpcCoreClientInterceptorTests
         using (var server = FoobarService.Start())
         {
             var client = FoobarService.ConstructRpcClient(
-                serverUriString ?? server.UriString,
+                serverUriString ?? server.Target,
                 new ClientTracingInterceptor(interceptorOptions),
                 [
                     new(FoobarService.RequestHeaderFailWithStatusCode, statusCode.ToString()),
@@ -588,7 +600,7 @@ public class GrpcCoreClientInterceptorTests
                 AdditionalTags = testTags.Tags,
             };
 
-            var client = FoobarService.ConstructRpcClient(server.UriString, new ClientTracingInterceptor(clientInterceptorOptions));
+            var client = FoobarService.ConstructRpcClient(server.Target, new ClientTracingInterceptor(clientInterceptorOptions));
             clientRequestAction(client);
         }
 

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -35,7 +35,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task AsyncUnarySuccess() =>
         await TestHandlerSuccess(
             FoobarService.MakeUnaryAsyncRequest,
-            "Unary",
+            FoobarService.UnaryMethod,
             DefaultMetadataFunc());
 
     /// <summary>
@@ -46,7 +46,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task AsyncUnaryUnavailable() =>
         await TestHandlerFailure(
             FoobarService.MakeUnaryAsyncRequest,
-            "Unary",
+            FoobarService.UnaryMethod,
             StatusCode.Unavailable,
             validateErrorDescription: false,
             BogusServerUri);
@@ -57,7 +57,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task AsyncUnaryFail() =>
-        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest, "Unary");
+        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest, FoobarService.UnaryMethod);
 
     /// <summary>
     /// Validates a failed AsyncUnary call because the client is disposed before completing the RPC.
@@ -70,7 +70,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.UnaryAsync(FoobarService.DefaultRequestMessage);
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "Unary");
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, FoobarService.UnaryMethod);
     }
 
     /// <summary>
@@ -79,7 +79,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, "ClientStreaming", DefaultMetadataFunc());
+        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, FoobarService.ClientStreamingMethod, DefaultMetadataFunc());
 
     /// <summary>
     /// Validates a failed ClientStreaming call when the service is unavailable.
@@ -89,7 +89,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task ClientStreamingUnavailable() =>
         await TestHandlerFailure(
             FoobarService.MakeClientStreamingRequest,
-            "ClientStreaming",
+            FoobarService.ClientStreamingMethod,
             StatusCode.Unavailable,
             validateErrorDescription: false,
             BogusServerUri);
@@ -100,7 +100,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingFail() =>
-        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest, "ClientStreaming");
+        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest, FoobarService.ClientStreamingMethod);
 
     /// <summary>
     /// Validates a failed ClientStreaming call because the client is disposed before completing the RPC.
@@ -113,7 +113,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.ClientStreaming();
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "ClientStreaming");
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, FoobarService.ClientStreamingMethod);
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, "ServerStreaming", DefaultMetadataFunc());
+        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, FoobarService.ServerStreamingMethod, DefaultMetadataFunc());
 
     /// <summary>
     /// Validates a failed ServerStreaming call.
@@ -130,7 +130,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingFail() =>
-        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest, "ServerStreaming");
+        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest, FoobarService.ServerStreamingMethod);
 
     /// <summary>
     /// Validates a failed ServerStreaming call because the client is disposed before completing the RPC.
@@ -143,7 +143,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.ServerStreaming(FoobarService.DefaultRequestMessage);
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "ServerStreaming");
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, FoobarService.ServerStreamingMethod);
     }
 
     /// <summary>
@@ -152,7 +152,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming", DefaultMetadataFunc());
+        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, FoobarService.DuplexStreamingMethod, DefaultMetadataFunc());
 
     /// <summary>
     /// Validates a failed DuplexStreaming call when the service is unavailable.
@@ -162,7 +162,7 @@ public class GrpcCoreClientInterceptorTests
     public async Task DuplexStreamingUnavailable() =>
         await TestHandlerFailure(
             FoobarService.MakeDuplexStreamingRequest,
-            "DuplexStreaming",
+            FoobarService.DuplexStreamingMethod,
             StatusCode.Unavailable,
             validateErrorDescription: false,
             BogusServerUri);
@@ -173,7 +173,7 @@ public class GrpcCoreClientInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingFail() =>
-        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming");
+        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest, FoobarService.DuplexStreamingMethod);
 
     /// <summary>
     /// Validates a failed DuplexStreaming call because the client is disposed before completing the RPC.
@@ -186,7 +186,7 @@ public class GrpcCoreClientInterceptorTests
             using var call = client.DuplexStreaming();
         }
 
-        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, "DuplexStreaming");
+        this.TestActivityIsCancelledWhenHandlerDisposed(MakeRequest, FoobarService.DuplexStreamingMethod);
     }
 
     /// <summary>
@@ -316,7 +316,7 @@ public class GrpcCoreClientInterceptorTests
         Assert.NotNull(response);
 
         var activity = activityListener.Activity;
-        ValidateCommonActivityTags(activity, "Unary");
+        ValidateCommonActivityTags(activity, FoobarService.UnaryMethod);
         Assert.Empty(activity!.Events);
     }
 

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -19,7 +19,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task UnaryServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest);
+        await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest, "Unary");
 
     /// <summary>
     /// Validates a failed UnaryServerHandler call.
@@ -27,7 +27,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task UnaryServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest);
+        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest, "Unary");
 
     /// <summary>
     /// Validates a successful ClientStreamingServerHandler call.
@@ -35,7 +35,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest);
+        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, "ClientStreaming");
 
     /// <summary>
     /// Validates a failed ClientStreamingServerHandler call.
@@ -43,7 +43,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest);
+        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest, "ClientStreaming");
 
     /// <summary>
     /// Validates a successful ServerStreamingServerHandler call.
@@ -51,7 +51,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest);
+        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, "ServerStreaming");
 
     /// <summary>
     /// Validates a failed ServerStreamingServerHandler call.
@@ -59,7 +59,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest);
+        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest, "ServerStreaming");
 
     /// <summary>
     /// Validates a successful DuplexStreamingServerHandler call.
@@ -67,7 +67,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest);
+        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming");
 
     /// <summary>
     /// Validates a failed DuplexStreamingServerHandler call.
@@ -75,7 +75,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest);
+        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming");
 
     /// <summary>
     /// Validates that non protobuf payloads do not abort server RPCs when
@@ -129,7 +129,9 @@ public class GrpcCoreServerInterceptorTests
                 Assert.NotNull(response);
 
                 var activity = activityListener.Activity;
-                GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity);
+
+                GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity, "Unary");
+
                 Assert.Empty(activity!.Events);
             }
             finally
@@ -147,9 +149,13 @@ public class GrpcCoreServerInterceptorTests
     /// A common method to test server interceptor handler success.
     /// </summary>
     /// <param name="clientRequestFunc">The specific client request function.</param>
+    /// <param name="expectedMethodName">The expected gRPC method name.</param>
     /// <param name="additionalMetadata">The additional metadata, if any.</param>
     /// <returns>A Task.</returns>
-    private static async Task TestHandlerSuccess(Func<Foobar.FoobarClient, Metadata?, Task> clientRequestFunc, Metadata? additionalMetadata = null)
+    private static async Task TestHandlerSuccess(
+        Func<Foobar.FoobarClient, Metadata?, Task> clientRequestFunc,
+        string expectedMethodName,
+        Metadata? additionalMetadata = null)
     {
         // starts the server with the server interceptor
         var testTags = new TestActivityTags();
@@ -163,7 +169,13 @@ public class GrpcCoreServerInterceptorTests
             await clientRequestFunc(client, additionalMetadata);
 
             var activity = activityListener.Activity;
-            GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity, StatusCode.OK, interceptorOptions.RecordMessageEvents);
+
+            GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(
+                activity,
+                expectedMethodName,
+                StatusCode.OK,
+                interceptorOptions.RecordMessageEvents);
+
             Assert.NotNull(activity);
             Assert.Equal(default, activity.ParentSpanId);
         }
@@ -178,7 +190,13 @@ public class GrpcCoreServerInterceptorTests
             await clientRequestFunc(client, additionalMetadata).ConfigureAwait(false);
 
             var activity = activityListener.Activity;
-            GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity, StatusCode.OK, interceptorOptions.RecordMessageEvents);
+
+            GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(
+                activity,
+                expectedMethodName,
+                StatusCode.OK,
+                interceptorOptions.RecordMessageEvents);
+
             Assert.NotNull(activity);
             Assert.Equal(FoobarService.DefaultParentFromTraceparentHeader.SpanId, activity.ParentSpanId);
         }
@@ -188,9 +206,13 @@ public class GrpcCoreServerInterceptorTests
     /// A common method to test server interceptor handler failure.
     /// </summary>
     /// <param name="clientRequestFunc">The specific client request function.</param>
+    /// <param name="expectedMethodName">The expected gRPC method name.</param>
     /// <param name="additionalMetadata">The additional metadata, if any.</param>
     /// <returns>A Task.</returns>
-    private static async Task TestHandlerFailure(Func<Foobar.FoobarClient, Metadata?, Task> clientRequestFunc, Metadata? additionalMetadata = null)
+    private static async Task TestHandlerFailure(
+        Func<Foobar.FoobarClient, Metadata?, Task> clientRequestFunc,
+        string expectedMethodName,
+        Metadata? additionalMetadata = null)
     {
         // starts the server with the server interceptor
         var testTags = new TestActivityTags();
@@ -210,7 +232,14 @@ public class GrpcCoreServerInterceptorTests
         await Assert.ThrowsAsync<RpcException>(async () => await clientRequestFunc(client, additionalMetadata).ConfigureAwait(false));
 
         var activity = activityListener.Activity;
-        GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity, StatusCode.ResourceExhausted, interceptorOptions.RecordMessageEvents, interceptorOptions.RecordException);
+
+        GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(
+            activity,
+            expectedMethodName,
+            StatusCode.ResourceExhausted,
+            interceptorOptions.RecordMessageEvents,
+            interceptorOptions.RecordException);
+
         Assert.NotNull(activity);
         Assert.Equal(FoobarService.DefaultParentFromTraceparentHeader.SpanId, activity.ParentSpanId);
     }

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -19,7 +19,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task UnaryServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest, "Unary");
+        await TestHandlerSuccess(FoobarService.MakeUnaryAsyncRequest, FoobarService.UnaryMethod);
 
     /// <summary>
     /// Validates a failed UnaryServerHandler call.
@@ -27,7 +27,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task UnaryServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest, "Unary");
+        await TestHandlerFailure(FoobarService.MakeUnaryAsyncRequest, FoobarService.UnaryMethod);
 
     /// <summary>
     /// Validates a successful ClientStreamingServerHandler call.
@@ -35,7 +35,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, "ClientStreaming");
+        await TestHandlerSuccess(FoobarService.MakeClientStreamingRequest, FoobarService.ClientStreamingMethod);
 
     /// <summary>
     /// Validates a failed ClientStreamingServerHandler call.
@@ -43,7 +43,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ClientStreamingServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest, "ClientStreaming");
+        await TestHandlerFailure(FoobarService.MakeClientStreamingRequest, FoobarService.ClientStreamingMethod);
 
     /// <summary>
     /// Validates a successful ServerStreamingServerHandler call.
@@ -51,7 +51,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, "ServerStreaming");
+        await TestHandlerSuccess(FoobarService.MakeServerStreamingRequest, FoobarService.ServerStreamingMethod);
 
     /// <summary>
     /// Validates a failed ServerStreamingServerHandler call.
@@ -59,7 +59,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task ServerStreamingServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest, "ServerStreaming");
+        await TestHandlerFailure(FoobarService.MakeServerStreamingRequest, FoobarService.ServerStreamingMethod);
 
     /// <summary>
     /// Validates a successful DuplexStreamingServerHandler call.
@@ -67,7 +67,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingServerHandlerSuccess() =>
-        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming");
+        await TestHandlerSuccess(FoobarService.MakeDuplexStreamingRequest, FoobarService.DuplexStreamingMethod);
 
     /// <summary>
     /// Validates a failed DuplexStreamingServerHandler call.
@@ -75,7 +75,7 @@ public class GrpcCoreServerInterceptorTests
     /// <returns>A task.</returns>
     [Fact]
     public async Task DuplexStreamingServerHandlerFail() =>
-        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest, "DuplexStreaming");
+        await TestHandlerFailure(FoobarService.MakeDuplexStreamingRequest, FoobarService.DuplexStreamingMethod);
 
     /// <summary>
     /// Validates that non protobuf payloads do not abort server RPCs when
@@ -130,7 +130,7 @@ public class GrpcCoreServerInterceptorTests
 
                 var activity = activityListener.Activity;
 
-                GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity, "Unary");
+                GrpcCoreClientInterceptorTests.ValidateCommonActivityTags(activity, FoobarService.UnaryMethod);
 
                 Assert.Empty(activity!.Events);
             }

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -111,7 +111,7 @@ public class GrpcCoreServerInterceptorTests
         };
 
         server.Start();
-        var serverUriString = new Uri("dns:localhost:" + server.Ports.Single().BoundPort).ToString();
+        var serverUriString = $"dns:localhost:{server.Ports.Single().BoundPort}";
 
         try
         {
@@ -159,13 +159,19 @@ public class GrpcCoreServerInterceptorTests
     {
         // starts the server with the server interceptor
         var testTags = new TestActivityTags();
-        var interceptorOptions = new ServerTracingInterceptorOptions { Propagator = new TraceContextPropagator(), RecordMessageEvents = true, AdditionalTags = testTags.Tags };
+        var interceptorOptions = new ServerTracingInterceptorOptions
+        {
+            Propagator = new TraceContextPropagator(),
+            RecordMessageEvents = true,
+            AdditionalTags = testTags.Tags,
+        };
+
         using var server = FoobarService.Start(new ServerTracingInterceptor(interceptorOptions));
 
         // No parent Activity, no context from header
         using (var activityListener = new InterceptorActivityListener(testTags))
         {
-            var client = FoobarService.ConstructRpcClient(server.UriString);
+            var client = FoobarService.ConstructRpcClient(server.Target);
             await clientRequestFunc(client, additionalMetadata);
 
             var activity = activityListener.Activity;
@@ -184,7 +190,7 @@ public class GrpcCoreServerInterceptorTests
         using (var activityListener = new InterceptorActivityListener(testTags))
         {
             var client = FoobarService.ConstructRpcClient(
-                server.UriString,
+                server.Target,
                 additionalMetadata: [new Metadata.Entry("traceparent", FoobarService.DefaultTraceparentWithSampling)]);
 
             await clientRequestFunc(client, additionalMetadata).ConfigureAwait(false);
@@ -221,7 +227,7 @@ public class GrpcCoreServerInterceptorTests
 
         using var activityListener = new InterceptorActivityListener(testTags);
         var client = FoobarService.ConstructRpcClient(
-            server.UriString,
+            server.Target,
             additionalMetadata:
             [
                 new Metadata.Entry("traceparent", FoobarService.DefaultTraceparentWithSampling),

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/InterceptorActivityListener.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/InterceptorActivityListener.cs
@@ -23,19 +23,18 @@ internal sealed class InterceptorActivityListener : IDisposable
     {
         this.activityListener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == GrpcCoreInstrumentation.ActivitySourceName,
-            ActivityStarted = activity =>
+            Sample = static (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+            ShouldListenTo = static (source) => source.Name is "OpenTelemetry.Instrumentation.GrpcCore",
+            ActivityStarted = (activity) =>
             {
                 if (testTags.HasTestTags(activity))
                 {
                     this.Activity = activity;
                 }
             },
-            Sample = this.Sample,
         };
 
         ActivitySource.AddActivityListener(this.activityListener);
-        Debug.Assert(GrpcCoreInstrumentation.ActivitySource.HasListeners(), "activity source has no listeners");
     }
 
     /// <summary>
@@ -45,14 +44,5 @@ internal sealed class InterceptorActivityListener : IDisposable
 
     /// <inheritdoc/>
     public void Dispose()
-    {
-        this.activityListener.Dispose();
-    }
-
-    /// <summary>
-    /// Always sample.
-    /// </summary>
-    /// <param name="options">The options.</param>
-    /// <returns>a result.</returns>
-    private ActivitySamplingResult Sample(ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded;
+        => this.activityListener.Dispose();
 }

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufGrpcTestHelpers.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/NonProtobufGrpcTestHelpers.cs
@@ -14,7 +14,7 @@ internal static class NonProtobufGrpcTestHelpers
         new(
             MethodType.Unary,
             "OpenTelemetry.Instrumentation.GrpcCore.Tests.Foobar",
-            "Unary",
+            FoobarService.UnaryMethod,
             PayloadMarshaller,
             PayloadMarshaller);
 }

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcServer.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcServer.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Tests;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Tests;
 
@@ -15,7 +16,11 @@ internal sealed class GrpcServer<TService> : IAsyncDisposable
 {
     private IHost? host;
 
-    public int Port { get; private set; }
+    public Uri Address
+    {
+        get => field ?? throw new InvalidOperationException("Server has not been started.");
+        set;
+    }
 
     public async Task StartAsync()
     {
@@ -24,29 +29,45 @@ internal sealed class GrpcServer<TService> : IAsyncDisposable
             throw new InvalidOperationException("Server is already started.");
         }
 
-        // Allows gRPC client to call insecure gRPC services
-        // https://docs.microsoft.com/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.1#call-insecure-grpc-services-with-net-core-client
-        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-
-        this.Port = 0;
-
         var retryCount = 5;
-        while (retryCount > 0)
+        var attemptsRemaining = retryCount;
+
+        while (attemptsRemaining > 0)
         {
             try
             {
-                this.Port = Random.Shared.Next(2000, 5000);
-                this.host = this.CreateServer();
+                var uri = new UriBuilder()
+                {
+                    Host = "localhost",
+                    Port = TcpPortProvider.GetOpenPort(),
+                    Scheme = Uri.UriSchemeHttp,
+                }.Uri;
 
-                await this.host.StartAsync();
-                break;
+                var host = this.CreateServer(uri.Port);
+
+                try
+                {
+                    await host.StartAsync();
+
+                    this.host = host;
+                    this.Address = uri;
+
+                    return;
+                }
+                catch (Exception)
+                {
+                    host.Dispose();
+                    throw;
+                }
             }
             catch (IOException)
             {
-                retryCount--;
+                attemptsRemaining--;
                 this.host?.Dispose();
             }
         }
+
+        throw new InvalidOperationException($"Failed to start server within {retryCount} attempts.");
     }
 
     public async ValueTask DisposeAsync()
@@ -60,17 +81,14 @@ internal sealed class GrpcServer<TService> : IAsyncDisposable
         GC.SuppressFinalize(this);
     }
 
-    private IHost CreateServer()
+    private IHost CreateServer(int port)
     {
         var hostBuilder = Host.CreateDefaultBuilder()
             .ConfigureWebHostDefaults(webBuilder =>
             {
+                // Setup a HTTP/2 endpoint without TLS
                 webBuilder
-                    .ConfigureKestrel(options =>
-                    {
-                        // Setup a HTTP/2 endpoint without TLS.
-                        options.ListenLocalhost(this.Port, o => o.Protocols = HttpProtocols.Http2);
-                    })
+                    .ConfigureKestrel(options => options.ListenLocalhost(port, o => o.Protocols = HttpProtocols.Http2))
                     .UseStartup<Startup>();
             });
 

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcServer.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcServer.cs
@@ -19,7 +19,7 @@ internal sealed class GrpcServer<TService> : IAsyncDisposable
     public Uri Address
     {
         get => field ?? throw new InvalidOperationException("Server has not been started.");
-        set;
+        private set;
     }
 
     public async Task StartAsync()

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -85,9 +85,7 @@ public partial class GrpcTests
         Assert.Equal("greet.Greeter", activity.GetTagValue(SemanticConventions.AttributeRpcService));
         Assert.Equal("SayHello", activity.GetTagValue(SemanticConventions.AttributeRpcMethod));
 
-        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
         Assert.Equal(uri.Host, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-
         Assert.Equal(uri.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
 

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -15,7 +15,6 @@ using OpenTelemetry.Tests;
 #endif
 using OpenTelemetry.Instrumentation.Grpc.Tests.GrpcTestHelpers;
 using OpenTelemetry.Instrumentation.GrpcNetClient;
-using OpenTelemetry.Instrumentation.GrpcNetClient.Implementation;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -35,8 +34,7 @@ public partial class GrpcTests
         var enrichWithHttpRequestMessageCalled = false;
         var enrichWithHttpResponseMessageCalled = false;
 
-        var uri = new Uri($"{baseAddress}:1234");
-        var uriHostNameType = Uri.CheckHostName(uri.Host);
+        var uri = new UriBuilder(baseAddress) { Port = 1234 }.Uri;
 
         using var httpClient = ClientTestHelpers.CreateTestClient(async request =>
         {
@@ -70,7 +68,7 @@ public partial class GrpcTests
                 HttpClient = httpClient,
             });
             var client = new Greeter.GreeterClient(channel);
-            var rs = client.SayHello(new HelloRequest());
+            _ = client.SayHello(new HelloRequest());
         }
 
         Assert.Single(exportedItems);
@@ -83,20 +81,12 @@ public partial class GrpcTests
         Assert.NotEqual(default, activity.Context.SpanId);
 
         Assert.Equal($"greet.Greeter/SayHello", activity.DisplayName);
-        Assert.Equal("grpc", activity.GetTagValue(SemanticConventions.AttributeRpcSystem));
+        Assert.Equal("grpc", activity.GetTagValue(SemanticConventions.AttributeRpcSystemName));
         Assert.Equal("greet.Greeter", activity.GetTagValue(SemanticConventions.AttributeRpcService));
         Assert.Equal("SayHello", activity.GetTagValue(SemanticConventions.AttributeRpcMethod));
 
-        if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
-        {
-            Assert.Equal(uri.Host, activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
-            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-        }
-        else
-        {
-            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
-            Assert.Equal(uri.Host, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-        }
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
+        Assert.Equal(uri.Host, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
 
         Assert.Equal(uri.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
@@ -104,7 +94,7 @@ public partial class GrpcTests
         // Tags added by the library then removed from the instrumentation
         Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
         Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcStatusCodeTagName));
-        Assert.Equal(0, activity.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Equal(0, activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         if (shouldEnrich)
         {
@@ -119,7 +109,6 @@ public partial class GrpcTests
     [InlineData(false)]
     public void GrpcAndHttpClientInstrumentationIsInvoked(bool shouldEnrich)
     {
-        var uri = new Uri($"http://localhost:{this.server.Port}");
         var exportedItems = new List<Activity>();
 
         using var parent = new Activity("parent")
@@ -146,15 +135,13 @@ public partial class GrpcTests
                 .AddInMemoryExporter(exportedItems)
                 .Build())
         {
-            // With net5, based on the grpc changes, the quantity of default activities changed.
-            // TODO: This is a workaround. https://github.com/open-telemetry/opentelemetry-dotnet/issues/1490
-            using var channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions()
+            using var channel = GrpcChannel.ForAddress(this.server.Address, new GrpcChannelOptions()
             {
                 HttpClient = new HttpClient(),
             });
 
             var client = new Greeter.GreeterClient(channel);
-            var rs = client.SayHello(new HelloRequest());
+            _ = client.SayHello(new HelloRequest());
         }
 
         Assert.Equal(2, exportedItems.Count);
@@ -163,7 +150,7 @@ public partial class GrpcTests
 
         ValidateGrpcActivity(grpcSpan);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan.DisplayName);
-        Assert.Equal(0, grpcSpan.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Equal(0, grpcSpan.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
         Assert.Equal("POST", httpSpan.DisplayName);
         Assert.Equal(grpcSpan.SpanId, httpSpan.ParentSpanId);
 
@@ -179,10 +166,9 @@ public partial class GrpcTests
         }
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1727")]
+    [Fact]
     public void GrpcAndHttpClientInstrumentationWithSuppressInstrumentation()
     {
-        var uri = new Uri($"http://localhost:{this.server.Port}");
         var exportedItems = new List<Activity>();
 
         using var parent = new Activity("parent")
@@ -203,9 +189,9 @@ public partial class GrpcTests
             },
             (value) =>
             {
-                var channel = GrpcChannel.ForAddress(uri);
+                using var channel = GrpcChannel.ForAddress(this.server.Address);
                 var client = new Greeter.GreeterClient(channel);
-                var rs = client.SayHello(new HelloRequest());
+                _ = client.SayHello(new HelloRequest());
             });
         }
 
@@ -217,27 +203,30 @@ public partial class GrpcTests
 
         ValidateGrpcActivity(grpcSpan1);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan1.DisplayName);
-        Assert.Equal(0, grpcSpan1.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Equal(0, grpcSpan1.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         ValidateGrpcActivity(grpcSpan2);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan2.DisplayName);
-        Assert.Equal(0, grpcSpan2.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Equal(0, grpcSpan2.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         ValidateGrpcActivity(grpcSpan3);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan3.DisplayName);
-        Assert.Equal(0, grpcSpan3.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Equal(0, grpcSpan3.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         ValidateGrpcActivity(grpcSpan4);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan4.DisplayName);
-        Assert.Equal(0, grpcSpan4.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Equal(0, grpcSpan4.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
     }
 
+#if NET
     [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1727")]
+#else
+    [Fact]
+#endif
     public void GrpcPropagatesContextWithSuppressInstrumentationOptionSetToTrue()
     {
         try
         {
-            var uri = new Uri($"http://localhost:{this.server.Port}");
             var exportedItems = new List<Activity>();
 
             using var source = new ActivitySource("test-source");
@@ -269,9 +258,10 @@ public partial class GrpcTests
             {
                 using var activity = source.StartActivity("parent");
                 Assert.NotNull(activity);
-                var channel = GrpcChannel.ForAddress(uri);
+
+                using var channel = GrpcChannel.ForAddress(this.server.Address);
                 var client = new Greeter.GreeterClient(channel);
-                var rs = client.SayHello(new HelloRequest());
+                _ = client.SayHello(new HelloRequest());
             }
 
             var serverActivity = exportedItems.Single(activity => activity.OperationName == OperationNameHttpRequestIn);
@@ -298,7 +288,6 @@ public partial class GrpcTests
     {
         try
         {
-            var uri = new Uri($"http://localhost:{this.server.Port}");
             var exportedItems = new List<Activity>();
             using var source = new ActivitySource("test-source");
 
@@ -322,9 +311,9 @@ public partial class GrpcTests
                 .Build())
             {
                 using var activity = source.StartActivity("parent");
-                var channel = GrpcChannel.ForAddress(uri);
+                using var channel = GrpcChannel.ForAddress(this.server.Address);
                 var client = new Greeter.GreeterClient(channel);
-                var rs = client.SayHello(new HelloRequest(), headers);
+                _ = client.SayHello(new HelloRequest(), headers);
             }
 
             Assert.Equal(2, exportedItems.Count);
@@ -344,12 +333,11 @@ public partial class GrpcTests
         }
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1727")]
+    [Fact]
     public void GrpcClientInstrumentationRespectsSdkSuppressInstrumentation()
     {
         try
         {
-            var uri = new Uri($"http://localhost:{this.server.Port}");
             var exportedItems = new List<Activity>();
 
             using var source = new ActivitySource("test-source");
@@ -364,19 +352,16 @@ public partial class GrpcTests
 
             using (Sdk.CreateTracerProviderBuilder()
                 .AddSource("test-source")
-                .AddGrpcClientInstrumentation(o =>
-                {
-                    o.SuppressDownstreamInstrumentation = true;
-                })
+                .AddGrpcClientInstrumentation(o => o.SuppressDownstreamInstrumentation = true)
                 .AddInMemoryExporter(exportedItems)
                 .Build())
             {
                 using var activity = source.StartActivity("parent");
                 using (SuppressInstrumentationScope.Begin())
                 {
-                    var channel = GrpcChannel.ForAddress(uri);
+                    using var channel = GrpcChannel.ForAddress(this.server.Address);
                     var client = new Greeter.GreeterClient(channel);
-                    var rs = client.SayHello(new HelloRequest());
+                    _ = client.SayHello(new HelloRequest());
                 }
             }
 
@@ -425,8 +410,10 @@ public partial class GrpcTests
 
     private static void ValidateGrpcActivity(Activity activityToValidate)
     {
-        Assert.Equal(GrpcClientDiagnosticListener.ActivitySourceName, activityToValidate.Source.Name);
-        Assert.Equal(GrpcClientDiagnosticListener.Version, activityToValidate.Source.Version);
+        Assert.Equal("OpenTelemetry.Instrumentation.GrpcNetClient", activityToValidate.Source.Name);
+        Assert.NotNull(activityToValidate.Source.Version);
+        Assert.NotEmpty(activityToValidate.Source.Version);
         Assert.Equal(ActivityKind.Client, activityToValidate.Kind);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", activityToValidate.Source.TelemetrySchemaUrl);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
@@ -56,10 +56,13 @@ public partial class GrpcTests : IAsyncLifetime
             .AddInMemoryExporter(exportedItems)
             .Build();
 
-        var clientLoopbackAddresses = new[] { IPAddress.Loopback.ToString(), IPAddress.IPv6Loopback.ToString() };
-        var uri = new Uri($"http://localhost:{this.server.Port}");
+        var clientLoopbackAddresses = new[]
+        {
+            IPAddress.Loopback.ToString(),
+            IPAddress.IPv6Loopback.ToString(),
+        };
 
-        using var channel = GrpcChannel.ForAddress(uri);
+        using var channel = GrpcChannel.ForAddress(this.server.Address);
         var client = new Greeter.GreeterClient(channel);
         var returnMsg = client.SayHello(new HelloRequest()).Message;
 
@@ -93,7 +96,7 @@ public partial class GrpcTests : IAsyncLifetime
 
         // The following are http.* attributes that are also included on the span for the gRPC invocation.
         Assert.Equal("localhost", activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-        Assert.Equal(this.server.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
+        Assert.Equal(this.server.Address.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
         Assert.Equal("POST", activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethod));
         Assert.Equal("http", activity.GetTagValue(SemanticConventions.AttributeUrlScheme));
         Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeUrlPath));
@@ -127,10 +130,13 @@ public partial class GrpcTests : IAsyncLifetime
                 .AddInMemoryExporter(exportedItems)
                 .Build();
 
-            var clientLoopbackAddresses = new[] { IPAddress.Loopback.ToString(), IPAddress.IPv6Loopback.ToString() };
-            var uri = new Uri($"http://localhost:{this.server.Port}");
+            var clientLoopbackAddresses = new[]
+            {
+                IPAddress.Loopback.ToString(),
+                IPAddress.IPv6Loopback.ToString(),
+            };
 
-            using var channel = GrpcChannel.ForAddress(uri);
+            using var channel = GrpcChannel.ForAddress(this.server.Address);
             var client = new Greeter.GreeterClient(channel);
             var headers = new Metadata
             {
@@ -149,14 +155,14 @@ public partial class GrpcTests : IAsyncLifetime
 
             if (enableGrpcAspNetCoreSupport != null && enableGrpcAspNetCoreSupport.Equals("true", StringComparison.OrdinalIgnoreCase))
             {
-                Assert.Equal("grpc", activity.GetTagValue(SemanticConventions.AttributeRpcSystem));
+                Assert.Equal("grpc", activity.GetTagValue(SemanticConventions.AttributeRpcSystemName));
                 Assert.Equal("greet.Greeter", activity.GetTagValue(SemanticConventions.AttributeRpcService));
                 Assert.Equal("SayHello", activity.GetTagValue(SemanticConventions.AttributeRpcMethod));
                 Assert.Contains(activity.GetTagValue(SemanticConventions.AttributeNetPeerIp), clientLoopbackAddresses);
                 Assert.NotEqual(0, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
                 Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
                 Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcStatusCodeTagName));
-                Assert.Equal(0, activity.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+                Assert.Equal(0, activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
             }
             else
             {
@@ -167,12 +173,13 @@ public partial class GrpcTests : IAsyncLifetime
             Assert.Equal(ActivityStatusCode.Unset, activity.Status);
 
             // The following are http.* attributes that are also included on the span for the gRPC invocation.
-            Assert.Equal("localhost", activity.GetTagValue(SemanticConventions.AttributeNetHostName));
-            Assert.Equal(this.server.Port, activity.GetTagValue(SemanticConventions.AttributeNetHostPort));
-            Assert.Equal("POST", activity.GetTagValue(SemanticConventions.AttributeHttpMethod));
-            Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpTarget));
-            Assert.Equal($"http://localhost:{this.server.Port}/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpUrl));
-            Assert.StartsWith("grpc-dotnet", activity.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
+            Assert.Equal("localhost", activity.GetTagValue(SemanticConventions.AttributeServerAddress));
+            Assert.Equal(this.server.Address.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
+            Assert.Equal("POST", activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethod));
+            Assert.Equal("http", activity.GetTagValue(SemanticConventions.AttributeUrlScheme));
+            Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeUrlPath));
+            Assert.Equal("2", activity.GetTagValue(SemanticConventions.AttributeNetworkProtocolVersion));
+            Assert.StartsWith("grpc-dotnet", activity.GetTagValue(SemanticConventions.AttributeUserAgentOriginal) as string);
         }
         finally
         {

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.AspNetCore.Server" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETCoreApp'" />
     <PackageReference Include="Grpc.Net.Client" />
-    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" />
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" />

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\CustomTextMapPropagator.cs" Link="Includes\CustomTextMapPropagator.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestActivityExportProcessor.cs" Link="Includes\TestActivityExportProcessor.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
   </ItemGroup>

--- a/test/Shared/TcpPortProvider.cs
+++ b/test/Shared/TcpPortProvider.cs
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace OpenTelemetry.Tests;
+
+/// <summary>
+/// Helper class that tries to provide unique ports numbers across processes and threads in the same machine.
+/// This class cannot guarantee a port is actually available, but should help avoid most conflicts.
+/// </summary>
+internal static class TcpPortProvider
+{
+    public static int GetOpenPort()
+    {
+        TcpListener? tcpListener = null;
+
+        try
+        {
+            tcpListener = new TcpListener(IPAddress.Loopback, 0);
+            tcpListener.Start();
+
+            var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+
+            return port;
+        }
+        finally
+        {
+#if NET
+            tcpListener?.Dispose();
+#else
+            tcpListener?.Stop();
+#endif
+
+        }
+    }
+}

--- a/test/Shared/TcpPortProvider.cs
+++ b/test/Shared/TcpPortProvider.cs
@@ -7,7 +7,7 @@ using System.Net.Sockets;
 namespace OpenTelemetry.Tests;
 
 /// <summary>
-/// Helper class that tries to provide unique ports numbers across processes and threads in the same machine.
+/// Helper class that tries to provide unique port numbers across processes and threads in the same machine.
 /// This class cannot guarantee a port is actually available, but should help avoid most conflicts.
 /// </summary>
 internal static class TcpPortProvider

--- a/test/Shared/TestWebSocketServer.cs
+++ b/test/Shared/TestWebSocketServer.cs
@@ -100,10 +100,10 @@ internal static class TestWebSocketServer
             //                                 genuine failure that happens to surface as code 1
             return ex is ObjectDisposedException
                 || (ex is HttpListenerException httpEx
-                    && (httpEx.ErrorCode == 995
-                        || httpEx.ErrorCode == 6
-                        || (httpEx.ErrorCode == 1 && !this.listener.IsListening)))
-                || (ex is InvalidOperationException && !this.listener.IsListening);
+                    && (httpEx.ErrorCode is 6 or 995 ||
+                        (httpEx.ErrorCode == 1 && !this.listener.IsListening)))
+                || (ex is InvalidOperationException && !this.listener.IsListening)
+                || (ex is ApplicationException appEx && (uint)appEx.HResult == 0x80070006); // The handle is invalid.
         }
 
         private async Task ListenAsync(Func<HttpListenerContext, WebSocket, Task> handler)


### PR DESCRIPTION
Fixes #4335
Contributes to #4064

## Changes

- Update to [v1.41.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.41.0/docs/rpc/rpc-spans.md) of the gRPC Semantic Conventions.
- ~~Add `net8.0` and `net10.0` TFMs for GrpcCore instrumentation.~~
- Improve gRPC test server fixture.
- Improve GrpcCore tests.
- Remove obsolete code.
- Unskip tests that pass.
- Apply Visual Studio refactor suggestions.
- Add `net462` target to GrpcCore tests.
- Fix broken behaviour in GrpcCore for .NET Framework found through testing.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
