### PR TITLE
[Shared.SqlProcessor] Add quadratic scan for malformed brackets in SQL sanitization

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -6,6 +6,10 @@
   clauses to avoid leaking following literal values.
   ([#4317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4317))
 
+* Fix SQL query text sanitization performance for malformed `FROM` clauses with
+  repeated unterminated bracketed identifiers.
+  ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -13,6 +13,10 @@
   clauses to avoid leaking following literal values.
   ([#4317](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4317))
 
+* Fix SQL query text sanitization performance for malformed `FROM` clauses with
+  repeated unterminated bracketed identifiers.
+  ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -229,8 +229,13 @@ internal static class SqlProcessor
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool HasTerminatingEscapedIdentifier(ReadOnlySpan<char> sql, int start)
+    private static bool HasTerminatingEscapedIdentifier(ReadOnlySpan<char> sql, int start, ref ParseState state)
     {
+        if (state.NoTerminatingEscapedIdentifierAhead)
+        {
+            return false;
+        }
+
         for (var i = start + 1; i < sql.Length; i++)
         {
             if (sql[i] == CloseSquareBracketChar)
@@ -246,6 +251,7 @@ internal static class SqlProcessor
             }
         }
 
+        state.NoTerminatingEscapedIdentifierAhead = true;
         return false;
     }
 
@@ -649,7 +655,7 @@ internal static class SqlProcessor
 
             if (state.CaptureNextNonKeywordTokenAsIdentifier
                 && currentChar is OpenSquareBracketChar
-                && HasTerminatingEscapedIdentifier(sql, state.ParsePosition))
+                && HasTerminatingEscapedIdentifier(sql, state.ParsePosition, ref state))
             {
                 state.InEscapedIdentifier = true;
                 AppendSummaryChar(OpenSquareBracketChar, ref state);
@@ -1022,6 +1028,11 @@ internal static class SqlProcessor
         /// Used to track if we are in an escaped identifier (e.g., "[table]").
         /// </summary>
         public bool InEscapedIdentifier; // 1 byte
+
+        /// <summary>
+        /// Used to avoid repeatedly scanning to the end of malformed SQL after finding an unterminated escaped identifier.
+        /// </summary>
+        public bool NoTerminatingEscapedIdentifierAhead; // 1 byte
 
         /// <summary>
         /// Used to track if we are in a FROM clause for special handling of comma-separated table lists.

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
@@ -49,6 +49,19 @@ public class SqlProcessorTests
         Assert.Equal("SELECT * FROM [Orders WHERE CustomerName = ? AND Id = ? AND Token = ?", sqlStatementInfo.SanitizedSql);
     }
 
+    [Fact]
+    public void GetSanitizedSql_RepeatedUnterminatedEscapedIdentifiersInFromClause_SanitizesLiterals()
+    {
+        var sql = $"SELECT * FROM {new string('[', 4096)} WHERE CustomerName = 'secret-name' AND Id = 123 AND Token = 0xDEADBEEF";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        Assert.Contains("?", sqlStatementInfo.SanitizedSql);
+        Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
+        Assert.DoesNotContain("123", sqlStatementInfo.SanitizedSql);
+        Assert.DoesNotContain("DEADBEEF", sqlStatementInfo.SanitizedSql);
+    }
+
     [SkippableTheory]
     [MemberData(nameof(TestData))]
     public void TestGetSanitizedSql(SqlProcessorTestCases.TestCase testCase)


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fix SQL query text sanitization performance for malformed `FROM` clauses with repeated unterminated bracketed identifiers.
  
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
