### PR TITLE
[StackExchange.Redis] Improved performance of Redis command draining

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -9,6 +9,16 @@
 * Add instrumentation scope version and schema URL to traces.
   ([#4095](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4095))
 
+* Add optimized path to flush commands on every `FlushInterval` tick
+  regardless whether the parent `Activity` completes. Whether the new behavior
+  is used depends on instrumentation configuration:
+  * If both `Enrich` and `Filter` are not set, commands are flushed
+    eagerly each tick without waiting for the parent `Activity` to complete, reducing
+    memory pressure for long-lived or high-volume parent spans.
+  * If `Enrich` or `Filter` is set, commands are buffered until the
+    parent `Activity` completes, maintaining the previous behavior.
+    ([#4398](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4398))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
@@ -143,6 +143,15 @@ Connections may be added or removed at any time.
 This instrumentation can be configured to change the default behavior by using
 `StackExchangeRedisCallsInstrumentationOptions`.
 
+### Command buffering
+
+If `Enrich` and `Filter` are not configured, profiled commands are flushed
+every `FlushInterval` without waiting for the parent activity to complete.
+
+If either `Enrich` or `Filter` is configured, all commands are buffered until
+the parent activity completes. This can cause high memory usage for long-lived
+or high-volume parent activities.
+
 ### FlushInterval
 
 StackExchange.Redis has its own internal profiler. OpenTelemetry converts each
@@ -185,6 +194,11 @@ raw `IProfiledCommand` object. The `Enrich` action is called only when
 `activity.IsAllDataRequested` is `true`. It contains the activity itself (which
 can be enriched), and the source profiled command object.
 
+> [!WARNING]
+> If `Enrich` is configured, all commands are buffered until the parent
+> activity completes. This can cause high memory usage for long-lived
+> or high-volume parent activities.
+
 The following code snippet shows how to add additional tags using `Enrich`.
 
 ```csharp
@@ -195,6 +209,29 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
         {
             activity.SetTag("is_fast", true);
         }
+    })
+    .Build();
+```
+
+## Filter
+
+This option allows profiled Redis commands to be excluded before an Activity is
+created.
+
+> [!WARNING]
+> If `Filter` is configured, all commands are buffered until the parent
+> activity completes. This can cause high memory usage for long-lived
+> or high-volume parent activities.
+
+The following code snippet shows how to conditionally filter out activties
+using `Filter`.
+
+```csharp
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddRedisInstrumentation(opt => opt.Filter = (activity, command) =>
+    {
+        // only record if command took over 1s
+        return command.ElapsedTime > TimeSpan.FromMilliseconds(1000);
     })
     .Build();
 ```

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
@@ -223,7 +223,7 @@ created.
 > activity completes. This can cause high memory usage for long-lived
 > or high-volume parent activities.
 
-The following code snippet shows how to conditionally filter out activties
+The following code snippet shows how to conditionally filter out activities
 using `Filter`.
 
 ```csharp

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -120,15 +120,18 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
         foreach (var entry in this.Cache)
         {
             var parent = entry.Value.Activity;
-            if (parent.Duration == TimeSpan.Zero)
+            var parentCompleted = parent.Duration != TimeSpan.Zero;
+
+            if (this.options.EnableEarlyCommandDrain || parentCompleted)
             {
-                // Activity is still running, don't drain.
-                continue;
+                var session = entry.Value.Session;
+                RedisProfilerEntryToActivityConverter.DrainSession(parent, session.FinishProfiling(), this.options);
             }
 
-            var session = entry.Value.Session;
-            RedisProfilerEntryToActivityConverter.DrainSession(parent, session.FinishProfiling(), this.options);
-            this.Cache.TryRemove((entry.Key.TraceId, entry.Key.SpanId), out _);
+            if (parentCompleted)
+            {
+                this.Cache.TryRemove((entry.Key.TraceId, entry.Key.SpanId), out _);
+            }
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisInstrumentationOptions.cs
@@ -76,4 +76,13 @@ public class StackExchangeRedisInstrumentationOptions
     /// Gets or sets a value indicating whether the new database attributes should be emitted.
     /// </summary>
     internal bool EmitNewAttributes { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether commands should be drained from profiling sessions prior to parent <see cref="Activity"/> completion.
+    /// Filter and Enrich callbacks have historically been passed completed parent <see cref="Activity"/> instances.
+    /// If both callbacks are null, commands may be drained prior to the parent <see cref="Activity"/> completion,
+    /// lowering memory pressure and improving performance.
+    /// If either callback is set, the old behavior is used to ensure the callbacks are passed completed parent <see cref="Activity"/> instances.
+    /// </summary>
+    internal bool EnableEarlyCommandDrain => this.Filter == null && this.Enrich == null;
 }

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -339,6 +339,10 @@ public class StackExchangeRedisCallsInstrumentationTests(RedisXunitFixture fixtu
             Assert.NotSame(profiler0, profiler1);
         }
 
+        var cacheKey = (rootActivity.TraceId, rootActivity.SpanId);
+        Assert.NotEmpty(instrumentation.Cache);
+        Assert.Contains(cacheKey, instrumentation.Cache);
+
         rootActivity.Stop();
         rootActivity.Dispose();
 
@@ -510,6 +514,93 @@ public class StackExchangeRedisCallsInstrumentationTests(RedisXunitFixture fixtu
 
         Assert.Single(exportedItems);
         Assert.Equal("SET", exportedItems[0].DisplayName);
+    }
+
+    [Fact]
+    public void EnableEarlyCommandDrain_TruthTable()
+    {
+        Assert.True(new StackExchangeRedisInstrumentationOptions().EnableEarlyCommandDrain);
+
+        Assert.False(new StackExchangeRedisInstrumentationOptions
+        {
+            Filter = _ => true,
+        }.EnableEarlyCommandDrain);
+
+        Assert.False(new StackExchangeRedisInstrumentationOptions
+        {
+            Enrich = (_, _) => { },
+        }.EnableEarlyCommandDrain);
+
+        Assert.False(new StackExchangeRedisInstrumentationOptions
+        {
+            Filter = _ => true,
+            Enrich = (_, _) => { },
+        }.EnableEarlyCommandDrain);
+    }
+
+    [EnabledOnDockerPlatformTheory(DockerPlatform.Linux)]
+    [InlineData(false, false)] // default options = early drain enabled
+    [InlineData(true, false)] // Enrich set = buffered until parent completes
+    [InlineData(false, true)] // Filter set = buffered until parent completes
+    public void DrainTiming_EarlyVsBuffered(bool setEnrich, bool setFilter)
+    {
+        var connectionOptions = new ConfigurationOptions { AbortOnConnectFail = true };
+        connectionOptions.EndPoints.Add(this.connectionString);
+        using var connection = ConnectionMultiplexer.Connect(connectionOptions);
+        var db = connection.GetDatabase();
+        db.KeyDelete("drain-timing-key");
+
+        var exportedItems = new List<Activity>();
+
+        var opts = new StackExchangeRedisInstrumentationOptions();
+        if (setEnrich)
+        {
+            opts.Enrich = (_, _) => { };
+        }
+
+        if (setFilter)
+        {
+            opts.Filter = _ => true;
+        }
+
+        var expectEarlyEmit = !setEnrich && !setFilter;
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(StackExchangeRedisConnectionInstrumentation.ActivitySource.Name)
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        using var instrumentation = new StackExchangeRedisConnectionInstrumentation(connection, name: null, opts);
+
+        using var rootActivity = new Activity("Parent")
+            .SetParentId(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded)
+            .Start();
+
+        Activity.Current = rootActivity;
+        db.StringSet("drain-timing-key", "v");
+        db.StringGet("drain-timing-key");
+
+        // Flush while the parent is still running.
+        instrumentation.Flush();
+
+        var cacheKey = (rootActivity.TraceId, rootActivity.SpanId);
+
+        if (expectEarlyEmit)
+        {
+            Assert.NotEmpty(exportedItems);
+            Assert.Contains(cacheKey, instrumentation.Cache);
+        }
+        else
+        {
+            Assert.Empty(exportedItems);
+            Assert.Contains(cacheKey, instrumentation.Cache);
+        }
+
+        rootActivity.Stop();
+        instrumentation.Flush();
+
+        Assert.NotEmpty(exportedItems);
+        Assert.DoesNotContain(cacheKey, instrumentation.Cache);
     }
 
     private static void VerifyOldActivityData(Activity activity, bool isSet, EndPoint endPoint, bool setCommandKey = false)

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -516,28 +516,6 @@ public class StackExchangeRedisCallsInstrumentationTests(RedisXunitFixture fixtu
         Assert.Equal("SET", exportedItems[0].DisplayName);
     }
 
-    [Fact]
-    public void EnableEarlyCommandDrain_TruthTable()
-    {
-        Assert.True(new StackExchangeRedisInstrumentationOptions().EnableEarlyCommandDrain);
-
-        Assert.False(new StackExchangeRedisInstrumentationOptions
-        {
-            Filter = _ => true,
-        }.EnableEarlyCommandDrain);
-
-        Assert.False(new StackExchangeRedisInstrumentationOptions
-        {
-            Enrich = (_, _) => { },
-        }.EnableEarlyCommandDrain);
-
-        Assert.False(new StackExchangeRedisInstrumentationOptions
-        {
-            Filter = _ => true,
-            Enrich = (_, _) => { },
-        }.EnableEarlyCommandDrain);
-    }
-
     [EnabledOnDockerPlatformTheory(DockerPlatform.Linux)]
     [InlineData(false, false)] // default options = early drain enabled
     [InlineData(true, false)] // Enrich set = buffered until parent completes

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisInstrumentationOptionsTests.cs
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests;
+
+[Collection("Redis")]
+public class StackExchangeRedisInstrumentationOptionsTests
+{
+    [Fact]
+    public void EnableEarlyCommandDrain_TruthTable()
+    {
+        Assert.True(new StackExchangeRedisInstrumentationOptions().EnableEarlyCommandDrain);
+
+        Assert.False(new StackExchangeRedisInstrumentationOptions
+        {
+            Filter = _ => true,
+        }.EnableEarlyCommandDrain);
+
+        Assert.False(new StackExchangeRedisInstrumentationOptions
+        {
+            Enrich = (_, _) => { },
+        }.EnableEarlyCommandDrain);
+
+        Assert.False(new StackExchangeRedisInstrumentationOptions
+        {
+            Filter = _ => true,
+            Enrich = (_, _) => { },
+        }.EnableEarlyCommandDrain);
+    }
+}


### PR DESCRIPTION
Fixes #4083 

## Changes

Adds an optimized path to flush profiled Redis commands on every `FlushInterval` tick regardless whether the parent `Activity` completes.

Whether this new optimized path is used depends on instrumentation configuration.

If both `Enrich` and `Filter` are not set, commands are flushed without waiting for the parent `Activity` to complete. For long-lived or high-volume parent spans this can alleviate memory pressure as seen in #4083.

if `Enrich` or `Filter` is set, commands are buffered until the parent `Activity` completes. The parameters for these two callbacks have historically received a completed parent `Activity`. This way, the previous behavior is maintained, avoiding a potential breaking change.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
