### PR TITLE
[OpAMP.Client] Bump proto files to v0.18.0

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/Protos/opamp.proto
+++ b/src/OpenTelemetry.OpAmp.Client/Protos/opamp.proto
@@ -169,7 +169,7 @@ message AvailableComponents {
     // Agent-calculated hash of the components.
     // This hash should be included in every AvailableComponents message.
     bytes hash = 2;
- }
+}
 
 message ComponentDetails {
     // Extra key/value pairs that may be used to describe the component.
@@ -444,7 +444,7 @@ message TLSConnectionSettings {
   // Minimum accepted TLS version; default "1.2".
   string min_version = 4;
 
-  // Minimum accepted TLS version; default "".
+  // Maximum accepted TLS version; default "".
   string max_version = 5;
 
   // Explicit list of cipher suites.


### PR DESCRIPTION
## Changes

[OpAMP.Client] Bump proto files to https://github.com/open-telemetry/opamp-spec/releases/tag/v0.18.0
This version includes all manual changes done previously in our local copy. No more manual modifications

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
