### PR TITLE
[SqlClient] Fix db.query.parameter.key value type

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
 
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
-  ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395)
+  ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
 
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO)
+  ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395)
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -10,6 +10,9 @@
   repeated unterminated bracketed identifiers.
   ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
 
+* Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO)
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -17,6 +17,9 @@
   repeated unterminated bracketed identifiers.
   ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
 
+* Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO)
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -18,7 +18,7 @@
   ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
 
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO)
+  ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395)
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -18,7 +18,7 @@
   ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
 
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
-  ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395)
+  ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395))
 
 ## 1.15.2
 

--- a/src/Shared/SqlParameterProcessor.cs
+++ b/src/Shared/SqlParameterProcessor.cs
@@ -27,7 +27,9 @@ internal static class SqlParameterProcessor
                     ? index.ToString(CultureInfo.InvariantCulture)
                     : dbDataParameter.ParameterName;
 
-                activity.SetTag($"db.query.parameter.{key}", dbDataParameter.Value);
+                var value = Convert.ToString(dbDataParameter.Value, CultureInfo.InvariantCulture);
+
+                activity.SetTag($"db.query.parameter.{key}", value);
             }
 
             index++;

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlParameterProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlParameterProcessorTests.cs
@@ -50,14 +50,16 @@ public static class SqlParameterProcessorTests
 
         command.Parameters.Add(new MyDbCommandParameter(1));
         command.Parameters.Add(new MyDbCommandParameter(2));
+        command.Parameters.Add(new MyDbCommandParameter(123.4));
 
         // Act
         SqlParameterProcessor.AddQueryParameters(activity, command);
 
         // Assert
-        Assert.Equal(1, activity.GetTagValue("db.query.parameter.0"));
-        Assert.Equal(2, activity.GetTagValue("db.query.parameter.1"));
-        Assert.Equal(2, activity.TagObjects.Count());
+        Assert.Equal("1", activity.GetTagValue("db.query.parameter.0"));
+        Assert.Equal("2", activity.GetTagValue("db.query.parameter.1"));
+        Assert.Equal("123.4", activity.GetTagValue("db.query.parameter.2"));
+        Assert.Equal(3, activity.TagObjects.Count());
     }
 
     [Fact]
@@ -69,14 +71,16 @@ public static class SqlParameterProcessorTests
 
         command.Parameters.Add(new MyDbCommandParameter("foo", 1));
         command.Parameters.Add(new MyDbCommandParameter("bar", 2));
+        command.Parameters.Add(new MyDbCommandParameter("@baz", 1.23));
 
         // Act
         SqlParameterProcessor.AddQueryParameters(activity, command);
 
         // Assert
-        Assert.Equal(1, activity.GetTagValue("db.query.parameter.foo"));
-        Assert.Equal(2, activity.GetTagValue("db.query.parameter.bar"));
-        Assert.Equal(2, activity.TagObjects.Count());
+        Assert.Equal("1", activity.GetTagValue("db.query.parameter.foo"));
+        Assert.Equal("2", activity.GetTagValue("db.query.parameter.bar"));
+        Assert.Equal("1.23", activity.GetTagValue("db.query.parameter.@baz"));
+        Assert.Equal(3, activity.TagObjects.Count());
     }
 
     [Fact]
@@ -95,9 +99,9 @@ public static class SqlParameterProcessorTests
         SqlParameterProcessor.AddQueryParameters(activity, command);
 
         // Assert
-        Assert.Equal(1, activity.GetTagValue("db.query.parameter.foo"));
-        Assert.Equal(2, activity.GetTagValue("db.query.parameter.1"));
-        Assert.Equal(3, activity.GetTagValue("db.query.parameter.FOO"));
+        Assert.Equal("1", activity.GetTagValue("db.query.parameter.foo"));
+        Assert.Equal("2", activity.GetTagValue("db.query.parameter.1"));
+        Assert.Equal("3", activity.GetTagValue("db.query.parameter.FOO"));
         Assert.Equal(3, activity.TagObjects.Count());
     }
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -339,16 +339,18 @@ public sealed class EntityFrameworkIntegrationTests :
 
             // Act
             await context.Database.ExecuteSqlRawAsync(
-                "SELECT @x + @y",
+                "SELECT @x + @y + @z",
                 CreateParameter(provider, "@x", 42),
-                CreateParameter(provider, "@y", 37));
+                CreateParameter(provider, "@y", 37),
+                CreateParameter(provider, "@z", 1234.56));
         }
 
         // Assert
         var activity = Assert.Single(activities);
 
-        Assert.Equal(42, activity.GetTagValue("db.query.parameter.@x"));
-        Assert.Equal(37, activity.GetTagValue("db.query.parameter.@y"));
+        Assert.Equal("42", activity.GetTagValue("db.query.parameter.@x"));
+        Assert.Equal("37", activity.GetTagValue("db.query.parameter.@y"));
+        Assert.Equal("1234.56", activity.GetTagValue("db.query.parameter.@z"));
     }
 
     [EnabledOnDockerPlatformTheory(DockerPlatform.Linux)]

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -137,21 +137,23 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
 
         sqlConnection.ChangeDatabase("master");
 
-        using var sqlCommand = new SqlCommand("SELECT @x + @y", sqlConnection);
+        using var sqlCommand = new SqlCommand("SELECT @x + @y + @z", sqlConnection);
 
         sqlCommand.Parameters.AddWithValue("@x", 42);
         sqlCommand.Parameters.AddWithValue("@y", 37);
+        sqlCommand.Parameters.AddWithValue("@z", 1234.56);
 
         // Act
         var result = await sqlCommand.ExecuteScalarAsync();
 
         // Assert
-        Assert.Equal(79, result);
+        Assert.Equal(1313.56, result);
 
         var activity = Assert.Single(activities);
 
-        Assert.Equal(42, activity.GetTagValue("db.query.parameter.@x"));
-        Assert.Equal(37, activity.GetTagValue("db.query.parameter.@y"));
+        Assert.Equal("42", activity.GetTagValue("db.query.parameter.@x"));
+        Assert.Equal("37", activity.GetTagValue("db.query.parameter.@y"));
+        Assert.Equal("1234.56", activity.GetTagValue("db.query.parameter.@z"));
     }
 #endif
 


### PR DESCRIPTION
## Changes

Fix `db.query.parameter.<key>` attributes to always represent the value as a string ([ref](https://github.com/open-telemetry/semantic-conventions/blob/9e993af31e53177cac4ccda014809ab0b5395835/model/database/registry.yaml#L81-L82)).

Found by #4393.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
