### PR TITLE
[SqlClient] Improve enum formatting

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -7,6 +7,8 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
+
 #if NET
 using System.Text;
 #endif
@@ -129,7 +131,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                         var parameter = setContextCommand.CreateParameter();
                         parameter.ParameterName = ContextInfoParameterName;
 
-                        var tracedflags = ((byte)activity.ActivityTraceFlags).ToString("x2", CultureInfo.InvariantCulture);
+                        var tracedflags = FormatActivityTraceFlags(activity.ActivityTraceFlags);
                         var traceparent = $"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-{tracedflags}";
 
                         parameter.DbType = DbType.Binary;
@@ -272,6 +274,39 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                 break;
             default:
                 break;
+        }
+    }
+
+    private static string FormatActivityTraceFlags(ActivityTraceFlags flags)
+    {
+        // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3867
+        // will change this code to use ActivityTraceFlags.RandomTraceId instead of 2.
+        // If new enem values are added in the future the Fallback path will ensure
+        // that the handling is functionally correct, but the switch should be updated
+        // to include the new value(s) for better readability and performance where possible.
+        return flags switch
+        {
+            ActivityTraceFlags.None => "00",
+            ActivityTraceFlags.Recorded => "01",
+            (ActivityTraceFlags)2 => "02",
+            ActivityTraceFlags.Recorded | (ActivityTraceFlags)2 => "03",
+            _ => Fallback((byte)flags),
+        };
+
+        static string Fallback(byte flags)
+        {
+            // IDE0302 suppressed as benchmarking showed that the explicitly stackalloc'd variant was more performant
+#pragma warning disable IDE0302 // Simplify collection initialization
+            Span<char> buffer = stackalloc char[2];
+#pragma warning restore IDE0302 // Simplify collection initialization
+
+            buffer[0] = GetHexChar(flags >> 4);
+            buffer[1] = GetHexChar(flags & 0xF);
+
+            return buffer.ToString();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static char GetHexChar(int value) => (char)(value + (value < 10 ? '0' : 'a' - 10));
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -281,7 +281,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
     {
         // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3867
         // will change this code to use ActivityTraceFlags.RandomTraceId instead of 2.
-        // If new enem values are added in the future the Fallback path will ensure
+        // If new enum values are added in the future the Fallback path will ensure
         // that the handling is functionally correct, but the switch should be updated
         // to include the new value(s) for better readability and performance where possible.
         return flags switch


### PR DESCRIPTION
Follow-up to #4397.

## Changes

Refactor formatting `ActivityTraceFlags` to a string to the most performant option.

## Benchmarks

The `Format_Composite_Stackalloc_Alternative` version was selected as the best overall option.

```text
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8457/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.300
  [Host]     : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
```

| Method                                  | Flags         | Mean       | Error     | StdDev    | Median     | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|---------------------------------------- |-------------- |-----------:|----------:|----------:|-----------:|------:|--------:|-------:|----------:|------------:|
| **Format_ToString**                         | **None**          | **14.0657 ns** | **0.9350 ns** | **2.6677 ns** | **13.1584 ns** |  **1.03** |    **0.26** | **0.0051** |      **64 B** |        **1.00** |
| Format_Constant_With_Fallback           | None          |  0.4085 ns | 0.0252 ns | 0.0211 ns |  0.4020 ns |  0.03 |    0.00 |      - |         - |        0.00 |
| Format_Span                             | None          |  6.6088 ns | 0.1644 ns | 0.4124 ns |  6.4820 ns |  0.48 |    0.08 | 0.0025 |      32 B |        0.50 |
| Format_Composite                        | None          |  0.6374 ns | 0.0107 ns | 0.0095 ns |  0.6389 ns |  0.05 |    0.01 |      - |         - |        0.00 |
| Format_Composite_Stackalloc             | None          |  0.2377 ns | 0.0543 ns | 0.0453 ns |  0.2245 ns |  0.02 |    0.00 |      - |         - |        0.00 |
| Format_Composite_Stackalloc_Alternative | None          |  0.2038 ns | 0.0107 ns | 0.0100 ns |  0.2067 ns |  0.01 |    0.00 |      - |         - |        0.00 |
|                                         |               |            |           |           |            |       |         |        |           |             |
| **Format_ToString**                         | **First**         | **13.4629 ns** | **0.5981 ns** | **1.7634 ns** | **12.9897 ns** |  **1.02** |    **0.18** | **0.0051** |      **64 B** |        **1.00** |
| Format_Constant_With_Fallback           | First         |  0.2275 ns | 0.0401 ns | 0.0375 ns |  0.2230 ns |  0.02 |    0.00 |      - |         - |        0.00 |
| Format_Span                             | First         | 10.4672 ns | 1.0665 ns | 3.1445 ns | 12.0753 ns |  0.79 |    0.26 | 0.0025 |      32 B |        0.50 |
| Format_Composite                        | First         |  0.7220 ns | 0.0718 ns | 0.1801 ns |  0.6257 ns |  0.05 |    0.02 |      - |         - |        0.00 |
| Format_Composite_Stackalloc             | First         |  0.6109 ns | 0.0258 ns | 0.0242 ns |  0.6026 ns |  0.05 |    0.01 |      - |         - |        0.00 |
| Format_Composite_Stackalloc_Alternative | First         |  0.6608 ns | 0.0142 ns | 0.0118 ns |  0.6596 ns |  0.05 |    0.01 |      - |         - |        0.00 |
|                                         |               |            |           |           |            |       |         |        |           |             |
| **Format_ToString**                         | **Second**        | **11.8538 ns** | **0.2400 ns** | **0.2004 ns** | **11.8405 ns** |  **1.00** |    **0.02** | **0.0051** |      **64 B** |        **1.00** |
| Format_Constant_With_Fallback           | Second        |  0.6490 ns | 0.0288 ns | 0.0240 ns |  0.6469 ns |  0.05 |    0.00 |      - |         - |        0.00 |
| Format_Span                             | Second        |  6.3513 ns | 0.1563 ns | 0.1673 ns |  6.3097 ns |  0.54 |    0.02 | 0.0025 |      32 B |        0.50 |
| Format_Composite                        | Second        |  0.6740 ns | 0.0112 ns | 0.0105 ns |  0.6726 ns |  0.06 |    0.00 |      - |         - |        0.00 |
| Format_Composite_Stackalloc             | Second        |  0.6305 ns | 0.0126 ns | 0.0112 ns |  0.6338 ns |  0.05 |    0.00 |      - |         - |        0.00 |
| Format_Composite_Stackalloc_Alternative | Second        |  0.1980 ns | 0.0116 ns | 0.0109 ns |  0.1963 ns |  0.02 |    0.00 |      - |         - |        0.00 |
|                                         |               |            |           |           |            |       |         |        |           |             |
| **Format_ToString**                         | **First, Second** | **11.8149 ns** | **0.1319 ns** | **0.1169 ns** | **11.8243 ns** |  **1.00** |    **0.01** | **0.0051** |      **64 B** |        **1.00** |
| Format_Constant_With_Fallback           | First, Second |  0.2204 ns | 0.0103 ns | 0.0096 ns |  0.2168 ns |  0.02 |    0.00 |      - |         - |        0.00 |
| Format_Span                             | First, Second |  6.1566 ns | 0.0869 ns | 0.0771 ns |  6.1419 ns |  0.52 |    0.01 | 0.0025 |      32 B |        0.50 |
| Format_Composite                        | First, Second |  0.2171 ns | 0.0102 ns | 0.0095 ns |  0.2174 ns |  0.02 |    0.00 |      - |         - |        0.00 |
| Format_Composite_Stackalloc             | First, Second |  0.2700 ns | 0.0184 ns | 0.0153 ns |  0.2650 ns |  0.02 |    0.00 |      - |         - |        0.00 |
| Format_Composite_Stackalloc_Alternative | First, Second |  0.1907 ns | 0.0321 ns | 0.0300 ns |  0.1764 ns |  0.02 |    0.00 |      - |         - |        0.00 |
|                                         |               |            |           |           |            |       |         |        |           |             |
| **Format_ToString**                         | **255**           | **11.5161 ns** | **0.2792 ns** | **0.3104 ns** | **11.4047 ns** |  **1.00** |    **0.04** | **0.0051** |      **64 B** |        **1.00** |
| Format_Constant_With_Fallback           | 255           | 12.0033 ns | 0.1652 ns | 0.1545 ns | 12.0527 ns |  1.04 |    0.03 | 0.0051 |      64 B |        1.00 |
| Format_Span                             | 255           |  6.2443 ns | 0.1326 ns | 0.1175 ns |  6.2284 ns |  0.54 |    0.02 | 0.0025 |      32 B |        0.50 |
| Format_Composite                        | 255           |  5.9266 ns | 0.1124 ns | 0.0996 ns |  5.8949 ns |  0.51 |    0.02 | 0.0025 |      32 B |        0.50 |
| Format_Composite_Stackalloc             | 255           |  6.4715 ns | 0.1860 ns | 0.3923 ns |  6.3271 ns |  0.56 |    0.04 | 0.0025 |      32 B |        0.50 |
| Format_Composite_Stackalloc_Alternative | 255           |  6.5194 ns | 0.1373 ns | 0.1284 ns |  6.5201 ns |  0.57 |    0.02 | 0.0025 |      32 B |        0.50 |

```csharp
using System.Runtime.CompilerServices;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;

namespace DotNetBenchmarks;

[MemoryDiagnoser]
public class EnumFormattingBenchmarks
{
    [Flags]
    public enum SampleEnum
    {
        None,
        First = 1,
        Second = 2,
    }

    [Params(SampleEnum.None, SampleEnum.First, SampleEnum.Second, SampleEnum.First | SampleEnum.Second, (SampleEnum)0xFF)]
    public SampleEnum Flags { get; set; }

    [Benchmark(Baseline = true)]
    public string Format_ToString()
        => string.Concat("-", ((byte)Flags).ToString("x2", CultureInfo.InvariantCulture));

    [Benchmark]
    public string Format_Constant_With_Fallback() => Flags switch
    {
        SampleEnum.None => "-00",
        SampleEnum.First => "-01",
        SampleEnum.Second => "-02",
        SampleEnum.First | SampleEnum.Second => "-03",
        _ => string.Concat("-", ((byte)Flags).ToString("x2", CultureInfo.InvariantCulture)),
    };

    [Benchmark]
    public string Format_Span()
    {
        Span<char> buffer = stackalloc char[3];

        var flags = (byte)Flags;
        buffer[0] = '-';
        buffer[1] = GetHexChar(flags >> 4);
        buffer[2] = GetHexChar(flags & 0xF);

        return buffer.ToString();

        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        static char GetHexChar(int value) => (char)(value + (value < 10 ? '0' : 'a' - 10));
    }

    [Benchmark]
    public string Format_Composite()
    {
        return Flags switch
        {
            SampleEnum.None => "-00",
            SampleEnum.First => "-01",
            SampleEnum.Second => "-02",
            SampleEnum.First | SampleEnum.Second => "-03",
            _ => Fallback((byte)Flags),
        };

        static string Fallback(byte flags)
        {
            ReadOnlySpan<char> buffer = ['-', GetHexChar(flags >> 4), GetHexChar(flags & 0xF)];
            return buffer.ToString();

            [MethodImpl(MethodImplOptions.AggressiveInlining)]
            static char GetHexChar(int value) => (char)(value + (value < 10 ? '0' : 'a' - 10));
        }
    }

    [Benchmark]
    public string Format_Composite_Stackalloc()
    {
        return Flags switch
        {
            SampleEnum.None => "-00",
            SampleEnum.First => "-01",
            SampleEnum.Second => "-02",
            SampleEnum.First | SampleEnum.Second => "-03",
            _ => Fallback((byte)Flags),
        };

        static string Fallback(byte flags)
        {
            ReadOnlySpan<char> buffer = stackalloc char[3] { '-', GetHexChar(flags >> 4), GetHexChar(flags & 0xF) };
            return buffer.ToString();

            [MethodImpl(MethodImplOptions.AggressiveInlining)]
            static char GetHexChar(int value) => (char)(value + (value < 10 ? '0' : 'a' - 10));
        }
    }

    [Benchmark]
    public string Format_Composite_Stackalloc_Alternative()
    {
        return Flags switch
        {
            SampleEnum.None => "-00",
            SampleEnum.First => "-01",
            SampleEnum.Second => "-02",
            SampleEnum.First | SampleEnum.Second => "-03",
            _ => Fallback((byte)Flags),
        };

        static string Fallback(byte flags)
        {
            Span<char> buffer = stackalloc char[3];

            buffer[0] = '-';
            buffer[1] = GetHexChar(flags >> 4);
            buffer[2] = GetHexChar(flags & 0xF);

            return buffer.ToString();

            [MethodImpl(MethodImplOptions.AggressiveInlining)]
            static char GetHexChar(int value) => (char)(value + (value < 10 ? '0' : 'a' - 10));
        }
    }
}
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
