### PR TITLE
[Infra] Add actionlint

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,11 +11,12 @@ env:
 
 jobs:
   lint:
+    name: Lint GitHub Actions workflows
     runs-on: ubuntu-24.04
 
     permissions:
-      actions: read
-      contents: read
+      actions: read # Read GitHub Actions workflows
+      contents: read # Read repository contents
 
     steps:
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,35 @@
+name: actionlint
+
+on:
+  workflow_call:
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 3
+  TERM: xterm
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
+
+    - name: Add actionlint problem matcher
+      run: echo "::add-matcher::.github/actionlint-matcher.json"
+
+    - name: Lint workflows with actionlint
+      uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+      with:
+        args: -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,7 @@ jobs:
       lint-misspell-sanitycheck,
       code-ql,
       detect-changes,
+      lint-actions,
       lint-md,
       lint-yml,
       lint-dotnet-format,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
           sampler-aws: ['*/OpenTelemetry.Sampler.AWS*/**', '!**/*.md']
           semanticconventions: ['*/OpenTelemetry.SemanticConventions*/**', '!**/*.md']
 
+  lint-actions:
+    needs: detect-changes
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'yml')
+      || contains(needs.detect-changes.outputs.changes, 'build')
+    uses: ./.github/workflows/actionlint.yml
+
   lint-md:
     needs: detect-changes
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           md: [ '**.md' ]
           yml: [ '**.yml', '**.yaml', '.yamllint' ]
           build: ['build/**', '.github/**/*.yml', '!.github/workflows/package-*', '**/*.targets', '**/*.props', 'global.json']
+          github: ['.github/**/*']
           shared: ['src/Shared/**', 'test/Shared/**']
           contrib-shared-tests: ['test/OpenTelemetry.Contrib.Shared.Benchmarks/**', 'test/OpenTelemetry.Contrib.Shared.FuzzTests/**', 'test/OpenTelemetry.Contrib.Shared.Tests/**']
           code: ['**.cs', '**.csproj', '.editorconfig']
@@ -97,8 +98,7 @@ jobs:
   lint-actions:
     needs: detect-changes
     if: |
-      contains(needs.detect-changes.outputs.changes, 'yml')
-      || contains(needs.detect-changes.outputs.changes, 'build')
+      contains(needs.detect-changes.outputs.changes, 'github')
     uses: ./.github/workflows/actionlint.yml
     permissions:
       actions: read # Read GitHub Actions workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       contains(needs.detect-changes.outputs.changes, 'yml')
       || contains(needs.detect-changes.outputs.changes, 'build')
     uses: ./.github/workflows/actionlint.yml
+    permissions:
+      actions: read # Read GitHub Actions workflows
+      contents: read # Read repository contents
 
   lint-md:
     needs: detect-changes


### PR DESCRIPTION
## Changes

Add a linting workflow that uses [actionlint](https://github.com/rhysd/actionlint) that has extended functionality to verify use of GitHub actions (e.g. missing/mis-named inputs).

For example, it would have [caught this](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4434#discussion_r3287000226) without needing Copilot.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
