### PR TITLE
[Infra] Fix new code analysis warnings

### DIFF
--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -193,7 +193,7 @@ public class EventCountersMetricsTests
     }
 
     [Fact]
-    public async Task OnlyConfiguredEventSourcesEmitMetrics()
+    public void OnlyConfiguredEventSourcesEmitMetrics()
     {
         // Arrange
         List<Metric> metrics = [];

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -255,7 +255,7 @@ public class WsTransportTest
         var sendException = await Record.ExceptionAsync(
             () => wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None));
         Assert.True(
-            sendException is null || sendException is WebSocketException || sendException is OperationCanceledException,
+            sendException is null or WebSocketException or OperationCanceledException,
             $"Unexpected exception from SendAsync: {sendException}");
 
         Assert.True(opAmpServer.TryGetClientCloseStatus(TimeSpan.FromSeconds(5), out var closeStatus));
@@ -332,7 +332,7 @@ public class WsTransportTest
         var sendException = await Record.ExceptionAsync(
             () => wsTransport.SendAsync(FrameGenerator.GenerateMockAgentFrame().Frame, CancellationToken.None));
         Assert.True(
-            sendException is null || sendException is WebSocketException || sendException is OperationCanceledException,
+            sendException is null or WebSocketException or OperationCanceledException,
             $"Unexpected exception from SendAsync: {sendException}");
 
         Assert.True(opAmpServer.TryGetClientCloseStatus(timeout, out var closeStatus));


### PR DESCRIPTION
## Changes

Fix new code analysis warnings raised when using the .NET 11 SDK in #3867.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
