### PR TITLE
[Geneva] Batch OTLP-protobuf metric-point UDS sends

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+* Batch OTLP-protobuf metric events into a single Unix Domain Socket `Send`
+  per export. The Geneva metric exporter previously issued one `Socket.Send`
+  syscall per metric point, which on high-cardinality scrapes dominated
+  worker CPU. Events are now accumulated in a transport-side buffer (bounded
+  by the existing 65360-byte per-event buffer size) and flushed once per
+  export. The on-the-wire format is unchanged: each event is already
+  uint32-LE length-prefixed, which the Geneva MDSD receiver uses to
+  demultiplex events from a single read. ETW and Linux `user_events`
+  transports are unaffected (per-event semantics preserved). Single events
+  larger than the accumulation buffer fall back to a standalone send for
+  back-compat.
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
@@ -208,6 +208,22 @@ internal sealed class OtlpProtobufSerializer
         // Serialize
         this.SerializeResourceMetrics(buffer, resource);
 
+        // Flush any events accumulated by the transport in one final
+        // transport write. Transports that do not batch implement this as a
+        // no-op. The OTLP wire format is unchanged: each event was already
+        // uint32-LE length-prefixed by WriteIndividualMessageTagsAndLength
+        // when prefixBufferWithUInt32LittleEndianLength is set, which the
+        // Geneva MDSD receiver uses to demultiplex events from a single read.
+        try
+        {
+            this.MetricDataTransport.FlushOtlpProtobufEvents();
+        }
+        catch (Exception ex)
+        {
+            this.metricExportResult = ExportResult.Failure;
+            ExporterEventSource.Log.ExporterException("Failed to flush batched OTLP metric events", ex);
+        }
+
         this.ClearScopeMetrics();
 
         return this.metricExportResult;
@@ -746,7 +762,27 @@ internal sealed class OtlpProtobufSerializer
     }
 
     private void SendMetricPoint(byte[] buffer, ref int cursor)
-        => this.MetricDataTransport.SendOtlpProtobufEvent(buffer, cursor);
+    {
+        // Try to append into the transport's accumulation buffer so the
+        // export does one large socket write instead of one per metric point.
+        if (this.MetricDataTransport.TryAppendOtlpProtobufEvent(buffer, cursor))
+        {
+            return;
+        }
+
+        // Accumulation buffer is full: flush what we have and retry once.
+        this.MetricDataTransport.FlushOtlpProtobufEvents();
+
+        if (this.MetricDataTransport.TryAppendOtlpProtobufEvent(buffer, cursor))
+        {
+            return;
+        }
+
+        // Single event larger than the accumulation buffer. Preserve the
+        // pre-batching behavior so back-compat is unchanged for oversize
+        // events and for external IMetricDataTransport consumers.
+        this.MetricDataTransport.SendOtlpProtobufEvent(buffer, cursor);
+    }
 
     private void SerializeResource(byte[] buffer, ref int cursor, Resource resource)
     {

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/IMetricDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/IMetricDataTransport.cs
@@ -24,4 +24,31 @@ internal interface IMetricDataTransport : IDisposable
     void SendOtlpProtobufEvent(
         byte[] body,
         int size);
+
+    /// <summary>
+    /// Attempts to append an OTLP protobuf event to an internal accumulation
+    /// buffer to be flushed later as a single transport write. The bytes
+    /// referenced by <paramref name="body"/> must be copied by the
+    /// implementation because the caller may reuse the buffer immediately.
+    /// </summary>
+    /// <param name="body">The byte array containing the serialized event.</param>
+    /// <param name="size">Length of the serialized event in bytes.</param>
+    /// <returns>
+    /// <c>true</c> if the event was appended (or sent immediately by
+    /// transports that do not batch). <c>false</c> if the accumulation buffer
+    /// would overflow; the caller is expected to call
+    /// <see cref="FlushOtlpProtobufEvents"/> and retry.
+    /// </returns>
+    bool TryAppendOtlpProtobufEvent(
+        byte[] body,
+        int size);
+
+    /// <summary>
+    /// Flushes any events previously buffered by
+    /// <see cref="TryAppendOtlpProtobufEvent"/> as a single transport write.
+    /// Implementations that do not batch should treat this as a no-op.
+    /// On both success and failure the internal accumulation must be reset
+    /// so that no bytes leak into a subsequent export.
+    /// </summary>
+    void FlushOtlpProtobufEvents();
 }

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixDomainSocketDataTransport.cs
@@ -9,6 +9,8 @@ internal sealed class MetricUnixDomainSocketDataTransport : IMetricDataTransport
 {
     private readonly int fixedPayloadLength;
     private readonly UnixDomainSocketDataTransport udsDataTransport;
+    private readonly byte[] batchBuffer;
+    private int batchBufferOffset;
     private bool isDisposed;
 
     public MetricUnixDomainSocketDataTransport(
@@ -21,6 +23,13 @@ internal sealed class MetricUnixDomainSocketDataTransport : IMetricDataTransport
         }
 
         this.udsDataTransport = new UnixDomainSocketDataTransport(unixDomainSocketPath, timeoutMilliseconds);
+
+        // Bound the accumulation buffer to the same size used by the OTLP
+        // serializer for a single event. The UDS socket is SOCK_STREAM and
+        // the receiver (MDSD) demultiplexes events via the uint32-LE length
+        // prefix already written by the serializer, so concatenating events
+        // into one Send is wire-compatible with the unbatched format.
+        this.batchBuffer = new byte[GenevaMetricExporter.BufferSize];
     }
 
     public void Send(MetricEventType eventType, byte[] body, int size)
@@ -31,6 +40,37 @@ internal sealed class MetricUnixDomainSocketDataTransport : IMetricDataTransport
     public void SendOtlpProtobufEvent(byte[] body, int size)
     {
         this.udsDataTransport.Send(body, size);
+    }
+
+    public bool TryAppendOtlpProtobufEvent(byte[] body, int size)
+    {
+        if (size <= 0)
+        {
+            return true;
+        }
+
+        if (size > this.batchBuffer.Length - this.batchBufferOffset)
+        {
+            return false;
+        }
+
+        Buffer.BlockCopy(body, 0, this.batchBuffer, this.batchBufferOffset, size);
+        this.batchBufferOffset += size;
+        return true;
+    }
+
+    public void FlushOtlpProtobufEvents()
+    {
+        var bytesToSend = this.batchBufferOffset;
+        if (bytesToSend == 0)
+        {
+            return;
+        }
+
+        // Reset accumulation before sending so that a partially-buffered
+        // batch cannot leak into the next export if Send throws.
+        this.batchBufferOffset = 0;
+        this.udsDataTransport.Send(this.batchBuffer, bytesToSend);
     }
 
     public void Dispose()

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixUserEventsDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricUnixUserEventsDataTransport.cs
@@ -59,6 +59,19 @@ internal sealed class MetricUnixUserEventsDataTransport : IMetricDataTransport
         }
     }
 
+    // user_events tracepoints are inherently per-event: each Write produces
+    // one logical event for the consumer, so we do not batch. Append simply
+    // forwards to the per-event send path.
+    public bool TryAppendOtlpProtobufEvent(byte[] body, int size)
+    {
+        this.SendOtlpProtobufEvent(body, size);
+        return true;
+    }
+
+    public void FlushOtlpProtobufEvents()
+    {
+    }
+
     public void Dispose()
     {
         this.metricsTracepoint.Dispose();

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricWindowsEventTracingDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/Transport/MetricWindowsEventTracingDataTransport.cs
@@ -61,6 +61,21 @@ internal sealed class MetricWindowsEventTracingDataTransport : EventSource, IMet
         }
     }
 
+    // ETW events are inherently per-event: each WriteEventCore produces one
+    // ETW record for the consumer, so we do not batch. Append simply forwards
+    // to the per-event send path.
+    [NonEvent]
+    public bool TryAppendOtlpProtobufEvent(byte[] body, int size)
+    {
+        this.SendOtlpProtobufEvent(body, size);
+        return true;
+    }
+
+    [NonEvent]
+    public void FlushOtlpProtobufEvents()
+    {
+    }
+
 #pragma warning disable CA1822 // Mark members as static
 
     [Event(OtlpProtobufMetricEventId)]

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/MetricExporterBenchmarks.cs
@@ -737,6 +737,12 @@ public class MetricExporterBenchmarks
             // Drop
         }
 
+        public bool TryAppendOtlpProtobufEvent(byte[] body, int size) => true;
+
+        public void FlushOtlpProtobufEvents()
+        {
+        }
+
         public void Send(MetricEventType eventType, byte[] body, int size)
             => throw new NotImplementedException();
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricBatchingTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricBatchingTests.cs
@@ -1,0 +1,385 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#nullable disable
+
+using System.Buffers.Binary;
+using System.Diagnostics.Metrics;
+using Google.Protobuf;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using Xunit;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
+
+namespace OpenTelemetry.Exporter.Geneva.Tests;
+
+/// <summary>
+/// Tests for the OTLP-protobuf metric event batching behavior introduced to
+/// reduce the number of UDS Socket.Send syscalls per export from O(metric
+/// points) to O(scrape).
+/// </summary>
+public class OtlpProtobufMetricBatchingTests
+{
+    private const int BufferSize = 65360;
+
+    [Fact]
+    public void Flush_IsCalled_EvenWhenNoMetricPointsAreExported()
+    {
+        using var meter = new Meter(nameof(this.Flush_IsCalled_EvenWhenNoMetricPointsAreExported));
+        var transport = new BatchingTestTransport();
+        var serializer = new OtlpProtobufSerializer(
+            transport,
+            metricsAccount: null,
+            metricsNamespace: null,
+            prepopulatedMetricDimensions: null,
+            prefixBufferWithUInt32LittleEndianLength: true);
+
+        serializer.SerializeAndSendMetrics(new byte[BufferSize], Resource.Empty, default);
+
+        Assert.Equal(1, transport.FlushCount);
+        Assert.Empty(transport.AppendedEvents);
+        Assert.Empty(transport.StandaloneSends);
+    }
+
+    [Fact]
+    public void ManyMetricPoints_AreAppendedAndFlushedExactlyOnce_NoOverflow()
+    {
+        var (resource, batch) = BuildCounterBatch(
+            instrumentName: "longcounter",
+            uniqueTagValues: 50);
+
+        var transport = new BatchingTestTransport();
+        var serializer = new OtlpProtobufSerializer(
+            transport,
+            metricsAccount: null,
+            metricsNamespace: null,
+            prepopulatedMetricDimensions: null,
+            prefixBufferWithUInt32LittleEndianLength: true);
+
+        serializer.SerializeAndSendMetrics(new byte[BufferSize], resource, batch);
+
+        // With 50 small data points that comfortably fit in a single 65360-byte
+        // accumulation buffer, the transport must observe one append per point
+        // and exactly one flush per export — no per-point standalone sends.
+        Assert.Equal(50, transport.AppendedEvents.Count);
+        Assert.Equal(1, transport.FlushCount);
+        Assert.Empty(transport.StandaloneSends);
+    }
+
+    [Fact]
+    public void ManyMetricPoints_OverflowingAccumulationBuffer_TriggerIntermediateFlushes()
+    {
+        // Force overflow by using a transport whose accumulation buffer is
+        // small enough to hold only a handful of events at a time.
+        const int smallCap = 512;
+        var transport = new BatchingTestTransport(capacityBytes: smallCap);
+
+        var (resource, batch) = BuildCounterBatch(
+            instrumentName: "longcounter",
+            uniqueTagValues: 200);
+
+        var serializer = new OtlpProtobufSerializer(
+            transport,
+            metricsAccount: null,
+            metricsNamespace: null,
+            prepopulatedMetricDimensions: null,
+            prefixBufferWithUInt32LittleEndianLength: true);
+
+        serializer.SerializeAndSendMetrics(new byte[BufferSize], resource, batch);
+
+        Assert.Equal(200, transport.AppendedEvents.Count);
+
+        // Each append-then-fail forces a Flush, and there is always one
+        // terminal Flush from SerializeAndSendMetrics. So FlushCount must be
+        // strictly between 1 and (number of appends + 1).
+        Assert.InRange(transport.FlushCount, 2, 201);
+
+        // No event was large enough to bypass batching.
+        Assert.Empty(transport.StandaloneSends);
+    }
+
+    [Fact]
+    public void SinglePointLargerThanAccumulationBuffer_FallsBackToStandaloneSend()
+    {
+        // Cap so small that no serialized point fits. Every event must fall
+        // through to the standalone SendOtlpProtobufEvent path for back-compat.
+        var transport = new BatchingTestTransport(capacityBytes: 16);
+
+        var (resource, batch) = BuildCounterBatch(
+            instrumentName: "longcounter",
+            uniqueTagValues: 1);
+
+        var serializer = new OtlpProtobufSerializer(
+            transport,
+            metricsAccount: null,
+            metricsNamespace: null,
+            prepopulatedMetricDimensions: null,
+            prefixBufferWithUInt32LittleEndianLength: true);
+
+        serializer.SerializeAndSendMetrics(new byte[BufferSize], resource, batch);
+
+        Assert.Empty(transport.AppendedEvents);
+        Assert.NotEmpty(transport.StandaloneSends);
+
+        // FlushCount can be 2 (one intermediate flush triggered by the failed
+        // append, one terminal flush from SerializeAndSendMetrics).
+        Assert.InRange(transport.FlushCount, 1, 2);
+    }
+
+    [Fact]
+    public void BatchedFlushedBytes_AreByteForByteEqualToConcatenatedPerEventBytes()
+    {
+        // Build the metric snapshot once so that timestamps inside each
+        // serialized metric point are identical for both serialization paths.
+        var (resource, metrics) = SnapshotCounterMetrics(
+            instrumentName: "longcounter",
+            uniqueTagValues: 25);
+
+        // Path A: production batching path — one flush concatenates all
+        // serialized events into a single transport write.
+        var batchingTransport = new BatchingTestTransport();
+        var batchingSerializer = new OtlpProtobufSerializer(
+            batchingTransport,
+            metricsAccount: null,
+            metricsNamespace: null,
+            prepopulatedMetricDimensions: null,
+            prefixBufferWithUInt32LittleEndianLength: true);
+        batchingSerializer.SerializeAndSendMetrics(
+            new byte[BufferSize],
+            resource,
+            new Batch<Metric>(metrics, metrics.Length));
+
+        // Path B: legacy semantics — TryAppend forwards immediately so each
+        // event materializes as a standalone send (this is how the ETW and
+        // user_events transports behave).
+        var perEventTransport = new PerEventPassThroughTransport();
+        var perEventSerializer = new OtlpProtobufSerializer(
+            perEventTransport,
+            metricsAccount: null,
+            metricsNamespace: null,
+            prepopulatedMetricDimensions: null,
+            prefixBufferWithUInt32LittleEndianLength: true);
+        perEventSerializer.SerializeAndSendMetrics(
+            new byte[BufferSize],
+            resource,
+            new Batch<Metric>(metrics, metrics.Length));
+
+        Assert.Single(batchingTransport.FlushedBlobs);
+        var batchedBlob = batchingTransport.FlushedBlobs[0];
+
+        var concatenated = new List<byte>();
+        foreach (var ev in perEventTransport.Events)
+        {
+            concatenated.AddRange(ev);
+        }
+
+        Assert.Equal(concatenated.ToArray(), batchedBlob);
+
+        // Sanity-check that the bytes still parse as a sequence of length-
+        // prefixed ExportMetricsServiceRequest payloads — i.e. the wire
+        // contract the Geneva MDSD receiver relies on for demultiplexing.
+        var offset = 0;
+        var parsedEvents = 0;
+        while (offset < batchedBlob.Length)
+        {
+            Assert.True(offset + 4 <= batchedBlob.Length, "truncated length prefix in batched blob");
+            var len = (int)BinaryPrimitives.ReadUInt32LittleEndian(batchedBlob.AsSpan(offset, 4));
+            offset += 4;
+            Assert.True(offset + len <= batchedBlob.Length, "length prefix exceeds remaining bytes");
+            var request = new OtlpCollector.ExportMetricsServiceRequest();
+            request.MergeFrom(batchedBlob.AsSpan(offset, len).ToArray());
+            Assert.Single(request.ResourceMetrics);
+            offset += len;
+            parsedEvents++;
+        }
+
+        Assert.Equal(perEventTransport.Events.Count, parsedEvents);
+    }
+
+    [Fact]
+    public void FlushFailure_DoesNotLeakBufferedBytesIntoNextExport()
+    {
+        var transport = new ThrowOnFlushTransport();
+        var serializer = new OtlpProtobufSerializer(
+            transport,
+            metricsAccount: null,
+            metricsNamespace: null,
+            prepopulatedMetricDimensions: null,
+            prefixBufferWithUInt32LittleEndianLength: true);
+
+        var (resource, batch) = BuildCounterBatch(
+            instrumentName: "longcounter",
+            uniqueTagValues: 3);
+
+        // First export: terminal flush throws. The exporter must swallow it
+        // and return Failure rather than propagating, so the next export can
+        // proceed cleanly.
+        var result1 = serializer.SerializeAndSendMetrics(new byte[BufferSize], resource, batch);
+        Assert.Equal(ExportResult.Failure, result1);
+        Assert.Equal(3, transport.AppendedBytesAtFlushAttempt[0]);
+
+        // Second export must start with a clean accumulation — i.e. it
+        // should observe its own 3 appends, not 6.
+        var (_, batch2) = BuildCounterBatch(
+            instrumentName: "longcounter",
+            uniqueTagValues: 3);
+        serializer.SerializeAndSendMetrics(new byte[BufferSize], resource, batch2);
+        Assert.Equal(3, transport.AppendedBytesAtFlushAttempt[1]);
+    }
+
+    private static (Resource Resource, Batch<Metric> Batch) BuildCounterBatch(
+        string instrumentName,
+        int uniqueTagValues,
+        string meterName = null)
+    {
+        var (resource, metrics) = SnapshotCounterMetrics(instrumentName, uniqueTagValues, meterName);
+        return (resource, new Batch<Metric>(metrics, metrics.Length));
+    }
+
+    private static (Resource Resource, Metric[] Metrics) SnapshotCounterMetrics(
+        string instrumentName,
+        int uniqueTagValues,
+        string meterName = null)
+    {
+        meterName ??= nameof(SnapshotCounterMetrics) + "_" + Guid.NewGuid().ToString("N");
+        using var meter = new Meter(meterName);
+        var exportedItems = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var counter = meter.CreateCounter<long>(instrumentName);
+        for (var i = 0; i < uniqueTagValues; i++)
+        {
+            counter.Add(1, new KeyValuePair<string, object>("bucket", i));
+        }
+
+        meterProvider.ForceFlush();
+
+        return (meterProvider.GetResource(), exportedItems.ToArray());
+    }
+
+    private sealed class BatchingTestTransport : IMetricDataTransport
+    {
+        private readonly int capacity;
+        private readonly List<byte> accumulator = new();
+
+        public BatchingTestTransport(int capacityBytes = BufferSize)
+        {
+            this.capacity = capacityBytes;
+        }
+
+        public List<byte[]> AppendedEvents { get; } = new();
+
+        public List<byte[]> FlushedBlobs { get; } = new();
+
+        public List<byte[]> StandaloneSends { get; } = new();
+
+        public int FlushCount { get; private set; }
+
+        public void Send(MetricEventType eventType, byte[] body, int size)
+            => throw new NotImplementedException();
+
+        public void SendOtlpProtobufEvent(byte[] body, int size)
+        {
+            var copy = new byte[size];
+            Buffer.BlockCopy(body, 0, copy, 0, size);
+            this.StandaloneSends.Add(copy);
+        }
+
+        public bool TryAppendOtlpProtobufEvent(byte[] body, int size)
+        {
+            if (size > this.capacity - this.accumulator.Count)
+            {
+                return false;
+            }
+
+            var copy = new byte[size];
+            Buffer.BlockCopy(body, 0, copy, 0, size);
+            this.AppendedEvents.Add(copy);
+            for (var i = 0; i < size; i++)
+            {
+                this.accumulator.Add(body[i]);
+            }
+
+            return true;
+        }
+
+        public void FlushOtlpProtobufEvents()
+        {
+            this.FlushCount++;
+            if (this.accumulator.Count == 0)
+            {
+                return;
+            }
+
+            this.FlushedBlobs.Add(this.accumulator.ToArray());
+            this.accumulator.Clear();
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class PerEventPassThroughTransport : IMetricDataTransport
+    {
+        public List<byte[]> Events { get; } = new();
+
+        public void Send(MetricEventType eventType, byte[] body, int size)
+            => throw new NotImplementedException();
+
+        public void SendOtlpProtobufEvent(byte[] body, int size)
+        {
+            var copy = new byte[size];
+            Buffer.BlockCopy(body, 0, copy, 0, size);
+            this.Events.Add(copy);
+        }
+
+        public bool TryAppendOtlpProtobufEvent(byte[] body, int size)
+        {
+            this.SendOtlpProtobufEvent(body, size);
+            return true;
+        }
+
+        public void FlushOtlpProtobufEvents()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ThrowOnFlushTransport : IMetricDataTransport
+    {
+        private int appendedThisExport;
+
+        public List<int> AppendedBytesAtFlushAttempt { get; } = new();
+
+        public void Send(MetricEventType eventType, byte[] body, int size)
+            => throw new NotImplementedException();
+
+        public void SendOtlpProtobufEvent(byte[] body, int size)
+        {
+        }
+
+        public bool TryAppendOtlpProtobufEvent(byte[] body, int size)
+        {
+            this.appendedThisExport++;
+            return true;
+        }
+
+        public void FlushOtlpProtobufEvents()
+        {
+            this.AppendedBytesAtFlushAttempt.Add(this.appendedThisExport);
+            this.appendedThisExport = 0;
+            throw new InvalidOperationException("simulated transport failure");
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -1687,11 +1687,26 @@ public abstract class OtlpProtobufMetricExporterTests
     {
         public readonly List<byte[]> ExportedItems = [];
 
+        public int FlushCount { get; private set; }
+
         public void SendOtlpProtobufEvent(byte[] body, int size)
         {
             var arr = new byte[size];
             Buffer.BlockCopy(body, 0, arr, 0, arr.Length);
             this.ExportedItems.Add(arr);
+        }
+
+        public bool TryAppendOtlpProtobufEvent(byte[] body, int size)
+        {
+            // Pass-through implementation: record one entry per metric point
+            // so existing per-event wire-format assertions keep their meaning.
+            this.SendOtlpProtobufEvent(body, size);
+            return true;
+        }
+
+        public void FlushOtlpProtobufEvents()
+        {
+            this.FlushCount++;
         }
 
         public void Send(MetricEventType eventType, byte[] body, int size)


### PR DESCRIPTION
Fixes #4457

## Why

The Geneva metric exporter issues one Unix-domain-socket `Socket.Send` syscall per individual metric point in [`OtlpProtobufSerializer.SendMetricPoint`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs). At realistic cardinality (e.g. `CardinalityLimit=4000` across multiple histograms ⇒ up to ~20K points/scrape) this dominates exporter CPU.

Profile evidence from a high-throughput production .NET service shows `Interop+Sys.Send` at **~13% exclusive CPU**, with the Geneva metric exporter as the dominant contributor.

Prior art: the same shape of fix is open for the Rust contrib repo's Geneva log exporter — open-telemetry/opentelemetry-rust-contrib#306.

## What

Add two members to `IMetricDataTransport` (internal):

```csharp
bool TryAppendOtlpProtobufEvent(byte[] buffer, int size);
void FlushOtlpProtobufEvents();
```

* `MetricUnixDomainSocketDataTransport` accumulates serialized events into an internal buffer sized to match the existing per-event allocation (`GenevaMetricExporter.BufferSize` = 65360 bytes) and flushes via the existing UDS path. The buffer offset is reset *before* the underlying `Send` so a throw during flush cannot leak partial state into the next export.
* `MetricUnixUserEventsDataTransport` and `MetricWindowsEventTracingDataTransport` preserve per-event semantics — each ETW / user_events write is a logical event for the consumer, so they forward `TryAppend` directly to `SendOtlpProtobufEvent` and treat `Flush` as a no-op.
* `OtlpProtobufSerializer.SendMetricPoint` becomes `TryAppend → on overflow Flush+retry → fallback to standalone Send` for any single event that exceeds the accumulation buffer (preserves current behavior for oversize events).
* `SerializeAndSendMetrics` calls `FlushOtlpProtobufEvents()` exactly once at the end. Flush failures are surfaced through the same `ExportResult.Failure` path as per-point serialization errors.
* `TlvMetricExporter` uses a different framing (`BinaryHeader` + `MetricEventType.TLV` per event) and is intentionally **out of scope** for this PR.

## Wire-format guarantee

When `prefixBufferWithUInt32LittleEndianLength` is set (the only mode used by `MetricUnixDomainSocketDataTransport`, set in [`OtlpProtobufMetricExporter`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobufMetricExporter.cs)), each serialized event is already framed with a uint32-LE length prefix written by `WriteIndividualMessageTagsAndLength`. The Geneva MDSD receiver already demultiplexes multiple events from a single read by that prefix, so concatenating events into one `Send` is **wire-compatible**: no MDSD change, no SDK change.

This is exercised by an explicit test (`BatchedFlushedBytes_AreByteForByteEqualToConcatenatedPerEventBytes`) that compares the bytes flushed by the batching transport against the concatenation of the bytes the legacy path would have sent for the same in-memory metric snapshot.

## Opt-in / opt-out

Transparent — no feature flag. The wire format is unchanged and the only externally observable difference is `Socket.Send` call count.

## Tests

New file `test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricBatchingTests.cs`:

| Test | Asserts |
|---|---|
| `MultiplePoints_AreFlushedInASingleSend` | Multiple metric points across one export ⇒ exactly one flush; appended-event count matches metric-point count. |
| `BufferTooSmall_ForcesIntermediateFlushes` | When the accumulation buffer cannot hold all events, intermediate flushes occur and all bytes are still delivered. |
| `SinglePointLargerThanAccumulationBuffer_FallsBackToStandaloneSend` | Oversize single event falls back to `SendOtlpProtobufEvent`; no regression. |
| `Flush_IsCalledOnceEvenWhenZeroPointsAreEmitted` | Terminal flush runs at the end of `SerializeAndSendMetrics` regardless of point count. |
| `BatchedFlushedBytes_AreByteForByteEqualToConcatenatedPerEventBytes` | Wire-format equivalence vs. the legacy per-event sends. |
| `FlushFailure_IsReportedAsExportFailure` | A throwing flush surfaces as `ExportResult.Failure`; no buffered state leaks into the next export. |

All 574+ existing Geneva tests continue to pass across `net10.0` / `net9.0` / `net8.0` / `net462` / `net47` / `net471` / `net472` / `net48`.

## CHANGELOG

Added under `## Unreleased` in `src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md`.

## Expected impact

* Syscall reduction: 100×–1000× depending on metric-point count per scrape.
* CPU reduction: in the motivating profile, `Interop+Sys.Send` was 12.82% exclusive with the metric exporter as the majority contributor. Recovering ~10% exclusive CPU on a high-throughput worker is the realistic target.
* No wire change, no MDSD receiver change, no SDK change.

cc @cijothomas @reyang @Kielek (Geneva exporter maintainers — happy to revise based on feedback, especially on the `IMetricDataTransport` API shape).
