### PR TITLE
[Repo] Add dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 3
     directory: "/"
     schedule:
       interval: yearly

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,8 @@
     "**/__fixtures__/**"
   ],
   "labels": ["dependencies", "infra"],
+  "minimumReleaseAge": "3 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
@@ -48,6 +50,12 @@
       "matchManagers": ["nuget"],
       "matchCurrentValue": "^\\[[^,]+,\\)$",
       "enabled": false
+    },
+    {
+      "extends": ["monorepo:dotnet"],
+      "description": ["Cooldown on .NET updates to maximize batching"],
+      "matchManagers": ["nuget"],
+      "minimumReleaseAge": "6 hours"
     },
     {
       "extends": ["monorepo:dotnet"],

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,3 +1,6 @@
 rules:
+  dependabot-cooldown:
+    config:
+      days: 3
   secrets-outside-env:
     disable: true


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet/pull/7325

## Changes

Add a cooldown period of 3 days for dependencies, except for .NET itself to allow rapid ingestion of monthly security patches.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
