### PR TITLE
[tests] add Xunit namespaces to global usings

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project>
   <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'Directory.Build.props'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'opentelemetry-dotnet-contrib.slnx'))\build\Common.nonprod.props" />
+
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests')) or $(MSBuildProjectName.EndsWith('.FuzzTests'))">
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Contrib.Shared.Benchmarks/SqlProcessorBenchmarks.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Benchmarks/SqlProcessorBenchmarks.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnosers;
 
 namespace OpenTelemetry.Instrumentation.Benchmarks;
 

--- a/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using FsCheck;
 using FsCheck.Xunit;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/ActivityInstrumentationHelperTest.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/ActivityInstrumentationHelperTest.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/ActivitySourceFactoryTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/ActivitySourceFactoryTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/DatabaseSemanticConventionHelperTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/DatabaseSemanticConventionHelperTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using Xunit;
 using static OpenTelemetry.Internal.DatabaseSemanticConventionHelper;
 
 namespace OpenTelemetry.Internal.Tests;

--- a/test/OpenTelemetry.Contrib.Shared.Tests/EventSourceTestHelperTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/EventSourceTestHelperTests.cs
@@ -5,7 +5,6 @@
 
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/GrpcTagHelperTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/GrpcTagHelperTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/HttpClientHelpersTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/HttpClientHelpersTests.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.IO.Compression;
 using System.Net;
 using System.Text;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/MeterFactoryTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/PropertyFetcherTest.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/RedactionHelperTest.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/RedactionHelperTest.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Internal.Tests;
 
 public class RedactionHelperTest

--- a/test/OpenTelemetry.Contrib.Shared.Tests/RenovateSchemaTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/RenovateSchemaTests.cs
@@ -8,8 +8,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/RequestDataHelperTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/RequestDataHelperTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Instrumentation.Tests;
 
 public class SqlConnectionDetailsTests

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlParameterProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlParameterProcessorTests.cs
@@ -6,7 +6,6 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTestCases.cs
@@ -4,8 +4,6 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.Tests;
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-using Xunit.Abstractions;
-
 namespace OpenTelemetry.Instrumentation.Tests;
 
 public class SqlProcessorTests

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDLogExporterBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TLDLogExporterBenchmarks.cs
@@ -7,7 +7,6 @@ using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Exporter.Geneva.Tld;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
 
 /*
 BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)

--- a/test/OpenTelemetry.Exporter.Geneva.FuzzTests/MessagePackSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.FuzzTests/MessagePackSerializerTests.cs
@@ -4,7 +4,6 @@
 using FsCheck;
 using FsCheck.Xunit;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva;
 

--- a/test/OpenTelemetry.Exporter.Geneva.FuzzTests/MetricSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.FuzzTests/MetricSerializerTests.cs
@@ -3,7 +3,6 @@
 
 using FsCheck;
 using FsCheck.Xunit;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/ConnectionStringBuilderTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/ConnectionStringBuilderTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Exporter.Geneva.Transports;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Exporter.Geneva.Transports;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaCorrelationFixture.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaCorrelationFixture.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 
 [CollectionDefinition(nameof(GenevaCorrelationFixture))]

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterAFDCorrelationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterAFDCorrelationTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Context;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Logs;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -15,7 +15,6 @@ using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 
 public class GenevaMetricExporterOptionsTests

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -14,8 +14,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Exporter.Geneva.Metrics;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
-using OpenTelemetry.Trace;
-using Xunit;
 using static OpenTelemetry.Exporter.Geneva.Tests.MetricsContract;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -13,7 +13,6 @@ using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/JsonSerializerTests.cs
@@ -5,7 +5,6 @@
 
 using System.Text;
 using OpenTelemetry.Exporter.Geneva.Tld;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/LogSerializationTests.cs
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Logs;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MessagePackSerializerTests.cs
@@ -6,7 +6,6 @@
 using System.Globalization;
 using System.Text;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
-using Xunit;
 using Xunit.Sdk;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MetricSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MetricSerializerTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Buffers.Binary;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackLogExporterTests.cs
@@ -5,7 +5,6 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackLogExporterThreadSafetyTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackLogExporterThreadSafetyTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Exporter.Geneva.MsgPack;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterThreadSafetyTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterThreadSafetyTests.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenTelemetry.Exporter.Geneva.MsgPack;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -9,8 +9,6 @@ using Google.Protobuf;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
-using Xunit;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
 using OtlpCommon = OpenTelemetry.Proto.Common.V1;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithPrefixTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithPrefixTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 
 [Collection("OtlpProtobufMetricExporterTests")]

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithoutPrefixTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterWithoutPrefixTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 
 [Collection("OtlpProtobufMetricExporterTests")]

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/TableNameSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/TableNameSerializerTests.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Text;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketDataTransportTests.cs
@@ -7,7 +7,6 @@ using System.Net.Sockets;
 using System.Reflection;
 using OpenTelemetry.Exporter.Geneva.Transports;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketEndPointTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixDomainSocketEndPointTests.cs
@@ -6,7 +6,6 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/UnixUserEventsDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/UnixUserEventsDataTransportTests.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 using Microsoft.LinuxTracepoints.Provider;
 using OpenTelemetry.Exporter.Geneva.Transports;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.InfluxDB.Tests;
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.Metrics;
 using System.Reflection;
 using OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.InfluxDB.Tests;
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/AssertUtils.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/AssertUtils.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 
 internal static class AssertUtils

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationHelperTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationHelperTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using System.Text.Json;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationStateTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/CommonSchemaJsonSerializationStateTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using System.Text.Json;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/ConnectionStringParserTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/ConnectionStringParserTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 
 public class ConnectionStringParserTests

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/EventNameManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/EventNameManagerTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Text;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/ExtensionFieldInformationManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/ExtensionFieldInformationManagerTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 
 public class ExtensionFieldInformationManagerTests

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/HttpJsonPostTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/HttpJsonPostTransportTests.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 #endif
 using System.Text;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/LogRecordCommonSchemaJsonSerializerTests.cs
@@ -7,7 +7,6 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorIntegrationTests.cs
@@ -9,8 +9,6 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorLogExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorLogExporterOptionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 
 public sealed class OneCollectorLogExporterOptionsTests

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorLoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorLoggerProviderBuilderExtensionsTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/WriteDirectlyToTransportSinkTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/WriteDirectlyToTransportSinkTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.OneCollector.Tests;
 

--- a/test/OpenTelemetry.Extensions.AWS.Tests/AWSXRayIdGeneratorTests.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/AWSXRayIdGeneratorTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.AWS.Tests;
 

--- a/test/OpenTelemetry.Extensions.AWS.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/OpenTelemetry.Extensions.AWS.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.AWS.Tests;
 

--- a/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.AWS.Tests/Trace/AWSXRayPropagatorTests.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Extensions.AWS.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.AWS.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests/AspNetCoreTraceEnrichmentProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests/AspNetCoreTraceEnrichmentProviderBuilderExtensionsTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests/AspNetCoreTraceEnrichmentServiceCollectionExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests/AspNetCoreTraceEnrichmentServiceCollectionExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.AspNetCore;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests/EnrichmentTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests/EnrichmentTests.cs
@@ -4,10 +4,8 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/ConfigureHttpClientTraceInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/ConfigureHttpClientTraceInstrumentationOptionsTests.cs
@@ -6,7 +6,6 @@ using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.Http;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentServiceCollectionExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentServiceCollectionExtensionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentTracerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientEnrichmentTracerProviderBuilderExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientTraceEnrichmentAcceptanceTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Http.Tests/HttpClientTraceEnrichmentAcceptanceTests.cs
@@ -8,7 +8,6 @@ using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.Http.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Tests/OpenTelemetryEnrichmentProviderBuilderExtensions.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Tests/OpenTelemetryEnrichmentProviderBuilderExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.Tests;
 

--- a/test/OpenTelemetry.Extensions.Enrichment.Tests/OpenTelemetryEnrichmentServiceCollectionExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Enrichment.Tests/OpenTelemetryEnrichmentServiceCollectionExtensionsTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Enrichment.Tests;
 

--- a/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/ActivityEventAttachingLogProcessorTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests;
 

--- a/test/OpenTelemetry.Extensions.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests;
 

--- a/test/OpenTelemetry.Extensions.Tests/Logs/LoggerFactoryBaggageLogRecordProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Logs/LoggerFactoryBaggageLogRecordProcessorTests.cs
@@ -3,11 +3,8 @@
 
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
-using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests.Logs;
 

--- a/test/OpenTelemetry.Extensions.Tests/Logs/LoggerProviderBuilderBaggageLogRecordProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Logs/LoggerProviderBuilderBaggageLogRecordProcessorTests.cs
@@ -6,8 +6,6 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
-using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests.Logs;
 

--- a/test/OpenTelemetry.Extensions.Tests/Trace/AutoFlushActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/AutoFlushActivityProcessorTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests.Trace;
 

--- a/test/OpenTelemetry.Extensions.Tests/Trace/BaggageActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/BaggageActivityProcessorTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests.Trace;
 

--- a/test/OpenTelemetry.Extensions.Tests/Trace/RateLimitingSamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/RateLimitingSamplerTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Tests.Trace;
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/AWSClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/AWSClientInstrumentationOptionsTests.cs
@@ -10,7 +10,6 @@ using Amazon.Runtime.Internal;
 using OpenTelemetry.Instrumentation.AWS.Implementation;
 using OpenTelemetry.Instrumentation.AWS.Tests.Tools;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/AssemblyInfo.cs
@@ -1,7 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 // Avoid mutations to RuntimePipelineCustomizerRegistry.Instance causing flaky tests
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/AWSMeterProviderTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/AWSMeterProviderTests.cs
@@ -4,7 +4,6 @@
 using OpenTelemetry.AWS;
 using OpenTelemetry.Instrumentation.AWS.Implementation.Metrics;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests.Implementation;
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/AWSTracerProviderTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/AWSTracerProviderTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.AWS;
 using OpenTelemetry.Instrumentation.AWS.Implementation.Tracing;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests.Implementation;
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
@@ -6,7 +6,6 @@ using Amazon.Runtime.Internal;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AWS.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 using SNS = Amazon.SimpleNotificationService.Model;
 using SQS = Amazon.SQS.Model;
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/TestsHelper.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/TestsHelper.cs
@@ -4,7 +4,6 @@
 using Amazon.Runtime;
 using Amazon.Runtime.Internal;
 using OpenTelemetry.Instrumentation.AWS.Implementation;
-using Xunit;
 using SNS = Amazon.SimpleNotificationService.Model;
 using SQS = Amazon.SQS.Model;
 

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -20,7 +20,6 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using OpenTelemetry.Instrumentation.AWS.Tests.Tools;
 using OpenTelemetry.Trace;
-using Xunit;
 using AWSTracingPipelineHandler = OpenTelemetry.Instrumentation.AWS.Implementation.AWSTracingPipelineHandler;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests;

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientMetricsInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientMetricsInstrumentation.cs
@@ -12,8 +12,6 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using OpenTelemetry.Instrumentation.AWS.Tests.Tools;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaHttpUtilsTests.cs
@@ -7,7 +7,6 @@ using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using OpenTelemetry.AWS;
 using OpenTelemetry.Instrumentation.AWSLambda.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Tests.Implementation;
 

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSLambdaUtilsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Instrumentation.AWSLambda.Implementation;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Tests.Implementation;
 

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSMessagingUtilsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/Implementation/AWSMessagingUtilsTests.cs
@@ -4,7 +4,6 @@
 using Amazon.Lambda.SQSEvents;
 using OpenTelemetry.Instrumentation.AWSLambda.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 using static Amazon.Lambda.SQSEvents.SQSEvent;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Tests.Implementation;

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Web;
 using OpenTelemetry.Context.Propagation;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigTransformTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigTransformTest.cs
@@ -3,7 +3,6 @@
 
 using System.Xml.Linq;
 using Microsoft.Web.XmlTransform;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigWithLocationTagTransformTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/WebConfigWithLocationTagTransformTest.cs
@@ -3,7 +3,6 @@
 
 using System.Xml.Linq;
 using Microsoft.Web.XmlTransform;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/BasicTests.cs
@@ -6,7 +6,6 @@ using System.Web;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -11,7 +11,6 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -4,7 +4,6 @@
 using System.Web;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpRequestRouteHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpRequestRouteHelperTests.cs
@@ -4,7 +4,6 @@
 using System.Web;
 using System.Web.Routing;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperExtensionsTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Specialized;
 using System.Web;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -18,7 +18,6 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using TestApp.AspNetCore;
 using TestApp.AspNetCore.Filters;
-using Xunit;
 using Uri = System.Uri;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EndToEndTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EndToEndTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/GrpcTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/GrpcTests.cs
@@ -6,7 +6,6 @@ using System.Net;
 using Microsoft.AspNetCore.Http;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Trace;
 using TestApp.AspNetCore;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Xunit;
 
 namespace RouteTests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestFixture.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestFixture.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
 using RouteTests.TestApplication;
-using Xunit;
 
 namespace RouteTests;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
@@ -6,7 +6,6 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using RouteTests.TestApplication;
-using Xunit;
 
 namespace RouteTests;
 

--- a/test/OpenTelemetry.Instrumentation.Cassandra.Tests/CassandraCollection.cs
+++ b/test/OpenTelemetry.Instrumentation.Cassandra.Tests/CassandraCollection.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Instrumentation.Cassandra.Tests;
 
 [CollectionDefinition(Name)]

--- a/test/OpenTelemetry.Instrumentation.Cassandra.Tests/CassandraInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Cassandra.Tests/CassandraInstrumentationTests.cs
@@ -6,7 +6,6 @@ using Cassandra.Mapping;
 using Cassandra.Metrics;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 using CassandraData = Cassandra.Data.Linq;
 
 namespace OpenTelemetry.Instrumentation.Cassandra.Tests;

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedMeteringTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedMeteringTests.cs
@@ -6,8 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedTracingAndMeteringTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedTracingAndMeteringTests.cs
@@ -8,8 +8,6 @@ using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedTracingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedTracingTests.cs
@@ -7,8 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using Confluent.Kafka;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using Confluent.Kafka;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/KafkaCollection.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/KafkaCollection.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 
 [CollectionDefinition(Name)]

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/MeteringTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/MeteringTests.cs
@@ -4,7 +4,6 @@
 using Confluent.Kafka;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Text;
 using Confluent.Kafka;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumerBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumerBuilderExtensionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Confluent.Kafka;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryProducerBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryProducerBuilderExtensionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Confluent.Kafka;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/TracingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/TracingTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using Confluent.Kafka;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/DependencyInjectionConfigTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/DependencyInjectionConfigTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ElasticsearchClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/ElasticsearchClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/ElasticsearchClientTests.cs
@@ -8,7 +8,6 @@ using Nest;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ElasticsearchClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.ElasticsearchClient.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ElasticsearchClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/DependencyInjectionConfigTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/DependencyInjectionConfigTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkDiagnosticListenerTests.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using Microsoft.Data.Sqlite;
@@ -9,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using OpenTelemetry.Instrumentation.EntityFrameworkCore.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkInstrumentationOptionsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Internal;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EntityFrameworkIntegrationTests.cs
@@ -11,8 +11,6 @@ using Npgsql;
 using OpenTelemetry.Instrumentation.SqlClient.Tests;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.EntityFrameworkCore.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventCountersMetricsTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.EventCounters.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.EventCounters.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.EventCounters.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -7,7 +7,6 @@ using Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 using StatusCode = Grpc.Core.StatusCode;
 
 namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreServerInterceptorTests.cs
@@ -4,7 +4,6 @@
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using OpenTelemetry.Context.Propagation;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.GrpcCore.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.GrpcNetClient.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -16,7 +16,6 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Instrumentation.Grpc.Tests.GrpcTestHelpers;
 using OpenTelemetry.Instrumentation.GrpcNetClient;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.Grpc.Services.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/DependencyInjectionConfigTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/DependencyInjectionConfigTests.cs
@@ -3,9 +3,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireFixture.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireFixture.cs
@@ -5,7 +5,6 @@ using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.States;
 using Hangfire.Storage;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireInstrumentationJobFilterAttributeTests.cs
@@ -13,7 +13,6 @@ using Hangfire.Storage;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.Hangfire.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireMetricsErrorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireMetricsErrorTests.cs
@@ -5,7 +5,6 @@ using Hangfire;
 using OpenTelemetry.Instrumentation.Hangfire.Implementation;
 using OpenTelemetry.Instrumentation.Hangfire.Tests.Utils;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireMetricsTests.cs
@@ -6,7 +6,6 @@ using Hangfire.States;
 using OpenTelemetry.Instrumentation.Hangfire.Implementation;
 using OpenTelemetry.Instrumentation.Hangfire.Tests.Utils;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireQueueLatencyTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/HangfireQueueLatencyTests.cs
@@ -5,7 +5,6 @@ using Hangfire;
 using OpenTelemetry.Instrumentation.Hangfire.Implementation;
 using OpenTelemetry.Instrumentation.Hangfire.Tests.Utils;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/Utils/AssertUtils.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/Utils/AssertUtils.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Tests.Utils;
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.Http.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
@@ -14,8 +14,6 @@ using OpenTelemetry.Instrumentation.Http.Implementation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -10,7 +10,6 @@ using System.Text.Json;
 #endif
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using System.Text.Json;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -11,7 +11,6 @@ using System.Net.Http;
 using OpenTelemetry.Instrumentation.Http.Implementation;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.cs
@@ -9,7 +9,6 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.Http.Implementation;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 #if !NETFRAMEWORK
 #pragma warning disable SYSLIB0014 // Type or member is obsolete

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Text.Json;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 #if !NETFRAMEWORK
 #pragma warning disable SYSLIB0014 // Type or member is obsolete

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
-    <Compile Include="$(RepoRoot)\test\Shared\CustomTextMapPropagator.cs" Link="/Includes/CustomTextMapPropagator.cs" />
-    <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="/Includes/EventSourceTestHelper.cs" />
-    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="/Includes/InMemoryEventListener.cs" />
-    <Compile Include="$(RepoRoot)\test\Shared\SkipUnlessEnvVarFoundTheoryAttribute.cs" Link="/Includes/SkipUnlessEnvVarFoundTheoryAttribute.cs" />
-    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="/Includes/TcpPortProvider.cs" />
-    <Compile Include="$(RepoRoot)\test\Shared\TestEventListener.cs" Link="/Includes/TestEventListener.cs" />
-    <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="/Includes/TestHttpServer.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\CustomTextMapPropagator.cs" Link="Includes\CustomTextMapPropagator.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\SkipUnlessEnvVarFoundTheoryAttribute.cs" Link="Includes\SkipUnlessEnvVarFoundTheoryAttribute.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Instrumentation.Kusto.Tests/DummyKustoTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Kusto.Tests/DummyKustoTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Instrumentation.Kusto.Tests;
 
 public class DummyKustoTests

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
@@ -12,7 +12,6 @@ using OpenTelemetry.Instrumentation.Owin.Implementation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Owin;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Owin.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Owin.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -95,25 +95,6 @@ public class ProcessMetricsTests
     }
 
     [Fact]
-    public void ProcessMetricsAreCapturedWithRuntimeInstrumentation()
-    {
-        const string ProcessMeterName = "OpenTelemetry.Instrumentation.Process";
-
-        var exportedItems = new List<Metric>();
-        using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddProcessInstrumentation()
-            .AddInMemoryExporter(exportedItems)
-            .Build();
-
-        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-
-        Assert.Contains(exportedItems, i => i.Name == "process.memory.usage" && i.MeterName == ProcessMeterName);
-        Assert.Contains(exportedItems, i => i.Name == "process.memory.virtual" && i.MeterName == ProcessMeterName);
-        Assert.Contains(exportedItems, i => i.Name == "process.cpu.time" && i.MeterName == ProcessMeterName);
-        Assert.Contains(exportedItems, i => i.Name == "process.thread.count" && i.MeterName == ProcessMeterName);
-    }
-
-    [Fact]
     public async Task ProcessMetricsAreCapturedWhenTasksOverlap()
     {
         var exportedItemsA = new List<Metric>();

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Process.Tests;
 
@@ -93,6 +92,25 @@ public class ProcessMetricsTests
 
         Assert.True(userTimeCaptured);
         Assert.True(systemTimeCaptured);
+    }
+
+    [Fact]
+    public void ProcessMetricsAreCapturedWithRuntimeInstrumentation()
+    {
+        const string ProcessMeterName = "OpenTelemetry.Instrumentation.Process";
+
+        var exportedItems = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddProcessInstrumentation()
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        Assert.Contains(exportedItems, i => i.Name == "process.memory.usage" && i.MeterName == ProcessMeterName);
+        Assert.Contains(exportedItems, i => i.Name == "process.memory.virtual" && i.MeterName == ProcessMeterName);
+        Assert.Contains(exportedItems, i => i.Name == "process.cpu.time" && i.MeterName == ProcessMeterName);
+        Assert.Contains(exportedItems, i => i.Name == "process.thread.count" && i.MeterName == ProcessMeterName);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.Quartz.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Quartz.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.Quartz.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Quartz.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Quartz.Tests/QuartzDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Quartz.Tests/QuartzDiagnosticListenerTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Trace;
 using Quartz;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Quartz.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.Remoting.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Remoting.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Runtime.Tests/RuntimeMetricsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Runtime.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/ServiceFabricRemotingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/ServiceFabricRemotingTests.cs
@@ -11,11 +11,9 @@ using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
 using Microsoft.ServiceFabric.Services.Remoting.V2;
 using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
 using OpenTelemetry.Context.Propagation;
-using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using ServiceFabric.Mocks;
 using ServiceFabric.Mocks.RemotingV2;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/MockCommandExecutor.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/MockCommandExecutor.netfx.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.Tracing;
 using Microsoft.Data.SqlClient;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -9,7 +9,6 @@ using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -7,7 +7,6 @@ using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Configuration;
 #endif
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.Tracing;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -10,7 +10,6 @@ using System.Net.Sockets;
 #endif
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation;
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/RedisXunitFixture.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/RedisXunitFixture.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests;
 
 public class RedisXunitFixture : RedisFixture, IAsyncLifetime

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -10,7 +10,6 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
 using StackExchange.Redis.Profiling;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisInstrumentationOptionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests;
 
 [Collection("Redis")]

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/AspNetParentSpanCorrectorTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/AspNetParentSpanCorrectorTests.netfx.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Reflection;
 using OpenTelemetry.Instrumentation.Wcf.Implementation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Instrumentation.Wcf.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelAsyncCallbackTests.cs
@@ -4,7 +4,6 @@
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using OpenTelemetry.Instrumentation.Wcf.Implementation;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelFactoryTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/InstrumentedChannelFactoryTests.cs
@@ -4,7 +4,6 @@
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using OpenTelemetry.Instrumentation.Wcf.Implementation;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/RunAsAdminTheoryAttribute.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/RunAsAdminTheoryAttribute.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Security.Principal;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForHttpTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForHttpTests.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.ServiceModel;
 using OpenTelemetry.Instrumentation.Wcf.Tests.Tools;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForTcpTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryBindingElementForTcpTests.netfx.cs
@@ -10,8 +10,6 @@ using System.ServiceModel;
 using System.ServiceModel.Security;
 using OpenTelemetry.Instrumentation.Wcf.Tests.Tools;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorForOneWayOperationsTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorForOneWayOperationsTests.netfx.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.ServiceModel;
 using OpenTelemetry.Instrumentation.Wcf.Tests.Tools;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryDispatchMessageInspectorTests.netfx.cs
@@ -5,8 +5,6 @@
 using System.Diagnostics;
 using System.ServiceModel;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryEndpointBehaviorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryEndpointBehaviorTests.cs
@@ -5,7 +5,6 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryPropagationTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TelemetryPropagationTests.netfx.cs
@@ -7,7 +7,6 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/WcfTestHelpers.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/WcfTestHelpers.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/AnyValueUnionTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/AnyValueUnionTests.cs
@@ -7,7 +7,6 @@ using OpenTelemetry.OpAmp.Client.Settings;
 #if NETFRAMEWORK
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
 #endif
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/DataGenerators/FrameBuilderTestData.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/DataGenerators/FrameBuilderTestData.cs
@@ -4,7 +4,6 @@
 using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests.DataGenerators;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/FrameBuilderTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/FrameBuilderTests.cs
@@ -5,7 +5,6 @@ using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Messages;
 using OpenTelemetry.OpAmp.Client.Tests.DataGenerators;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/FrameDispatcherTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/FrameDispatcherTests.cs
@@ -6,7 +6,6 @@
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/FrameProcessorTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/FrameProcessorTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using OpenTelemetry.OpAmp.Client.Internal;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/HeartbeatServiceTests.cs
@@ -7,7 +7,6 @@ using OpenTelemetry.OpAmp.Client.Internal.Listeners.Messages;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/IdentificationSettingsTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/IdentificationSettingsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.OpAmp.Client.Settings;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/CustomCapabilitiesMessageTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/CustomCapabilitiesMessageTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.OpAmp.Client.Tests.Messages;
 
 public class CustomCapabilitiesMessageTests

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/CustomMessageMessageTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/CustomMessageMessageTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Google.Protobuf;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests.Messages;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/EffectiveConfigFileTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.OpAmp.Client.Messages;
-using Xunit;
 
 #if NET
 using OpenTelemetry.OpAmp.Client.Internal;

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Messages/RemoteConfigMessageTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Messages/RemoteConfigMessageTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Google.Protobuf;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests.Messages;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -14,7 +14,6 @@ using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.DataGenerators;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/PlainHttpTransportTests.cs
@@ -16,7 +16,6 @@ using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/SequenceHelperTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/SequenceHelperTests.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using OpenTelemetry.OpAmp.Client.Internal.Utils;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Varint64Tests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Varint64Tests.cs
@@ -4,8 +4,6 @@
 using System.Buffers;
 using OpenTelemetry.OpAmp.Client.Internal.Utils;
 
-using Xunit;
-
 namespace OpenTelemetry.OpAmp.Client.Tests;
 
 public class Varint64Tests

--- a/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/WsTransportTest.cs
@@ -11,7 +11,6 @@ using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
 using OpenTelemetry.OpAmp.Client.Tests.Tools;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.OpAmp.Client.Tests;
 

--- a/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.PersistentStorage.Abstractions.Tests;
 

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/DirectorySizeTrackerTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/DirectorySizeTrackerTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
 
 public class DirectorySizeTrackerTests

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
 

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobProviderTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text;
-using Xunit;
 
 namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
 

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/FileBlobTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using OpenTelemetry.PersistentStorage.Abstractions;
-using Xunit;
 
 namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
 

--- a/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/PersistentStorageHelperTests.cs
+++ b/test/OpenTelemetry.PersistentStorage.FileSystem.Tests/PersistentStorageHelperTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
-using Xunit;
 
 namespace OpenTelemetry.PersistentStorage.FileSystem.Tests;
 

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSEBSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSEBSDetectorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Resources.AWS.Tests;
 
 public class AWSEBSDetectorTests

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
@@ -4,7 +4,6 @@
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
-using Xunit;
 
 namespace OpenTelemetry.Resources.AWS.Tests;
 

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 namespace OpenTelemetry.Resources.AWS.Tests;
 

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSEKSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSEKSDetectorTests.cs
@@ -3,8 +3,6 @@
 
 #if !NETFRAMEWORK
 
-using Xunit;
-
 namespace OpenTelemetry.Resources.AWS.Tests;
 
 public class AWSEKSDetectorTests

--- a/test/OpenTelemetry.Resources.AWS.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Resources.AWS.Tests;
 

--- a/test/OpenTelemetry.Resources.AWS.Tests/Http/ServerCertificateValidationHandlerTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/Http/ServerCertificateValidationHandlerTests.cs
@@ -3,8 +3,6 @@
 
 #if !NETFRAMEWORK
 
-using Xunit;
-
 namespace OpenTelemetry.Resources.AWS.Tests.Http;
 
 public class ServerCertificateValidationHandlerTests

--- a/test/OpenTelemetry.Resources.AWS.Tests/Http/ServerCertificateValidationProviderTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/Http/ServerCertificateValidationProviderTests.cs
@@ -4,7 +4,6 @@
 #if !NETFRAMEWORK
 
 using System.Security.Cryptography.X509Certificates;
-using Xunit;
 
 namespace OpenTelemetry.Resources.AWS.Tests.Http;
 

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Resources.Azure.Tests;
 

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureVmMetaDataRequestorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureVmMetaDataRequestorTests.cs
@@ -4,7 +4,6 @@
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
-using Xunit;
 
 namespace OpenTelemetry.Resources.Azure.Tests;
 

--- a/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Resources.Container.Tests;
 
 public class ContainerDetectorTests

--- a/test/OpenTelemetry.Resources.Container.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Resources.Container.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Resources.Container.Tests;
 

--- a/test/OpenTelemetry.Resources.Gcp.Tests/GcpResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Gcp.Tests/GcpResourceDetectorTests.cs
@@ -3,7 +3,6 @@
 
 using Google.Api.Gax;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Resources.Gcp.Tests;
 

--- a/test/OpenTelemetry.Resources.Host.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Resources.Host.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Resources.Host.Tests;
 

--- a/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
@@ -4,7 +4,6 @@
 #if NET
 using System.Runtime.InteropServices;
 #endif
-using Xunit;
 
 namespace OpenTelemetry.Resources.Host.Tests;
 

--- a/test/OpenTelemetry.Resources.OperatingSystem.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Resources.OperatingSystem.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Resources.OperatingSystem.Tests;
 

--- a/test/OpenTelemetry.Resources.OperatingSystem.Tests/OperatingSystemDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.OperatingSystem.Tests/OperatingSystemDetectorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Runtime.InteropServices;
-using Xunit;
 
 namespace OpenTelemetry.Resources.OperatingSystem.Tests;
 

--- a/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Resources.Process.Tests;
 
 public class ProcessDetectorTests

--- a/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Resources.ProcessRuntime.Tests;
 
 public class ProcessRuntimeDetectorTests

--- a/test/OpenTelemetry.Sampler.AWS.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Sampler.AWS.Tests;
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRayRemoteSampler.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Sampler.AWS.Tests;
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestAWSXRaySamplerClient.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Sampler.AWS.Tests;
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestMatcher.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestMatcher.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Sampler.AWS.Tests;
 
 public class TestMatcher

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestRateLimiter.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestRateLimiter.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Sampler.AWS.Tests;
 
 /// <summary>

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestRateLimitingSampler.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestRateLimitingSampler.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Sampler.AWS.Tests;
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestRulesCache.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestRulesCache.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Sampler.AWS.Tests;
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestSamplingRuleApplier.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestSamplingRuleApplier.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Sampler.AWS.Tests;
 

--- a/test/Shared/EnabledOnDockerPlatformFactAttribute.cs
+++ b/test/Shared/EnabledOnDockerPlatformFactAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 /// <summary>

--- a/test/Shared/EnabledOnDockerPlatformTheoryAttribute.cs
+++ b/test/Shared/EnabledOnDockerPlatformTheoryAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 /// <summary>

--- a/test/Shared/EventSourceTestHelper.cs
+++ b/test/Shared/EventSourceTestHelper.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.Tracing;
 using System.Reflection;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 

--- a/test/Shared/PlatformHelpers.cs
+++ b/test/Shared/PlatformHelpers.cs
@@ -6,7 +6,6 @@
 
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 

--- a/test/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
+++ b/test/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 internal sealed class SkipUnlessEnvVarFoundFactAttribute : FactAttribute

--- a/test/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
+++ b/test/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 internal sealed class SkipUnlessEnvVarFoundTheoryAttribute : TheoryAttribute

--- a/test/Shared/StrongNameTests.cs
+++ b/test/Shared/StrongNameTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 // The tests can only be strong named if they only depend on assemblies that are strong named,

--- a/test/Shared/TestHttpServer.cs
+++ b/test/Shared/TestHttpServer.cs
@@ -9,7 +9,7 @@ internal static class TestHttpServer
 {
     public static IDisposable RunServer(Action<HttpListenerContext> action, out Uri baseAddress)
     {
-        var uri = new UriBuilder()
+        var uri = new UriBuilder
         {
             Host = "localhost",
             Scheme = Uri.UriSchemeHttp,

--- a/test/Shared/XunitContainerFixture{T}.cs
+++ b/test/Shared/XunitContainerFixture{T}.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using DotNet.Testcontainers.Containers;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 


### PR DESCRIPTION
Propagates https://github.com/open-telemetry/opentelemetry-dotnet/pull/7365

## Changes

[tests] add Xunit namespaces to global usings

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
