### PR TITLE
[PersistentStorage.FileSystem] Fix null byte buffers create empty file blobs

### DIFF
--- a/src/OpenTelemetry.PersistentStorage.FileSystem/FileBlobProvider.cs
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/FileBlobProvider.cs
@@ -114,14 +114,18 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
 
     protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob)
     {
-        blob = this.CreateFileBlob(new ReadOnlySpan<byte>(buffer), leasePeriodMilliseconds);
+        Guard.ThrowIfNull(buffer);
+
+        blob = this.CreateFileBlob(buffer.AsSpan(), leasePeriodMilliseconds);
 
         return blob != null;
     }
 
     protected override bool OnTryCreateBlob(byte[] buffer, [NotNullWhen(true)] out PersistentBlob? blob)
     {
-        blob = this.CreateFileBlob(new ReadOnlySpan<byte>(buffer));
+        Guard.ThrowIfNull(buffer);
+
+        blob = this.CreateFileBlob(buffer.AsSpan());
 
         return blob != null;
     }

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
@@ -66,6 +66,25 @@ public class FileBlobProviderTests
     }
 
     [Fact]
+    public void FileBlobProvider_CreateBlobReturnsFalseForNullByteArray()
+    {
+        var testDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+        using var blobProvider = new FileBlobProvider(testDirectory.FullName);
+        byte[] buffer = null!;
+
+#pragma warning disable CS0618 // Validate obsolete byte[] overload compatibility.
+        Assert.False(blobProvider.TryCreateBlob(buffer, out var blob));
+        Assert.False(blobProvider.TryCreateBlob(buffer, 1000, out var leasedBlob));
+#pragma warning restore CS0618
+
+        Assert.Null(blob);
+        Assert.Null(leasedBlob);
+        Assert.Empty(Directory.EnumerateFiles(blobProvider.DirectoryPath));
+
+        testDirectory.Delete(true);
+    }
+
+    [Fact]
     public void FileBlobProvider_TestRetentionPeriod()
     {
         var testDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
@@ -66,16 +66,15 @@ public class FileBlobProviderTests
     }
 
     [Fact]
+    [Obsolete("Validates obsolete byte[] overload compatibility.")]
     public void FileBlobProvider_CreateBlobReturnsFalseForNullByteArray()
     {
         var testDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
         using var blobProvider = new FileBlobProvider(testDirectory.FullName);
         byte[] buffer = null!;
 
-#pragma warning disable CS0618 // Validate obsolete byte[] overload compatibility.
         Assert.False(blobProvider.TryCreateBlob(buffer, out var blob));
         Assert.False(blobProvider.TryCreateBlob(buffer, 1000, out var leasedBlob));
-#pragma warning restore CS0618
 
         Assert.Null(blob);
         Assert.Null(leasedBlob);


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fix `FileBlobProvider` obsolete `byte[]` overloads to reject null buffers instead of creating empty blobs.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~
