### PR TITLE
[SqlClient] Fix trace flags to handle random IDs

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -17,6 +17,10 @@
   repeated unterminated bracketed identifiers.
   ([#4339](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4339))
 
+* Fix `SqlClientTraceInstrumentationOptions.EnableTraceContextPropagation` to behave
+  correctly when `ActivityTraceFlags.RandomTraceId` is available.
+  ([#4397](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4397))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -129,7 +129,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                         var parameter = setContextCommand.CreateParameter();
                         parameter.ParameterName = ContextInfoParameterName;
 
-                        var tracedflags = ((int)activity.ActivityTraceFlags).ToString("00", CultureInfo.InvariantCulture);
+                        var tracedflags = ((byte)activity.ActivityTraceFlags).ToString("x2", CultureInfo.InvariantCulture);
                         var traceparent = $"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-{tracedflags}";
 
                         parameter.DbType = DbType.Binary;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -129,7 +129,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                         var parameter = setContextCommand.CreateParameter();
                         parameter.ParameterName = ContextInfoParameterName;
 
-                        var tracedflags = (activity.ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0 ? "01" : "00";
+                        var tracedflags = ((int)activity.ActivityTraceFlags).ToString("00", CultureInfo.InvariantCulture);
                         var traceparent = $"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-{tracedflags}";
 
                         parameter.DbType = DbType.Binary;


### PR DESCRIPTION
## Changes

Update flag formatting when `EnableTraceContextPropagation` is enabled to cater for `ActivityTraceFlags.RandomTraceId` (https://github.com/dotnet/runtime/issues/124509).

Found in #3867 with .NET 11 preview.4.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
