### PR TITLE
[Instrumentation.AspNet] Fix IndexOutOfRangeException in route token matching

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed route template token matching so short route parameters no longer throw
+  `IndexOutOfRangeException` during route extraction.
+  ([#4340](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4340))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
@@ -51,8 +51,13 @@ internal sealed class HttpRequestRouteHelper
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CompareStringToSubstring(string example, string target, int start)
+    private static bool CompareStringToSubstring(string example, string target, int start, int end)
     {
+        if (end - start - 1 != example.Length)
+        {
+            return false;
+        }
+
         for (var i = 0; i < example.Length; i++)
         {
             if (target[start + 1 + i] != example[i])
@@ -84,11 +89,11 @@ internal sealed class HttpRequestRouteHelper
                 var end = template.IndexOf('}', i + 1);
                 if (end != -1)
                 {
-                    if (hasController && CompareStringToSubstring(controllerToken, template, i))
+                    if (hasController && CompareStringToSubstring(controllerToken, template, i, end))
                     {
                         sb.Append(controller);
                     }
-                    else if (hasAction && CompareStringToSubstring(actionToken, template, i))
+                    else if (hasAction && CompareStringToSubstring(actionToken, template, i, end))
                     {
                         sb.Append(action);
                     }

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -42,6 +42,7 @@ public class HttpInListenerTests
     [InlineData("http://localhost:80/Weather/Today/10", "http", "/Weather/Today/10", null, null, "localhost", 80, "GET", "GET", null, 1, "{controller}/{action}/{id}", "GET", "GET Weather/Today/{id}")]
     [InlineData("https://localhost:443/about_attr_route/10", "https", "/about_attr_route/10", null, null, "localhost", 443, "HEAD", "HEAD", null, 2, "about_attr_route/{customerId}", "HEAD", "HEAD about_attr_route/{customerId}")]
     [InlineData("http://localhost:1880/api/WeatherForecast", "http", "/api/WeatherForecast", null, null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{id}", "GET", "GET api/WeatherForecast")]
+    [InlineData("http://localhost:1880/api/WeatherForecast/Details", "http", "/api/WeatherForecast/Details", null, null, "localhost", 1880, "GET", "GET", null, 3, "api/{controller}/{actionName}", "GET", "GET api/WeatherForecast/{actionName}")]
     [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 4, "subroute/{customerId}", "GET", "GET subroute/{customerId}")]
     [InlineData("https://localhost:1843/subroute/10", "https", "/subroute/10", null, null, "localhost", 1843, "GET", "GET", null, 5, "subroute/{customerId}", "GET", "GET subroute/{customerId}")]
     [InlineData("http://localhost/api/value", "http", "/api/value", null, null, "localhost", 80, "GET", "GET", null, 0, null, "GET", "GET", false, "/api/value")] // Request will be filtered

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -21,6 +21,7 @@ public class HttpInMetricsListenerTests
     [InlineData("http://localhost/api/Values/5", 3, "api/{controller}/{id}", null, "http", "localhost", "api/Values/{id}", 80, 200)]
     [InlineData("http://localhost/api/Values/5", 4, "api/Values/{id}", null, "http", "localhost", "api/Values/{id}", 80, 200)]
     [InlineData("http://localhost/api/Values/5", 1, "api/{controller}/{id}", null, "http", "localhost", "api/Values/{id}", 80, 500)]
+    [InlineData("http://localhost/api/Values/Details", 3, "api/{controller}/{actionName}", null, "http", "localhost", "api/Values/{actionName}", 80, 200)]
     [InlineData("http://localhost:8080/api/Values/5", 0, null, null, "http", "localhost", null, 8080, 200)]
     [InlineData("http://localhost:8080/api/Values/5", 1, "api/{controller}/{id}", null, "http", "localhost", "api/Values/{id}", 8080, 200)]
     [InlineData("http://localhost:8080/api/Values/5", 3, "api/{controller}/{id}", "enrich", "http", "localhost", "api/Values/{id}", 8080, 200)]


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed route template token matching so parameters whose names only share a prefix with `controller` or `action` are preserved correctly.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
