### PR TITLE
[Instrumentation.Wcf] Fix incorrect session support advertising in instrumented channels

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -10,6 +10,10 @@
   operation has a `null` Action (e.g., when WCF service help pages are enabled).
   ([#4026](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4026))
 
+* Fixed an issue where non-session WCF client channels could be wrapped in
+  instrumented channel types that incorrectly advertised session support.
+  ([#4368](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4368))
+
 ## 1.15.1-beta.2
 
 Released 2026-Apr-22

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedChannelFactory.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedChannelFactory.cs
@@ -27,10 +27,14 @@ internal sealed class InstrumentedChannelFactory<TChannel> : InstrumentedChannel
     {
         Guard.ThrowIfNull(innerChannel);
 
-        return typeof(TChannel) == typeof(IRequestChannel) || typeof(TChannel) == typeof(IRequestSessionChannel)
+        return typeof(TChannel) == typeof(IRequestChannel)
             ? (TChannel)(IRequestChannel)new InstrumentedRequestChannel((IRequestChannel)innerChannel)
-            : typeof(TChannel) == typeof(IDuplexChannel) || typeof(TChannel) == typeof(IDuplexSessionChannel)
+            : typeof(TChannel) == typeof(IRequestSessionChannel)
+            ? (TChannel)(IRequestSessionChannel)new InstrumentedRequestSessionChannel((IRequestSessionChannel)innerChannel)
+            : typeof(TChannel) == typeof(IDuplexChannel)
             ? (TChannel)(IDuplexChannel)new InstrumentedDuplexChannel((IDuplexChannel)innerChannel, this.binding.SendTimeout)
+            : typeof(TChannel) == typeof(IDuplexSessionChannel)
+            ? (TChannel)(IDuplexSessionChannel)new InstrumentedDuplexSessionChannel((IDuplexSessionChannel)innerChannel, this.binding.SendTimeout)
             : throw new NotImplementedException();
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
@@ -7,7 +7,7 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
 
-internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexChannel>, IDuplexSessionChannel
+internal class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexChannel>, IDuplexChannel
 {
     private readonly TimeSpan telemetryTimeout;
 
@@ -22,8 +22,6 @@ internal sealed class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexCha
     public EndpointAddress RemoteAddress => this.Inner.RemoteAddress;
 
     public Uri Via => this.Inner.Via;
-
-    public IDuplexSession Session => ((IDuplexSessionChannel)this.Inner).Session;
 
     public void Send(Message message)
     {

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexSessionChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexSessionChannel.cs
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.ServiceModel.Channels;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
+
+internal sealed class InstrumentedDuplexSessionChannel : InstrumentedDuplexChannel, IDuplexSessionChannel
+{
+    private readonly IDuplexSessionChannel inner;
+
+    public InstrumentedDuplexSessionChannel(IDuplexSessionChannel inner, TimeSpan telemetryTimeout)
+        : base(inner, telemetryTimeout)
+    {
+        this.inner = inner;
+    }
+
+    public IDuplexSession Session => this.inner.Session;
+}

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
@@ -7,7 +7,7 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
 
-internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestChannel>, IRequestSessionChannel
+internal class InstrumentedRequestChannel : InstrumentedChannel<IRequestChannel>, IRequestChannel
 {
     public InstrumentedRequestChannel(IRequestChannel inner)
         : base(inner)
@@ -17,8 +17,6 @@ internal sealed class InstrumentedRequestChannel : InstrumentedChannel<IRequestC
     EndpointAddress IRequestChannel.RemoteAddress => this.Inner.RemoteAddress;
 
     Uri IRequestChannel.Via => this.Inner.Via;
-
-    IOutputSession ISessionChannel<IOutputSession>.Session => ((ISessionChannel<IOutputSession>)this.Inner).Session;
 
     Message IRequestChannel.Request(Message message)
     {

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestSessionChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestSessionChannel.cs
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.ServiceModel.Channels;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Implementation;
+
+internal sealed class InstrumentedRequestSessionChannel : InstrumentedRequestChannel, IRequestSessionChannel
+{
+    private readonly IRequestSessionChannel inner;
+
+    public InstrumentedRequestSessionChannel(IRequestSessionChannel inner)
+        : base(inner)
+    {
+        this.inner = inner;
+    }
+
+    IOutputSession ISessionChannel<IOutputSession>.Session => this.inner.Session;
+}

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
@@ -61,6 +61,24 @@ public class InstrumentedChannelAsyncCallbackTests
         Assert.Same(state, inner.LastBeginReceiveArgs[1]);
     }
 
+    [Fact]
+    public void RequestChannel_DoesNotAdvertiseSessionWhenInnerChannelDoesNotSupportIt()
+    {
+        var inner = new RecordingRequestChannel();
+        var channel = new InstrumentedRequestChannel(inner);
+
+        Assert.IsNotAssignableFrom<IRequestSessionChannel>(channel);
+    }
+
+    [Fact]
+    public void DuplexChannel_DoesNotAdvertiseSessionWhenInnerChannelDoesNotSupportIt()
+    {
+        var inner = new RecordingDuplexChannel();
+        var channel = new InstrumentedDuplexChannel(inner, TimeSpan.FromSeconds(1));
+
+        Assert.IsNotAssignableFrom<IDuplexSessionChannel>(channel);
+    }
+
     private sealed class FakeAsyncResult : IAsyncResult
     {
         public FakeAsyncResult(object? asyncState)

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelFactoryTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelFactoryTests.cs
@@ -8,57 +8,30 @@ using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 
-public class InstrumentedChannelAsyncCallbackTests
+public class InstrumentedChannelFactoryTests
 {
     [Fact]
-    public void BeginRequest_AllowsNullAsyncCallback()
+    public void CreateChannel_ForRequestChannel_DoesNotAdvertiseSessionWhenInnerChannelDoesNotSupportIt()
     {
-        var inner = new RecordingRequestChannel();
-        var channel = (IRequestChannel)new InstrumentedRequestChannel(inner);
-        var state = new object();
+        var innerChannel = new RecordingRequestChannel();
+        var innerFactory = new RecordingChannelFactory<IRequestChannel>(innerChannel);
+        var factory = (IChannelFactory<IRequestChannel>)new InstrumentedChannelFactory<IRequestChannel>(innerFactory, new CustomBinding());
 
-        var asyncResult = channel.BeginRequest(
-            Message.CreateMessage(MessageVersion.Soap11, "urn:test"),
-            callback: null,
-            state);
+        var channel = factory.CreateChannel(new EndpointAddress("net.tcp://localhost/Service"));
 
-        Assert.NotNull(asyncResult);
-        Assert.NotNull(inner.LastBeginRequestArgs);
-        Assert.Null(inner.LastBeginRequestArgs![1]);
-        Assert.Same(state, inner.LastBeginRequestArgs[2]);
+        Assert.IsNotAssignableFrom<IRequestSessionChannel>(channel);
     }
 
     [Fact]
-    public void BeginSend_AllowsNullAsyncCallback()
+    public void CreateChannel_ForDuplexChannel_DoesNotAdvertiseSessionWhenInnerChannelDoesNotSupportIt()
     {
-        var inner = new RecordingDuplexChannel();
-        var channel = new InstrumentedDuplexChannel(inner, TimeSpan.FromSeconds(1));
-        var state = new object();
+        var innerChannel = new RecordingDuplexChannel();
+        var innerFactory = new RecordingChannelFactory<IDuplexChannel>(innerChannel);
+        var factory = (IChannelFactory<IDuplexChannel>)new InstrumentedChannelFactory<IDuplexChannel>(innerFactory, new CustomBinding());
 
-        var asyncResult = channel.BeginSend(
-            Message.CreateMessage(MessageVersion.Soap11, "urn:test"),
-            callback: null,
-            state);
+        var channel = factory.CreateChannel(new EndpointAddress("net.tcp://localhost/Service"));
 
-        Assert.NotNull(asyncResult);
-        Assert.NotNull(inner.LastBeginSendArgs);
-        Assert.Null(inner.LastBeginSendArgs![1]);
-        Assert.Same(state, inner.LastBeginSendArgs[2]);
-    }
-
-    [Fact]
-    public void BeginReceive_AllowsNullAsyncCallback()
-    {
-        var inner = new RecordingDuplexChannel();
-        var channel = new InstrumentedDuplexChannel(inner, TimeSpan.FromSeconds(1));
-        var state = new object();
-
-        var asyncResult = channel.BeginReceive(callback: null, state);
-
-        Assert.NotNull(asyncResult);
-        Assert.NotNull(inner.LastBeginReceiveArgs);
-        Assert.Null(inner.LastBeginReceiveArgs![0]);
-        Assert.Same(state, inner.LastBeginReceiveArgs[1]);
+        Assert.IsNotAssignableFrom<IDuplexSessionChannel>(channel);
     }
 
     private sealed class FakeAsyncResult : IAsyncResult
@@ -75,6 +48,124 @@ public class InstrumentedChannelAsyncCallbackTests
         public bool CompletedSynchronously => true;
 
         public bool IsCompleted => true;
+    }
+
+    private sealed class RecordingChannelFactory<TChannel> : IChannelFactory<TChannel>
+        where TChannel : IChannel
+    {
+        private readonly TChannel channel;
+
+        public RecordingChannelFactory(TChannel channel)
+        {
+            this.channel = channel;
+        }
+
+        event EventHandler ICommunicationObject.Closed
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Closing
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Faulted
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Opened
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        event EventHandler ICommunicationObject.Opening
+        {
+            add
+            {
+            }
+
+            remove
+            {
+            }
+        }
+
+        public CommunicationState State => CommunicationState.Opened;
+
+        public TChannel CreateChannel(EndpointAddress to)
+            => this.channel;
+
+        public TChannel CreateChannel(EndpointAddress to, Uri via)
+            => this.channel;
+
+        public T? GetProperty<T>()
+            where T : class
+            => default;
+
+        public void Abort()
+        {
+        }
+
+        public IAsyncResult BeginClose(AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public IAsyncResult BeginClose(TimeSpan timeout, AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public IAsyncResult BeginOpen(AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public IAsyncResult BeginOpen(TimeSpan timeout, AsyncCallback callback, object state)
+            => new FakeAsyncResult(state);
+
+        public void Close()
+        {
+        }
+
+        public void Close(TimeSpan timeout)
+        {
+        }
+
+        public void EndClose(IAsyncResult result)
+        {
+        }
+
+        public void EndOpen(IAsyncResult result)
+        {
+        }
+
+        public void Open()
+        {
+        }
+
+        public void Open(TimeSpan timeout)
+        {
+        }
     }
 
     private abstract class RecordingChannel : IChannel
@@ -136,7 +227,7 @@ public class InstrumentedChannelAsyncCallbackTests
 
         public CommunicationState State => CommunicationState.Opened;
 
-        public virtual T? GetProperty<T>()
+        public T? GetProperty<T>()
             where T : class
             => default;
 
@@ -183,8 +274,6 @@ public class InstrumentedChannelAsyncCallbackTests
 
     private sealed class RecordingRequestChannel : RecordingChannel, IRequestChannel
     {
-        public object?[]? LastBeginRequestArgs { get; private set; }
-
         public EndpointAddress RemoteAddress { get; } = new("net.tcp://localhost/Service");
 
         public Uri Via { get; } = new("net.tcp://localhost/Service");
@@ -196,16 +285,10 @@ public class InstrumentedChannelAsyncCallbackTests
             => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
 
         public IAsyncResult BeginRequest(Message message, AsyncCallback callback, object state)
-        {
-            this.LastBeginRequestArgs = [message, callback, state];
-            return new FakeAsyncResult(state);
-        }
+            => new FakeAsyncResult(state);
 
         public IAsyncResult BeginRequest(Message message, TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            this.LastBeginRequestArgs = [message, timeout, callback, state];
-            return new FakeAsyncResult(state);
-        }
+            => new FakeAsyncResult(state);
 
         public Message EndRequest(IAsyncResult result)
             => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
@@ -213,10 +296,6 @@ public class InstrumentedChannelAsyncCallbackTests
 
     private sealed class RecordingDuplexChannel : RecordingChannel, IDuplexChannel
     {
-        public object?[]? LastBeginReceiveArgs { get; private set; }
-
-        public object?[]? LastBeginSendArgs { get; private set; }
-
         public EndpointAddress LocalAddress { get; } = new("net.tcp://localhost/Local");
 
         public EndpointAddress RemoteAddress { get; } = new("net.tcp://localhost/Service");
@@ -232,16 +311,10 @@ public class InstrumentedChannelAsyncCallbackTests
         }
 
         public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state)
-        {
-            this.LastBeginSendArgs = [message, callback, state];
-            return new FakeAsyncResult(state);
-        }
+            => new FakeAsyncResult(state);
 
         public IAsyncResult BeginSend(Message message, TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            this.LastBeginSendArgs = [message, timeout, callback, state];
-            return new FakeAsyncResult(state);
-        }
+            => new FakeAsyncResult(state);
 
         public void EndSend(IAsyncResult result)
         {
@@ -254,16 +327,10 @@ public class InstrumentedChannelAsyncCallbackTests
             => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");
 
         public IAsyncResult BeginReceive(AsyncCallback callback, object state)
-        {
-            this.LastBeginReceiveArgs = [callback, state];
-            return new FakeAsyncResult(state);
-        }
+            => new FakeAsyncResult(state);
 
         public IAsyncResult BeginReceive(TimeSpan timeout, AsyncCallback callback, object state)
-        {
-            this.LastBeginReceiveArgs = [timeout, callback, state];
-            return new FakeAsyncResult(state);
-        }
+            => new FakeAsyncResult(state);
 
         public Message EndReceive(IAsyncResult result)
             => Message.CreateMessage(MessageVersion.Soap11, "urn:reply");


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed an issue where non-session WCF client channels could be wrapped in instrumented channel types that incorrectly advertised session support.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
