### PR TITLE
[Infra] Lint PowerShell scripts

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -93,8 +93,8 @@ jobs:
           -project ([ref]$project) `
           -component ([ref]$component)
 
-        echo "title=$title" >> $env:GITHUB_OUTPUT
-        echo "project=$project" >> $env:GITHUB_OUTPUT
+        Write-Output "title=$title" >> $env:GITHUB_OUTPUT
+        Write-Output "project=$project" >> $env:GITHUB_OUTPUT
 
         $artifactName = $component
         if ([string]::IsNullOrEmpty($artifactName)) {
@@ -104,11 +104,11 @@ jobs:
           }
         }
 
-        echo "name=$artifactName" >> $env:GITHUB_OUTPUT
+        Write-Output "name=$artifactName" >> $env:GITHUB_OUTPUT
 
         # Note: BUILD_COMPONENT envvar tells Component.proj what to build. Only
         # used if $project ends up Component.proj.
-        echo "BUILD_COMPONENT=$component" >> $env:GITHUB_ENV
+        Write-Output "BUILD_COMPONENT=$component" >> $env:GITHUB_ENV
 
     - name: Setup previous .NET runtimes
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,7 @@ jobs:
       code-ql,
       detect-changes,
       lint-md,
+      lint-pwsh,
       lint-yml,
       lint-dotnet-format,
       build-test-contrib-shared-tests,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         filters: |
           md: [ '**.md' ]
+          pwsh: [ '**.ps1', '**.psm1', '**.psd1' ]
           yml: [ '**.yml', '**.yaml', '.yamllint' ]
           build: ['build/**', '.github/**/*.yml', '!.github/workflows/package-*', '**/*.targets', '**/*.props', 'global.json']
           shared: ['src/Shared/**', 'test/Shared/**']
@@ -100,6 +101,15 @@ jobs:
       contains(needs.detect-changes.outputs.changes, 'md')
       || contains(needs.detect-changes.outputs.changes, 'build')
     uses: ./.github/workflows/markdownlint.yml
+
+  lint-pwsh:
+    needs: detect-changes
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'pwsh')
+      || contains(needs.detect-changes.outputs.changes, 'yml')
+    uses: ./.github/workflows/pwshlint.yml
+    permissions:
+      contents: read # To checkout the code
 
   lint-yml:
     needs: detect-changes

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -80,12 +80,12 @@ jobs:
             -project ([ref]$project) `
             -component ([ref]$component)
 
-          echo "title=$title" >> ${env:GITHUB_OUTPUT}
-          echo "PROJECT_PATH=$project" >> ${env:GITHUB_ENV}
+          Write-Output "title=$title" >> ${env:GITHUB_OUTPUT}
+          Write-Output "PROJECT_PATH=$project" >> ${env:GITHUB_ENV}
 
           # Note: BUILD_COMPONENT envvar tells Component.proj what to build. Only
           # used if $project ends up Component.proj.
-          echo "BUILD_COMPONENT=$component" >> ${env:GITHUB_ENV}
+          Write-Output "BUILD_COMPONENT=$component" >> ${env:GITHUB_ENV}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/pwshlint.yml
+++ b/.github/workflows/pwshlint.yml
@@ -1,0 +1,55 @@
+name: pwshlint
+
+on:
+  workflow_call:
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 3
+  # renovate: datasource=github-releases depName=powershell-yaml packageName=cloudbase/powershell-yaml
+  POWERSHELL_YAML_VERSION: '0.4.12'
+  # renovate: datasource=github-releases depName=PSScriptAnalyzer packageName=PowerShell/PSScriptAnalyzer
+  PSSCRIPTANALYZER_VERSION: '1.25.0'
+  TERM: xterm
+
+jobs:
+  pwsh-lint:
+    name: Lint PowerShell in workflows and scripts
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
+
+    - name: Lint PowerShell in workflows
+      uses: martincostello/lint-actions-powershell@e088367ebeb113cd7c1ebee5c541175d93e945b7 # v1.0.1
+      with:
+        powershell-yaml-version: ${{ env.POWERSHELL_YAML_VERSION }}
+        psscriptanalyzer-version: ${{ env.PSSCRIPTANALYZER_VERSION }}
+        treat-warnings-as-errors: true
+
+    - name: Lint PowerShell scripts
+      shell: pwsh
+      run: |
+        $settings = @{
+          IncludeDefaultRules = $true
+          Severity = @("Error", "Warning")
+        }
+        $issues = Invoke-ScriptAnalyzer -Path ${env:GITHUB_WORKSPACE} -Recurse -ReportSummary -Settings $settings
+        foreach ($issue in $issues) {
+          $severity = $issue.Severity.ToString()
+          $level = $severity.Contains("Error") ? "error" : $severity.Contains("Warning") ? "warning" : "notice"
+          Write-Output "::${level} file=$($issue.ScriptName),line=$($issue.Line),title=PSScriptAnalyzer::$($issue.Message)"
+        }
+        if ($issues.Count -gt 0) {
+          exit 1
+        }

--- a/build/scripts/add-labels.psm1
+++ b/build/scripts/add-labels.psm1
@@ -90,7 +90,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
       $rawProjectName = $match.Groups[1].Value
       if ($rawProjectName.Contains(".benchmarks") -or $rawProjectName.Contains(".stress"))
       {
-        $labelsToAdd.Add("perf")
+        [void]$labelsToAdd.Add("perf")
       }
 
       $projectName = $rawProjectName.Replace(".tests", "").Replace(".benchmarks", "").Replace(".stress", "")
@@ -99,7 +99,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
         continue
       }
 
-      $visitedProjects.Add($projectName)
+      [void]$visitedProjects.Add($projectName)
 
       foreach ($repoLabel in $repoLabels)
       {
@@ -113,7 +113,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
             }
             if ($package -eq $projectName)
             {
-                $labelsToAdd.Add($repoLabel.name)
+                [void]$labelsToAdd.Add($repoLabel.name)
                 break
             }
         }
@@ -124,7 +124,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
         $fileChanged.StartsWith('docs/') -or
         $fileChanged.StartsWith('examples/'))
     {
-        $labelsToAdd.Add("documentation")
+        [void]$labelsToAdd.Add("documentation")
     }
 
     if ($fileChanged.StartsWith('build/') -or
@@ -134,17 +134,17 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
         $fileExtension -eq ".targets" -or
         $fileChanged.StartsWith('test/openTelemetry.aotcompatibility'))
     {
-        $labelsToAdd.Add("infra")
+        [void]$labelsToAdd.Add("infra")
     }
 
     if ($fileChanged.StartsWith('test/benchmarks'))
     {
-        $labelsToAdd.Add("perf")
+        [void]$labelsToAdd.Add("perf")
     }
 
     if ($fullFileName -eq 'directory.packages.props')
     {
-        $labelsToAdd.Add("dependencies")
+        [void]$labelsToAdd.Add("dependencies")
     }
   }
 
@@ -152,12 +152,12 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
   {
      if ($labelsToAdd.Contains($labelOnPullRequest.name))
      {
-        $labelsToAdd.Remove($labelOnPullRequest.name)
+        [void]$labelsToAdd.Remove($labelOnPullRequest.name)
      }
      elseif ($labelOnPullRequest.name.StartsWith($labelPackagePrefix) -or
         $managedLabels.Contains($labelOnPullRequest.name))
      {
-        $labelsToRemove.Add($labelOnPullRequest.name)
+        [void]$labelsToRemove.Add($labelOnPullRequest.name)
      }
   }
 

--- a/build/scripts/add-labels.psm1
+++ b/build/scripts/add-labels.psm1
@@ -78,7 +78,6 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
   {
     $fileChanged = $fileChanged.ToLower()
     $fullFileName = [System.IO.Path]::GetFileName($fileChanged)
-    $fileName = [System.IO.Path]::GetFileNameWithoutExtension($fileChanged)
     $fileExtension = [System.IO.Path]::GetExtension($fileChanged)
 
     if ($fileChanged.StartsWith('src/') -or $fileChanged.StartsWith('test/'))
@@ -91,7 +90,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
       $rawProjectName = $match.Groups[1].Value
       if ($rawProjectName.Contains(".benchmarks") -or $rawProjectName.Contains(".stress"))
       {
-        $added = $labelsToAdd.Add("perf")
+        $labelsToAdd.Add("perf")
       }
 
       $projectName = $rawProjectName.Replace(".tests", "").Replace(".benchmarks", "").Replace(".stress", "")
@@ -100,7 +99,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
         continue
       }
 
-      $added = $visitedProjects.Add($projectName);
+      $visitedProjects.Add($projectName)
 
       foreach ($repoLabel in $repoLabels)
       {
@@ -114,7 +113,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
             }
             if ($package -eq $projectName)
             {
-                $added = $labelsToAdd.Add($repoLabel.name)
+                $labelsToAdd.Add($repoLabel.name)
                 break
             }
         }
@@ -125,7 +124,7 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
         $fileChanged.StartsWith('docs/') -or
         $fileChanged.StartsWith('examples/'))
     {
-        $added = $labelsToAdd.Add("documentation")
+        $labelsToAdd.Add("documentation")
     }
 
     if ($fileChanged.StartsWith('build/') -or
@@ -135,17 +134,17 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
         $fileExtension -eq ".targets" -or
         $fileChanged.StartsWith('test/openTelemetry.aotcompatibility'))
     {
-        $added = $labelsToAdd.Add("infra")
+        $labelsToAdd.Add("infra")
     }
 
     if ($fileChanged.StartsWith('test/benchmarks'))
     {
-        $added = $labelsToAdd.Add("perf")
+        $labelsToAdd.Add("perf")
     }
 
     if ($fullFileName -eq 'directory.packages.props')
     {
-        $added = $labelsToAdd.Add("dependencies")
+        $labelsToAdd.Add("dependencies")
     }
   }
 
@@ -153,12 +152,12 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
   {
      if ($labelsToAdd.Contains($labelOnPullRequest.name))
      {
-        $removed = $labelsToAdd.Remove($labelOnPullRequest.name)
+        $labelsToAdd.Remove($labelOnPullRequest.name)
      }
      elseif ($labelOnPullRequest.name.StartsWith($labelPackagePrefix) -or
         $managedLabels.Contains($labelOnPullRequest.name))
      {
-        $added = $labelsToRemove.Add($labelOnPullRequest.name)
+        $labelsToRemove.Add($labelOnPullRequest.name)
      }
   }
 

--- a/build/scripts/build.psm1
+++ b/build/scripts/build.psm1
@@ -21,10 +21,9 @@ function ResolveProjectForTag {
   }
 
   $tagPrefix = $match.Groups[1].Value
-  $version = $match.Groups[2].Value
 
   # Step 1: Look for a .proj file in build/Projects with a matching MinVerTagPrefix
-  $buildProjects = @(Get-ChildItem -Path build/Projects/*.proj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select Path)
+  $buildProjects = @(Get-ChildItem -Path build/Projects/*.proj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select-Object Path)
 
   if ($buildProjects.Length -gt 1)
   {
@@ -40,7 +39,7 @@ function ResolveProjectForTag {
   }
 
   # Step 2: If no .proj file found use component build for the csproj found matching MinVerTagPrefix
-  $projects = @(Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select Path)
+  $projects = @(Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select-Object Path)
 
   if ($projects.Length -gt 1)
   {
@@ -117,7 +116,7 @@ function FindComponentOwners {
 
   $minVerTagPrefix = $match.Groups[1].Value
 
-  $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+  $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select-Object Path | Split-Path -Parent
 
   $componentOwnersContent = Get-Content '.github/component_owners.yml' -Raw
 
@@ -128,11 +127,11 @@ function FindComponentOwners {
     $match = [regex]::Match($componentOwnersContent, "src\/$projectName\/:([\w\W\s]*?)(src|test)")
     if ($match.Success -eq $true)
     {
-      $matches = [regex]::Matches($match.Groups[1].Value, "-\s*(.*)")
-      foreach ($match in $matches)
+      $ownerMatches = [regex]::Matches($match.Groups[1].Value, "-\s*(.*)")
+      foreach ($match in $ownerMatches)
       {
         $owner = $match.Groups[1].Value
-        $_ = $componentOwners.Value.Add($owner.Trim())
+        $componentOwners.Value.Add($owner.Trim())
       }
     }
   }

--- a/build/scripts/finalize-publicapi.ps1
+++ b/build/scripts/finalize-publicapi.ps1
@@ -9,7 +9,7 @@ $InformationPreference = "Continue"
 
 $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select-Object Path | Split-Path -Parent
 
-$path = "\.publicApi\**\PublicAPI.Shipped.txt";
+$path = ".publicApi\**\PublicAPI.Shipped.txt";
 
 foreach ($projectDir in $projectDirs) {
     $searchPath = Join-Path -Path $projectDir -ChildPath $path;

--- a/build/scripts/finalize-publicapi.ps1
+++ b/build/scripts/finalize-publicapi.ps1
@@ -2,26 +2,29 @@ param(
   [Parameter(Mandatory=$true)][string]$minVerTagPrefix
 )
 
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
 # For stable releases "Unshipped" PublicApi text files are merged into "Shipped" versions.
 
-$projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+$projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select-Object Path | Split-Path -Parent
 
 $path = "\.publicApi\**\PublicAPI.Shipped.txt";
 
 foreach ($projectDir in $projectDirs) {
     $searchPath = Join-Path -Path $projectDir -ChildPath $path;
 
-    Write-Host "Search glob: $searchPath";
+    Write-Information "Search glob: $searchPath"
 
     Get-ChildItem -Path $searchPath -Recurse |
         ForEach-Object {
-            Write-Host "Shipped: $_";
+            Write-Information "Shipped: $($_.FullName)"
 
             [string]$shipped = $_.FullName;
             [string]$unshipped = $shipped -replace ".shipped.txt", ".Unshipped.txt";
 
             if (Test-Path $unshipped) {
-                Write-Host "Unshipped: $unshipped";
+                Write-Information "Unshipped: $unshipped"
 
                 Get-Content $shipped, $unshipped |  # get contents of both text files
                     Where-Object {$_ -ne ""} |      # filter empty lines
@@ -31,9 +34,9 @@ foreach ($projectDir in $projectDirs) {
 
                 Clear-Content $unshipped;           # empty unshipped.txt
 
-                Write-Host "...MERGED and SORTED";
+                Write-Information '...MERGED and SORTED'
             }
 
-            Write-Host "";
+            Write-Information ''
         }
 }

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -7,6 +7,7 @@ function CreateRelease {
 
   $ErrorActionPreference = "Stop"
   $InformationPreference = "Continue"
+  $WarningPreference = "Continue"
 
   $match = [regex]::Match($tag, '^(.*?-)(.*)$')
   if ($match.Success -eq $false)
@@ -159,7 +160,7 @@ Have a nice day!
     return
   }
 
-  Write-Information 'No prepare release PR found matched author and title with a valid comment'
+  Write-Warning 'No prepare release PR found matched author and title with a valid comment'
 }
 
 Export-ModuleMember -Function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -5,6 +5,9 @@ function CreateRelease {
     [Parameter()][string]$releaseFiles
   )
 
+  $ErrorActionPreference = "Stop"
+  $InformationPreference = "Continue"
+
   $match = [regex]::Match($tag, '^(.*?-)(.*)$')
   if ($match.Success -eq $false)
   {
@@ -14,7 +17,7 @@ function CreateRelease {
   $tagPrefix = $match.Groups[1].Value
   $version = $match.Groups[2].Value
 
-  $projects = @(Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select Path)
+  $projects = @(Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select-Object Path)
 
   $notes = ''
 
@@ -107,7 +110,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
 
   if ($prListResponse.Length -eq 0)
   {
-    Write-Host 'No prepare release PR found for tag & commit skipping post notice'
+    Write-Information 'No prepare release PR found for tag & commit skipping post notice'
     return
   }
 
@@ -156,7 +159,7 @@ Have a nice day!
     return
   }
 
-  Write-Host 'No prepare release PR found matched author and title with a valid comment'
+  Write-Information 'No prepare release PR found matched author and title with a valid comment'
 }
 
 Export-ModuleMember -Function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest
@@ -190,7 +193,7 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
     git config user.email $gitUserEmail
   }
 
-  git switch --create $branch origin/$targetBranch --no-track 2>&1 | % ToString
+  git switch --create $branch origin/$targetBranch --no-track 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git switch failure'
@@ -199,8 +202,8 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
   $versionTagRegex = "<PackageValidationBaselineVersion>.*</PackageValidationBaselineVersion>"
 
   $projects = Get-ChildItem -Path src/**/*.csproj |
-    where { $_ | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" } |
-    where { $_ | Select-String $versionTagRegex }
+    Where-Object { $_ | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" } |
+    Where-Object { $_ | Select-String $versionTagRegex }
 
   if ($projects.Length -ne 0)
   {
@@ -209,7 +212,7 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
           -replace $versionTagRegex, "<PackageValidationBaselineVersion>$version</PackageValidationBaselineVersion>" |
         Set-Content $project
 
-      git add $project 2>&1 | % ToString
+      git add $project 2>&1 | ForEach-Object { $_.ToString() }
       if ($LASTEXITCODE -gt 0)
       {
           throw 'git add failure'
@@ -220,8 +223,8 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
   $disabledTag = "<DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>"
 
   $disabledProjects = Get-ChildItem -Path src/**/*.csproj |
-    where { $_ | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" } |
-    where { $_ | Select-String $disabledTag }
+    Where-Object { $_ | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" } |
+    Where-Object { $_ | Select-String $disabledTag }
 
   if ($disabledProjects.Length -ne 0)
   {
@@ -234,7 +237,7 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
 
       Set-Content $project -Value $content.TrimEnd()
 
-      git add $project 2>&1 | % ToString
+      git add $project 2>&1 | ForEach-Object { $_.ToString() }
       if ($LASTEXITCODE -gt 0)
       {
           throw 'git add failure'
@@ -242,7 +245,7 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
     }
   }
 
-  git commit -m "Update PackageValidationBaselineVersion in $tagPrefix projects to $version." -s 2>&1 | % ToString
+  git commit -m "Update PackageValidationBaselineVersion in $tagPrefix projects to $version." -s 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git commit failure'
@@ -252,7 +255,7 @@ function CreatePackageValidationBaselineVersionUpdatePullRequest {
   UpdateCommonPropsVersion -tagPrefix $tagPrefix -version $version -propertyName 'Instrumentation.Http-' -propertyDisplayName 'OpenTelemetryInstrumentationHttpLatestStableVersion'
   UpdateCommonPropsVersion -tagPrefix $tagPrefix -version $version -propertyName 'Instrumentation.Runtime-' -propertyDisplayName 'OpenTelemetryInstrumentationRuntimeLatestStableVersion'
 
-  git push -u origin $branch 2>&1 | % ToString
+  git push -u origin $branch 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git push failure'
@@ -337,7 +340,7 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
     git config user.email $gitUserEmail
   }
 
-  git switch --create $branch origin/$targetBranch --no-track 2>&1 | % ToString
+  git switch --create $branch origin/$targetBranch --no-track 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git switch failure'
@@ -368,19 +371,19 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
     }
   }
 
-  git add Directory.Packages.props 2>&1 | % ToString
+  git add Directory.Packages.props 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git add failure'
   }
 
-  git commit -m "Update $propertyName in Directory.Packages.props to $version." -s 2>&1 | % ToString
+  git commit -m "Update $propertyName in Directory.Packages.props to $version." -s 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git commit failure'
   }
 
-  git push -u origin $branch 2>&1 | % ToString
+  git push -u origin $branch 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git push failure'
@@ -404,7 +407,7 @@ Merge once packages are available on NuGet and the build passes.
     --head $branch `
     --label release
 
-  Write-Host $createPullRequestResponse
+  Write-Information $createPullRequestResponse
 
   $match = [regex]::Match($createPullRequestResponse, "\/pull\/(.*)$")
   if ($match.Success -eq $false)
@@ -435,7 +438,7 @@ $entry = @"
 
       if ([System.IO.File]::Exists($path) -eq $false)
       {
-        Write-Host "No CHANGELOG found in $projectDir"
+        Write-Information "No CHANGELOG found in $projectDir"
         continue
       }
 
@@ -507,7 +510,7 @@ $entry = @"
 
       Set-Content -Path $path -Value $content.TrimEnd()
 
-      git add $path 2>&1 | % ToString
+      git add $path 2>&1 | ForEach-Object { $_.ToString() }
       if ($LASTEXITCODE -gt 0)
       {
           throw 'git add failure'
@@ -518,13 +521,13 @@ $entry = @"
 
   if ($changelogFilesUpdated -gt 0)
   {
-    git commit -m "Update CHANGELOGs for projects using $propertyName." -s 2>&1 | % ToString
+    git commit -m "Update CHANGELOGs for projects using $propertyName." -s 2>&1 | ForEach-Object { $_.ToString() }
     if ($LASTEXITCODE -gt 0)
     {
         throw 'git commit failure'
     }
 
-    git push -u origin $branch 2>&1 | % ToString
+    git push -u origin $branch 2>&1 | ForEach-Object { $_.ToString() }
     if ($LASTEXITCODE -gt 0)
     {
         throw 'git push failure'
@@ -542,7 +545,7 @@ function GetCoreDependenciesForProjects {
     foreach ($project in $projects)
     {
         # Note: dotnet restore may fail if the core packages aren't available yet but that is fine, we just want to generate project.assets.json for these projects.
-        $output = dotnet restore $project
+        dotnet restore $project
 
         $projectDir = $project | Split-Path -Parent
         $projectDirName = $projectDir | Split-Path -Leaf
@@ -552,8 +555,8 @@ function GetCoreDependenciesForProjects {
 
         $projectDependencies = @{}
 
-        $matches = [regex]::Matches($content, '"(OpenTelemetry(?:.*))?": {[\S\s]*?"target": "Package",[\S\s]*?"version": "(.*)"[\S\s]*?}')
-        foreach ($match in $matches)
+        $dependencyMatches = [regex]::Matches($content, '"(OpenTelemetry(?:.*))?": {[\S\s]*?"target": "Package",[\S\s]*?"version": "(.*)"[\S\s]*?}')
+        foreach ($match in $dependencyMatches)
         {
             $packageName = $match.Groups[1].Value
             $packageVersion = $match.Groups[2].Value
@@ -590,13 +593,13 @@ function UpdateCommonPropsVersion {
                "<$propertyDisplayName>$version</$propertyDisplayName>" |
       Set-Content Directory.Packages.props -NoNewline
 
-    git add Directory.Packages.props 2>&1 | % ToString
+    git add Directory.Packages.props 2>&1 | ForEach-Object { $_.ToString() }
     if ($LASTEXITCODE -gt 0)
     {
         throw 'git add failure'
     }
 
-    git commit -m "Update $propertyDisplayName version in Directory.Packages.props to $version." -s 2>&1 | % ToString
+    git commit -m "Update $propertyDisplayName version in Directory.Packages.props to $version." -s 2>&1 | ForEach-Object { $_.ToString() }
     if ($LASTEXITCODE -gt 0)
     {
         throw 'git commit failure'

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -12,6 +12,9 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
     [Parameter()][string]$gitUserEmail
   )
 
+  $ErrorActionPreference = "Stop"
+  $InformationPreference = "Continue"
+
   $match = [regex]::Match($version, '^(\d+\.\d+\.\d+)(?:-((?:alpha)|(?:beta)|(?:rc))\.(\d+))?$')
   if ($match.Success -eq $false)
   {
@@ -39,7 +42,7 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
     git config user.email $gitUserEmail
   }
 
-  git switch --create $branch 2>&1 | % ToString
+  git switch --create $branch 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git switch failure'
@@ -85,13 +88,13 @@ Requested by: @$requestedByUserName
 ``/CreateReleaseTag``: Use after merging to push the release tag and trigger the job to create packages and push to NuGet [``approvers``, ``maintainers``]
 "@
 
-  git commit -a -m "Prepare repo to release $tag." -s 2>&1 | % ToString
+  git commit -a -m "Prepare repo to release $tag." -s 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git commit failure'
   }
 
-  git push -u origin $branch 2>&1 | % ToString
+  git push -u origin $branch 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git push failure'
@@ -188,13 +191,13 @@ function CreateReleaseTagAndPostNoticeOnPullRequest {
     git config user.email $gitUserEmail
   }
 
-  git tag -a $tag -m "$tag" $commit 2>&1 | % ToString
+  git tag -a $tag -m "$tag" $commit 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git tag failure'
   }
 
-  git push origin $tag 2>&1 | % ToString
+  git push origin $tag 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git push failure'
@@ -203,7 +206,7 @@ function CreateReleaseTagAndPostNoticeOnPullRequest {
   gh pr unlock $pullRequestNumber
 
   # Avoid race condition between the PR being unlocked and being able to post a comment
-  sleep 10
+  Start-Sleep -Seconds 10
 
   $body =
 @"
@@ -268,7 +271,7 @@ function UpdateChangelogReleaseDatesAndPostNoticeOnPullRequest {
     git config user.email $gitUserEmail
   }
 
-  git switch $prViewResponse.headRefName 2>&1 | % ToString
+  git switch $prViewResponse.headRefName 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git switch failure'
@@ -282,7 +285,7 @@ function UpdateChangelogReleaseDatesAndPostNoticeOnPullRequest {
 Released $(Get-Date -UFormat '%Y-%b-%d')
 "@
 
-  $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+  $projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$tagPrefix</MinVerTagPrefix>" -List | Select-Object Path | Split-Path -Parent
 
   foreach ($projectDir in $projectDirs)
   {
@@ -303,13 +306,13 @@ Released $(Get-Date -UFormat '%Y-%b-%d')
     return
   }
 
-  git commit -a -m "Update CHANGELOG release dates for $tag." -s 2>&1 | % ToString
+  git commit -a -m "Update CHANGELOG release dates for $tag." -s 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git commit failure'
   }
 
-  git push -u origin $prViewResponse.headRefName 2>&1 | % ToString
+  git push -u origin $prViewResponse.headRefName 2>&1 | ForEach-Object { $_.ToString() }
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git push failure'
@@ -337,7 +340,7 @@ function TagCodeOwnersOnOrRunWorkflowForRequestReleaseIssue {
   $match = [regex]::Match($issueBody, '^[#]+ Component\s*(OpenTelemetry\.(?:.|\w+)+)$', [Text.RegularExpressions.RegexOptions]::Multiline)
   if ($match.Success -eq $false)
   {
-      Write-Host 'Component could not be parsed from body'
+      Write-Information 'Component could not be parsed from body'
       Return
   }
 
@@ -347,7 +350,7 @@ function TagCodeOwnersOnOrRunWorkflowForRequestReleaseIssue {
   $titleMatch = [regex]::Match($issueTitle, '^\[release request\]\s+(OpenTelemetry\.[^\s]+)(?:\s+(.+))?\s*$')
   if ($titleMatch.Success -eq $false)
   {
-      Write-Host 'Component and version could not be parsed from title'
+      Write-Information 'Component and version could not be parsed from title'
       Return
   }
 
@@ -362,7 +365,7 @@ function TagCodeOwnersOnOrRunWorkflowForRequestReleaseIssue {
   $match = [regex]::Match($issueBody, '^[#]+ Version\s*(.*)$', [Text.RegularExpressions.RegexOptions]::Multiline)
   if ($match.Success -eq $false)
   {
-      Write-Host 'Version could not be parsed from body'
+      Write-Information 'Version could not be parsed from body'
       Return
   }
 

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -14,6 +14,7 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
 
   $ErrorActionPreference = "Stop"
   $InformationPreference = "Continue"
+  $WarningPreference = "Continue"
 
   $match = [regex]::Match($version, '^(\d+\.\d+\.\d+)(?:-((?:alpha)|(?:beta)|(?:rc))\.(\d+))?$')
   if ($match.Success -eq $false)
@@ -340,7 +341,7 @@ function TagCodeOwnersOnOrRunWorkflowForRequestReleaseIssue {
   $match = [regex]::Match($issueBody, '^[#]+ Component\s*(OpenTelemetry\.(?:.|\w+)+)$', [Text.RegularExpressions.RegexOptions]::Multiline)
   if ($match.Success -eq $false)
   {
-      Write-Information 'Component could not be parsed from body'
+      Write-Warning 'Component could not be parsed from body'
       Return
   }
 
@@ -350,7 +351,7 @@ function TagCodeOwnersOnOrRunWorkflowForRequestReleaseIssue {
   $titleMatch = [regex]::Match($issueTitle, '^\[release request\]\s+(OpenTelemetry\.[^\s]+)(?:\s+(.+))?\s*$')
   if ($titleMatch.Success -eq $false)
   {
-      Write-Information 'Component and version could not be parsed from title'
+      Write-Warning 'Component and version could not be parsed from title'
       Return
   }
 
@@ -365,7 +366,7 @@ function TagCodeOwnersOnOrRunWorkflowForRequestReleaseIssue {
   $match = [regex]::Match($issueBody, '^[#]+ Version\s*(.*)$', [Text.RegularExpressions.RegexOptions]::Multiline)
   if ($match.Success -eq $false)
   {
-      Write-Information 'Version could not be parsed from body'
+      Write-Warning 'Version could not be parsed from body'
       Return
   }
 

--- a/build/scripts/test-aot-compatibility.ps1
+++ b/build/scripts/test-aot-compatibility.ps1
@@ -1,6 +1,7 @@
 param([string]$targetNetFramework)
 
 $ErrorActionPreference = "Stop"
+$WarningPreference = "Continue"
 $InformationPreference = "Continue"
 
 $rootDirectory = Get-Location
@@ -14,7 +15,7 @@ foreach ($line in $($publishOutput -split "`r`n"))
 {
     if (($line -like "*analysis warning IL*") -or ($line -like "*analysis error IL*"))
     {
-        Write-Information $line
+        Write-Warning $line
         $actualWarningCount += 1
     }
 }
@@ -25,8 +26,8 @@ $expectedWarningCount = 0
 if ($LastExitCode -ne 0)
 {
     $testPassed = 1
-    Write-Information "There was an error while publishing AotCompatibility Test App. LastExitCode is: $LastExitCode"
-    Write-Information $publishOutput
+    Write-Warning "There was an error while publishing AotCompatibility Test App. LastExitCode is: $LastExitCode"
+    Write-Warning $publishOutput
 }
 
 $app = $IsWindows ? "./OpenTelemetry.AotCompatibility.TestApp.exe" : "./OpenTelemetry.AotCompatibility.TestApp"
@@ -40,7 +41,7 @@ Write-Information 'Finished executing test App'
 if ($LastExitCode -ne 0)
 {
     $testPassed = 1
-    Write-Information "There was an error while executing AotCompatibility Test App. LastExitCode is: $LastExitCode"
+    Write-Warning "There was an error while executing AotCompatibility Test App. LastExitCode is: $LastExitCode"
 }
 
 Pop-Location
@@ -48,7 +49,7 @@ Pop-Location
 if ($actualWarningCount -ne $expectedWarningCount)
 {
     $testPassed = 1
-    Write-Information "Actual warning count: $actualWarningCount is not as expected. Expected warning count is: $expectedWarningCount"
+    Write-Warning "Actual warning count: $actualWarningCount is not as expected. Expected warning count is: $expectedWarningCount"
 }
 
 Exit $testPassed

--- a/build/scripts/test-aot-compatibility.ps1
+++ b/build/scripts/test-aot-compatibility.ps1
@@ -8,6 +8,7 @@ $rootDirectory = Get-Location
 $publishOutput = dotnet publish $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj --framework $targetNetFramework -nodeReuse:false /p:UseSharedCompilation=false
 
 $actualWarningCount = 0
+$testPassed = 0
 
 foreach ($line in $($publishOutput -split "`r`n"))
 {
@@ -23,6 +24,7 @@ $expectedWarningCount = 0
 
 if ($LastExitCode -ne 0)
 {
+    $testPassed = 1
     Write-Information "There was an error while publishing AotCompatibility Test App. LastExitCode is: $LastExitCode"
     Write-Information $publishOutput
 }
@@ -37,12 +39,12 @@ Write-Information 'Finished executing test App'
 
 if ($LastExitCode -ne 0)
 {
-  Write-Information "There was an error while executing AotCompatibility Test App. LastExitCode is: $LastExitCode"
+    $testPassed = 1
+    Write-Information "There was an error while executing AotCompatibility Test App. LastExitCode is: $LastExitCode"
 }
 
 Pop-Location
 
-$testPassed = 0
 if ($actualWarningCount -ne $expectedWarningCount)
 {
     $testPassed = 1

--- a/build/scripts/test-aot-compatibility.ps1
+++ b/build/scripts/test-aot-compatibility.ps1
@@ -1,5 +1,8 @@
 param([string]$targetNetFramework)
 
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
 $rootDirectory = Get-Location
 
 $publishOutput = dotnet publish $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj --framework $targetNetFramework -nodeReuse:false /p:UseSharedCompilation=false
@@ -10,31 +13,31 @@ foreach ($line in $($publishOutput -split "`r`n"))
 {
     if (($line -like "*analysis warning IL*") -or ($line -like "*analysis error IL*"))
     {
-        Write-Host $line
+        Write-Information $line
         $actualWarningCount += 1
     }
 }
 
-Write-Host "Actual warning count is:", $actualWarningCount
+Write-Information "Actual warning count is: $actualWarningCount"
 $expectedWarningCount = 0
 
 if ($LastExitCode -ne 0)
 {
-    Write-Host "There was an error while publishing AotCompatibility Test App. LastExitCode is:", $LastExitCode
-    Write-Host $publishOutput
+    Write-Information "There was an error while publishing AotCompatibility Test App. LastExitCode is: $LastExitCode"
+    Write-Information $publishOutput
 }
 
 $app = $IsWindows ? "./OpenTelemetry.AotCompatibility.TestApp.exe" : "./OpenTelemetry.AotCompatibility.TestApp"
 
 Push-Location $rootDirectory/artifacts/publish/OpenTelemetry.AotCompatibility.TestApp/release_$targetNetFramework
 
-Write-Host "Executing test App..."
+Write-Information 'Executing test App...'
 $app
-Write-Host "Finished executing test App"
+Write-Information 'Finished executing test App'
 
 if ($LastExitCode -ne 0)
 {
-  Write-Host "There was an error while executing AotCompatibility Test App. LastExitCode is:", $LastExitCode
+  Write-Information "There was an error while executing AotCompatibility Test App. LastExitCode is: $LastExitCode"
 }
 
 Pop-Location
@@ -43,7 +46,7 @@ $testPassed = 0
 if ($actualWarningCount -ne $expectedWarningCount)
 {
     $testPassed = 1
-    Write-Host "Actual warning count:", $actualWarningCount, "is not as expected. Expected warning count is:", $expectedWarningCount
+    Write-Information "Actual warning count: $actualWarningCount is not as expected. Expected warning count is: $expectedWarningCount"
 }
 
 Exit $testPassed

--- a/build/scripts/update-changelogs.ps1
+++ b/build/scripts/update-changelogs.ps1
@@ -3,7 +3,10 @@ param(
   [Parameter(Mandatory=$true)][string]$version
 )
 
-$projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
+$projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select-Object Path | Split-Path -Parent
 
 $content = "Unreleased
 
@@ -14,7 +17,7 @@ Released $(Get-Date -UFormat '%Y-%b-%d')"
 foreach ($projectDir in $projectDirs) {
   $path = Join-Path -Path $projectDir -ChildPath "CHANGELOG.md"
 
-  Write-Host "Updating $path"
+  Write-Information "Updating $path"
 
   (Get-Content -Path $path) -replace "Unreleased", $content | Set-Content -Path $path
 }


### PR DESCRIPTION
## Changes

Add linting for `.ps1` scripts and inline PowerShell in GitHub Actions workflows.

This is something I built a while ago for my personal repositories and I thought I'd suggest using it while I was doing other linting and hygiene-related PRs.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
