### PR TITLE
[Infra] Fix slow windows-11-arm runs

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -143,7 +143,7 @@ jobs:
         --no-build
         --logger:"console;verbosity=detailed"
         --logger:"GitHubActions;report-warnings=false"
-        --logger:"junit;LogFilePath=TestResults/junit.xml"
+        --logger:"junit;LogFilePath=${env:GITHUB_WORKSPACE}/TestResults/junit.xml"
         --filter "${env:TEST_FILTER}"
         -- RunConfiguration.DisableAppDomain=${{ matrix.version == 'net462' && 'false' || 'true' }}
         ${{ inputs.test-require-elevated && matrix.os != 'windows-latest' && '&& sudo chmod a+rw ./TestResults' || '' }}
@@ -181,7 +181,7 @@ jobs:
         codecov_yml_path: .github/codecov.yml
 
     - name: Upload test results  ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
-      if: ${{ !cancelled() && inputs.run-tests && hashFiles('./**/TestResults/junit.xml') != '' }}
+      if: ${{ !cancelled() && inputs.run-tests && hashFiles('./TestResults/junit.xml') != '' }}
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         disable_search: true

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -149,7 +149,7 @@ jobs:
           --no-build `
           --logger:"console;verbosity=detailed" `
           --logger:"GitHubActions;report-warnings=false" `
-          --logger:"junit;LogFilePath=TestResults/junit.xml" `
+          --logger:"junit;LogFilePath=${env:GITHUB_WORKSPACE}/TestResults/junit.xml" `
           --filter "${env:TEST_FILTER}" `
           -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
 
@@ -171,7 +171,7 @@ jobs:
           --no-build `
           --logger:"console;verbosity=detailed" `
           --logger:"GitHubActions;report-warnings=false" `
-          --logger:"junit;LogFilePath=${env:GITHUB_WORKSPACE}/TestResults/junit.xml"
+          --logger:"junit;LogFilePath=${env:GITHUB_WORKSPACE}/TestResults/junit.xml" `
           --filter "${env:TEST_FILTER}" `
           -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
         sudo chmod a+rw ./TestResults

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -173,6 +173,7 @@ jobs:
         FILTER: ${{ inputs.test-case-filter }}
         token: ${{ secrets.CODECOV_TOKEN }}
       with:
+        disable_search: true
         files: TestResults/Cobertura.xml
         env_vars: OS,TFM,FILTER
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
@@ -183,7 +184,9 @@ jobs:
       if: ${{ !cancelled() && inputs.run-tests && hashFiles('./**/TestResults/junit.xml') != '' }}
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
+        disable_search: true
         env_vars: OS,TFM,FILTER
+        files: TestResults/junit.xml
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Test results for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
         report_type: test_results


### PR DESCRIPTION
## Changes

Apply Copilot-suggested fix to solve slow windows-11-arm jobs by containing the search path for codecov files and specifying the results path to avoid slow x64 emulation and file search.

Prompt:

> Investigate why the codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 action might hang (or just take a long time) when running on the windows-11-arm runner.
>
> It usually seem to hang with the `report_type: test_results` input.

Response:

> Most likely cause: the test_results upload is doing a full workspace search, and that is the only Codecov step here that lacks an explicit files: path.
>
> Why that points to the root cause:
>
> 1. In Component.BuildTest.yml, the coverage upload passes files: TestResults/Cobertura.xml, but the report_type: test_results step passes no files at all.
> 2. Codecov’s action defaults disable_search to false, and its docs say directory defaults to the current working directory. So the test-results upload can recurse through the whole checkout instead of just .\TestResults.
> 3. Your workflow already knows the exact JUnit path: dotnet test writes TestResults/junit.xml.
> 4. This fits your symptom: if the slowdown were mainly the wrapper download, GPG verification, or token/auth setup, the coverage upload would usually be just as bad, because it uses the same action version immediately before.
>
> There is a secondary ARM-specific concern, but it’s probably not the main differentiator here: Codecov’s action only distinguishes linux-arm64/alpine-arm64; for Windows it always detects plain windows. The wrapper downloads https://cli.codecov.io/latest/windows/codecov.exe, and windows-arm64 endpoints return 404, so there is no distinct Windows ARM64 CLI artifact being selected. On windows-11-arm, that likely means the CLI runs via Windows x64 emulation, which can make the step slower, but again that would affect both uploads, not just test_results.
>
>Conclusion: the likely reason it “hangs” on windows-11-arm is that report_type: test_results is recursively scanning a slow Windows workspace with an emulated/non-native Codecov CLI on top.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
