### PR TITLE
[Infra] zizmor fixes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,20 @@
   "automerge": false,
   "commitBodyTable": true,
   "commitMessageAction": "Bump",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": ["Update GitHub runner labels in workflow fields and matrix values"],
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate:\\s*datasource=(?<datasource>github-runners)\\s+depName=(?<depName>[^\\s]+)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*[A-Za-z0-9_-]+:\\s*['\"]?(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}github-runner{{/if}}"
+    }
+  ],
   "dependencyDashboard": false,
   "extends": [
     "config:best-practices",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
         "/(^|/)action\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate:\\s*datasource=(?<datasource>github-runners)\\s+depName=(?<depName>[^\\s]+)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*[A-Za-z0-9_-]+:\\s*['\"]?(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
+        "# renovate:\\s*datasource=(?<datasource>github-runners)\\s+depName=(?<depName>[^\\s]+)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}github-runner{{/if}}"
     }

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       os-list:
-        default: '[ "windows-latest", "ubuntu-24.04" ]'
+        default: '[ "windows-2025", "ubuntu-24.04" ]'
         required: false
         type: string
       tfm-list:
@@ -42,6 +42,7 @@ permissions:
 
 jobs:
   build-test:
+    name: build-test
 
     strategy:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
@@ -49,21 +50,26 @@ jobs:
         os: ${{ fromJSON(inputs.os-list) }}
         version: ${{ fromJSON(inputs.tfm-list) }}
         exclude:
+        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
         - os: ubuntu-24.04
           version: net462
-        - os: macos-latest
+        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+        - os: macos-26
           version: net462
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit. MinVer needs to find
         # the version tag which is typically NOT on the first commit so we
         # retrieve them all.
         fetch-depth: 0
+        persist-credentials: false
+        show-progress: false
 
     - name: Resolve project
       id: resolve-project
@@ -129,11 +135,12 @@ jobs:
       if: inputs.run-tests
       shell: pwsh
       env:
+        DISABLE_APP_DOMAIN: ${{ matrix.version == 'net462' && 'false' || 'true' }}
         PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
         TARGET_FRAMEWORK: ${{ matrix.version }}
         TEST_FILTER: ${{ inputs.test-case-filter }}
       run: >
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && 'sudo -E' || '' }}
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-2025' && 'sudo -E' || '' }}
         dotnet test ${env:PROJECT_PATH}
         --collect:"Code Coverage"
         --results-directory:TestResults
@@ -145,21 +152,21 @@ jobs:
         --logger:"GitHubActions;report-warnings=false"
         --logger:"junit;LogFilePath=TestResults/junit.xml"
         --filter "${env:TEST_FILTER}"
-        -- RunConfiguration.DisableAppDomain=${{ matrix.version == 'net462' && 'false' || 'true' }}
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && '&& sudo chmod a+rw ./TestResults' || '' }}
+        -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
+        ${{ inputs.test-require-elevated && matrix.os != 'windows-2025' && '&& sudo chmod a+rw ./TestResults' || '' }}
 
     - name: dotnet pack ${{ steps.resolve-project.outputs.title }}
-      if: matrix.os == 'windows-latest' && inputs.pack
+      if: matrix.os == 'windows-2025' && inputs.pack
       run: dotnet pack ${env:PROJECT_PATH} --configuration Release --no-restore --no-build -p:EnablePackageValidation=true
       shell: pwsh
       env:
         PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
 
-    - name: Install coverage tool
+    - name: Install dotnet-coverage
       if: inputs.run-tests
       run: dotnet tool install -g dotnet-coverage
 
-    - name: Merging test results
+    - name: Merge test results
       if: inputs.run-tests && hashFiles('./TestResults/**/*.coverage') != ''
       run: dotnet-coverage merge -f cobertura -o ./TestResults/Cobertura.xml ./TestResults/**/*.coverage
 
@@ -179,7 +186,7 @@ jobs:
         name: Code Coverage for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
         codecov_yml_path: .github/codecov.yml
 
-    - name: Upload test results  ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
+    - name: Upload test results ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
       if: ${{ !cancelled() && inputs.run-tests && hashFiles('./**/TestResults/junit.xml') != '' }}
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
@@ -192,7 +199,7 @@ jobs:
     - name: Publish ${{ steps.resolve-project.outputs.name }} NuGet packages to Artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       # Only publish packages from the first job, which should be net462 for Windows in most cases, which is preferred for .NET Framework support
-      if: matrix.os == 'windows-latest' && inputs.pack && strategy.job-index == 0
+      if: matrix.os == 'windows-2025' && inputs.pack && strategy.job-index == 0
       with:
         name: ${{ steps.resolve-project.outputs.name }}-packages
         path: ./artifacts/package/release

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -132,28 +132,49 @@ jobs:
         PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
 
     - name: dotnet test ${{ steps.resolve-project.outputs.title }}
-      if: inputs.run-tests
+      if: inputs.run-tests && (!inputs.test-require-elevated || matrix.os == 'windows-2025')
       shell: pwsh
       env:
         DISABLE_APP_DOMAIN: ${{ matrix.version == 'net462' && 'false' || 'true' }}
         PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
         TARGET_FRAMEWORK: ${{ matrix.version }}
         TEST_FILTER: ${{ inputs.test-case-filter }}
-      run: >
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-2025' && 'sudo -E' || '' }}
-        dotnet test ${env:PROJECT_PATH}
-        --collect:"Code Coverage"
-        --results-directory:TestResults
-        --framework ${env:TARGET_FRAMEWORK}
-        --configuration Release
-        --no-restore
-        --no-build
-        --logger:"console;verbosity=detailed"
-        --logger:"GitHubActions;report-warnings=false"
-        --logger:"junit;LogFilePath=TestResults/junit.xml"
-        --filter "${env:TEST_FILTER}"
-        -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
-        ${{ inputs.test-require-elevated && matrix.os != 'windows-2025' && '&& sudo chmod a+rw ./TestResults' || '' }}
+      run: |
+        dotnet test ${env:PROJECT_PATH} `
+          --collect:"Code Coverage" `
+          --results-directory:TestResults `
+          --framework ${env:TARGET_FRAMEWORK} `
+          --configuration Release `
+          --no-restore `
+          --no-build `
+          --logger:"console;verbosity=detailed" `
+          --logger:"GitHubActions;report-warnings=false" `
+          --logger:"junit;LogFilePath=TestResults/junit.xml" `
+          --filter "${env:TEST_FILTER}" `
+          -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
+
+    - name: dotnet test ${{ steps.resolve-project.outputs.title }} (elevated)
+      if: inputs.run-tests && inputs.test-require-elevated && matrix.os != 'windows-2025'
+      shell: pwsh
+      env:
+        DISABLE_APP_DOMAIN: ${{ matrix.version == 'net462' && 'false' || 'true' }}
+        PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
+        TARGET_FRAMEWORK: ${{ matrix.version }}
+        TEST_FILTER: ${{ inputs.test-case-filter }}
+      run: |
+        sudo -E dotnet test ${env:PROJECT_PATH} `
+          --collect:"Code Coverage" `
+          --results-directory:TestResults `
+          --framework ${env:TARGET_FRAMEWORK} `
+          --configuration Release `
+          --no-restore `
+          --no-build `
+          --logger:"console;verbosity=detailed" `
+          --logger:"GitHubActions;report-warnings=false" `
+          --logger:"junit;LogFilePath=TestResults/junit.xml" `
+          --filter "${env:TEST_FILTER}" `
+          -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
+        sudo chmod a+rw ./TestResults
 
     - name: dotnet pack ${{ steps.resolve-project.outputs.title }}
       if: matrix.os == 'windows-2025' && inputs.pack

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -53,7 +53,7 @@ jobs:
         # renovate: datasource=github-runners depName=ubuntu depType=github-runner
         - os: ubuntu-24.04
           version: net462
-        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+        # renovate: datasource=github-runners depName=macos depType=github-runner
         - os: macos-26
           version: net462
 

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -3,23 +3,32 @@ on:
   issues:
     types: [ opened ]
 
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] Only code from the main branch is executed
     branches: [ 'main*', 'instrumentation*', 'exporter*', 'extensions*' ]
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   add-labels-on-issues:
+    name: Add labels to issues
     permissions:
-      issues: write
+      contents: read # To checkout the code
+      issues: write # To add labels to the issue
     if: github.event_name == 'issues' && !github.event.issue.pull_request
 
     runs-on: ubuntu-24.04
 
     steps:
-      - name: check out code
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
 
       - name: Add labels for component found in bug issue descriptions
         shell: pwsh
@@ -37,17 +46,23 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
   add-labels-on-pull-requests:
+    name: Add labels to pull requests
     permissions:
-      pull-requests: write
+      contents: read # To checkout the code
+      pull-requests: write # To add labels to the PR
     if: github.event_name == 'pull_request_target'
 
     runs-on: ubuntu-24.04
 
     steps:
-      - name: check out code
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.repository.default_branch }} # Note: Do not run on the PR branch we want to execute add-labels.psm1 from main on the base repo only because pull_request_target can see secrets
+          filter: 'tree:0'
+          persist-credentials: false
+          # Note: Do not run on the PR branch we want to execute add-labels.psm1 from main on the base repo only because pull_request_target can see secrets
+          ref: ${{ github.event.repository.default_branch }}
+          show-progress: false
 
       - name: Add labels for files changed on pull requests
         shell: pwsh

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -3,7 +3,7 @@ on:
   # pull_request_target is suggested for projects where pull requests will be
   # made from forked repositories. If pull_request is used in these cases,
   # the github token will not have sufficient permission to update the PR.
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] No user code is executed
 
 permissions:
   contents: read
@@ -11,7 +11,7 @@ permissions:
 jobs:
   assign:
     permissions:
-      pull-requests: write # required for assigning reviewers to PRs
+      pull-requests: write # Required for assigning reviewers to PRs
     runs-on: ubuntu-24.04
     name: Assign Reviewers
     steps:

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -19,7 +19,8 @@ jobs:
       pull-requests: write # Required for assigning reviewers to PRs
     runs-on: ubuntu-24.04
     steps:
-      - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
+      - name: Assign reviewers based on CODEOWNERS
+        uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
         with:
           assign-owners: ${{ github.event.pull_request.draft == false }}
           request-owner-reviews: ${{ github.event.pull_request.draft == false }}

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -16,10 +16,11 @@ jobs:
   assign:
     name: Assign Reviewers
     permissions:
+      contents: read # To read the .github/component_owners.yml file
       pull-requests: write # Required for assigning reviewers to PRs
     runs-on: ubuntu-24.04
     steps:
-      - name: Assign reviewers based on CODEOWNERS
+      - name: Assign reviewers based on .github/component_owners.yml
         uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
         with:
           assign-owners: ${{ github.event.pull_request.draft == false }}

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -8,12 +8,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   assign:
+    name: Assign Reviewers
     permissions:
       pull-requests: write # Required for assigning reviewers to PRs
     runs-on: ubuntu-24.04
-    name: Assign Reviewers
     steps:
       - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
         with:

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   resolve-automation:
+    name: Resolve automation secrets access
 
     runs-on: ubuntu-24.04
 
@@ -29,7 +30,8 @@ jobs:
       enabled: ${{ steps.evaluate.outputs.enabled }}
 
     steps:
-    - id: evaluate
+    - name: Evaluate settings
+      id: evaluate
       env:
         IS_ENABLED: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY != '' }}
       run: |

--- a/.github/workflows/ci-Exporter.OneCollector-Integration.yml
+++ b/.github/workflows/ci-Exporter.OneCollector-Integration.yml
@@ -3,6 +3,10 @@ name: Integration Build OpenTelemetry.Exporter.OneCollector
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] Code is gated on maintainer approval for forks
     branches: [ 'main*', 'exporter*' ]
@@ -14,6 +18,7 @@ on:
 
 jobs:
   authorize:
+    name: Authorize external PR
     environment: # Run external PRs from forks on the "external" environment which requires approval
       ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&

--- a/.github/workflows/ci-Exporter.OneCollector-Integration.yml
+++ b/.github/workflows/ci-Exporter.OneCollector-Integration.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
-          - ubuntu-24.04
-          # renovate: datasource=github-runners depName=windows depType=github-runner
-          - windows-2025
+        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+        - ubuntu-24.04
+        # renovate: datasource=github-runners depName=windows depType=github-runner
+        - windows-2025
         version: [ net462, net8.0, net10.0 ]
         exclude:
         - os: ubuntu-24.04

--- a/.github/workflows/ci-Exporter.OneCollector-Integration.yml
+++ b/.github/workflows/ci-Exporter.OneCollector-Integration.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 on:
-  pull_request_target: # Allows secret access from forks see: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
+  pull_request_target: # zizmor: ignore[dangerous-triggers] Code is gated on maintainer approval for forks
     branches: [ 'main*', 'exporter*' ]
     paths:
     - '*/OpenTelemetry.Exporter.OneCollector*/**'
@@ -14,7 +14,7 @@ on:
 
 jobs:
   authorize:
-    environment: # Run external PRs from forks on the "external"" environment which requires approval
+    environment: # Run external PRs from forks on the "external" environment which requires approval
       ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
       'external' || 'internal' }}
@@ -27,7 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, ubuntu-24.04 ]
+        os:
+          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          - ubuntu-24.04
+          # renovate: datasource=github-runners depName=windows depType=github-runner
+          - windows-2025
         version: [ net462, net8.0, net10.0 ]
         exclude:
         - os: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 jobs:
   lint-misspell-sanitycheck:
     uses: ./.github/workflows/sanitycheck.yml
@@ -18,20 +22,26 @@ jobs:
   code-ql:
     uses: ./.github/workflows/codeql-analysis-steps.yml
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab
 
   detect-changes:
-    runs-on: windows-latest
+    name: Detect changes
+    runs-on: windows-2025
     outputs:
       changes: ${{ steps.changes.outputs.changes }}
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: github.event_name == 'push' || github.event_name == 'merge_group'
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
+    - name: Filter paths
+      uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
       id: changes
       with:
         filters: |
@@ -206,7 +216,7 @@ jobs:
     with:
       project-name: OpenTelemetry.Instrumentation.AspNet
       code-cov-name: Instrumentation.AspNet
-      os-list: '[ "windows-latest" ]'
+      os-list: '[ "windows-2025" ]'
       tfm-list: '[ "net462" ]'
 
   build-test-instrumentation-aspnetcore:
@@ -354,7 +364,7 @@ jobs:
     with:
       project-name: OpenTelemetry.Instrumentation.Owin
       code-cov-name: Instrumentation.Owin
-      os-list: '[ "windows-latest" ]'
+      os-list: '[ "windows-2025" ]'
       tfm-list: '[ "net462" ]'
 
   build-test-instrumentation-process:
@@ -389,7 +399,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Instrumentation.Remoting]
       code-cov-name: Instrumentation.Remoting
-      os-list: '[ "windows-latest" ]'
+      os-list: '[ "windows-2025" ]'
       tfm-list: '[ "net462" ]'
 
   build-test-instrumentation-runtime:
@@ -523,7 +533,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Resources.Host]
       code-cov-name: Resources.Host
-      os-list: '[ "windows-latest", "ubuntu-24.04", "macos-latest" ]'
+      os-list: '[ "windows-2025", "ubuntu-24.04", "macos-26" ]'
 
   build-test-resources-operatingsystem:
     needs: detect-changes
@@ -535,7 +545,7 @@ jobs:
     with:
       project-name: Component[OpenTelemetry.Resources.OperatingSystem]
       code-cov-name: Resources.OperatingSystem
-      os-list: '[ "windows-latest", "ubuntu-24.04", "macos-latest" ]'
+      os-list: '[ "windows-2025", "ubuntu-24.04", "macos-26" ]'
 
   build-test-resources-process:
     needs: detect-changes
@@ -631,6 +641,7 @@ jobs:
     uses: ./.github/workflows/verifyaotcompat.yml
 
   build-test:
+    name: build-test
     needs: [
       lint-misspell-sanitycheck,
       code-ql,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,6 +696,8 @@ jobs:
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
+    - name: Debugging failure
+      run: echo '${{ toJson(needs) }}'
     - name: Report CI status
       shell: bash
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,8 +696,6 @@ jobs:
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
-    - name: Debugging failure
-      run: echo '${{ toJson(needs) }}'
     - name: Report CI status
       shell: bash
       env:

--- a/.github/workflows/codeql-analysis-steps.yml
+++ b/.github/workflows/codeql-analysis-steps.yml
@@ -7,11 +7,12 @@ permissions: {}
 
 jobs:
   analyze:
+    name: 'Analyze ${{ matrix.language }}'
     permissions:
-      actions: read  # for github/codeql-action/init to get workflow details
-      contents: read  # for actions/checkout to fetch code
-      security-events: write  # for github/codeql-action/analyze to upload SARIF results
-    runs-on: windows-latest
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab
+    runs-on: windows-2025
 
     strategy:
       fail-fast: false
@@ -27,7 +28,7 @@ jobs:
           maximum-size: 32GB
           disk-root: "D:"
 
-      - name: Checkout repository
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: 'tree:0'
@@ -47,9 +48,10 @@ jobs:
           category: '/language:${{ matrix.language }}'
 
   results:
+    name: results
     if: ${{ !cancelled() }}
     needs: [ analyze ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Report status

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   schedule:
-    - cron: '0 0 * * *' # once in a day at 00:00
+    - cron: '0 0 * * *' # Once a day at 00:00 UTC
   workflow_dispatch:
 
 permissions: {}
@@ -11,6 +11,6 @@ jobs:
   code-ql:
     uses: ./.github/workflows/codeql-analysis-steps.yml
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab

--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -30,7 +30,8 @@ jobs:
     if: needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}

--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -33,12 +33,15 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
         ref: ${{ github.event.repository.default_branch }}
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: Create GitHub Pull Request to update core version in props and update CHANGELOGs in projects

--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -18,6 +22,7 @@ jobs:
       OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
 
   core-version-update:
+    name: Update core package versions
     runs-on: ubuntu-24.04
 
     needs: automation

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   submit-nuget:
     if: github.event.repository.fork == false
-    runs-on: windows-latest
+    runs-on: windows-2025
     timeout-minutes: 10
 
     permissions:
@@ -24,7 +24,7 @@ jobs:
           "DOTNET_ROOT=D:\tools\dotnet" >> ${env:GITHUB_ENV}
           "NUGET_PACKAGES=D:\.nuget\packages" >> ${env:GITHUB_ENV}
 
-      - name: Checkout repository
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: 'tree:0'

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -6,15 +6,20 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 jobs:
   submit-nuget:
+    name: Submit NuGet dependency snapshot
     if: github.event.repository.fork == false
     runs-on: windows-2025
     timeout-minutes: 10
 
     permissions:
-      contents: write
-      id-token: write
+      contents: write # Submit the generated dependency snapshot to the repository dependency graph
+      id-token: write # Authenticate the dependency submission with GitHub OIDC
 
     steps:
       - name: Update agent configuration

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -8,11 +8,16 @@ permissions:
 
 jobs:
   run-dotnet-format:
-    runs-on: windows-latest
+    name: Run dotnet format
+    runs-on: windows-2025
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,19 +5,31 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   fossa:
-    runs-on: ubuntu-latest
+    name: Run FOSSA scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     if: github.event.repository.fork == false
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
 
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+      - name: Run FOSSA analysis
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         if: env.FOSSA_API_KEY != ''
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/integration-test-reusable.yml
+++ b/.github/workflows/integration-test-reusable.yml
@@ -47,10 +47,12 @@ jobs:
     # this checkout requires prior approval via the 'authorize' job environment.
     # The workflow has limited permissions (contents: read) and uses persist-credentials: false
     # to prevent credential theft.
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
         ref: ${{ inputs.checkout-ref }}
+        show-progress: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/integration-test-reusable.yml
+++ b/.github/workflows/integration-test-reusable.yml
@@ -3,6 +3,10 @@ name: Reusable Integration Test
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}-${{ inputs.component }}-${{ inputs.os }}-${{ inputs.version }}
+  cancel-in-progress: false
+
 on:
   workflow_call:
     inputs:
@@ -39,6 +43,7 @@ on:
 
 jobs:
   build-and-test:
+    name: Build and test ${{ inputs.component }} (${{ inputs.os }}, ${{ inputs.version }})
     runs-on: ${{ inputs.os }}
     env:
       BUILD_COMPONENT: ${{ inputs.component }}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -8,13 +8,18 @@ permissions:
 
 jobs:
   run-markdownlint:
+    name: Run markdownlint
     runs-on: ubuntu-24.04
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: run markdownlint
+    - name: Run markdownlint
       uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
       with:
         globs: |

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -5,43 +5,49 @@ on:
     branches:
       - main
   schedule:
-    - cron: "11 8 * * 6" # once a week
+    - cron: "11 8 * * 6" # Once a week
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
+    name: Scorecard analysis
+    runs-on: ubuntu-24.04
     permissions:
-      # Needed for Code scanning upload
-      security-events: write
-      # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
+      checks: read # Read CI results
+      contents: read # Checkout the repository
+      id-token: write # Publish Scorecard results with GitHub OIDC
+      issues: read # Read issues
+      pull-requests: read # Read pull requests
+      security-events: write # Upload the SARIF results to code scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          filter: 'tree:0'
           persist-credentials: false
+          show-progress: false
 
-      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      # Upload the results as artifacts (optional). Commenting out will disable
-      # uploads of run results in SARIF format to the repository Actions tab.
-      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
-      - name: "Upload artifact"
+      - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      # Upload the results to GitHub's code scanning dashboard (optional).
-      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
-      - name: "Upload to code-scanning"
+      - name: Upload code scanning results
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: results.sarif

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -20,6 +24,7 @@ jobs:
       OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
 
   post-release:
+    name: Post-release updates
     runs-on: ubuntu-24.04
 
     needs:
@@ -28,7 +33,8 @@ jobs:
     if: needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
@@ -36,12 +42,15 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit. We need all the tags
         # for this work.
         fetch-depth: 0
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
         ref: ${{ github.event.repository.default_branch }}
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create GitHub Pull Request to update PackageValidationBaselineVersion in projects

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -78,6 +78,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -108,6 +112,7 @@ jobs:
       OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
 
   prepare-release-pr:
+    name: Prepare release pull request
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -115,7 +120,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
@@ -123,9 +129,11 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create GitHub Pull Request to prepare release
@@ -152,6 +160,7 @@ jobs:
           -gitUserEmail ${env:BOT_USER_EMAIL}
 
   lock-pr-and-post-notice-to-create-release-tag:
+    name: Lock pull request and post release tag notice
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -165,7 +174,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
@@ -173,9 +183,11 @@ jobs:
         permission-contents: read
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Lock GitHub Pull Request to prepare release
@@ -193,6 +205,7 @@ jobs:
           -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME}
 
   create-release-tag-unlock-pr-post-notice:
+    name: Create release tag and post notice
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -208,7 +221,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
@@ -216,11 +230,13 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create release tag
@@ -243,6 +259,7 @@ jobs:
           -gitUserEmail ${env:BOT_USER_EMAIL}
 
   update-changelog-release-dates-on-prepare-pr-post-notice:
+    name: Update changelog release dates and post notice
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -258,7 +275,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
@@ -266,11 +284,13 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Update release date
@@ -295,6 +315,7 @@ jobs:
           -gitUserEmail ${env:BOT_USER_EMAIL}
 
   process-release-request-issue:
+    name: Process release request issue
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -313,7 +334,8 @@ jobs:
       )
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
@@ -322,9 +344,11 @@ jobs:
         permission-issues: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Process release request issue being opened or commented

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -26,26 +30,30 @@ jobs:
       OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
 
   build-pack-publish:
+    name: Build, pack, and publish
 
     permissions:
-      artifact-metadata: write
-      attestations: write
-      contents: read
-      id-token: write
+      artifact-metadata: write # Publish artifact metadata for the uploaded packages
+      attestations: write # Create GitHub attestations for the build outputs
+      contents: read # Checkout the repository
+      id-token: write # Sign packages and attestations with GitHub OIDC
 
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     outputs:
       artifact-url: ${{ steps.upload-artifacts.outputs.artifact-url }}
       artifact-id: ${{ steps.upload-artifacts.outputs.artifact-id }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Note: By default GitHub only fetches 1 commit. MinVer needs to find
           # the version tag which is typically NOT on the first commit so we
           # retrieve them all.
           fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
 
       - name: Resolve project
         id: resolve-project
@@ -79,7 +87,7 @@ jobs:
           # used if $project ends up Component.proj.
           echo "BUILD_COMPONENT=$component" >> ${env:GITHUB_ENV}
 
-      - name: Setup dotnet
+      - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
       - name: dotnet restore ${{ steps.resolve-project.outputs.title }}
@@ -198,6 +206,7 @@ jobs:
         run: dotnet nuget push *.nupkg --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
 
   post-build:
+    name: Post build release tasks
     runs-on: ubuntu-24.04
 
     needs:
@@ -207,7 +216,8 @@ jobs:
     if: needs.automation.outputs.enabled && github.event_name == 'push'
 
     steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
           client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
@@ -215,9 +225,11 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Check out code
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+          show-progress: false
           token: ${{ steps.otelbot-token.outputs.token }}
 
       - name: Download Artifacts

--- a/.github/workflows/sanitycheck.yml
+++ b/.github/workflows/sanitycheck.yml
@@ -8,21 +8,31 @@ permissions:
 
 jobs:
   run-typos:
+    name: Check for typos
     runs-on: ubuntu-24.04
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: check for typos
+    - name: Check for typos
       uses: crate-ci/typos@aca895bf05aec0cb7dffa6f94495e923224d9f17 # v1.46.2
 
   run-sanitycheck:
+    name: Run sanity check
     runs-on: ubuntu-24.04
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: validate file encoding, line endings, indentation, and whitespace
+    - name: Validate file encoding, line endings, indentation, and whitespace
       run: python3 ./build/scripts/sanitycheck.py

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,22 +1,24 @@
-# Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
-# Github Actions Stale: https://github.com/actions/stale
-
 name: "Close stale pull requests"
 on:
   schedule:
-    - cron: "12 3 * * *"  # arbitrary time not to DDOS GitHub
+    - cron: "12 3 * * *"  # Arbitrary time not to DDoS GitHub
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   stale:
+    if: github.event.repository.fork == false
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
+    name: stale
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write  # For actions/stale to close stale issues
+      pull-requests: write  # For actions/stale to close stale PRs
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'

--- a/.github/workflows/sync-sql-tests.yml
+++ b/.github/workflows/sync-sql-tests.yml
@@ -7,8 +7,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   sync-sql-tests:
+    name: Sync SQL tests
     runs-on: ubuntu-24.04
     if: github.event.repository.fork == false
 

--- a/.github/workflows/sync-sql-tests.yml
+++ b/.github/workflows/sync-sql-tests.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   sync-sql-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.repository.fork == false
 
     steps:
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: 'tree:0'
-          persist-credentials: true
+          persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
           token: ${{ steps.otelbot-token.outputs.token }}
 

--- a/.github/workflows/sync-sql-tests.yml
+++ b/.github/workflows/sync-sql-tests.yml
@@ -19,7 +19,8 @@ jobs:
 
     steps:
 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
           client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}

--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os:
-          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
-          - ubuntu-24.04
-          # renovate: datasource=github-runners depName=windows depType=github-runner
-          - windows-2025
+        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+        - ubuntu-24.04
+        # renovate: datasource=github-runners depName=windows depType=github-runner
+        - windows-2025
         version: [ net8.0, net9.0, net10.0 ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -8,21 +8,31 @@ permissions:
 
 jobs:
   run-verify-aot-compat:
+    name: Verify AOT compatibility
 
     strategy:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
-        os: [ ubuntu-24.04, windows-latest ]
+        os:
+          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          - ubuntu-24.04
+          # renovate: datasource=github-runners depName=windows depType=github-runner
+          - windows-2025
         version: [ net8.0, net9.0, net10.0 ]
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
-    - name: publish AOT testApp, assert static analysis warning count, and run the app
+    - name: Publish AOT testApp, assert static analysis warning count, and run the app
       shell: pwsh
       run: .\build\scripts\test-aot-compatibility.ps1 ${env:TARGET_FRAMEWORK}
       env:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -2,7 +2,6 @@ name: Lint - YAML
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,10 +10,6 @@ jobs:
   run-yamllint:
     name: Run yamllint
     runs-on: ubuntu-24.04
-
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.sha }}
-      cancel-in-progress: false
 
     steps:
     - name: Checkout code

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -7,8 +7,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 jobs:
   run-yamllint:
+    name: Run yamllint
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -12,8 +12,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: run yamllint
+    - name: Run yamllint
       run: yamllint --no-warnings .

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.sha }}
-  cancel-in-progress: false
-
 jobs:
   run-yamllint:
     name: Run yamllint
     runs-on: ubuntu-24.04
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.sha }}
+      cancel-in-progress: false
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Changes

- Fix zizmor findings from #4419.
- Use `windows-2025` instead of `windows-latest`
- Use `ubuntu-24.04` instead of `ubuntu-latest`
- Use `macos-26` instead of `macos-latest`
- Allow renovate to update GitHub Actions runner labels in matrices

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
