### PR TITLE
[Instrumentation.EntityFrameworkCore] Fix postgresql datasource parsing for server address and port tags

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
   ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395))
 
+* Fix `SqlConnectionDetails` to parse also PostgreSQL data source URI correctly.
+  ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
   ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395))
 
-* Fix `SqlConnectionDetails` to parse also PostgreSQL data source URI correctly.
+* Fix `SqlConnectionDetails` to parse PostgreSQL data source URIs correctly.
   ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
 
 ## 1.15.1-beta.1

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -24,6 +24,9 @@
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
   ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395))
 
+* Fix `SqlConnectionDetails` to parse also PostgreSQL data source URI correctly.
+  ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -24,7 +24,7 @@
 * Fix `db.query.parameter.<key>` attributes to always emit the value as a string.
   ([#4395](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4395))
 
-* Fix `SqlConnectionDetails` to parse also PostgreSQL data source URI correctly.
+* Fix `SqlConnectionDetails` to parse PostgreSQL data source URIs correctly.
   ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
 
 ## 1.15.2

--- a/src/Shared/SqlConnectionDetails.cs
+++ b/src/Shared/SqlConnectionDetails.cs
@@ -132,11 +132,11 @@ internal sealed partial class SqlConnectionDetails
      *  np:\\serverName\pipe\MSSQL$instanceName\pipeName - in this case a separate regex (see NamedPipeRegex below)
      *  is used to extract instanceName
      */
-    [GeneratedRegex("^(?<protocol>[^[]*\\s*:\\s*\\\\{0,2})?(?<host>.*?)\\s*(?:[\\\\,]|$)\\s*(?<nameOrPort>.*?)\\s*(?:,|$)\\s*(?<port>.*)$", RegexOptions.None, RegexTimeoutMs)]
+    [GeneratedRegex("^(?<protocol>[^:[]*\\s*:\\s*(?:[\\\\/]{0,2})?)?(?<host>\\[[^\\]]+\\]|.*?)\\s*(?:[\\\\,:]|$)\\s*(?<nameOrPort>.*?)\\s*(?:,|$)\\s*(?<port>.*)$", RegexOptions.None, RegexTimeoutMs)]
     private static partial Regex DataSourceRegex();
 #else
 #pragma warning disable SA1201 // A field should not follow a method
-    private static readonly Regex DataSourceRegexField = new("^(?<protocol>[^[]*\\s*:\\s*\\\\{0,2})?(?<host>.*?)\\s*(?:[\\\\,]|$)\\s*(?<nameOrPort>.*?)\\s*(?:,|$)\\s*(?<port>.*)$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(RegexTimeoutMs));
+    private static readonly Regex DataSourceRegexField = new("^(?<protocol>[^:[]*\\s*:\\s*(?:[\\\\/]{0,2})?)?(?<host>\\[[^\\]]+\\]|.*?)\\s*(?:[\\\\,:]|$)\\s*(?<nameOrPort>.*?)\\s*(?:,|$)\\s*(?<port>.*)$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(RegexTimeoutMs));
 #pragma warning restore SA1201 // A field should not follow a method
 
     private static Regex DataSourceRegex() => DataSourceRegexField;

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
@@ -22,6 +22,8 @@ public class SqlConnectionDetailsTests
     [InlineData("tcp : localhost", "localhost", null, null, null)]
     [InlineData("tcp://some.domain.local:5432", "some.domain.local", null, null, 5432)]
     [InlineData("tcp://some.domain.local", "some.domain.local", null, null, null)]
+    [InlineData("tcp://[::1]:5432", null, "[::1]", null, 5432)]
+    [InlineData("tcp://[::1]", null, "[::1]", null, null)]
     [InlineData("np : localhost", "localhost", null, null, null)]
     [InlineData("lpc:localhost", "localhost", null, null, null)]
     [InlineData("np:\\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
@@ -20,6 +20,8 @@ public class SqlConnectionDetailsTests
     [InlineData("tcp:localhost", "localhost", null, null, null)]
     [InlineData("tcp:[::1]", null, "[::1]", null, null)]
     [InlineData("tcp : localhost", "localhost", null, null, null)]
+    [InlineData("tcp://some.domain.local:5432", "some.domain.local", null, null, 5432)]
+    [InlineData("tcp://some.domain.local", "some.domain.local", null, null, null)]
     [InlineData("np : localhost", "localhost", null, null, null)]
     [InlineData("lpc:localhost", "localhost", null, null, null)]
     [InlineData("np:\\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]


### PR DESCRIPTION
## Changes

This is a fix for #4443. I added ability to properly parse DataSource string produced by Npgsql (Postgresql) provider. The provider set to datasource URI like tcp://some.domain.local:5432. Which was parsed as host=5432, port=null, which is wrong and should be  host=some.domain.local, port=5432.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
