### PR TITLE
[OpAMP.Client] Remove System.Net.Http NuGet reference

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed System.Net.Http package version resolution issues for .NET 4.6.2.
+  ([#4402](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4402))
+
 * Add support for multivalue identification attributes.
   ([#4350](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4350))
 

--- a/src/OpenTelemetry.OpAmp.Client/OpenTelemetry.OpAmp.Client.csproj
+++ b/src/OpenTelemetry.OpAmp.Client/OpenTelemetry.OpAmp.Client.csproj
@@ -22,11 +22,6 @@
     <PackageReference Include="Grpc.Tools" VersionOverride="[2.72.0,)" PrivateAssets="all" />
   </ItemGroup>
 
-  <!-- .NET Framework supporting packages -->
-  <ItemGroup Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework'">
-    <PackageReference Include="System.Net.Http" />
-  </ItemGroup>
-
   <ItemGroup>
     <Protobuf Include="Protos\anyvalue.proto" ProtoRoot="Protos" Access="Internal" />
     <Protobuf Include="Protos\opamp.proto" ProtoRoot="Protos" Access="Internal" />


### PR DESCRIPTION
Fixes issues with net462 System.Net.Http version resolving.

## Changes

* Uses framework reference instead of NuGet package.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes