### PR TITLE
[Instrumentation.AspNet] Fix stop callback can crash requests

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -203,9 +203,9 @@ internal static class ActivityHelper
         {
             callback?.Invoke(aspNetActivity, context);
         }
-        catch (Exception callbackEx)
+        catch (Exception ex)
         {
-            AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, eventName, callbackEx);
+            AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, eventName, ex);
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -114,7 +114,7 @@ internal static class ActivityHelper
 
             // This is the case where a start was called but no activity was
             // created due to a sampling decision.
-            onRequestStoppedInstrumentationCallback?.Invoke(aspNetActivity, context);
+            InvokeRequestStoppedCallback(aspNetActivity, context, onRequestStoppedInstrumentationCallback, "OnInstrumentationStopped");
             context.Items[ContextKey] = null;
             return;
         }
@@ -131,16 +131,9 @@ internal static class ActivityHelper
             aspNetActivity.SetEndTime(ActivityDateTimeHelper.GetUtcNow());
         }
 
-        onRequestStoppedInstrumentationCallback?.Invoke(aspNetActivity, context);
+        InvokeRequestStoppedCallback(aspNetActivity, context, onRequestStoppedInstrumentationCallback, "OnInstrumentationStopped");
 
-        try
-        {
-            onRequestStoppedCallback?.Invoke(aspNetActivity, context);
-        }
-        catch (Exception callbackEx)
-        {
-            AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, "OnStopped", callbackEx);
-        }
+        InvokeRequestStoppedCallback(aspNetActivity, context, onRequestStoppedCallback, "OnStopped");
 
         aspNetActivity.Stop();
         AspNetTelemetryEventSource.Log.ActivityStopped(aspNetActivity);
@@ -197,6 +190,22 @@ internal static class ActivityHelper
             }
 
             AspNetTelemetryEventSource.Log.ActivityRestored(contextHolder.Activity);
+        }
+    }
+
+    private static void InvokeRequestStoppedCallback(
+        Activity? aspNetActivity,
+        HttpContextBase context,
+        Action<Activity?, HttpContextBase>? callback,
+        string eventName)
+    {
+        try
+        {
+            callback?.Invoke(aspNetActivity, context);
+        }
+        catch (Exception callbackEx)
+        {
+            AspNetTelemetryEventSource.Log.CallbackException(aspNetActivity, eventName, callbackEx);
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -6,6 +6,10 @@
   created.
   ([#4307](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4307))
 
+* Fixed internal request stop instrumentation callback exception handling so
+  telemetry processing failures do not escape request stop processing.
+  ([#4344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4344))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -6,6 +6,10 @@
   `IndexOutOfRangeException` during route extraction.
   ([#4340](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4340))
 
+* Fixed route template extraction for routes with missing MVC route values or
+  `null` defaults.
+  ([#4344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4344))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpRequestRouteHelper.cs
@@ -23,7 +23,11 @@ internal sealed class HttpRequestRouteHelper
     /// <returns>The route template or <see langword="null"/>.</returns>
     internal string? GetRouteTemplate(HttpRequestBase request)
     {
-        var routeData = request.RequestContext.RouteData;
+        var routeData = request.RequestContext?.RouteData;
+        if (routeData == null)
+        {
+            return null;
+        }
 
         string? template = null;
         if (routeData.Values.TryGetValue("MS_SubRoutes", out var msSubRoutes))
@@ -75,8 +79,13 @@ internal sealed class HttpRequestRouteHelper
         const string actionToken = "action";
 
         var template = route.Url;
-        var controller = (string)routeData.Values[controllerToken];
-        var action = (string)routeData.Values[actionToken];
+        if (string.IsNullOrEmpty(template))
+        {
+            return template;
+        }
+
+        var controller = routeData.Values[controllerToken] as string;
+        var action = routeData.Values[actionToken] as string;
         var hasController = !string.IsNullOrWhiteSpace(controller);
         var hasAction = !string.IsNullOrWhiteSpace(action);
         var sb = new StringBuilder(template.Length);
@@ -103,7 +112,7 @@ internal sealed class HttpRequestRouteHelper
                         var values = routeData.Values;
                         var token = template.Substring(i + 1, end - i - 1);
 
-                        if (defaults.ContainsKey(token) && !values.ContainsKey(token))
+                        if (defaults != null && defaults.ContainsKey(token) && !values.ContainsKey(token))
                         {
                             // Ignore defaults with no values.
                         }

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -377,6 +377,57 @@ public class ActivityHelperTest : IDisposable
     }
 
     [Fact]
+    public void Should_Handle_Instrumentation_Stop_Callback_Exception()
+    {
+        this.EnableListener();
+        var context = HttpContextHelper.GetFakeHttpContextBase();
+        using var rootActivity = ActivityHelper.StartAspNetActivity(this.noopTextMapPropagator, context, this.StartTestActivity)!;
+
+        var publicCallbackFired = false;
+        context.Items[StopInstrumentationCallbackContextKey] = (Action<Activity?, HttpContextBase>)((_, _) =>
+        {
+            throw new InvalidOperationException();
+        });
+
+        var exception = Record.Exception(() => ActivityHelper.StopAspNetActivity(
+            this.noopTextMapPropagator,
+            rootActivity,
+            context,
+            (_, _) => publicCallbackFired = true));
+
+        Assert.Null(exception);
+        Assert.True(publicCallbackFired);
+        Assert.True(rootActivity.Duration != TimeSpan.Zero);
+        Assert.Null(context.Items[ActivityHelper.ContextKey]);
+        Assert.Null(context.Items[StopInstrumentationCallbackContextKey]);
+    }
+
+    [Fact]
+    public void Should_Handle_Instrumentation_Stop_Callback_Exception_Without_RootActivity()
+    {
+        var context = HttpContextHelper.GetFakeHttpContextBase();
+        using var rootActivity = ActivityHelper.StartAspNetActivity(this.noopTextMapPropagator, context, null);
+
+        Assert.Null(rootActivity);
+        Assert.Equal(ActivityHelper.StartedButNotSampledObj, context.Items[ActivityHelper.ContextKey]);
+
+        context.Items[StopInstrumentationCallbackContextKey] = (Action<Activity?, HttpContextBase>)((_, _) =>
+        {
+            throw new InvalidOperationException();
+        });
+
+        var exception = Record.Exception(() => ActivityHelper.StopAspNetActivity(
+            this.noopTextMapPropagator,
+            rootActivity,
+            context,
+            onRequestStoppedCallback: null));
+
+        Assert.Null(exception);
+        Assert.Null(context.Items[ActivityHelper.ContextKey]);
+        Assert.Null(context.Items[StopInstrumentationCallbackContextKey]);
+    }
+
+    [Fact]
     public void Can_Create_RootActivity_From_W3C_Traceparent()
     {
         this.EnableListener();

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpRequestRouteHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpRequestRouteHelperTests.cs
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Web;
+using System.Web.Routing;
+using OpenTelemetry.Instrumentation.AspNet.Implementation;
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.AspNet.Tests;
+
+public class HttpRequestRouteHelperTests
+{
+    [Fact]
+    public void GetRouteTemplate_DoesNotThrow_WhenRouteDefaultsAreNull()
+    {
+        var request = new HttpRequest(string.Empty, "http://localhost/custom/value", string.Empty)
+        {
+            RequestContext = new RequestContext
+            {
+                RouteData = new RouteData
+                {
+                    Route = new Route("custom/{value}", routeHandler: null),
+                },
+            },
+        };
+
+        var routeHelper = new HttpRequestRouteHelper();
+
+        var template = routeHelper.GetRouteTemplate(new HttpRequestWrapper(request));
+
+        Assert.Equal("custom/{value}", template);
+    }
+
+    [Fact]
+    public void GetRouteTemplate_DoesNotThrow_WhenControllerAndActionAreMissing()
+    {
+        var request = new HttpRequest(string.Empty, "http://localhost/custom/value", string.Empty)
+        {
+            RequestContext = new RequestContext
+            {
+                RouteData = new RouteData
+                {
+                    Route = new Route("custom/{controller}/{action}/{value}", routeHandler: null),
+                },
+            },
+        };
+
+        var routeHelper = new HttpRequestRouteHelper();
+
+        var template = routeHelper.GetRouteTemplate(new HttpRequestWrapper(request));
+
+        Assert.Equal("custom/{controller}/{action}/{value}", template);
+    }
+}


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed route template extraction for routes with missing MVC route values or `null` defaults.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
