### PR TITLE
[Instrumentation.Wcf] Fix async WCF client operations throwing when `ExecutionContext` flow is suppressed

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -14,6 +14,10 @@
   instrumented channel types that incorrectly advertised session support.
   ([#4368](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4368))
 
+* Fixed an issue where async WCF client operations could throw when
+  `ExecutionContext` flow was suppressed.
+  ([#4378](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4378))
+
 ## 1.15.1-beta.2
 
 Released 2026-Apr-22

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedDuplexChannel.cs
@@ -174,15 +174,17 @@ internal class InstrumentedDuplexChannel : InstrumentedChannel<IDuplexChannel>, 
             executeSend(telemetryState);
         }
 
-        var executionContext = ExecutionContext.Capture();
-        if (executionContext == null)
-        {
-            throw new InvalidOperationException("Cannot fetch execution context");
-        }
-
         try
         {
-            ExecutionContext.Run(executionContext, ExecuteInChildContext, null);
+            var executionContext = ExecutionContext.Capture();
+            if (executionContext == null)
+            {
+                ExecuteInChildContext(null);
+            }
+            else
+            {
+                ExecutionContext.Run(executionContext, ExecuteInChildContext, null);
+            }
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/InstrumentedRequestChannel.cs
@@ -106,10 +106,13 @@ internal class InstrumentedRequestChannel : InstrumentedChannel<IRequestChannel>
         var executionContext = ExecutionContext.Capture();
         if (executionContext == null)
         {
-            throw new InvalidOperationException("Cannot fetch execution context");
+            ExecuteInChildContext(null);
+        }
+        else
+        {
+            ExecutionContext.Run(executionContext, ExecuteInChildContext, null);
         }
 
-        ExecutionContext.Run(executionContext, ExecuteInChildContext, null);
         return result!;
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
@@ -29,6 +29,28 @@ public class InstrumentedChannelAsyncCallbackTests
     }
 
     [Fact]
+    public void BeginRequest_AllowsSuppressedExecutionContextFlow()
+    {
+        var inner = new RecordingRequestChannel();
+        var channel = (IRequestChannel)new InstrumentedRequestChannel(inner);
+        var state = new object();
+
+        using (ExecutionContext.SuppressFlow())
+        {
+            var asyncResult = channel.BeginRequest(
+                Message.CreateMessage(MessageVersion.Soap11, "urn:test"),
+                callback: null,
+                state);
+
+            Assert.NotNull(asyncResult);
+        }
+
+        Assert.NotNull(inner.LastBeginRequestArgs);
+        Assert.Null(inner.LastBeginRequestArgs![1]);
+        Assert.Same(state, inner.LastBeginRequestArgs[2]);
+    }
+
+    [Fact]
     public void BeginSend_AllowsNullAsyncCallback()
     {
         var inner = new RecordingDuplexChannel();
@@ -44,6 +66,42 @@ public class InstrumentedChannelAsyncCallbackTests
         Assert.NotNull(inner.LastBeginSendArgs);
         Assert.Null(inner.LastBeginSendArgs![1]);
         Assert.Same(state, inner.LastBeginSendArgs[2]);
+    }
+
+    [Fact]
+    public void BeginSend_AllowsSuppressedExecutionContextFlow()
+    {
+        var inner = new RecordingDuplexChannel();
+        var channel = new InstrumentedDuplexChannel(inner, TimeSpan.FromSeconds(1));
+        var state = new object();
+
+        using (ExecutionContext.SuppressFlow())
+        {
+            var asyncResult = channel.BeginSend(
+                Message.CreateMessage(MessageVersion.Soap11, "urn:test"),
+                callback: null,
+                state);
+
+            Assert.NotNull(asyncResult);
+        }
+
+        Assert.NotNull(inner.LastBeginSendArgs);
+        Assert.Null(inner.LastBeginSendArgs![1]);
+        Assert.Same(state, inner.LastBeginSendArgs[2]);
+    }
+
+    [Fact]
+    public void Send_AllowsSuppressedExecutionContextFlow()
+    {
+        var inner = new RecordingDuplexChannel();
+        var channel = new InstrumentedDuplexChannel(inner, TimeSpan.FromSeconds(1));
+
+        using (ExecutionContext.SuppressFlow())
+        {
+            channel.Send(Message.CreateMessage(MessageVersion.Soap11, "urn:test"));
+        }
+
+        Assert.True(inner.SendCalled);
     }
 
     [Fact]
@@ -217,6 +275,8 @@ public class InstrumentedChannelAsyncCallbackTests
 
         public object?[]? LastBeginSendArgs { get; private set; }
 
+        public bool SendCalled { get; private set; }
+
         public EndpointAddress LocalAddress { get; } = new("net.tcp://localhost/Local");
 
         public EndpointAddress RemoteAddress { get; } = new("net.tcp://localhost/Service");
@@ -225,10 +285,12 @@ public class InstrumentedChannelAsyncCallbackTests
 
         public void Send(Message message)
         {
+            this.SendCalled = true;
         }
 
         public void Send(Message message, TimeSpan timeout)
         {
+            this.SendCalled = true;
         }
 
         public IAsyncResult BeginSend(Message message, AsyncCallback callback, object state)

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
@@ -24,7 +24,7 @@ public class InstrumentedChannelAsyncCallbackTests
 
         Assert.NotNull(asyncResult);
         Assert.NotNull(inner.LastBeginRequestArgs);
-        Assert.Null(inner.LastBeginRequestArgs![1]);
+        Assert.Null(inner.LastBeginRequestArgs[1]);
         Assert.Same(state, inner.LastBeginRequestArgs[2]);
     }
 
@@ -46,7 +46,7 @@ public class InstrumentedChannelAsyncCallbackTests
         }
 
         Assert.NotNull(inner.LastBeginRequestArgs);
-        Assert.Null(inner.LastBeginRequestArgs![1]);
+        Assert.Null(inner.LastBeginRequestArgs[1]);
         Assert.Same(state, inner.LastBeginRequestArgs[2]);
     }
 
@@ -64,7 +64,7 @@ public class InstrumentedChannelAsyncCallbackTests
 
         Assert.NotNull(asyncResult);
         Assert.NotNull(inner.LastBeginSendArgs);
-        Assert.Null(inner.LastBeginSendArgs![1]);
+        Assert.Null(inner.LastBeginSendArgs[1]);
         Assert.Same(state, inner.LastBeginSendArgs[2]);
     }
 
@@ -86,7 +86,7 @@ public class InstrumentedChannelAsyncCallbackTests
         }
 
         Assert.NotNull(inner.LastBeginSendArgs);
-        Assert.Null(inner.LastBeginSendArgs![1]);
+        Assert.Null(inner.LastBeginSendArgs[1]);
         Assert.Same(state, inner.LastBeginSendArgs[2]);
     }
 
@@ -115,7 +115,7 @@ public class InstrumentedChannelAsyncCallbackTests
 
         Assert.NotNull(asyncResult);
         Assert.NotNull(inner.LastBeginReceiveArgs);
-        Assert.Null(inner.LastBeginReceiveArgs![0]);
+        Assert.Null(inner.LastBeginReceiveArgs[0]);
         Assert.Same(state, inner.LastBeginReceiveArgs[1]);
     }
 


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex analysis

## Changes

Fixed an issue where async WCF client operations could throw when `ExecutionContext` flow was suppressed.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
