### PR TITLE
[SemanticConvention] fix SEMCONV_VERSION typo in generate.sh

### DIFF
--- a/src/OpenTelemetry.SemanticConventions/scripts/generate.sh
+++ b/src/OpenTelemetry.SemanticConventions/scripts/generate.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/../"
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-SEMCONV_VERSION="1.51.0"
+SEMCONV_VERSION="1.41.0"
 GENERATOR_VERSION="v0.23.0"
 
 cd ${SCRIPT_DIR}


### PR DESCRIPTION
## Fixes

`scripts/generate.sh` line 8 pinned `SEMCONV_VERSION="1.51.0"`, but the latest released `open-telemetry/semantic-conventions` spec is **v1.41.0** (matching the contents currently committed under `Attributes/`, generated as part of #4313). Running the script as-is fails at the `git fetch origin "v$SEMCONV_VERSION"` step because the `v1.51.0` tag does not exist upstream.

The PowerShell variant (`scripts/generate.ps1`) was already correct at `1.41.0`; this PR aligns the bash script with it.

## Verification

After the fix, re-running `./scripts/generate.sh` regenerates `Attributes/*.cs` **byte-identically** to the current committed output:

```
$ bash scripts/generate.sh
... (90 files generated) ...
✔ Artifacts generated successfully
Total execution time: 0.247s

$ git status --short src/OpenTelemetry.SemanticConventions/Attributes/
(no changes)
```

Confirms PR #4313 was a clean v1.41.0 generation and the script is fully reproducible after this typo fix.

## Changelog

Will be added on request — this is a contributor-tooling fix only and doesn't change the generated NuGet package contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)