### PR TITLE
[Extensions.AWS] Fix sampling behaviour for .NET 11 compatibility

### DIFF
--- a/src/OpenTelemetry.Extensions.AWS/AWSXRayIdGenerator.cs
+++ b/src/OpenTelemetry.Extensions.AWS/AWSXRayIdGenerator.cs
@@ -80,7 +80,11 @@ public static class AWSXRayIdGenerator
             // any other trace flags that may have been set which are not available
             // in the version of the ActivityTraceFlags enum we are compiling against
             // (e.g. ActivityTraceFlags.RandomTraceId added in .NET 11).
-            if (result != ActivitySamplingResult.AllDataAndRecorded)
+            if (result == ActivitySamplingResult.AllDataAndRecorded)
+            {
+                activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
+            }
+            else
             {
                 activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
             }

--- a/src/OpenTelemetry.Extensions.AWS/AWSXRayIdGenerator.cs
+++ b/src/OpenTelemetry.Extensions.AWS/AWSXRayIdGenerator.cs
@@ -71,15 +71,18 @@ public static class AWSXRayIdGenerator
         {
             var result = !Sdk.SuppressInstrumentation ? ComputeRootActivitySamplingResult(activity, sampler) : ActivitySamplingResult.None;
 
-            activity.ActivityTraceFlags = ActivityTraceFlags.None;
-
             // Following the same behavior when .NET runtime sets the trace flag for a newly created root activity.
             // See: https://github.com/dotnet/runtime/blob/master/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs#L1022-L1027
             activity.IsAllDataRequested = result is ActivitySamplingResult.AllData or ActivitySamplingResult.AllDataAndRecorded;
 
-            if (result == ActivitySamplingResult.AllDataAndRecorded)
+            // Disable recording when the data is not required. We do this,
+            // rather than override to None then turn it on, in order to preserve
+            // any other trace flags that may have been set which are not available
+            // in the version of the ActivityTraceFlags enum we are compiling against
+            // (e.g. ActivityTraceFlags.RandomTraceId added in .NET 11).
+            if (result != ActivitySamplingResult.AllDataAndRecorded)
             {
-                activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
+                activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
             }
         }
     }

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix sampling behaviour to be compatible with .NET 11.
+  ([#4396](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4396))
+
 ## 1.15.1
 
 Released 2026-Apr-21


### PR DESCRIPTION
## Changes

Fix sampling behaviour to be compatible with `ActivityTraceFlags.RandomTraceId` in .NET 11 (https://github.com/dotnet/runtime/issues/124509).

OpenTelemetry.Extensions.AWS doesn't directly reference System.DiagnosticSource and the relevant code only targets .NET Framework so `Activity.HasRandomizedTraceId` can't be referenced in the code, but if the flag were set by other code the current approach would clobber the flag.

This refactors to leave the original flags as-is, then turn off `ActivityTraceFlags.Recorded` if needed.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
