### PR TITLE
[Fix] Allow emitting of metrics and traces when ConsumeException is encountered on InstrumentedConsumer

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fixed an issue on `InstrumentedConsumer` where `messaging.receive.duration`
+* Fixed an issue in `InstrumentedConsumer` where `messaging.receive.duration`
   and `messaging.receive.messages` metrics were not emitted when `ConsumeException`
   is thrown by the `Consume` method.
   ([#4433](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4433))

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fixed an issue on `InstrumentedConsumer` where `messaging.receive.duration`
   and `messaging.receive.messages` metrics were not emitted when `ConsumeException`
   is thrown by the `Consume` method.
-  ([#4432](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4432))
+  ([#4433](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4433))
 
 ## 0.1.0-alpha.6
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fixed an issue on `InstrumentedConsumer` wherein `messaging.receive.duration`
+  and `messaging.receive.messages` metrics are not emitted when `ConsumeException`
+  is thrown by the `Consume` method.
+  ([#4432](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4432))
+
 ## 0.1.0-alpha.6
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Fixed an issue on `InstrumentedConsumer` wherein `messaging.receive.duration`
-  and `messaging.receive.messages` metrics are not emitted when `ConsumeException`
+* Fixed an issue on `InstrumentedConsumer` where `messaging.receive.duration`
+  and `messaging.receive.messages` metrics were not emitted when `ConsumeException`
   is thrown by the `Consume` method.
   ([#4432](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4432))
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
@@ -61,9 +61,9 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
         finally
         {
-            var end = DateTimeOffset.UtcNow;
-            if (result is { IsPartitionEOF: false })
+            if (ShouldInstrument(result, errorType))
             {
+                var end = DateTimeOffset.UtcNow;
                 this.InstrumentConsumption(start, end, consumeResult, errorType);
             }
         }
@@ -88,9 +88,9 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
         finally
         {
-            var end = DateTimeOffset.UtcNow;
-            if (result is { IsPartitionEOF: false })
+            if (ShouldInstrument(result, errorType))
             {
+                var end = DateTimeOffset.UtcNow;
                 this.InstrumentConsumption(start, end, consumeResult, errorType);
             }
         }
@@ -115,9 +115,9 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
         finally
         {
-            var end = DateTimeOffset.UtcNow;
-            if (result is { IsPartitionEOF: false })
+            if (ShouldInstrument(result, errorType))
             {
+                var end = DateTimeOffset.UtcNow;
                 this.InstrumentConsumption(start, end, consumeResult, errorType);
             }
         }
@@ -200,6 +200,10 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
     public void Close()
         => this.consumer.Close();
 
+    private static bool ShouldInstrument(ConsumeResult<TKey, TValue>? result, string? errorType) =>
+        result is { IsPartitionEOF: false } ||
+        (result is null && errorType is not null);
+
     private static string FormatConsumeException(ConsumeException consumeException) =>
         $"ConsumeException: {consumeException.Error}";
 
@@ -217,7 +221,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         _ => (new ConsumeResult(exception.ConsumerRecord.TopicPartitionOffset, exception.ConsumerRecord.Message.Headers, exception.ConsumerRecord.Message.Key), FormatConsumeException(exception)),
     };
 
-    private static void GetTags(string topic, out TagList tags, int? partition = null, string? errorType = null)
+    private static void GetTags(string? topic, out TagList tags, int? partition = null, string? errorType = null)
     {
         tags = new TagList()
         {
@@ -227,10 +231,15 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             new KeyValuePair<string, object?>(
                 SemanticConventions.AttributeMessagingSystem,
                 ConfluentKafkaCommon.KafkaMessagingSystem),
-            new KeyValuePair<string, object?>(
-                SemanticConventions.AttributeMessagingDestinationName,
-                topic),
         };
+
+        if (topic is not null)
+        {
+            tags.Add(
+                new KeyValuePair<string, object?>(
+                    SemanticConventions.AttributeMessagingDestinationName,
+                    topic));
+        }
 
         if (partition is not null)
         {
@@ -249,9 +258,9 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
     }
 
-    private static void RecordReceive(TopicPartition topicPartition, TimeSpan duration, string? errorType = null)
+    private static void RecordReceive(TopicPartition? topicPartition, TimeSpan duration, string? errorType = null)
     {
-        GetTags(topicPartition.Topic, out var tags, partition: topicPartition.Partition, errorType);
+        GetTags(topicPartition?.Topic, out var tags, partition: topicPartition?.Partition, errorType);
 
         ConfluentKafkaCommon.ReceiveMessagesCounter.Add(1, in tags);
         ConfluentKafkaCommon.ReceiveDurationHistogram.Record(duration.TotalSeconds, in tags);
@@ -284,7 +293,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         if (this.options.Metrics)
         {
             var duration = endTime - startTime;
-            RecordReceive(consumeResult.TopicPartitionOffset!.TopicPartition, duration, errorType);
+            RecordReceive(consumeResult.TopicPartitionOffset?.TopicPartition, duration, errorType);
         }
     }
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text;
 using Confluent.Kafka;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Xunit;
 
@@ -179,9 +180,657 @@ public class InstrumentedConsumerTests
             activity.Links.First().Context.TraceId.ToHexString());
     }
 
+    [Fact]
+    public void Consume_ConsumeException_WithNullConsumerRecord_CreatesActivityWithError()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
+            ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
+            var exception = new ConsumeException(nullConsumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
+            {
+                GroupId = "test-group",
+            };
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "receive");
+        Assert.NotNull(activity);
+        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
+        Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("ConsumeException: Deserialization error", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
+    }
+
+    [Fact]
+    public void Consume_ConsumeException_WithNullMessage_CreatesActivityWithError()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "error-topic",
+                Partition = new Partition(2),
+                Offset = new Offset(100),
+                Message = null,
+            };
+
+            var error = new Error(ErrorCode.Local_KeyDeserialization, "Key deserialization error");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
+            {
+                GroupId = "test-group",
+            };
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "error-topic receive");
+        Assert.NotNull(activity);
+        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
+        Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("ConsumeException: Key deserialization error", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal("error-topic", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
+        Assert.Equal(2, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
+        Assert.Equal(100L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
+    }
+
+    [Fact]
+    public void Consume_ConsumeException_WithValidMessageWithoutHeaders_CreatesActivityWithError()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "error-topic-no-headers",
+                Partition = new Partition(3),
+                Offset = new Offset(150),
+                Message = new Message<byte[], byte[]>
+                {
+                    Key = Encoding.UTF8.GetBytes("error-key"),
+                    Value = Encoding.UTF8.GetBytes("error-value"),
+                },
+            };
+
+            var error = new Error(ErrorCode.Local_AllBrokersDown, "All brokers down");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
+            {
+                GroupId = "test-group",
+            };
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "error-topic-no-headers receive");
+        Assert.NotNull(activity);
+        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
+        Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("ConsumeException: All brokers down", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal("error-topic-no-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
+        Assert.Equal(3, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
+        Assert.Equal(150L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Equal("error-key", Encoding.UTF8.GetString((byte[])activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey)!));
+    }
+
+    [Fact]
+    public void Consume_ConsumeException_WithValidMessageWithHeaders_CreatesActivityWithError()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            // A well-formed traceparent header representing a remote producer span
+            const string traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+            var headers = new Headers
+            {
+                { "traceparent", Encoding.UTF8.GetBytes(traceparent) },
+            };
+
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "error-topic-with-headers",
+                Partition = new Partition(5),
+                Offset = new Offset(200),
+                Message = new Message<byte[], byte[]>
+                {
+                    Key = Encoding.UTF8.GetBytes("error-key-with-headers"),
+                    Value = Encoding.UTF8.GetBytes("error-value-with-headers"),
+                    Headers = headers,
+                },
+            };
+
+            var error = new Error(ErrorCode.BrokerNotAvailable, "Broker not available");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
+            {
+                GroupId = "test-group",
+            };
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "error-topic-with-headers receive");
+        Assert.NotNull(activity);
+        Assert.NotEmpty(activity.Links);
+        Assert.Equal("0af7651916cd43dd8448eb211c80319c", activity.Links.First().Context.TraceId.ToHexString());
+        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
+        Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("ConsumeException: Broker not available", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal("error-topic-with-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
+        Assert.Equal(5, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
+        Assert.Equal(200L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Equal("error-key-with-headers", Encoding.UTF8.GetString((byte[])activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey)!));
+    }
+
+    [Fact]
+    public void Consume_TimeSpan_ConsumeException_CreatesActivityWithError()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "timeout-topic",
+                Partition = new Partition(0),
+                Offset = new Offset(50),
+                Message = new Message<byte[], byte[]>
+                {
+                    Value = Encoding.UTF8.GetBytes("timeout-value"),
+                },
+            };
+
+            var error = new Error(ErrorCode.Local_TimedOut, "Operation timed out");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(TimeSpan.FromSeconds(1)));
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "timeout-topic receive");
+        Assert.NotNull(activity);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("ConsumeException: Operation timed out", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+    }
+
+    [Fact]
+    public void Consume_Milliseconds_ConsumeException_CreatesActivityWithError()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "broker-error-topic",
+                Partition = new Partition(1),
+                Offset = new Offset(75),
+                Message = new Message<byte[], byte[]>
+                {
+                    Value = Encoding.UTF8.GetBytes("broker-error-value"),
+                },
+            };
+
+            var error = new Error(ErrorCode.Local_Transport, "Transport error");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(1000));
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "broker-error-topic receive");
+        Assert.NotNull(activity);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("ConsumeException: Transport error", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+    }
+
+    [Fact]
+    public void Consume_ConsumeException_WithNullConsumerRecord_RecordsMetricsWithError()
+    {
+        var metrics = new List<Metric>();
+
+        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(metrics)
+            .Build())
+        {
+            var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
+            ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
+            var exception = new ConsumeException(nullConsumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = false,
+                Metrics = true,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            meterProvider.EnsureMetricsAreFlushed();
+        }
+
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        AssertMetric(
+            actualMetric: receiveMessagesMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: null,
+            expectedKafkaDestinationPartition: null,
+            expectedErrorType: "ConsumeException: Deserialization error");
+
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        AssertMetric(
+            actualMetric: receiveDurationMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: null,
+            expectedKafkaDestinationPartition: null,
+            expectedErrorType: "ConsumeException: Deserialization error");
+    }
+
+    [Fact]
+    public void Consume_ConsumeException_WithNullMessage_RecordsMetricsWithError()
+    {
+        var metrics = new List<Metric>();
+
+        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(metrics)
+            .Build())
+        {
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "error-topic",
+                Partition = new Partition(2),
+                Offset = new Offset(100),
+                Message = null,
+            };
+
+            var error = new Error(ErrorCode.Local_KeyDeserialization, "Key Deserialization error");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = false,
+                Metrics = true,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            meterProvider.EnsureMetricsAreFlushed();
+        }
+
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        AssertMetric(
+            actualMetric: receiveMessagesMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: "error-topic",
+            expectedKafkaDestinationPartition: 2,
+            expectedErrorType: "ConsumeException: Key Deserialization error");
+
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        AssertMetric(
+            actualMetric: receiveDurationMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: "error-topic",
+            expectedKafkaDestinationPartition: 2,
+            expectedErrorType: "ConsumeException: Key Deserialization error");
+    }
+
+    [Fact]
+    public void Consume_ConsumeException_WithValidMessageWithoutHeaders_RecordsMetricsWithError()
+    {
+        var metrics = new List<Metric>();
+
+        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(metrics)
+            .Build())
+        {
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "error-topic-no-headers",
+                Partition = new Partition(3),
+                Offset = new Offset(150),
+                Message = new Message<byte[], byte[]>
+                {
+                    Key = Encoding.UTF8.GetBytes("error-key"),
+                    Value = Encoding.UTF8.GetBytes("error-value"),
+                },
+            };
+
+            var error = new Error(ErrorCode.Local_AllBrokersDown, "All brokers down");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = false,
+                Metrics = true,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            meterProvider.EnsureMetricsAreFlushed();
+        }
+
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        AssertMetric(
+            actualMetric: receiveMessagesMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: "error-topic-no-headers",
+            expectedKafkaDestinationPartition: 3,
+            expectedErrorType: "ConsumeException: All brokers down");
+
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        AssertMetric(
+            actualMetric: receiveDurationMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: "error-topic-no-headers",
+            expectedKafkaDestinationPartition: 3,
+            expectedErrorType: "ConsumeException: All brokers down");
+    }
+
+    [Fact]
+    public void Consume_ConsumeException_WithValidMessageWithHeaders_RecordsMetricsWithError()
+    {
+        var metrics = new List<Metric>();
+
+        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
+            .AddInMemoryExporter(metrics)
+            .Build())
+        {
+            var headers = new Headers
+            {
+                { "test-header", Encoding.UTF8.GetBytes("test-value") },
+                { "another-header", Encoding.UTF8.GetBytes("another-value") },
+            };
+
+            var consumerRecord = new ConsumeResult<byte[], byte[]>
+            {
+                Topic = "error-topic-with-headers",
+                Partition = new Partition(5),
+                Offset = new Offset(200),
+                Message = new Message<byte[], byte[]>
+                {
+                    Key = Encoding.UTF8.GetBytes("error-key-with-headers"),
+                    Value = Encoding.UTF8.GetBytes("error-value-with-headers"),
+                    Headers = headers,
+                },
+            };
+
+            var error = new Error(ErrorCode.BrokerNotAvailable, "Broker not available");
+            var exception = new ConsumeException(consumerRecord, error);
+
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumerExceptionToThrow = exception,
+            };
+
+            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+            {
+                Traces = false,
+                Metrics = true,
+            };
+            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
+            {
+                GroupId = "test-group",
+            };
+
+            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+
+            meterProvider.EnsureMetricsAreFlushed();
+        }
+
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        AssertMetric(
+            actualMetric: receiveMessagesMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: "error-topic-with-headers",
+            expectedKafkaDestinationPartition: 5,
+            expectedErrorType: "ConsumeException: Broker not available");
+
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        AssertMetric(
+            actualMetric: receiveDurationMetric,
+            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
+            expectedKafkaDestinationName: "error-topic-with-headers",
+            expectedKafkaDestinationPartition: 5,
+            expectedErrorType: "ConsumeException: Broker not available");
+    }
+
+    private static void AssertMetric(
+       Metric? actualMetric,
+       string? expectedMessagingOperation,
+       string? expectedMessagingSystem,
+       string? expectedKafkaDestinationName,
+       int? expectedKafkaDestinationPartition,
+       string? expectedErrorType)
+    {
+        Assert.NotNull(actualMetric);
+
+        var metricPoint = GetMetricPoint(actualMetric);
+
+        var destinationNameFound = false;
+        var destinationPartitionFound = false;
+        var errorTypeFound = false;
+
+        foreach (var tag in metricPoint!.Value.Tags)
+        {
+            if (tag.Key == SemanticConventions.AttributeMessagingOperation)
+            {
+                Assert.Equal(expectedMessagingOperation, tag.Value?.ToString());
+            }
+
+            if (tag.Key == SemanticConventions.AttributeMessagingSystem)
+            {
+                Assert.Equal(expectedMessagingSystem, tag.Value?.ToString());
+            }
+
+            if (tag.Key == SemanticConventions.AttributeMessagingDestinationName)
+            {
+                Assert.Equal(expectedKafkaDestinationName, tag.Value?.ToString());
+                destinationNameFound = true;
+            }
+
+            if (tag.Key == SemanticConventions.AttributeMessagingKafkaDestinationPartition)
+            {
+                Assert.Equal(expectedKafkaDestinationPartition, tag.Value);
+                destinationPartitionFound = true;
+            }
+
+            if (tag.Key == SemanticConventions.AttributeErrorType)
+            {
+                Assert.Equal(expectedErrorType, tag.Value?.ToString());
+                errorTypeFound = true;
+            }
+        }
+
+        if (expectedKafkaDestinationName is null)
+        {
+            Assert.False(destinationNameFound);
+        }
+
+        if (expectedKafkaDestinationPartition is null)
+        {
+            Assert.False(destinationPartitionFound);
+        }
+
+        if (expectedErrorType is null)
+        {
+            Assert.False(errorTypeFound);
+        }
+    }
+
+    private static MetricPoint? GetMetricPoint(Metric? metric)
+    {
+        if (metric == null)
+        {
+            return null;
+        }
+
+        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
+        {
+            return metricPoint;
+        }
+
+        return null;
+    }
+
     private sealed class FakeConsumer<TKey, TValue> : IConsumer<TKey, TValue>
     {
         public ConsumeResult<TKey, TValue>? ConsumeResult { get; set; }
+
+        public ConsumeException? ConsumerExceptionToThrow { get; set; }
 
         public Handle Handle => null!;
 
@@ -202,11 +851,35 @@ public class InstrumentedConsumerTests
             // No-op
         }
 
-        public ConsumeResult<TKey, TValue>? Consume(int millisecondsTimeout) => this.ConsumeResult;
+        public ConsumeResult<TKey, TValue>? Consume(int millisecondsTimeout)
+        {
+            if (this.ConsumerExceptionToThrow != null)
+            {
+                throw this.ConsumerExceptionToThrow;
+            }
 
-        public ConsumeResult<TKey, TValue>? Consume(CancellationToken cancellationToken = default) => this.ConsumeResult;
+            return this.ConsumeResult;
+        }
 
-        public ConsumeResult<TKey, TValue>? Consume(TimeSpan timeout) => this.ConsumeResult;
+        public ConsumeResult<TKey, TValue>? Consume(CancellationToken cancellationToken = default)
+        {
+            if (this.ConsumerExceptionToThrow != null)
+            {
+                throw this.ConsumerExceptionToThrow;
+            }
+
+            return this.ConsumeResult;
+        }
+
+        public ConsumeResult<TKey, TValue>? Consume(TimeSpan timeout)
+        {
+            if (this.ConsumerExceptionToThrow != null)
+            {
+                throw this.ConsumerExceptionToThrow;
+            }
+
+            return this.ConsumeResult;
+        }
 
         public void Subscribe(IEnumerable<string> topics)
         {

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -760,6 +760,8 @@ public class InstrumentedConsumerTests
 
         var metricPoint = GetMetricPoint(actualMetric);
 
+        var messagingOperationFound = false;
+        var messagingSystemFound = false;
         var destinationNameFound = false;
         var destinationPartitionFound = false;
         var errorTypeFound = false;
@@ -769,11 +771,13 @@ public class InstrumentedConsumerTests
             if (tag.Key == SemanticConventions.AttributeMessagingOperation)
             {
                 Assert.Equal(expectedMessagingOperation, tag.Value?.ToString());
+                messagingOperationFound = true;
             }
 
             if (tag.Key == SemanticConventions.AttributeMessagingSystem)
             {
                 Assert.Equal(expectedMessagingSystem, tag.Value?.ToString());
+                messagingSystemFound = true;
             }
 
             if (tag.Key == SemanticConventions.AttributeMessagingDestinationName)
@@ -795,20 +799,23 @@ public class InstrumentedConsumerTests
             }
         }
 
-        if (expectedKafkaDestinationName is null)
+        static void AssertTagExist(bool tagFound, string? tagExpecedValue)
         {
-            Assert.False(destinationNameFound);
+            if (tagExpecedValue is null)
+            {
+                Assert.False(tagFound);
+            }
+            else
+            {
+                Assert.True(tagFound);
+            }
         }
 
-        if (expectedKafkaDestinationPartition is null)
-        {
-            Assert.False(destinationPartitionFound);
-        }
-
-        if (expectedErrorType is null)
-        {
-            Assert.False(errorTypeFound);
-        }
+        AssertTagExist(messagingOperationFound, expectedMessagingOperation);
+        AssertTagExist(messagingSystemFound, expectedMessagingSystem);
+        AssertTagExist(destinationNameFound, expectedKafkaDestinationName);
+        AssertTagExist(destinationPartitionFound, expectedKafkaDestinationPartition?.ToString());
+        AssertTagExist(errorTypeFound, expectedErrorType);
     }
 
     private static MetricPoint? GetMetricPoint(Metric? metric)

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -17,10 +17,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var fakeConsumer = new FakeConsumer<string, string>
             {
@@ -63,10 +60,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var fakeConsumer = new FakeConsumer<string, string>
             {
@@ -99,10 +93,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var fakeConsumer = new FakeConsumer<string, string>
             {
@@ -135,10 +126,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             // A well-formed traceparent header representing a remote producer span
             const string traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
@@ -185,10 +173,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
             ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
@@ -234,10 +219,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var consumerRecord = new ConsumeResult<byte[], byte[]>
             {
@@ -290,10 +272,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var consumerRecord = new ConsumeResult<byte[], byte[]>
             {
@@ -350,10 +329,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             // A well-formed traceparent header representing a remote producer span
             const string traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
@@ -420,10 +396,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var consumerRecord = new ConsumeResult<byte[], byte[]>
             {
@@ -467,10 +440,7 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
-        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(activities)
-            .Build())
+        using (var tracerProvider = CreateTraceProvider(activities))
         {
             var consumerRecord = new ConsumeResult<byte[], byte[]>
             {
@@ -514,10 +484,7 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
-        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(metrics)
-            .Build())
+        using (var meterProvider = CreateMeterProvider(metrics))
         {
             var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
             ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
@@ -564,10 +531,7 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
-        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(metrics)
-            .Build())
+        using (var meterProvider = CreateMeterProvider(metrics))
         {
             var consumerRecord = new ConsumeResult<byte[], byte[]>
             {
@@ -621,10 +585,7 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
-        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(metrics)
-            .Build())
+        using (var meterProvider = CreateMeterProvider(metrics))
         {
             var consumerRecord = new ConsumeResult<byte[], byte[]>
             {
@@ -682,10 +643,7 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
-        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
-            .AddInMemoryExporter(metrics)
-            .Build())
+        using (var meterProvider = CreateMeterProvider(metrics))
         {
             var headers = new Headers
             {
@@ -748,6 +706,16 @@ public class InstrumentedConsumerTests
             expectedErrorType: "ConsumeException: Broker not available");
     }
 
+    private static TracerProvider CreateTraceProvider(List<Activity> activities) => Sdk.CreateTracerProviderBuilder()
+                .AddSource(ConfluentKafkaCommon.InstrumentationName)
+                .AddInMemoryExporter(activities)
+                .Build();
+
+    private static MeterProvider CreateMeterProvider(List<Metric> metrics) => Sdk.CreateMeterProviderBuilder()
+                .AddMeter(ConfluentKafkaCommon.InstrumentationName)
+                .AddInMemoryExporter(metrics)
+                .Build();
+
     private static void AssertMetric(
        Metric? actualMetric,
        string? expectedMessagingOperation,
@@ -799,9 +767,9 @@ public class InstrumentedConsumerTests
             }
         }
 
-        static void AssertTagExist(bool tagFound, string? tagExpecedValue)
+        static void AssertTagExists(bool tagFound, string? tagExpectedValue)
         {
-            if (tagExpecedValue is null)
+            if (tagExpectedValue is null)
             {
                 Assert.False(tagFound);
             }
@@ -811,11 +779,11 @@ public class InstrumentedConsumerTests
             }
         }
 
-        AssertTagExist(messagingOperationFound, expectedMessagingOperation);
-        AssertTagExist(messagingSystemFound, expectedMessagingSystem);
-        AssertTagExist(destinationNameFound, expectedKafkaDestinationName);
-        AssertTagExist(destinationPartitionFound, expectedKafkaDestinationPartition?.ToString());
-        AssertTagExist(errorTypeFound, expectedErrorType);
+        AssertTagExists(messagingOperationFound, expectedMessagingOperation);
+        AssertTagExists(messagingSystemFound, expectedMessagingSystem);
+        AssertTagExists(destinationNameFound, expectedKafkaDestinationName);
+        AssertTagExists(destinationPartitionFound, expectedKafkaDestinationPartition?.ToString());
+        AssertTagExists(errorTypeFound, expectedErrorType);
     }
 
     private static MetricPoint? GetMetricPoint(Metric? metric)

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -30,17 +30,7 @@ public class InstrumentedConsumerTests
                 },
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = true,
-                Metrics = false,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
-            {
-                GroupId = "test-group",
-            };
-
-            _ = instrumentedConsumer.Consume(CancellationToken.None);
+            ConsumeEventAndCaptureTraces(fakeConsumer);
 
             tracerProvider.ForceFlush();
         }
@@ -106,14 +96,7 @@ public class InstrumentedConsumerTests
                 },
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = true,
-                Metrics = false,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
-
-            _ = instrumentedConsumer.Consume(CancellationToken.None);
+            ConsumeEventAndCaptureTraces(fakeConsumer);
 
             tracerProvider.ForceFlush();
         }
@@ -146,14 +129,7 @@ public class InstrumentedConsumerTests
                 },
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = true,
-                Metrics = false,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
-
-            _ = instrumentedConsumer.Consume(CancellationToken.None);
+            ConsumeEventAndCaptureTraces(fakeConsumer);
 
             tracerProvider.ForceFlush();
         }
@@ -173,28 +149,18 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
+        var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
+        ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
+        var exception = new ConsumeException(nullConsumerRecord, error);
+
         using (var tracerProvider = CreateTraceProvider(activities))
         {
-            var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
-            ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
-            var exception = new ConsumeException(nullConsumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = true,
-                Metrics = false,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
-            {
-                GroupId = "test-group",
-            };
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureTraces(fakeConsumer));
 
             tracerProvider.ForceFlush();
         }
@@ -207,7 +173,7 @@ public class InstrumentedConsumerTests
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
         Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
         Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal("ConsumeException: Deserialization error", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
         Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
         Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
@@ -219,35 +185,25 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "error-topic",
+            Partition = new Partition(2),
+            Offset = new Offset(100),
+            Message = null,
+        };
+
+        var error = new Error(ErrorCode.Local_KeyDeserialization, "Key deserialization error");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var tracerProvider = CreateTraceProvider(activities))
         {
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "error-topic",
-                Partition = new Partition(2),
-                Offset = new Offset(100),
-                Message = null,
-            };
-
-            var error = new Error(ErrorCode.Local_KeyDeserialization, "Key deserialization error");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = true,
-                Metrics = false,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
-            {
-                GroupId = "test-group",
-            };
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureTraces(fakeConsumer));
 
             tracerProvider.ForceFlush();
         }
@@ -260,7 +216,7 @@ public class InstrumentedConsumerTests
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
         Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
         Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal("ConsumeException: Key deserialization error", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Equal("error-topic", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
         Assert.Equal(2, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
         Assert.Equal(100L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
@@ -272,39 +228,29 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "error-topic-no-headers",
+            Partition = new Partition(3),
+            Offset = new Offset(150),
+            Message = new Message<byte[], byte[]>
+            {
+                Key = Encoding.UTF8.GetBytes("error-key"),
+                Value = Encoding.UTF8.GetBytes("error-value"),
+            },
+        };
+
+        var error = new Error(ErrorCode.Local_AllBrokersDown, "All brokers down");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var tracerProvider = CreateTraceProvider(activities))
         {
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "error-topic-no-headers",
-                Partition = new Partition(3),
-                Offset = new Offset(150),
-                Message = new Message<byte[], byte[]>
-                {
-                    Key = Encoding.UTF8.GetBytes("error-key"),
-                    Value = Encoding.UTF8.GetBytes("error-value"),
-                },
-            };
-
-            var error = new Error(ErrorCode.Local_AllBrokersDown, "All brokers down");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = true,
-                Metrics = false,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
-            {
-                GroupId = "test-group",
-            };
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureTraces(fakeConsumer));
 
             tracerProvider.ForceFlush();
         }
@@ -317,7 +263,7 @@ public class InstrumentedConsumerTests
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
         Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
         Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal("ConsumeException: All brokers down", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Equal("error-topic-no-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
         Assert.Equal(3, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
         Assert.Equal(150L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
@@ -329,47 +275,37 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
+        // A well-formed traceparent header representing a remote producer span
+        const string traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        var headers = new Headers
+        {
+            { "traceparent", Encoding.UTF8.GetBytes(traceparent) },
+        };
+
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "error-topic-with-headers",
+            Partition = new Partition(5),
+            Offset = new Offset(200),
+            Message = new Message<byte[], byte[]>
+            {
+                Key = Encoding.UTF8.GetBytes("error-key-with-headers"),
+                Value = Encoding.UTF8.GetBytes("error-value-with-headers"),
+                Headers = headers,
+            },
+        };
+
+        var error = new Error(ErrorCode.BrokerNotAvailable, "Broker not available");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var tracerProvider = CreateTraceProvider(activities))
         {
-            // A well-formed traceparent header representing a remote producer span
-            const string traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
-            var headers = new Headers
-            {
-                { "traceparent", Encoding.UTF8.GetBytes(traceparent) },
-            };
-
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "error-topic-with-headers",
-                Partition = new Partition(5),
-                Offset = new Offset(200),
-                Message = new Message<byte[], byte[]>
-                {
-                    Key = Encoding.UTF8.GetBytes("error-key-with-headers"),
-                    Value = Encoding.UTF8.GetBytes("error-value-with-headers"),
-                    Headers = headers,
-                },
-            };
-
-            var error = new Error(ErrorCode.BrokerNotAvailable, "Broker not available");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = true,
-                Metrics = false,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
-            {
-                GroupId = "test-group",
-            };
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureTraces(fakeConsumer));
 
             tracerProvider.ForceFlush();
         }
@@ -384,7 +320,7 @@ public class InstrumentedConsumerTests
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
         Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
         Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal("ConsumeException: Broker not available", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Equal("error-topic-with-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
         Assert.Equal(5, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
         Assert.Equal(200L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
@@ -396,22 +332,22 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "timeout-topic",
+            Partition = new Partition(0),
+            Offset = new Offset(50),
+            Message = new Message<byte[], byte[]>
+            {
+                Value = Encoding.UTF8.GetBytes("timeout-value"),
+            },
+        };
+
+        var error = new Error(ErrorCode.Local_TimedOut, "Operation timed out");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var tracerProvider = CreateTraceProvider(activities))
         {
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "timeout-topic",
-                Partition = new Partition(0),
-                Offset = new Offset(50),
-                Message = new Message<byte[], byte[]>
-                {
-                    Value = Encoding.UTF8.GetBytes("timeout-value"),
-                },
-            };
-
-            var error = new Error(ErrorCode.Local_TimedOut, "Operation timed out");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
@@ -432,7 +368,7 @@ public class InstrumentedConsumerTests
         var activity = activities.FirstOrDefault(a => a.DisplayName == "timeout-topic receive");
         Assert.NotNull(activity);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
-        Assert.Equal("ConsumeException: Operation timed out", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
     }
 
     [Fact]
@@ -440,22 +376,22 @@ public class InstrumentedConsumerTests
     {
         var activities = new List<Activity>();
 
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "broker-error-topic",
+            Partition = new Partition(1),
+            Offset = new Offset(75),
+            Message = new Message<byte[], byte[]>
+            {
+                Value = Encoding.UTF8.GetBytes("broker-error-value"),
+            },
+        };
+
+        var error = new Error(ErrorCode.Local_Transport, "Transport error");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var tracerProvider = CreateTraceProvider(activities))
         {
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "broker-error-topic",
-                Partition = new Partition(1),
-                Offset = new Offset(75),
-                Message = new Message<byte[], byte[]>
-                {
-                    Value = Encoding.UTF8.GetBytes("broker-error-value"),
-                },
-            };
-
-            var error = new Error(ErrorCode.Local_Transport, "Transport error");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
@@ -476,7 +412,7 @@ public class InstrumentedConsumerTests
         var activity = activities.FirstOrDefault(a => a.DisplayName == "broker-error-topic receive");
         Assert.NotNull(activity);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
-        Assert.Equal("ConsumeException: Transport error", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
     }
 
     [Fact]
@@ -484,25 +420,18 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
+        var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
+        ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
+        var exception = new ConsumeException(nullConsumerRecord, error);
+
         using (var meterProvider = CreateMeterProvider(metrics))
         {
-            var error = new Error(ErrorCode.Local_ValueDeserialization, "Deserialization error");
-            ConsumeResult<byte[], byte[]>? nullConsumerRecord = null;
-            var exception = new ConsumeException(nullConsumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = false,
-                Metrics = true,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureMetrics(fakeConsumer));
 
             meterProvider.EnsureMetricsAreFlushed();
         }
@@ -514,7 +443,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: null,
             expectedKafkaDestinationPartition: null,
-            expectedErrorType: "ConsumeException: Deserialization error");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
 
         var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
         AssertMetric(
@@ -523,7 +452,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: null,
             expectedKafkaDestinationPartition: null,
-            expectedErrorType: "ConsumeException: Deserialization error");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
     }
 
     [Fact]
@@ -531,32 +460,25 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "error-topic",
+            Partition = new Partition(2),
+            Offset = new Offset(100),
+            Message = null,
+        };
+
+        var error = new Error(ErrorCode.Local_KeyDeserialization, "Key Deserialization error");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var meterProvider = CreateMeterProvider(metrics))
         {
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "error-topic",
-                Partition = new Partition(2),
-                Offset = new Offset(100),
-                Message = null,
-            };
-
-            var error = new Error(ErrorCode.Local_KeyDeserialization, "Key Deserialization error");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = false,
-                Metrics = true,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureMetrics(fakeConsumer));
 
             meterProvider.EnsureMetricsAreFlushed();
         }
@@ -568,7 +490,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic",
             expectedKafkaDestinationPartition: 2,
-            expectedErrorType: "ConsumeException: Key Deserialization error");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
 
         var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
         AssertMetric(
@@ -577,7 +499,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic",
             expectedKafkaDestinationPartition: 2,
-            expectedErrorType: "ConsumeException: Key Deserialization error");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
     }
 
     [Fact]
@@ -585,36 +507,29 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "error-topic-no-headers",
+            Partition = new Partition(3),
+            Offset = new Offset(150),
+            Message = new Message<byte[], byte[]>
+            {
+                Key = Encoding.UTF8.GetBytes("error-key"),
+                Value = Encoding.UTF8.GetBytes("error-value"),
+            },
+        };
+
+        var error = new Error(ErrorCode.Local_AllBrokersDown, "All brokers down");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var meterProvider = CreateMeterProvider(metrics))
         {
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "error-topic-no-headers",
-                Partition = new Partition(3),
-                Offset = new Offset(150),
-                Message = new Message<byte[], byte[]>
-                {
-                    Key = Encoding.UTF8.GetBytes("error-key"),
-                    Value = Encoding.UTF8.GetBytes("error-value"),
-                },
-            };
-
-            var error = new Error(ErrorCode.Local_AllBrokersDown, "All brokers down");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = false,
-                Metrics = true,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options);
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureMetrics(fakeConsumer));
 
             meterProvider.EnsureMetricsAreFlushed();
         }
@@ -626,7 +541,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-no-headers",
             expectedKafkaDestinationPartition: 3,
-            expectedErrorType: "ConsumeException: All brokers down");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
 
         var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
         AssertMetric(
@@ -635,7 +550,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-no-headers",
             expectedKafkaDestinationPartition: 3,
-            expectedErrorType: "ConsumeException: All brokers down");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
     }
 
     [Fact]
@@ -643,46 +558,36 @@ public class InstrumentedConsumerTests
     {
         var metrics = new List<Metric>();
 
+        var headers = new Headers
+        {
+            { "test-header", Encoding.UTF8.GetBytes("test-value") },
+            { "another-header", Encoding.UTF8.GetBytes("another-value") },
+        };
+
+        var consumerRecord = new ConsumeResult<byte[], byte[]>
+        {
+            Topic = "error-topic-with-headers",
+            Partition = new Partition(5),
+            Offset = new Offset(200),
+            Message = new Message<byte[], byte[]>
+            {
+                Key = Encoding.UTF8.GetBytes("error-key-with-headers"),
+                Value = Encoding.UTF8.GetBytes("error-value-with-headers"),
+                Headers = headers,
+            },
+        };
+
+        var error = new Error(ErrorCode.BrokerNotAvailable, "Broker not available");
+        var exception = new ConsumeException(consumerRecord, error);
+
         using (var meterProvider = CreateMeterProvider(metrics))
         {
-            var headers = new Headers
-            {
-                { "test-header", Encoding.UTF8.GetBytes("test-value") },
-                { "another-header", Encoding.UTF8.GetBytes("another-value") },
-            };
-
-            var consumerRecord = new ConsumeResult<byte[], byte[]>
-            {
-                Topic = "error-topic-with-headers",
-                Partition = new Partition(5),
-                Offset = new Offset(200),
-                Message = new Message<byte[], byte[]>
-                {
-                    Key = Encoding.UTF8.GetBytes("error-key-with-headers"),
-                    Value = Encoding.UTF8.GetBytes("error-value-with-headers"),
-                    Headers = headers,
-                },
-            };
-
-            var error = new Error(ErrorCode.BrokerNotAvailable, "Broker not available");
-            var exception = new ConsumeException(consumerRecord, error);
-
             var fakeConsumer = new FakeConsumer<string, string>
             {
                 ConsumerExceptionToThrow = exception,
             };
 
-            var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
-            {
-                Traces = false,
-                Metrics = true,
-            };
-            var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
-            {
-                GroupId = "test-group",
-            };
-
-            Assert.Throws<ConsumeException>(() => instrumentedConsumer.Consume(CancellationToken.None));
+            Assert.Throws<ConsumeException>(() => ConsumeEventAndCaptureMetrics(fakeConsumer));
 
             meterProvider.EnsureMetricsAreFlushed();
         }
@@ -694,7 +599,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-with-headers",
             expectedKafkaDestinationPartition: 5,
-            expectedErrorType: "ConsumeException: Broker not available");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
 
         var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
         AssertMetric(
@@ -703,7 +608,7 @@ public class InstrumentedConsumerTests
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-with-headers",
             expectedKafkaDestinationPartition: 5,
-            expectedErrorType: "ConsumeException: Broker not available");
+            expectedErrorType: $"ConsumeException: {exception.Error}");
     }
 
     private static TracerProvider CreateTraceProvider(List<Activity> activities) => Sdk.CreateTracerProviderBuilder()
@@ -715,6 +620,38 @@ public class InstrumentedConsumerTests
                 .AddMeter(ConfluentKafkaCommon.InstrumentationName)
                 .AddInMemoryExporter(metrics)
                 .Build();
+
+    private static void ConsumeEventAndCaptureTraces(IConsumer<string, string> fakeConsumer)
+    {
+        var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+        {
+            Traces = true,
+            Metrics = false,
+        };
+
+        var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
+        {
+            GroupId = "test-group",
+        };
+
+        _ = instrumentedConsumer.Consume(CancellationToken.None);
+    }
+
+    private static void ConsumeEventAndCaptureMetrics(IConsumer<string, string> fakeConsumer)
+    {
+        var options = new ConfluentKafkaConsumerInstrumentationOptions<string, string>
+        {
+            Traces = false,
+            Metrics = true,
+        };
+
+        var instrumentedConsumer = new InstrumentedConsumer<string, string>(fakeConsumer, options)
+        {
+            GroupId = "test-group",
+        };
+
+        _ = instrumentedConsumer.Consume(CancellationToken.None);
+    }
 
     private static void AssertMetric(
        Metric? actualMetric,
@@ -767,7 +704,7 @@ public class InstrumentedConsumerTests
             }
         }
 
-        static void AssertTagExists(bool tagFound, string? tagExpectedValue)
+        static void AssertTagExists(bool tagFound, object? tagExpectedValue)
         {
             if (tagExpectedValue is null)
             {
@@ -782,7 +719,7 @@ public class InstrumentedConsumerTests
         AssertTagExists(messagingOperationFound, expectedMessagingOperation);
         AssertTagExists(messagingSystemFound, expectedMessagingSystem);
         AssertTagExists(destinationNameFound, expectedKafkaDestinationName);
-        AssertTagExists(destinationPartitionFound, expectedKafkaDestinationPartition?.ToString());
+        AssertTagExists(destinationPartitionFound, expectedKafkaDestinationPartition);
         AssertTagExists(errorTypeFound, expectedErrorType);
     }
 


### PR DESCRIPTION
Fixes #[4400](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/4400)

## Changes
Provided a fix for the gap that was identified when emitting metrics / traces and a `ConsumeException` is encountered while consuming events:
- Update the logic when instrumentation (emitting traces and metrics) is triggered.
   - Current Logic: Only calls `InstrumentConsumption` when result is not `PartitionEOF`
     ```
         public ConsumeResult<TKey, TValue>? Consume(int millisecondsTimeout)
         {
             var start = DateTimeOffset.UtcNow;
             ConsumeResult<TKey, TValue>? result = null;
             ConsumeResult consumeResult = default;
             string? errorType = null;
             try
             {
                 result = this.consumer.Consume(millisecondsTimeout);
                 consumeResult = ExtractConsumeResult(result);
                 return result;
             }
             catch (ConsumeException e)
             {
                 (consumeResult, errorType) = ExtractConsumeResult(e);
                 throw;
             }
             finally
             {
                 var end = DateTimeOffset.UtcNow;
                 if (result is { IsPartitionEOF: false })
                 {
                     this.InstrumentConsumption(start, end, consumeResult, errorType);
                 }
             }
         }
     ```
   - Proposed New Logic: Added new condition to also emit metrics / traces when a ConsumeException is encountered.
     ```
         public ConsumeResult<TKey, TValue>? Consume(int millisecondsTimeout)
         {
             var start = DateTimeOffset.UtcNow;
             ConsumeResult<TKey, TValue>? result = null;
             ConsumeResult consumeResult = default;
             string? errorType = null;
             try
             {
                 result = this.consumer.Consume(millisecondsTimeout);
                 consumeResult = ExtractConsumeResult(result);
                 return result;
             }
             catch (ConsumeException e)
             {
                 (consumeResult, errorType) = ExtractConsumeResult(e);
                 throw;
             }
             finally
             {
                 var end = DateTimeOffset.UtcNow;
                 if (result is { IsPartitionEOF: false } ||
                     result is null && errorType is not null)   >>>>>>>>>>>>>> new condition
                 {
                     this.InstrumentConsumption(start, end, consumeResult, errorType);
                 }
             }
         }
     ```
     
- Add Unit Tests for the Consume Error Scenarios since this is not yet covered by existing tests.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
