### PR TITLE
[Instrumentation.ConfluentKafka] Document signal selection and link runnable example

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Documented how to enable Kafka traces and metrics independently and linked
+  the runnable `examples/kafka` sample from the package README.
+  ([#1935](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1935))
+
 ## 0.1.0-alpha.6
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-* Documented how to enable Kafka traces and metrics independently and linked
-  the runnable `examples/kafka` sample from the package README.
-  ([#1935](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1935))
-
 ## 0.1.0-alpha.6
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
@@ -51,17 +51,19 @@ steps:
     builder.Services.AddOpenTelemetry()
         .WithTracing(tracing =>
         {
-            // Calls under WithTracing enable Kafka traces; omit them to skip tracing.
             tracing.AddConsoleExporter()
                 .AddOtlpExporter()
+                // AddKafkaProducerInstrumentation and AddKafkaConsumerInstrumentation
+                // are what enable Kafka traces.
                 .AddKafkaProducerInstrumentation<string, string>()
                 .AddKafkaConsumerInstrumentation<string, string>();
         })
         .WithMetrics(metering =>
         {
-            // Calls under WithMetrics enable Kafka metrics; omit them to skip metrics.
             metering.AddConsoleExporter()
                 .AddOtlpExporter()
+                // AddKafkaProducerInstrumentation and AddKafkaConsumerInstrumentation
+                // are what enable Kafka metrics.
                 .AddKafkaProducerInstrumentation<string, string>()
                 .AddKafkaConsumerInstrumentation<string, string>();
         });
@@ -79,10 +81,9 @@ and consumers, allowing you to collect and export telemetry data.
 
 A complete end-to-end sample that produces and consumes messages with
 instrumentation enabled is available in
-[`examples/kafka`](../../examples/kafka). Run it against a local Kafka broker
-(for example the `confluentinc/cp-kafka` Docker image listening on
-`localhost:9092`) to see traces and metrics flowing to the configured
-exporters.
+[`examples/kafka`](../../examples/kafka). Follow that example's README to
+start a local Kafka broker and see traces and metrics flowing to the
+configured exporters.
 
 ## Extending `ConsumerBuilder` or `ProducerBuilder` instances
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
@@ -51,6 +51,7 @@ steps:
     builder.Services.AddOpenTelemetry()
         .WithTracing(tracing =>
         {
+            // Calls under WithTracing enable Kafka traces; omit them to skip tracing.
             tracing.AddConsoleExporter()
                 .AddOtlpExporter()
                 .AddKafkaProducerInstrumentation<string, string>()
@@ -58,6 +59,7 @@ steps:
         })
         .WithMetrics(metering =>
         {
+            // Calls under WithMetrics enable Kafka metrics; omit them to skip metrics.
             metering.AddConsoleExporter()
                 .AddOtlpExporter()
                 .AddKafkaProducerInstrumentation<string, string>()
@@ -72,25 +74,6 @@ steps:
 
 This will set up OpenTelemetry instrumentation for Confluent.Kafka producers
 and consumers, allowing you to collect and export telemetry data.
-
-## Enabling traces and metrics independently
-
-The `AddKafkaProducerInstrumentation<TKey, TValue>()` and
-`AddKafkaConsumerInstrumentation<TKey, TValue>()` extension methods are
-defined on both `TracerProviderBuilder` and `MeterProviderBuilder`. Calling
-them under `WithTracing(...)` enables tracing for the registered builders;
-calling them under `WithMetrics(...)` enables metrics. You can opt in to one
-signal, both, or neither; the `InstrumentedProducerBuilder<TKey, TValue>`
-and `InstrumentedConsumerBuilder<TKey, TValue>` only emit telemetry for
-signals that were registered.
-
-```csharp
-// Traces only -- no metrics will be emitted for Kafka.
-builder.Services.AddOpenTelemetry()
-    .WithTracing(tracing => tracing
-        .AddKafkaProducerInstrumentation<string, string>()
-        .AddKafkaConsumerInstrumentation<string, string>());
-```
 
 ## Runnable example
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
@@ -73,6 +73,34 @@ steps:
 This will set up OpenTelemetry instrumentation for Confluent.Kafka producers
 and consumers, allowing you to collect and export telemetry data.
 
+## Enabling traces and metrics independently
+
+The `AddKafkaProducerInstrumentation<TKey, TValue>()` and
+`AddKafkaConsumerInstrumentation<TKey, TValue>()` extension methods are
+defined on both `TracerProviderBuilder` and `MeterProviderBuilder`. Calling
+them under `WithTracing(...)` enables tracing for the registered builders;
+calling them under `WithMetrics(...)` enables metrics. You can opt in to one
+signal, both, or neither — the `InstrumentedProducerBuilder<TKey, TValue>`
+and `InstrumentedConsumerBuilder<TKey, TValue>` only emit telemetry for
+signals that were registered.
+
+```csharp
+// Traces only — no metrics will be emitted for Kafka.
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddKafkaProducerInstrumentation<string, string>()
+        .AddKafkaConsumerInstrumentation<string, string>());
+```
+
+## Runnable example
+
+A complete end-to-end sample that produces and consumes messages with
+instrumentation enabled is available in
+[`examples/kafka`](../../examples/kafka). Run it against a local Kafka broker
+(for example the `confluentinc/cp-kafka` Docker image listening on
+`localhost:9092`) to see traces and metrics flowing to the configured
+exporters.
+
 ## Extending `ConsumerBuilder` or `ProducerBuilder` instances
 
 To extend an already built `ConsumerBuilder<TKey, TValue>`

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
@@ -80,12 +80,12 @@ The `AddKafkaProducerInstrumentation<TKey, TValue>()` and
 defined on both `TracerProviderBuilder` and `MeterProviderBuilder`. Calling
 them under `WithTracing(...)` enables tracing for the registered builders;
 calling them under `WithMetrics(...)` enables metrics. You can opt in to one
-signal, both, or neither — the `InstrumentedProducerBuilder<TKey, TValue>`
+signal, both, or neither; the `InstrumentedProducerBuilder<TKey, TValue>`
 and `InstrumentedConsumerBuilder<TKey, TValue>` only emit telemetry for
 signals that were registered.
 
 ```csharp
-// Traces only — no metrics will be emitted for Kafka.
+// Traces only -- no metrics will be emitted for Kafka.
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddKafkaProducerInstrumentation<string, string>()


### PR DESCRIPTION
Fixes #1935.

The README for `OpenTelemetry.Instrumentation.ConfluentKafka` showed a single end-to-end snippet that registered both traces and metrics, but did not explain that the two signals are independent or where to find a runnable sample. The follow-up question from the original PR (#1493) was specifically *"link the example from here, or have some basic examples on how to configure the instrumentation"*, and a user later asked in the issue thread about toggling tracing/metrics separately.

This PR updates the package README to:

- Add inline comments in the usage snippet noting that `AddKafkaProducerInstrumentation` and `AddKafkaConsumerInstrumentation` are what enable Kafka traces/metrics, so a user can opt in to one signal, both, or neither.
- Add a "Runnable example" section linking to the existing `examples/kafka` project and deferring to that example's README for the Kafka broker setup.

No code changes; docs only.
