### PR TITLE
[Extensions.AWS] Enable X-Ray ALB trace context parsing with only Root value

### DIFF
--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fix sampling behaviour to be compatible with .NET 11.
   ([#4396](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4396))
 
+* Changed AWSXRayPropagator behavior to parse AWS ALB headers with only Root value in it.
+  ([#4403](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4403))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix sampling behaviour to be compatible with .NET 11.
   ([#4396](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4396))
 
-* Changed AWSXRayPropagator behavior to parse AWS ALB headers with only Root value in it.
+* `AWSXRayPropagator` now parses AWS ALB headers with only a Root value.
   ([#4403](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4403))
 
 ## 1.15.1

--- a/src/OpenTelemetry.Extensions.AWS/Trace/AWSXRayPropagator.cs
+++ b/src/OpenTelemetry.Extensions.AWS/Trace/AWSXRayPropagator.cs
@@ -222,7 +222,7 @@ public class AWSXRayPropagator : TextMapPropagator
         var activityTraceId = ActivityTraceId.CreateFromString(traceId);
 
         // Generate a new span ID if Parent is missing (ALB generating only Root param scenario)
-        var activityParentId = parentId.IsEmpty ? ActivitySpanId.CreateRandom() : ActivitySpanId.CreateFromString(parentId);
+        var activityParentId = parentId.IsEmpty ? default : ActivitySpanId.CreateFromString(parentId);
 
         // Default to None if not specified
         var activityTraceOptions = traceOptions == SampledValue ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None;

--- a/src/OpenTelemetry.Extensions.AWS/Trace/AWSXRayPropagator.cs
+++ b/src/OpenTelemetry.Extensions.AWS/Trace/AWSXRayPropagator.cs
@@ -214,13 +214,17 @@ public class AWSXRayPropagator : TextMapPropagator
             }
         }
 
-        if (traceId.IsEmpty || parentId.IsEmpty || traceOptions == default)
+        if (traceId.IsEmpty)
         {
             return false;
         }
 
         var activityTraceId = ActivityTraceId.CreateFromString(traceId);
-        var activityParentId = ActivitySpanId.CreateFromString(parentId);
+
+        // Generate a new span ID if Parent is missing (ALB generating only Root param scenario)
+        var activityParentId = parentId.IsEmpty ? ActivitySpanId.CreateRandom() : ActivitySpanId.CreateFromString(parentId);
+
+        // Default to None if not specified
         var activityTraceOptions = traceOptions == SampledValue ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None;
 
         activityContext = new ActivityContext(activityTraceId, activityParentId, activityTraceOptions, isRemote: true);

--- a/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
@@ -183,7 +183,7 @@ public class AWSXRayPropagatorTests
 
         Assert.Equal(traceId, result.ActivityContext.TraceId);
         Assert.Equal(default, result.ActivityContext.SpanId);
-        Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0, "because Sampled=1");
+        Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0, $"Expected TraceFlags check to pass because Sampled=1, but got: {result.ActivityContext.TraceFlags}");
         Assert.True(result.ActivityContext.IsRemote);
     }
 
@@ -215,7 +215,7 @@ public class AWSXRayPropagatorTests
 
         Assert.Equal(traceId, result.ActivityContext.TraceId);
         Assert.Equal(default, result.ActivityContext.SpanId);
-        Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.None) == 0, "because Sampled is missing");
+        Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.None) == 0, $"Expected TraceFlags check to pass because Sampled is missing, but got: {result.ActivityContext.TraceFlags}");
         Assert.True(result.ActivityContext.IsRemote);
     }
 

--- a/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
@@ -182,7 +182,7 @@ public class AWSXRayPropagatorTests
         var result = this.awsXRayPropagator.Extract(default, carrier, Getter);
 
         Assert.Equal(traceId, result.ActivityContext.TraceId);
-        Assert.NotEqual(default, result.ActivityContext.SpanId); // "because a new SpanId should be generated when Parent is missing"
+        Assert.Equal(default, result.ActivityContext.SpanId);
         Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0, "because Sampled=1");
         Assert.True(result.ActivityContext.IsRemote);
     }
@@ -214,7 +214,7 @@ public class AWSXRayPropagatorTests
         var result = this.awsXRayPropagator.Extract(default, carrier, Getter);
 
         Assert.Equal(traceId, result.ActivityContext.TraceId);
-        Assert.NotEqual(default, result.ActivityContext.SpanId); // "because a new SpanId should be generated when Parent is missing"
+        Assert.Equal(default, result.ActivityContext.SpanId);
         Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.None) == 0, "because Sampled is missing");
         Assert.True(result.ActivityContext.IsRemote);
     }

--- a/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
@@ -177,8 +177,14 @@ public class AWSXRayPropagatorTests
         {
             { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1" },
         };
+        var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
 
-        Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        var result = this.awsXRayPropagator.Extract(default, carrier, Getter);
+
+        Assert.Equal(traceId, result.ActivityContext.TraceId);
+        Assert.NotEqual(default, result.ActivityContext.SpanId); // "because a new SpanId should be generated when Parent is missing"
+        Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0, "because Sampled=1");
+        Assert.True(result.ActivityContext.IsRemote);
     }
 
     [Fact]
@@ -188,8 +194,29 @@ public class AWSXRayPropagatorTests
         {
             { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8" },
         };
+        var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+        var parentId = ActivitySpanId.CreateFromString(ParentId.AsSpan());
+        var traceFlags = ActivityTraceFlags.None;
+        var activityContext = new ActivityContext(traceId, parentId, traceFlags, isRemote: true);
 
-        Assert.Equal(default, this.awsXRayPropagator.Extract(default, carrier, Getter));
+        Assert.Equal(new PropagationContext(activityContext, default), this.awsXRayPropagator.Extract(default, carrier, Getter));
+    }
+
+    [Fact]
+    public void TestExtractTraceHeaderWithoutParentIdAndSampleDecision()
+    {
+        var carrier = new Dictionary<string, string>()
+        {
+            { AWSXRayTraceHeaderKey, "Root=1-5759e988-bd862e3fe1be46a994272793" },
+        };
+        var traceId = ActivityTraceId.CreateFromString(TraceId.AsSpan());
+
+        var result = this.awsXRayPropagator.Extract(default, carrier, Getter);
+
+        Assert.Equal(traceId, result.ActivityContext.TraceId);
+        Assert.NotEqual(default, result.ActivityContext.SpanId); // "because a new SpanId should be generated when Parent is missing"
+        Assert.True((result.ActivityContext.TraceFlags & ActivityTraceFlags.None) == 0, "because Sampled is missing");
+        Assert.True(result.ActivityContext.IsRemote);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #867

## Changes

Fix to the case when AWSXRayPropagator parses XRay Trace only in full format (e.g. with Root and Parent). If it's missing parent or sampled segment, new context is not created. This is a common case in AWS that X-Amzn-Trace-Id value consist of only Root (TraceId) value. In this case a new SpanId is generated and ActivityTraceFlags to None.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes - N/A
* [ ] Changes in public API reviewed (if applicable) - N/A
