### PR TITLE
[Infra] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -271,7 +271,7 @@ internal class HttpInListener : ListenerHandler
             {
                 // Single pass over the tag collection to retrieve both gRPC tags,
                 // avoiding separate GetTagValue iterations.
-                int grpcStatusCode = -1;
+                var grpcStatusCode = -1;
                 var hasGrpcStatusCode = false;
 
                 var tagEnumerator = activity.EnumerateTagObjects();
@@ -293,9 +293,9 @@ internal class HttpInListener : ListenerHandler
                     }
                 }
 
-                if (!string.IsNullOrEmpty(grpcMethod))
+                if (grpcMethod is { Length: > 0 })
                 {
-                    AddGrpcAttributes(activity, grpcMethod!, context, grpcStatusCode, hasGrpcStatusCode);
+                    AddGrpcAttributes(activity, grpcMethod, context, grpcStatusCode, hasGrpcStatusCode);
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -306,7 +306,10 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
             return buffer.ToString();
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static char GetHexChar(int value) => (char)(value + (value < 10 ? '0' : 'a' - 10));
+            static char GetHexChar(int value)
+            {
+                return (char)(value + (value < 10 ? '0' : 'a' - 10));
+            }
         }
     }
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Utils/AnyValueExtensions.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Utils/AnyValueExtensions.cs
@@ -29,7 +29,9 @@ internal static class AnyValueExtensions
 
         Debug.Assert(value.ArrayValue != null, "ArrayValue should not be null in case of AnyValueType.Array");
 
+#pragma warning disable IDE0370 // Remove unnecessary suppression
         foreach (var item in value.ArrayValue!)
+#pragma warning restore IDE0370 // Remove unnecessary suppression
         {
             anyValue.ArrayValue.Values.Add(item.ToAnyValue());
         }

--- a/src/Shared/GrpcTagHelper.cs
+++ b/src/Shared/GrpcTagHelper.cs
@@ -61,7 +61,7 @@ internal static class GrpcTagHelper
     {
         var status = ActivityStatusCode.Error;
 
-        if (statusCode >= 0 && statusCode <= (int)GrpcStatusCanonicalCode.MaxValue)
+        if (statusCode is >= 0 and <= (int)GrpcStatusCanonicalCode.MaxValue)
         {
             status = (GrpcStatusCanonicalCode)statusCode switch
             {
@@ -99,7 +99,7 @@ internal static class GrpcTagHelper
     /// <returns>Resolved span <see cref="Status"/> for the Grpc status code.</returns>
     public static ActivityStatusCode ResolveSpanStatusForGrpcStatusCodeOnServer(int statusCode)
     {
-        if (statusCode >= 0 && statusCode <= (int)GrpcStatusCanonicalCode.MaxValue)
+        if (statusCode is >= 0 and <= (int)GrpcStatusCanonicalCode.MaxValue)
         {
 #pragma warning disable IDE0072 // Add missing cases
             return (GrpcStatusCanonicalCode)statusCode switch

--- a/test/OpenTelemetry.OpAmp.Client.Tests/AnyValueUnionTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/AnyValueUnionTests.cs
@@ -165,6 +165,7 @@ public class AnyValueUnionTests
             case AnyValueType.Double:
                 Assert.Equal(doubleValue, protoValue.DoubleValue);
                 break;
+            case AnyValueType.Array:
             default:
                 Assert.Fail($"Unhandled type {type}");
                 break;


### PR DESCRIPTION
## Changes

Fix new code analysis warnings from the .NET 11 SDK in #3867.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
