### PR TITLE
[infra] Use package repository URL to avoid leaking credentials in Git remote

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -102,7 +102,7 @@
     <PropertyGroup>
       <MarkdownCommentRegex>\[([^]]+?)\]\(\.(.+?)\)</MarkdownCommentRegex>
       <!-- Use the package repository URL instead of git remote origin because remotes may include credentials. -->
-      <GitHubRepoUrl>$(RepositoryUrl.Replace('.git',''))</GitHubRepoUrl>
+      <GitHubRepoUrl>$(RepositoryUrl)</GitHubRepoUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' != ''">$(GitHubRepoUrl)/blob/$(PackTag)</GitHubPermalinkUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' == ''">$(GitHubRepoUrl)/blob/$(GitCommitConsoleOutput)</GitHubPermalinkUrl>
     </PropertyGroup>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -99,23 +99,15 @@
       <Output PropertyName="GitCommitExitCode" TaskParameter="ExitCode"/>
     </Exec>
 
-    <Exec
-      Command="git remote get-url origin"
-      ConsoleToMsBuild="True"
-      IgnoreExitCode="True"
-      StandardOutputImportance="low">
-      <Output PropertyName="GitOriginConsoleOutput" TaskParameter="ConsoleOutput"/>
-      <Output PropertyName="GitOriginExitCode" TaskParameter="ExitCode"/>
-    </Exec>
-
     <PropertyGroup>
       <MarkdownCommentRegex>\[([^]]+?)\]\(\.(.+?)\)</MarkdownCommentRegex>
-      <GitHubRepoUrl>$(GitOriginConsoleOutput.Replace('.git',''))</GitHubRepoUrl>
+      <!-- Use the package repository URL instead of git remote origin because remotes may include credentials. -->
+      <GitHubRepoUrl>$(RepositoryUrl.Replace('.git',''))</GitHubRepoUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' != ''">$(GitHubRepoUrl)/blob/$(PackTag)</GitHubPermalinkUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' == ''">$(GitHubRepoUrl)/blob/$(GitCommitConsoleOutput)</GitHubPermalinkUrl>
     </PropertyGroup>
 
-    <Message Importance="high" Text="**GitInformationDebug** GitCommitConsoleOutput: $(GitCommitConsoleOutput), GitCommitExitCode: $(GitCommitExitCode), GitOriginConsoleOutput: $(GitOriginConsoleOutput), GitOriginExitCode: $(GitOriginExitCode), GitHubPermalinkUrl: $(GitHubPermalinkUrl)" />
+    <Message Importance="high" Text="**GitInformationDebug** GitCommitConsoleOutput: $(GitCommitConsoleOutput), GitCommitExitCode: $(GitCommitExitCode), GitHubPermalinkUrl: $(GitHubPermalinkUrl)" />
 
     <ItemGroup>
       <PackageMarkdownFiles Include="README.md" />


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Use package repository URL to avoid leaking credentials in Git remote

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~Unit tests added/updated~
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~
