### PR TITLE
[OpAMP.Client] Bump opamp protos v0.18.0

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bumped OpAMP spec to v0.18.0.
+  ([#4421](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4421))
+
 * Fixed System.Net.Http package version resolution issues for .NET 4.6.2.
   ([#4402](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4402))
 

--- a/src/OpenTelemetry.OpAmp.Client/Protos/opamp.proto
+++ b/src/OpenTelemetry.OpAmp.Client/Protos/opamp.proto
@@ -169,7 +169,7 @@ message AvailableComponents {
     // Agent-calculated hash of the components.
     // This hash should be included in every AvailableComponents message.
     bytes hash = 2;
- }
+}
 
 message ComponentDetails {
     // Extra key/value pairs that may be used to describe the component.
@@ -444,7 +444,7 @@ message TLSConnectionSettings {
   // Minimum accepted TLS version; default "1.2".
   string min_version = 4;
 
-  // Minimum accepted TLS version; default "".
+  // Maximum accepted TLS version; default "".
   string max_version = 5;
 
   // Explicit list of cipher suites.


### PR DESCRIPTION
OpAMP spec v0.18.0 was released
https://github.com/open-telemetry/opamp-spec/pull/341

## Changes

This PR contains minor changes. Some changes were already ahead of spec.
This PR marks opamp spec (protos) now fully in sync with v0.18.0

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
