### PR TITLE
[Infra] Refactor TestHttpServer

### DIFF
--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/OpenTelemetry.Exporter.InfluxDB.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\IsExternalInit.cs" Link="Includes\IsExternalInit.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
@@ -31,23 +31,18 @@ internal class InfluxDBFakeServer : IDisposable
                 context.Response.StatusCode = (int)HttpStatusCode.OK;
                 context.Response.Close();
             },
-            out var host,
-            out var port);
-        this.Endpoint = new Uri($"http://{host}:{port}");
+            out var baseAddress);
+        this.Endpoint = baseAddress;
     }
 
     public Uri Endpoint { get; }
 
     public void Dispose()
-    {
-        this.httpServer.Dispose();
-    }
+        => this.httpServer.Dispose();
 
-    public PointData ReadPoint()
-    {
-        return this.lines.TryTake(out var line, TimeSpan.FromSeconds(5))
+    public PointData ReadPoint() =>
+        this.lines.TryTake(out var line, TimeSpan.FromSeconds(5))
             ? LineProtocolParser.ParseLine(line)
             : throw new InvalidOperationException(
                 "Failed to read a data point from the InfluxDB server within the 5-second timeout.");
-    }
 }

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/HttpJsonPostTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/HttpJsonPostTransportTests.cs
@@ -376,11 +376,10 @@ public class HttpJsonPostTransportTests
                     context.Response.OutputStream.Close();
                 }
             },
-            out var testServerHost,
-            out var testServerPort);
+            out var baseAddress);
 
         var transport = createTransportFunc(
-            new Uri($"http://{testServerHost}:{(transportFailure ? 0 : testServerPort)}/"));
+            transportFailure ? new Uri($"http://localhost:0/") : baseAddress);
 
         try
         {

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OpenTelemetry.Exporter.OneCollector.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OpenTelemetry.Exporter.OneCollector.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\SkipUnlessEnvVarFoundFactAttribute.cs" Link="Includes\SkipUnlessEnvVarFoundFactAttribute.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\SkipUnlessEnvVarFoundTheoryAttribute.cs" Link="Includes\SkipUnlessEnvVarFoundTheoryAttribute.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientTraceEnrichmentAcceptanceTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientTraceEnrichmentAcceptanceTests.cs
@@ -15,28 +15,17 @@ namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
 public class HttpClientTraceEnrichmentAcceptanceTests : IDisposable
 {
     private readonly IDisposable serverLifeTime;
-    private readonly string url;
+    private readonly Uri uri;
 
     public HttpClientTraceEnrichmentAcceptanceTests()
     {
         this.serverLifeTime = TestHttpServer.RunServer(
             ctx =>
             {
-                if (ctx.Request.Url != null && ctx.Request.Url.PathAndQuery.Contains("500"))
-                {
-                    ctx.Response.StatusCode = 500;
-                }
-                else
-                {
-                    ctx.Response.StatusCode = 200;
-                }
-
+                ctx.Response.StatusCode = ctx.Request.Url?.PathAndQuery.Contains("500") == true ? 500 : 200;
                 ctx.Response.OutputStream.Close();
             },
-            out var host,
-            out var port);
-
-        this.url = $"http://{host}:{port}/";
+            out this.uri);
     }
 
     [Fact]
@@ -55,11 +44,11 @@ public class HttpClientTraceEnrichmentAcceptanceTests : IDisposable
 
 #if NET
         using var httpClient = new HttpClient();
-        var request = new HttpRequestMessage(HttpMethod.Get, this.url);
+        var request = new HttpRequestMessage(HttpMethod.Get, this.uri);
 
         using var response = await httpClient.SendAsync(request);
 #else
-        var request = (HttpWebRequest)WebRequest.Create(new Uri(this.url));
+        var request = (HttpWebRequest)WebRequest.Create(this.uri);
         request.Method = "GET";
 
         using var response = await request.GetResponseAsync();

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/OpenTelemetry.Extensions.Enrichment.Http.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/OpenTelemetry.Extensions.Enrichment.Http.Tests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="/Includes/TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="/Includes/TestHttpServer.cs" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
@@ -6,8 +6,8 @@ using Microsoft.Extensions.Configuration;
 
 #if NETFRAMEWORK
 using System.Net.Http;
-
 #endif
+
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.Http.Implementation;
@@ -23,9 +23,7 @@ public partial class HttpClientTests : IDisposable
 {
     private readonly ITestOutputHelper output;
     private readonly IDisposable serverLifeTime;
-    private readonly string host;
-    private readonly int port;
-    private readonly string url;
+    private readonly Uri uri;
 
     public HttpClientTests(ITestOutputHelper output)
     {
@@ -69,14 +67,9 @@ public partial class HttpClientTests : IDisposable
 
                 ctx.Response.OutputStream.Close();
             },
-            out var host,
-            out var port);
+            out this.uri);
 
-        this.host = host;
-        this.port = port;
-        this.url = $"http://{host}:{port}/";
-
-        this.output.WriteLine($"HttpServer started: {this.url}");
+        this.output.WriteLine($"HttpServer started: {this.uri}");
     }
 
     [Fact]
@@ -116,7 +109,7 @@ public partial class HttpClientTests : IDisposable
 
         using var request = new HttpRequestMessage
         {
-            RequestUri = new Uri(this.url),
+            RequestUri = this.uri,
             Method = new HttpMethod("GET"),
         };
 
@@ -223,7 +216,7 @@ public partial class HttpClientTests : IDisposable
         var exportedItems = new List<Activity>();
 
         using var request = new HttpRequestMessage();
-        request.RequestUri = new Uri(this.url);
+        request.RequestUri = this.uri;
         request.Method = new HttpMethod("GET");
 
         using var parent = new Activity("parent")
@@ -285,7 +278,7 @@ public partial class HttpClientTests : IDisposable
             var exportedItems = new List<Activity>();
 
             using var request = new HttpRequestMessage();
-            request.RequestUri = new Uri(this.url);
+            request.RequestUri = this.uri;
             request.Method = new HttpMethod("GET");
 
             using var parent = new Activity("parent")
@@ -330,7 +323,7 @@ public partial class HttpClientTests : IDisposable
         var exportedItems = new List<Activity>();
         using var request = new HttpRequestMessage
         {
-            RequestUri = new Uri(this.url),
+            RequestUri = this.uri,
             Method = new HttpMethod("GET"),
         };
 
@@ -396,7 +389,7 @@ public partial class HttpClientTests : IDisposable
         var exportedItems = new List<Activity>();
         using var request = new HttpRequestMessage
         {
-            RequestUri = new Uri(this.url),
+            RequestUri = this.uri,
             Method = new HttpMethod(originalMethod),
         };
 
@@ -463,7 +456,7 @@ public partial class HttpClientTests : IDisposable
         var metricItems = new List<Metric>();
         using var request = new HttpRequestMessage
         {
-            RequestUri = new Uri(this.url),
+            RequestUri = this.uri,
             Method = new HttpMethod(originalMethod),
         };
 
@@ -520,7 +513,7 @@ public partial class HttpClientTests : IDisposable
             .Build())
         {
             using var c = new HttpClient();
-            await c.GetAsync(new Uri($"{this.url}redirect"));
+            await c.GetAsync(new Uri($"{this.uri}redirect"));
         }
 
 #if NETFRAMEWORK
@@ -553,19 +546,19 @@ public partial class HttpClientTests : IDisposable
                     opt.FilterHttpWebRequest = req =>
                     {
                         httpWebRequestFilterApplied = true;
-                        return !req.RequestUri.OriginalString.Contains(this.url);
+                        return !req.RequestUri.OriginalString.Contains(this.uri.ToString());
                     };
                     opt.FilterHttpRequestMessage = req =>
                     {
                         httpRequestMessageFilterApplied = true;
-                        return req.RequestUri != null && !req.RequestUri.OriginalString.Contains(this.url);
+                        return req.RequestUri != null && !req.RequestUri.OriginalString.Contains(this.uri.ToString());
                     };
                 })
             .AddInMemoryExporter(exportedItems)
             .Build())
         {
             using var c = new HttpClient();
-            await c.GetAsync(new Uri(this.url));
+            await c.GetAsync(this.uri);
         }
 
 #if NETFRAMEWORK
@@ -596,7 +589,7 @@ public partial class HttpClientTests : IDisposable
         {
             using var c = new HttpClient();
             using var inMemoryEventListener = new InMemoryEventListener(HttpInstrumentationEventSource.Log);
-            await c.GetAsync(new Uri(this.url));
+            await c.GetAsync(this.uri);
             Assert.Single(inMemoryEventListener.Events, e => e.EventId == 4);
         }
 
@@ -649,7 +642,7 @@ public partial class HttpClientTests : IDisposable
         using var c = new HttpClient();
         try
         {
-            await c.GetAsync(new Uri($"{this.url}500"));
+            await c.GetAsync(new Uri($"{this.uri}500"));
         }
         catch
         {
@@ -668,7 +661,7 @@ public partial class HttpClientTests : IDisposable
         var exceptionThrown = false;
         using var request = new HttpRequestMessage
         {
-            RequestUri = new Uri($"{this.url}500"),
+            RequestUri = new Uri($"{this.uri}500"),
             Method = new HttpMethod("GET"),
         };
 
@@ -680,7 +673,7 @@ public partial class HttpClientTests : IDisposable
         using var c = new HttpClient();
         try
         {
-            await c.GetStringAsync(new Uri($"{this.url}500"));
+            await c.GetStringAsync(new Uri($"{this.uri}500"));
         }
         catch
         {
@@ -740,7 +733,7 @@ public partial class HttpClientTests : IDisposable
         using var c = new HttpClient();
         try
         {
-            await c.GetStringAsync(new Uri($"{this.url}path{urlQuery}"));
+            await c.GetStringAsync(new Uri($"{this.uri}path{urlQuery}"));
         }
         catch
         {
@@ -749,14 +742,14 @@ public partial class HttpClientTests : IDisposable
         Assert.Single(exportedItems);
         var activity = exportedItems[0];
 
-        var expectedUrl = $"{this.url}path{expectedUrlQuery}";
+        var expectedUrl = $"{this.uri}path{expectedUrlQuery}";
 
 #if NET9_0_OR_GREATER
         // In .NET 9+ URIs are redacted by default. We could disable it with the
         // System.Net.Http.DisableUriRedaction=true AppContext switch, but as that
         // is process-wide it affects other tests. Instead, we adjust our expectations
         // here. For more information see: https://github.com/dotnet/docs/issues/42792
-        expectedUrl = $"{this.url}path?*";
+        expectedUrl = $"{this.uri}path?*";
 #endif
 
         Assert.Equal(expectedUrl, activity.GetTagValue(SemanticConventions.AttributeUrlFull));
@@ -808,7 +801,7 @@ public partial class HttpClientTests : IDisposable
             }
 
             using var request = new HttpRequestMessage();
-            request.RequestUri = new Uri(this.url);
+            request.RequestUri = this.uri;
             request.Method = new HttpMethod("GET");
 
             using var c = new HttpClient();
@@ -874,7 +867,7 @@ public partial class HttpClientTests : IDisposable
             .Build();
         {
             using var c = new HttpClient();
-            await c.GetAsync(new Uri(this.url));
+            await c.GetAsync(this.uri);
         }
 
 #if NETFRAMEWORK
@@ -926,7 +919,7 @@ public partial class HttpClientTests : IDisposable
             .Build())
         {
             using var client = new HttpClient();
-            await client.GetAsync(new Uri(this.url));
+            await client.GetAsync(this.uri);
         }
 
         Assert.Equal(1, callCountDefault);
@@ -940,7 +933,7 @@ public partial class HttpClientTests : IDisposable
     public void Dispose()
     {
         this.serverLifeTime?.Dispose();
-        this.output.WriteLine($"HttpServer stopped: {this.url}");
+        this.output.WriteLine($"HttpServer stopped: {this.uri}");
         Activity.Current = null;
         GC.SuppressFinalize(this);
     }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -25,8 +25,8 @@ public partial class HttpClientTests
     [MemberData(nameof(HttpTestData.TestData), MemberType = typeof(HttpTestData))]
     public async Task HttpOutCallsAreCollectedSuccessfullyTracesAndMetricsSemanticConventionsAsync(HttpOutTestCase tc) =>
         await HttpOutCallsAreCollectedSuccessfullyBodyAsync(
-            this.host,
-            this.port,
+            this.uri.Host,
+            this.uri.Port,
             tc,
             enableTracing: true,
             enableMetrics: true);
@@ -35,8 +35,8 @@ public partial class HttpClientTests
     [MemberData(nameof(HttpTestData.TestData), MemberType = typeof(HttpTestData))]
     public async Task HttpOutCallsAreCollectedSuccessfullyMetricsOnlyAsync(HttpOutTestCase tc) =>
         await HttpOutCallsAreCollectedSuccessfullyBodyAsync(
-            this.host,
-            this.port,
+            this.uri.Host,
+            this.uri.Port,
             tc,
             enableTracing: false,
             enableMetrics: true);
@@ -45,8 +45,8 @@ public partial class HttpClientTests
     [MemberData(nameof(HttpTestData.TestData), MemberType = typeof(HttpTestData))]
     public async Task HttpOutCallsAreCollectedSuccessfullyTracesOnlyAsync(HttpOutTestCase tc) =>
         await HttpOutCallsAreCollectedSuccessfullyBodyAsync(
-            this.host,
-            this.port,
+            this.uri.Host,
+            this.uri.Port,
             tc,
             enableTracing: true,
             enableMetrics: false);
@@ -55,8 +55,8 @@ public partial class HttpClientTests
     [MemberData(nameof(HttpTestData.TestData), MemberType = typeof(HttpTestData))]
     public async Task HttpOutCallsAreCollectedSuccessfullyNoSignalsAsync(HttpOutTestCase tc) =>
         await HttpOutCallsAreCollectedSuccessfullyBodyAsync(
-            this.host,
-            this.port,
+            this.uri.Host,
+            this.uri.Port,
             tc,
             enableTracing: false,
             enableMetrics: false);
@@ -98,8 +98,8 @@ public partial class HttpClientTests
     [Fact]
     public async Task CheckEnrichmentWhenSampling()
     {
-        await CheckEnrichment(new AlwaysOffSampler(), false, this.url);
-        await CheckEnrichment(new AlwaysOnSampler(), true, this.url);
+        await CheckEnrichment(new AlwaysOffSampler(), false, this.uri.ToString());
+        await CheckEnrichment(new AlwaysOnSampler(), true, this.uri.ToString());
     }
 
 #if NET
@@ -113,7 +113,7 @@ public partial class HttpClientTests
             .AddInMemoryExporter(metrics)
             .Build();
 
-        var testUrl = HttpTestData.NormalizeValues(tc.Url, this.host, this.port);
+        var testUrl = HttpTestData.NormalizeValues(tc.Url, this.uri.Host, this.uri.Port);
 
         try
         {
@@ -169,7 +169,7 @@ public partial class HttpClientTests
             using var c = new HttpClient();
             using var request = new HttpRequestMessage
             {
-                RequestUri = new Uri($"{this.url}/slow"),
+                RequestUri = new Uri($"{this.uri}/slow"),
                 Method = new HttpMethod("GET"),
             };
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -20,10 +20,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
 {
     private static bool validateBaggage;
     private readonly IDisposable testServer;
-    private readonly string testServerHost;
-    private readonly int testServerPort;
-    private readonly string netPeerName;
-    private readonly int netPeerPort;
+    private readonly Uri uri;
 
     static HttpWebRequestActivitySourceTests()
     {
@@ -55,11 +52,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
 
         this.testServer = TestHttpServer.RunServer(
             ProcessServerRequest,
-            out this.testServerHost,
-            out this.testServerPort);
-
-        this.netPeerName = this.testServerHost;
-        this.netPeerPort = this.testServerPort;
+            out this.uri);
 
         void ProcessServerRequest(HttpListenerContext context)
         {
@@ -175,7 +168,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         // Check to make sure: The first record must be a request, the next record must be a response.
         var activity = AssertFirstEventWasStart(eventRecords);
 
-        VerifyActivityStartTags(this.netPeerName, this.netPeerPort, method, url, activity);
+        VerifyActivityStartTags(this.uri.Host, this.uri.Port, method, url, activity);
 
         Assert.True(eventRecords.Records.TryDequeue(out var stopEvent));
         Assert.Equal("Stop", stopEvent.Key);
@@ -355,7 +348,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         // Check to make sure: The first record must be a request, the next record must be a response.
         var activity = AssertFirstEventWasStart(eventRecords);
 
-        VerifyActivityStartTags(this.netPeerName, this.netPeerPort, method, url, activity);
+        VerifyActivityStartTags(this.uri.Host, this.uri.Port, method, url, activity);
 
         Assert.True(eventRecords.Records.TryDequeue(out var stopEvent));
         Assert.Equal("Stop", stopEvent.Key);
@@ -461,7 +454,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         // Check to make sure: The first record must be a request, the next record must be a response.
         var activity = AssertFirstEventWasStart(eventRecords);
 
-        VerifyActivityStartTags(this.netPeerName, this.netPeerPort, method, url, activity);
+        VerifyActivityStartTags(this.uri.Host, this.uri.Port, method, url, activity);
 
         Assert.True(eventRecords.Records.TryDequeue(out var stopEvent));
         Assert.Equal("Stop", stopEvent.Key);
@@ -565,7 +558,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         Assert.Equal(1, eventRecords.Records.Count(rec => rec.Key == "Stop"));
 
         var activity = AssertFirstEventWasStart(eventRecords);
-        VerifyActivityStartTags(this.netPeerName, this.netPeerPort, method, url, activity);
+        VerifyActivityStartTags(this.uri.Host, this.uri.Port, method, url, activity);
 
         Assert.True(eventRecords.Records.TryDequeue(out var exceptionEvent));
         Assert.Equal("Stop", exceptionEvent.Key);
@@ -646,7 +639,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         Assert.Equal(1, eventRecords.Records.Count(rec => rec.Key == "Stop"));
 
         var activity = AssertFirstEventWasStart(eventRecords);
-        VerifyActivityStartTags(this.netPeerName, this.netPeerPort, method, url, activity);
+        VerifyActivityStartTags(this.uri.Host, this.uri.Port, method, url, activity);
 
         Assert.True(eventRecords.Records.TryDequeue(out var exceptionEvent));
         Assert.Equal("Stop", exceptionEvent.Key);
@@ -783,7 +776,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
     }
 
     private string BuildRequestUrl(bool useHttps = false, string path = "echo", string queryString = null)
-        => $"{(useHttps ? "https" : "http")}://{this.testServerHost}:{this.testServerPort}/{path}{(string.IsNullOrWhiteSpace(queryString) ? string.Empty : $"?{queryString}")}";
+        => $"{(useHttps ? "https" : "http")}://{this.uri.Host}:{this.uri.Port}/{path}{(string.IsNullOrWhiteSpace(queryString) ? string.Empty : $"?{queryString}")}";
 
     private void CleanUpActivity()
     {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests;
 public partial class HttpWebRequestTests : IDisposable
 {
     private readonly IDisposable serverLifeTime;
-    private readonly string url;
+    private readonly Uri uri;
 
     public HttpWebRequestTests()
     {
@@ -45,10 +45,7 @@ public partial class HttpWebRequestTests : IDisposable
 
                 ctx.Response.OutputStream.Close();
             },
-            out var host,
-            out var port);
-
-        this.url = $"http://{host}:{port}/";
+            out this.uri);
     }
 
     public void Dispose()
@@ -63,7 +60,7 @@ public partial class HttpWebRequestTests : IDisposable
             .AddHttpClientInstrumentation()
             .Build();
 
-        var request = (HttpWebRequest)WebRequest.Create(new Uri(this.url));
+        var request = (HttpWebRequest)WebRequest.Create(this.uri);
 
         request.Method = "GET";
 
@@ -94,17 +91,17 @@ public partial class HttpWebRequestTests : IDisposable
                     options.FilterHttpWebRequest = req =>
                     {
                         httpWebRequestFilterApplied = true;
-                        return !req.RequestUri.OriginalString.Contains(this.url);
+                        return !req.RequestUri.OriginalString.Contains(this.uri.Host.ToString());
                     };
                     options.FilterHttpRequestMessage = req =>
                     {
                         httpRequestMessageFilterApplied = true;
-                        return req.RequestUri != null && !req.RequestUri.OriginalString.Contains(this.url);
+                        return req.RequestUri != null && !req.RequestUri.OriginalString.Contains(this.uri.ToString());
                     };
                 })
             .Build();
 
-        var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.url}?bypassHeaderCheck=true"));
+        var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.uri}?bypassHeaderCheck=true"));
 
         request.Method = "GET";
 
@@ -138,7 +135,7 @@ public partial class HttpWebRequestTests : IDisposable
 
         using (var inMemoryEventListener = new InMemoryEventListener(HttpInstrumentationEventSource.Log))
         {
-            var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.url}?bypassHeaderCheck=true"));
+            var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.uri}?bypassHeaderCheck=true"));
 
             request.Method = "GET";
 
@@ -159,7 +156,7 @@ public partial class HttpWebRequestTests : IDisposable
             .AddHttpClientInstrumentation()
             .Build();
 
-        var request = (HttpWebRequest)WebRequest.Create(new Uri(this.url));
+        var request = (HttpWebRequest)WebRequest.Create(this.uri);
 
         request.Method = "GET";
 
@@ -237,7 +234,7 @@ public partial class HttpWebRequestTests : IDisposable
 #endif
             }
 
-            var request = (HttpWebRequest)WebRequest.Create(new Uri(this.url));
+            var request = (HttpWebRequest)WebRequest.Create(this.uri);
 
             request.Method = "GET";
 
@@ -343,7 +340,7 @@ public partial class HttpWebRequestTests : IDisposable
 
         try
         {
-            var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.url}500"));
+            var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.uri}500"));
 
             request.Method = "GET";
 
@@ -396,7 +393,7 @@ public partial class HttpWebRequestTests : IDisposable
                 })
             .Build();
 
-        var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.url}?bypassHeaderCheck=true"));
+        var request = (HttpWebRequest)WebRequest.Create(new Uri($"{this.uri}?bypassHeaderCheck=true"));
 
         request.Method = "GET";
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
@@ -29,8 +29,7 @@ public partial class HttpWebRequestTests
                 ctx.Response.StatusCode = tc.ResponseCode == 0 ? 200 : tc.ResponseCode;
                 ctx.Response.OutputStream.Close();
             },
-            out var host,
-            out var port);
+            out var uri);
 
         var enrichWithHttpWebRequestCalled = false;
         var enrichWithHttpWebResponseCalled = false;
@@ -52,7 +51,7 @@ public partial class HttpWebRequestTests
             })
             .Build();
 
-        tc.Url = HttpTestData.NormalizeValues(tc.Url, host, port);
+        tc.Url = HttpTestData.NormalizeValues(tc.Url, uri.Host, uri.Port);
 
         try
         {
@@ -88,10 +87,7 @@ public partial class HttpWebRequestTests
 
         tc.SpanAttributes = tc.SpanAttributes.ToDictionary(
             x => x.Key,
-            x =>
-            {
-                return x.Key == "network.protocol.version" ? "1.1" : HttpTestData.NormalizeValues(x.Value, host, port);
-            });
+            x => x.Key == "network.protocol.version" ? "1.1" : HttpTestData.NormalizeValues(x.Value, uri.Host, uri.Port));
 
         foreach (var tag in activity.TagObjects)
         {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -12,6 +12,7 @@
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="/Includes/EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="/Includes/InMemoryEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\SkipUnlessEnvVarFoundTheoryAttribute.cs" Link="/Includes/SkipUnlessEnvVarFoundTheoryAttribute.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="/Includes/TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestEventListener.cs" Link="/Includes/TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="/Includes/TestHttpServer.cs" />
   </ItemGroup>

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpenTelemetry.OpAmp.Client.Tests.csproj
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpenTelemetry.OpAmp.Client.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestWebSocketServer.cs" Link="Includes\TestWebSocketServer.cs" />

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
@@ -108,12 +108,11 @@ public class PlainHttpTransportTests
                 context.Response.OutputStream.Write(oversizedBody, 0, oversizedBody.Length);
                 context.Response.Close();
             },
-            out var host,
-            out var port);
+            out var serverUrl);
 
         var settings = new OpAmpClientSettings
         {
-            ServerUrl = new Uri($"http://{host}:{port}"),
+            ServerUrl = serverUrl,
         };
 
         var frameProcessor = new FrameProcessor();
@@ -164,12 +163,11 @@ public class PlainHttpTransportTests
                 context.Response.OutputStream.Write(compressedBody, 0, compressedBody.Length);
                 context.Response.Close();
             },
-            out var host,
-            out var port);
+            out var serverUrl);
 
         var settings = new OpAmpClientSettings
         {
-            ServerUrl = new Uri($"http://{host}:{port}"),
+            ServerUrl = serverUrl,
             HttpClientFactory = () =>
             {
                 var handler = new HttpClientHandler
@@ -234,12 +232,11 @@ public class PlainHttpTransportTests
                     thresholdReached.Set();
                 }
             },
-            out var host,
-            out var port);
+            out var serverUrl);
 
         var settings = new OpAmpClientSettings
         {
-            ServerUrl = new Uri($"http://{host}:{port}"),
+            ServerUrl = serverUrl,
         };
 
         var frameProcessor = new FrameProcessor();
@@ -307,12 +304,11 @@ public class PlainHttpTransportTests
                     }
                 }
             },
-            out var host,
-            out var port);
+            out var serverUrl);
 
         var settings = new OpAmpClientSettings
         {
-            ServerUrl = new Uri($"http://{host}:{port}"),
+            ServerUrl = serverUrl,
         };
 
         var frameProcessor = new FrameProcessor();
@@ -340,12 +336,11 @@ public class PlainHttpTransportTests
                 context.Response.OutputStream.Write(body, 0, body.Length);
                 context.Response.Close();
             },
-            out var host,
-            out var port);
+            out var serverUrl);
 
         var settings = new OpAmpClientSettings
         {
-            ServerUrl = new Uri($"http://{host}:{port}"),
+            ServerUrl = serverUrl,
         };
 
         var frameProcessor = new FrameProcessor();

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeHttpServer.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Tools/OpAmpFakeHttpServer.cs
@@ -40,9 +40,8 @@ internal class OpAmpFakeHttpServer : IDisposable
 #pragma warning restore IDE0370 // Suppression is unnecessary
                 context.Response.Close();
             },
-            out var host,
-            out var port);
-        this.Endpoint = new Uri($"http://{host}:{port}");
+            out var endpoint);
+        this.Endpoint = endpoint;
     }
 
     public Uri Endpoint { get; }

--- a/test/OpenTelemetry.Sampler.AWS.Tests/OpenTelemetry.Sampler.AWS.Tests.csproj
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/OpenTelemetry.Sampler.AWS.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
@@ -52,13 +52,12 @@ public class TestAWSXRayRemoteSampler
 
         using var mockServer = TestHttpServer.RunServer(
             requestHandler.Handle,
-            out var host,
-            out var port);
+            out var endpoint);
 
         // create sampler
         var sampler = AWSXRayRemoteSampler.Builder(ResourceBuilder.CreateEmpty().Build())
             .SetPollingInterval(TimeSpan.FromMilliseconds(10))
-            .SetEndpoint($"http://{host}:{port}")
+            .SetEndpoint(endpoint.ToString().TrimEnd('/'))
             .SetClock(clock)
             .Build();
 
@@ -111,12 +110,11 @@ public class TestAWSXRayRemoteSampler
 
         using var mockServer = TestHttpServer.RunServer(
             requestHandler.Handle,
-            out var host,
-            out var port);
+            out var endpoint);
 
         var parentBasedSampler = AWSXRayRemoteSampler.Builder(ResourceBuilder.CreateEmpty().Build())
             .SetPollingInterval(TimeSpan.FromMilliseconds(10))
-            .SetEndpoint($"http://{host}:{port}")
+            .SetEndpoint(endpoint.ToString().TrimEnd('/'))
             .SetClock(clock)
             .Build();
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
@@ -17,9 +17,8 @@ public class TestAWSXRaySamplerClient : IDisposable
         this.requestHandler = new MockServerRequestHandler();
         this.mockServer = TestHttpServer.RunServer(
             this.requestHandler.Handle,
-            out var host,
-            out var port);
-        this.client = new AWSXRaySamplerClient($"http://{host}:{port}");
+            out var endpoint);
+        this.client = new AWSXRaySamplerClient(endpoint.ToString().TrimEnd('/'));
     }
 
     public void Dispose()

--- a/test/Shared/TestHttpServer.cs
+++ b/test/Shared/TestHttpServer.cs
@@ -1,26 +1,20 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Note: When implicit usings are enabled in a project this file will generate
-// warnings/errors without this suppression.
-
 using System.Net;
-#if !NETFRAMEWORK
-using System.Security.Cryptography;
-#endif
 
 namespace OpenTelemetry.Tests;
 
 internal static class TestHttpServer
 {
-#if !NET
-    private static readonly Random GlobalRandom = new();
-#endif
-
-    public static IDisposable RunServer(Action<HttpListenerContext> action, out string host, out int port)
+    public static IDisposable RunServer(Action<HttpListenerContext> action, out Uri baseAddress)
     {
-        host = "localhost";
-        port = 0;
+        var uri = new UriBuilder()
+        {
+            Host = "localhost",
+            Scheme = Uri.UriSchemeHttp,
+        };
+
         RunningServer? server = null;
 
         var retryCount = 5;
@@ -28,14 +22,8 @@ internal static class TestHttpServer
         {
             try
             {
-#if NET
-                port = RandomNumberGenerator.GetInt32(2000, 5000);
-#else
-#pragma warning disable CA5394 // Do not use insecure randomness
-                port = GlobalRandom.Next(2000, 5000);
-#pragma warning restore CA5394 // Do not use insecure randomness
-#endif
-                server = new RunningServer(action, host, port);
+                uri.Port = TcpPortProvider.GetOpenPort();
+                server = new RunningServer(action, uri.Uri);
                 server.Start();
                 break;
             }
@@ -50,6 +38,8 @@ internal static class TestHttpServer
             }
         }
 
+        baseAddress = uri.Uri;
+
         return server;
     }
 
@@ -60,11 +50,11 @@ internal static class TestHttpServer
         private readonly TaskCompletionSource<bool> initialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly CancellationTokenSource cancellationTokenSource = new();
 
-        public RunningServer(Action<HttpListenerContext> action, string host, int port)
+        public RunningServer(Action<HttpListenerContext> action, Uri baseAddress)
         {
             this.listener = new HttpListener();
 
-            this.listener.Prefixes.Add($"http://{host}:{port}/");
+            this.listener.Prefixes.Add(baseAddress.ToString());
             this.listener.Start();
 
             this.httpListenerTask = Task.Factory.StartNew(


### PR DESCRIPTION
## Changes

- Use `TcpPortProvider` instead of `Random`.
- Use one `Uri` out parameter for the server's address.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
