### PR TITLE
[Exporter.InfluxDB] Add backpressure support for async metric writes

### DIFF
--- a/src/OpenTelemetry.Exporter.InfluxDB/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.InfluxDB/.publicApi/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
 #nullable enable
+OpenTelemetry.Exporter.InfluxDB.BackpressureMode
+OpenTelemetry.Exporter.InfluxDB.BackpressureMode.DropNewest = 1 -> OpenTelemetry.Exporter.InfluxDB.BackpressureMode
+OpenTelemetry.Exporter.InfluxDB.BackpressureMode.DropOldest = 2 -> OpenTelemetry.Exporter.InfluxDB.BackpressureMode
+OpenTelemetry.Exporter.InfluxDB.BackpressureMode.Wait = 0 -> OpenTelemetry.Exporter.InfluxDB.BackpressureMode
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.BackpressureMode.get -> OpenTelemetry.Exporter.InfluxDB.BackpressureMode
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.BackpressureMode.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Bucket.get -> string?
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Bucket.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Endpoint.get -> System.Uri?
@@ -7,8 +13,12 @@ OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Endpoint.set -> v
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.FlushInterval.get -> int
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.FlushInterval.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.InfluxDBMetricsExporterOptions() -> void
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MaxPendingExports.get -> int
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MaxPendingExports.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricExportIntervalMilliseconds.get -> int
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricExportIntervalMilliseconds.set -> void
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricsSchema.get -> OpenTelemetry.Exporter.InfluxDB.MetricsSchema
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.MetricsSchema.set -> void
 OpenTelemetry.Exporter.InfluxDB.InfluxDBMetricsExporterOptions.Org.get -> string?

--- a/src/OpenTelemetry.Exporter.InfluxDB/BackpressureMode.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/BackpressureMode.cs
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter.InfluxDB;
+
+/// <summary>
+/// Describes how pending exports are handled when the exporter backpressure limit is reached.
+/// </summary>
+public enum BackpressureMode
+{
+    /// <summary>
+    /// Wait until space becomes available.
+    /// </summary>
+    Wait = 0,
+
+    /// <summary>
+    /// Drop the newest export.
+    /// </summary>
+    DropNewest = 1,
+
+    /// <summary>
+    /// Drop the oldest queued export when possible; otherwise drop the newest export.
+    /// </summary>
+    DropOldest = 2,
+}

--- a/src/OpenTelemetry.Exporter.InfluxDB/IInfluxDBExportPayloadWriter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/IInfluxDBExportPayloadWriter.cs
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter.InfluxDB;
+
+internal interface IInfluxDBExportPayloadWriter
+{
+    Task WriteAsync(IReadOnlyCollection<string> lineProtocol, CancellationToken cancellationToken);
+}

--- a/src/OpenTelemetry.Exporter.InfluxDB/IMetricsWriter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/IMetricsWriter.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using InfluxDB.Client;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 
@@ -9,5 +8,5 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal interface IMetricsWriter
 {
-    void Write(Metric metric, Resource? resource, WriteApi writeApi);
+    void Write(Metric metric, Resource? resource, ICollection<string> lineProtocol);
 }

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBBackpressureWorker.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBBackpressureWorker.cs
@@ -1,0 +1,224 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Exporter.InfluxDB;
+
+internal sealed class InfluxDBBackpressureWorker : IDisposable
+{
+    private readonly object syncObject = new();
+    private readonly Queue<IReadOnlyList<string>> pendingExports = [];
+    private readonly SemaphoreSlim exportSignal = new(0);
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+    private readonly Task processingTask;
+    private readonly int maxPendingExports;
+    private readonly BackpressureMode backpressureMode;
+    private readonly IInfluxDBExportPayloadWriter payloadWriter;
+    private readonly Action<Exception> exportExceptionHandler;
+    private int activeEnqueueCount;
+    private bool disposed;
+    private bool writeFailedSinceLastFlush;
+    private bool writeInProgress;
+
+    public InfluxDBBackpressureWorker(
+        int maxPendingExports,
+        BackpressureMode backpressureMode,
+        IInfluxDBExportPayloadWriter payloadWriter,
+        Action<Exception> exportExceptionHandler)
+    {
+        this.maxPendingExports = maxPendingExports;
+        this.backpressureMode = backpressureMode;
+        this.payloadWriter = payloadWriter;
+        this.exportExceptionHandler = exportExceptionHandler;
+        this.processingTask = Task.Run(this.ProcessPendingExportsAsync);
+    }
+
+    public bool Enqueue(IReadOnlyList<string> lineProtocol, out int droppedWriteCount)
+    {
+        droppedWriteCount = 0;
+
+        lock (this.syncObject)
+        {
+            this.activeEnqueueCount++;
+
+            try
+            {
+                this.ThrowIfDisposed();
+
+                while (this.GetPendingExportCountUnsafe() >= this.maxPendingExports)
+                {
+                    switch (this.backpressureMode)
+                    {
+                        case BackpressureMode.Wait:
+                            Monitor.Wait(this.syncObject);
+                            this.ThrowIfDisposed();
+                            break;
+                        case BackpressureMode.DropNewest:
+                            droppedWriteCount = lineProtocol.Count;
+                            return false;
+                        case BackpressureMode.DropOldest:
+                            if (this.pendingExports.Count == 0)
+                            {
+                                droppedWriteCount = lineProtocol.Count;
+                                return false;
+                            }
+
+                            droppedWriteCount = this.pendingExports.Dequeue().Count;
+
+                            // Best-effort reclaim the dropped payload's signal when it has not
+                            // already been consumed by the background worker.
+                            _ = this.exportSignal.Wait(0);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Unsupported {nameof(BackpressureMode)} value '{this.backpressureMode}'.");
+                    }
+                }
+
+                this.ThrowIfDisposed();
+
+                this.pendingExports.Enqueue(lineProtocol);
+                this.exportSignal.Release();
+                return true;
+            }
+            finally
+            {
+                this.activeEnqueueCount--;
+                Monitor.PulseAll(this.syncObject);
+            }
+        }
+    }
+
+    public bool Flush(int timeoutMilliseconds)
+    {
+        Stopwatch? stopwatch = null;
+        if (timeoutMilliseconds != Timeout.Infinite)
+        {
+            Guard.ThrowIfOutOfRange(timeoutMilliseconds, min: 0);
+            stopwatch = Stopwatch.StartNew();
+        }
+
+        lock (this.syncObject)
+        {
+            while (this.activeEnqueueCount > 0 || this.writeInProgress || this.pendingExports.Count > 0)
+            {
+                if (timeoutMilliseconds == Timeout.Infinite)
+                {
+                    Monitor.Wait(this.syncObject);
+                }
+                else
+                {
+                    var remainingMilliseconds = timeoutMilliseconds - stopwatch!.ElapsedMilliseconds;
+                    if (remainingMilliseconds <= 0 ||
+                        !Monitor.Wait(this.syncObject, (int)remainingMilliseconds))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            var writeFailed = this.writeFailedSinceLastFlush;
+            this.writeFailedSinceLastFlush = false;
+            return !writeFailed;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (this.syncObject)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            Monitor.PulseAll(this.syncObject);
+        }
+
+        this.cancellationTokenSource.Cancel();
+        this.exportSignal.Release();
+
+        try
+        {
+            this.processingTask.GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            this.exportSignal.Dispose();
+            this.cancellationTokenSource.Dispose();
+        }
+    }
+
+    private async Task ProcessPendingExportsAsync()
+    {
+        try
+        {
+            while (true)
+            {
+                await this.exportSignal.WaitAsync(this.cancellationTokenSource.Token).ConfigureAwait(false);
+
+                IReadOnlyList<string>? lineProtocol = null;
+                lock (this.syncObject)
+                {
+                    if (this.pendingExports.Count > 0)
+                    {
+                        lineProtocol = this.pendingExports.Dequeue();
+                        this.writeInProgress = true;
+                        Monitor.PulseAll(this.syncObject);
+                    }
+                }
+
+                if (lineProtocol == null)
+                {
+                    continue;
+                }
+
+                var writeFailed = false;
+                try
+                {
+                    await this.payloadWriter.WriteAsync(lineProtocol, this.cancellationTokenSource.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (this.cancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception exception)
+                {
+                    writeFailed = true;
+                    this.exportExceptionHandler(exception);
+                }
+                finally
+                {
+                    lock (this.syncObject)
+                    {
+                        this.writeFailedSinceLastFlush |= writeFailed;
+                        this.writeInProgress = false;
+                        Monitor.PulseAll(this.syncObject);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) when (this.cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+    }
+
+    private int GetPendingExportCountUnsafe() => this.pendingExports.Count + (this.writeInProgress ? 1 : 0);
+
+    private void ThrowIfDisposed()
+    {
+#if NET
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+#else
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(InfluxDBBackpressureWorker));
+        }
+#endif
+    }
+}

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBEventSource.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBEventSource.cs
@@ -22,4 +22,10 @@ internal sealed class InfluxDBEventSource : EventSource
     {
         this.WriteEvent(1, exception);
     }
+
+    [Event(2, Message = "Dropped '{0}' metric writes due to backpressure using mode '{1}'", Level = EventLevel.Warning)]
+    public void MetricWritesDropped(int count, string mode)
+    {
+        this.WriteEvent(2, count, mode);
+    }
 }

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExportPayloadWriter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExportPayloadWriter.cs
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using InfluxDB.Client;
+
+namespace OpenTelemetry.Exporter.InfluxDB;
+
+internal sealed class InfluxDBExportPayloadWriter : IInfluxDBExportPayloadWriter
+{
+    private readonly IWriteApiAsync writeApiAsync;
+
+    public InfluxDBExportPayloadWriter(IWriteApiAsync writeApiAsync)
+    {
+        this.writeApiAsync = writeApiAsync;
+    }
+
+    public Task WriteAsync(IReadOnlyCollection<string> lineProtocol, CancellationToken cancellationToken) =>
+        this.writeApiAsync.WriteRecordsAsync(lineProtocol.ToArray(), cancellationToken: cancellationToken);
+}

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExporterExtensions.cs
@@ -42,12 +42,23 @@ public static class InfluxDBExporterExtensions
             }
 
             var influxDbClient = new InfluxDBClient(influxDbClientOptions);
-            var writeApi = influxDbClient.GetWriteApi(new WriteOptions
-            {
-                FlushInterval = options.FlushInterval,
-            });
             var metricsWriter = CreateMetricsWriter(options.MetricsSchema);
-            var exporter = new InfluxDBMetricsExporter(metricsWriter, influxDbClient, writeApi);
+            var exporter = options.MaxPendingExports > 0
+                ? new InfluxDBMetricsExporter(
+                    metricsWriter,
+                    influxDbClient,
+                    writeApi: null,
+                    writeApiAsync: influxDbClient.GetWriteApiAsync(),
+                    options)
+                : new InfluxDBMetricsExporter(
+                    metricsWriter,
+                    influxDbClient,
+                    influxDbClient.GetWriteApi(new WriteOptions
+                    {
+                        FlushInterval = options.FlushInterval,
+                    }),
+                    writeApiAsync: null,
+                    options);
             return new PeriodicExportingMetricReader(exporter, options.MetricExportIntervalMilliseconds)
             {
                 TemporalityPreference = MetricReaderTemporalityPreference.Cumulative,

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using InfluxDB.Client;
-using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter.InfluxDB;
@@ -11,36 +11,92 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
 {
     private readonly IMetricsWriter writer;
     private readonly InfluxDBClient influxDbClient;
-    private readonly WriteApi writeApi;
+    private readonly WriteApi? writeApi;
+    private readonly InfluxDBBackpressureWorker? backpressureWorker;
+    private readonly InfluxDBMetricsExporterOptions options;
 
-    public InfluxDBMetricsExporter(IMetricsWriter writer, InfluxDBClient influxDbClient, WriteApi writeApi)
+    public InfluxDBMetricsExporter(
+        IMetricsWriter writer,
+        InfluxDBClient influxDbClient,
+        WriteApi? writeApi,
+        IWriteApiAsync? writeApiAsync,
+        InfluxDBMetricsExporterOptions options)
+        : this(
+            writer,
+            influxDbClient,
+            writeApi,
+            writeApiAsync,
+            options,
+            payloadWriter: null)
+    {
+    }
+
+    internal InfluxDBMetricsExporter(
+        IMetricsWriter writer,
+        InfluxDBClient influxDbClient,
+        WriteApi? writeApi,
+        IWriteApiAsync? writeApiAsync,
+        InfluxDBMetricsExporterOptions options,
+        IInfluxDBExportPayloadWriter? payloadWriter)
     {
         this.writer = writer;
         this.influxDbClient = influxDbClient;
         this.writeApi = writeApi;
+        this.options = options;
 
-        this.writeApi.EventHandler += (_, args) =>
+        this.writeApi?.EventHandler += (_, args) =>
         {
-            switch (args)
+            if (args.GetType().Name == "WriteErrorEvent")
             {
-                case WriteErrorEvent writeErrorEvent:
-                    InfluxDBEventSource.Log.FailedToExport(writeErrorEvent.Exception.Message);
-                    break;
-                default:
-                    break;
+                var exception = args.GetType().GetProperty("Exception")?.GetValue(args) as Exception;
+                if (exception != null)
+                {
+                    InfluxDBEventSource.Log.FailedToExport(exception.Message);
+                }
             }
         };
+
+        if (writeApiAsync != null || payloadWriter != null)
+        {
+            this.backpressureWorker = new InfluxDBBackpressureWorker(
+                options.MaxPendingExports,
+                options.BackpressureMode,
+                payloadWriter ?? new InfluxDBExportPayloadWriter(writeApiAsync!),
+                exception => InfluxDBEventSource.Log.FailedToExport(exception.Message));
+        }
     }
 
     public override ExportResult Export(in Batch<Metric> batch)
     {
         try
         {
+            List<string> lineProtocol = [];
             foreach (var metric in batch)
             {
-                this.writer.Write(metric, this.ParentProvider?.GetResource(), this.writeApi);
+                this.writer.Write(metric, this.ParentProvider?.GetResource(), lineProtocol);
             }
 
+            if (lineProtocol.Count == 0)
+            {
+                return ExportResult.Success;
+            }
+
+            if (this.backpressureWorker != null)
+            {
+                var enqueued = this.backpressureWorker.Enqueue(lineProtocol, out var droppedWriteCount);
+                if (droppedWriteCount > 0)
+                {
+                    InfluxDBEventSource.Log.MetricWritesDropped(droppedWriteCount, this.options.BackpressureMode.ToString());
+                }
+
+                Debug.Assert(enqueued || droppedWriteCount > 0, "Enqueue returned false without dropping any payload.");
+
+                return enqueued || droppedWriteCount > 0
+                    ? ExportResult.Success
+                    : ExportResult.Failure;
+            }
+
+            this.writeApi!.WriteRecords(lineProtocol);
             return ExportResult.Success;
         }
         catch (Exception exception)
@@ -50,11 +106,35 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
         }
     }
 
+    protected override bool OnForceFlush(int timeoutMilliseconds)
+    {
+        if (this.backpressureWorker != null)
+        {
+            return this.backpressureWorker.Flush(timeoutMilliseconds);
+        }
+
+        this.writeApi?.Flush();
+        return true;
+    }
+
+    protected override bool OnShutdown(int timeoutMilliseconds)
+    {
+        if (this.backpressureWorker != null)
+        {
+            return this.backpressureWorker.Flush(timeoutMilliseconds);
+        }
+
+        this.writeApi?.Flush();
+        return true;
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            this.writeApi.Dispose();
+            this.Shutdown(this.options.TimeoutMilliseconds);
+            this.backpressureWorker?.Dispose();
+            this.writeApi?.Dispose();
             this.influxDbClient.Dispose();
         }
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporterOptions.cs
@@ -11,6 +11,8 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 public class InfluxDBMetricsExporterOptions
 {
     private int metricExportIntervalMilliseconds = 60000;
+    private int maxPendingExports;
+    private int timeoutMilliseconds = 10000;
 
     /// <summary>
     /// Gets or sets HTTP/S destination for line protocol.
@@ -43,6 +45,25 @@ public class InfluxDBMetricsExporterOptions
     public int FlushInterval { get; set; } = 1000;
 
     /// <summary>
+    /// Gets or sets the maximum number of exports pending write completion.
+    /// Set to <see langword="0"/> to preserve the client-managed buffered write behavior.
+    /// </summary>
+    public int MaxPendingExports
+    {
+        get => this.maxPendingExports;
+        set
+        {
+            Guard.ThrowIfNegative(value);
+            this.maxPendingExports = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the behavior used when <see cref="MaxPendingExports"/> is reached.
+    /// </summary>
+    public BackpressureMode BackpressureMode { get; set; } = BackpressureMode.Wait;
+
+    /// <summary>
     /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
     /// </summary>
     public int MetricExportIntervalMilliseconds
@@ -52,6 +73,19 @@ public class InfluxDBMetricsExporterOptions
         {
             Guard.ThrowIfOutOfRange(value, min: 1000);
             this.metricExportIntervalMilliseconds = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the timeout in milliseconds for export-dispose operations. The default value is 10000.
+    /// </summary>
+    public int TimeoutMilliseconds
+    {
+        get => this.timeoutMilliseconds;
+        set
+        {
+            Guard.ThrowIfOutOfRange(value, min: 1000);
+            this.timeoutMilliseconds = value;
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.InfluxDB/README.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/README.md
@@ -39,6 +39,8 @@ package on .NET 6.0+:
             options.Token = "token";
             options.Endpoint = new Uri("http://localhost:8086");
             options.MetricsSchema = MetricsSchema.TelegrafPrometheusV2;
+            options.MaxPendingExports = 1;
+            options.BackpressureMode = BackpressureMode.Wait;
         }));
 ```
 
@@ -56,6 +58,8 @@ package on .NET 6.0+:
         options.Token = "token";
         options.Endpoint = new Uri("http://localhost:8086");
         options.MetricsSchema = MetricsSchema.TelegrafPrometheusV2;
+        options.MaxPendingExports = 1;
+        options.BackpressureMode = BackpressureMode.Wait;
     })
     .Build();
     builder.Services.AddSingleton(meterProvider);
@@ -91,6 +95,22 @@ The chosen metrics schema to write. Default value is
 
 The time to wait at most (in milliseconds) with the write. Default value
 is 1000.
+
+### MaxPendingExports
+
+The maximum number of exports that may be pending write completion at the same
+time. The default value is 0, which preserves the InfluxDB client's buffered
+write behavior. Set this to a positive value to enable exporter-managed
+backpressure with a bounded export queue.
+
+### BackpressureMode
+
+The behavior used when `MaxPendingExports` is reached:
+
+* `BackpressureMode.Wait` blocks until space becomes available.
+* `BackpressureMode.DropNewest` drops the current export.
+* `BackpressureMode.DropOldest` drops the oldest queued export when possible;
+  if only an in-flight export remains, the current export is dropped instead.
 
 ## InfluxDB 1.8 API Compatibility
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV1.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV1.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
-using InfluxDB.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
@@ -12,7 +11,7 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
 {
-    public void Write(Metric metric, Resource? resource, WriteApi writeApi)
+    public void Write(Metric metric, Resource? resource, ICollection<string> lineProtocol)
     {
         var measurement = metric.Name;
 
@@ -29,7 +28,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -46,7 +45,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -63,7 +62,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -80,7 +79,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -97,7 +96,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -114,7 +113,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -146,7 +145,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                         pointData = pointData.Field(boundFieldKey, histogramBucket.BucketCount);
                     }
 
-                    writeApi.WritePoint(pointData);
+                    lineProtocol.Add(pointData.ToLineProtocol());
                 }
 
                 break;

--- a/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV2.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV2.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
-using InfluxDB.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
@@ -12,7 +11,7 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
 {
-    public void Write(Metric metric, Resource? resource, WriteApi writeApi)
+    public void Write(Metric metric, Resource? resource, ICollection<string> lineProtocol)
     {
         var measurement = "prometheus";
         var metricName = metric.Name;
@@ -30,7 +29,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -47,7 +46,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -64,7 +63,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -81,7 +80,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -98,7 +97,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -115,7 +114,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -142,7 +141,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Field($"{metricName}_max", max);
                     }
 
-                    writeApi.WritePoint(headPoint);
+                    lineProtocol.Add(headPoint.ToLineProtocol());
 
                     long cumulativeCount = 0;
 
@@ -156,7 +155,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                         var bucketPoint = basePoint
                             .Tag("le", boundFieldKey)
                             .Field($"{metricName}_bucket", cumulativeCount);
-                        writeApi.WritePoint(bucketPoint);
+                        lineProtocol.Add(bucketPoint.ToLineProtocol());
                     }
                 }
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBBackpressureWorkerTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBBackpressureWorkerTests.cs
@@ -1,0 +1,273 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.InfluxDB.Tests;
+
+public class InfluxDBBackpressureWorkerTests
+{
+    [Fact]
+    public async Task WaitModeBlocksUntilCapacityBecomesAvailable()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        using var writer = new TestPayloadWriter(gate);
+        using var worker = new InfluxDBBackpressureWorker(1, BackpressureMode.Wait, writer, _ => { });
+
+        Assert.True(worker.Enqueue(["first"], out var droppedWriteCount));
+        Assert.Equal(0, droppedWriteCount);
+
+        await writer.WaitForFirstWriteAsync();
+
+        var enqueueTask = Task.Run(() =>
+        {
+            var enqueued = worker.Enqueue(["second"], out var droppedWrites);
+            return (enqueued, droppedWrites);
+        });
+
+        await Task.Delay(200);
+        Assert.False(enqueueTask.IsCompleted);
+
+        gate.Set();
+
+        var enqueueResult = await enqueueTask;
+        Assert.True(enqueueResult.enqueued);
+        Assert.Equal(0, enqueueResult.droppedWrites);
+        Assert.True(worker.Flush(5000));
+
+        var writes = writer.Writes.ToArray();
+        Assert.Collection(
+            writes,
+            payload => Assert.Equal(["first"], payload),
+            payload => Assert.Equal(["second"], payload));
+    }
+
+    [Fact]
+    public async Task DropNewestModeDropsCurrentPayloadWhenCapacityIsReached()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        using var writer = new TestPayloadWriter(gate);
+        using var worker = new InfluxDBBackpressureWorker(2, BackpressureMode.DropNewest, writer, _ => { });
+
+        Assert.True(worker.Enqueue(["first"], out _));
+        await writer.WaitForFirstWriteAsync();
+
+        Assert.True(worker.Enqueue(["second"], out var secondDroppedWriteCount));
+        Assert.Equal(0, secondDroppedWriteCount);
+
+        var enqueued = worker.Enqueue(["third"], out var droppedWriteCount);
+
+        Assert.False(enqueued);
+        Assert.Equal(1, droppedWriteCount);
+
+        gate.Set();
+        Assert.True(worker.Flush(5000));
+
+        var writes = writer.Writes.ToArray();
+        Assert.Collection(
+            writes,
+            payload => Assert.Equal(["first"], payload),
+            payload => Assert.Equal(["second"], payload));
+    }
+
+    [Fact]
+    public async Task DropOldestModeDropsQueuedPayloadWhenCapacityIsReached()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        using var writer = new TestPayloadWriter(gate);
+        using var worker = new InfluxDBBackpressureWorker(2, BackpressureMode.DropOldest, writer, _ => { });
+
+        Assert.True(worker.Enqueue(["first"], out _));
+        await writer.WaitForFirstWriteAsync();
+
+        Assert.True(worker.Enqueue(["second"], out var secondDroppedWriteCount));
+        Assert.Equal(0, secondDroppedWriteCount);
+
+        var enqueued = worker.Enqueue(["third"], out var droppedWriteCount);
+
+        Assert.True(enqueued);
+        Assert.Equal(1, droppedWriteCount);
+
+        gate.Set();
+        Assert.True(worker.Flush(5000));
+
+        var writes = writer.Writes.ToArray();
+        Assert.Collection(
+            writes,
+            payload => Assert.Equal(["first"], payload),
+            payload => Assert.Equal(["third"], payload));
+    }
+
+    [Fact]
+    public async Task DropOldestModeDoesNotLeakSignalsAcrossRepeatedDrops()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        using var writer = new TestPayloadWriter(gate);
+        using var worker = new InfluxDBBackpressureWorker(2, BackpressureMode.DropOldest, writer, _ => { });
+
+        Assert.True(worker.Enqueue(["first"], out _));
+        await writer.WaitForFirstWriteAsync();
+
+        Assert.True(worker.Enqueue(["second"], out _));
+
+        for (var i = 0; i < 50; i++)
+        {
+            Assert.True(worker.Enqueue([$"payload-{i}"], out var droppedWriteCount));
+            Assert.Equal(1, droppedWriteCount);
+        }
+
+        gate.Set();
+
+        Assert.True(worker.Flush(5000));
+
+        var writes = writer.Writes.ToArray();
+        Assert.Equal(["first"], writes[0]);
+        Assert.Equal(["payload-49"], writes[writes.Length - 1]);
+        Assert.Equal(2, writes.Length);
+    }
+
+    [Fact]
+    public async Task FlushReturnsFalseWhenBackgroundWriteFails()
+    {
+        using var writer = new ThrowingPayloadWriter();
+        using var worker = new InfluxDBBackpressureWorker(1, BackpressureMode.Wait, writer, _ => { });
+
+        Assert.True(worker.Enqueue(["first"], out _));
+        await writer.WaitForWriteAttemptAsync();
+
+        Assert.False(worker.Flush(5000));
+        Assert.True(worker.Flush(5000));
+    }
+
+    [Fact]
+    public async Task FlushReturnsFalseWhenTimeoutExpires()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        using var writer = new TestPayloadWriter(gate);
+        using var worker = new InfluxDBBackpressureWorker(1, BackpressureMode.Wait, writer, _ => { });
+
+        Assert.True(worker.Enqueue(["first"], out _));
+        await writer.WaitForFirstWriteAsync();
+
+        Assert.False(worker.Flush(10));
+
+        gate.Set();
+        Assert.True(worker.Flush(5000));
+    }
+
+    [Fact]
+    public async Task FlushWaitsForBlockedEnqueueToComplete()
+    {
+        using var firstWriteGate = new ManualResetEventSlim(false);
+        using var secondWriteGate = new ManualResetEventSlim(false);
+        using var writer = new SequencedPayloadWriter(firstWriteGate, secondWriteGate);
+        using var worker = new InfluxDBBackpressureWorker(1, BackpressureMode.Wait, writer, _ => { });
+
+        Assert.True(worker.Enqueue(["first"], out _));
+        await writer.WaitForFirstWriteAsync();
+
+        var enqueueTask = Task.Run(() => worker.Enqueue(["second"], out _));
+        await Task.Delay(100);
+        Assert.False(enqueueTask.IsCompleted);
+
+        var flushTask = Task.Run(() => worker.Flush(5000));
+        await Task.Delay(100);
+        Assert.False(flushTask.IsCompleted);
+
+        firstWriteGate.Set();
+        await writer.WaitForSecondWriteAsync();
+
+        await Task.Delay(100);
+        Assert.False(flushTask.IsCompleted);
+
+        secondWriteGate.Set();
+
+        Assert.True(await enqueueTask);
+        Assert.True(await flushTask);
+    }
+
+    private sealed class TestPayloadWriter : IInfluxDBExportPayloadWriter, IDisposable
+    {
+        private readonly ManualResetEventSlim gate;
+        private readonly TaskCompletionSource<bool> firstWriteStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TestPayloadWriter(ManualResetEventSlim gate)
+        {
+            this.gate = gate;
+        }
+
+        public ConcurrentQueue<string[]> Writes { get; } = new();
+
+        public void Dispose()
+        {
+        }
+
+        public Task WaitForFirstWriteAsync() => this.firstWriteStarted.Task;
+
+        public Task WriteAsync(IReadOnlyCollection<string> lineProtocol, CancellationToken cancellationToken)
+        {
+            this.Writes.Enqueue(lineProtocol.ToArray());
+            this.firstWriteStarted.TrySetResult(true);
+            this.gate.Wait(cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingPayloadWriter : IInfluxDBExportPayloadWriter, IDisposable
+    {
+        private readonly TaskCompletionSource<bool> writeAttempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Dispose()
+        {
+        }
+
+        public Task WaitForWriteAttemptAsync() => this.writeAttempted.Task;
+
+        public Task WriteAsync(IReadOnlyCollection<string> lineProtocol, CancellationToken cancellationToken)
+        {
+            this.writeAttempted.TrySetResult(true);
+            throw new InvalidOperationException("Simulated export failure.");
+        }
+    }
+
+    private sealed class SequencedPayloadWriter : IInfluxDBExportPayloadWriter, IDisposable
+    {
+        private readonly ManualResetEventSlim firstWriteGate;
+        private readonly ManualResetEventSlim secondWriteGate;
+        private readonly TaskCompletionSource<bool> firstWriteStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> secondWriteStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int writeCount;
+
+        public SequencedPayloadWriter(ManualResetEventSlim firstWriteGate, ManualResetEventSlim secondWriteGate)
+        {
+            this.firstWriteGate = firstWriteGate;
+            this.secondWriteGate = secondWriteGate;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public Task WaitForFirstWriteAsync() => this.firstWriteStarted.Task;
+
+        public Task WaitForSecondWriteAsync() => this.secondWriteStarted.Task;
+
+        public Task WriteAsync(IReadOnlyCollection<string> lineProtocol, CancellationToken cancellationToken)
+        {
+            var currentWrite = Interlocked.Increment(ref this.writeCount);
+            if (currentWrite == 1)
+            {
+                this.firstWriteStarted.TrySetResult(true);
+                this.firstWriteGate.Wait(cancellationToken);
+            }
+            else
+            {
+                this.secondWriteStarted.TrySetResult(true);
+                this.secondWriteGate.Wait(cancellationToken);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.Metrics;
 using System.Reflection;
+using InfluxDB.Client;
 using OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 using OpenTelemetry.Metrics;
 
@@ -516,6 +517,103 @@ public class InfluxDBMetricsExporterTests
         AssertUtils.HasTag("MeterTag", "MeterValue", 0, dataPoint.Tags);
     }
 
+    [Fact]
+    public void ExportMetricWhenBackpressureHandlingIsEnabled()
+    {
+        // Arrange
+        using var influxServer = new InfluxDBFakeServer();
+        var influxServerEndpoint = influxServer.Endpoint;
+
+        using var meter = new Meter("test-meter", "0.0.1");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
+            .AddInfluxDBMetricsExporter(options =>
+            {
+                options.WithDefaultTestConfiguration();
+                options.Endpoint = influxServerEndpoint;
+                options.MaxPendingExports = 1;
+                options.BackpressureMode = BackpressureMode.Wait;
+            })
+            .Build();
+
+        // Act
+        _ = meter.CreateObservableGauge("test-gauge", () => new[]
+        {
+            new Measurement<int>(42, new("tag_key_2", "tag_value_2"), new("tag_key_1", "tag_value_1")),
+        });
+
+        var before = DateTime.UtcNow;
+        provider.ForceFlush();
+        var after = DateTime.UtcNow;
+
+        // Assert
+        var dataPoint = influxServer.ReadPoint();
+        Assert.Equal("test-gauge", dataPoint.Measurement);
+        Assert.Single(dataPoint.Fields);
+        AssertUtils.HasField("gauge", 42L, dataPoint.Fields);
+        AssertTags(dataPoint);
+        Assert.InRange(dataPoint.Timestamp, before, after);
+    }
+
+    [Fact]
+    public async Task ExportReturnsSuccessWhenDropNewestDropsCurrentPayload()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        using var payloadWriter = new BlockingPayloadWriter(gate);
+        using var batch = CreateBatchWithSingleMetric();
+
+        var options = new InfluxDBMetricsExporterOptions
+        {
+            MaxPendingExports = 1,
+            BackpressureMode = BackpressureMode.DropNewest,
+        };
+
+        using var exporter = new InfluxDBMetricsExporter(
+            new TestMetricsWriter(),
+            new InfluxDBClient(new InfluxDBClientOptions("http://localhost:8086")),
+            writeApi: null,
+            writeApiAsync: null,
+            options,
+            payloadWriter);
+
+        Assert.Equal(ExportResult.Success, exporter.Export(batch.Batch));
+        await payloadWriter.WaitForFirstWriteAsync();
+
+        Assert.Equal(ExportResult.Success, exporter.Export(batch.Batch));
+
+        gate.Set();
+        Assert.True(exporter.ForceFlush());
+    }
+
+    [Fact]
+    public async Task ForceFlushReturnsFalseWhenBackgroundWriteFails()
+    {
+        using var payloadWriter = new ThrowingPayloadWriter();
+        using var batch = CreateBatchWithSingleMetric();
+
+        var options = new InfluxDBMetricsExporterOptions
+        {
+            MaxPendingExports = 1,
+            BackpressureMode = BackpressureMode.Wait,
+        };
+
+        using var exporter = new InfluxDBMetricsExporter(
+            new TestMetricsWriter(),
+            new InfluxDBClient(new InfluxDBClientOptions("http://localhost:8086")),
+            writeApi: null,
+            writeApiAsync: null,
+            options,
+            payloadWriter);
+
+        Assert.Equal(ExportResult.Success, exporter.Export(batch.Batch));
+        await payloadWriter.WaitForWriteAttemptAsync();
+
+        Assert.False(exporter.ForceFlush());
+        Assert.True(exporter.ForceFlush());
+    }
+
     private static void AssertTags(PointData dataPoint)
     {
         Assert.Equal(9, dataPoint.Tags.Count);
@@ -528,5 +626,104 @@ public class InfluxDBMetricsExporterTests
         AssertUtils.HasTag("telemetry.sdk.language", "dotnet", 6, dataPoint.Tags);
         AssertUtils.HasTag("telemetry.sdk.name", "opentelemetry", 7, dataPoint.Tags);
         AssertUtils.HasTag("telemetry.sdk.version", OpenTelemetrySdkVersion, 8, dataPoint.Tags);
+    }
+
+    private static CapturedBatch CreateBatchWithSingleMetric()
+    {
+        var meter = new Meter("InfluxDBMetricsExporterTests.BatchGenerator", "0.0.1");
+        var counter = meter.CreateCounter<long>("test-counter");
+
+        var batchGeneratorExporter = new BatchGenerator();
+        var batchGeneratorReader = new BaseExportingMetricReader(batchGeneratorExporter);
+        var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddReader(batchGeneratorReader)
+            .Build();
+
+        counter.Add(1);
+        meterProvider.ForceFlush();
+
+        return new CapturedBatch(meter, meterProvider, batchGeneratorExporter.Batch);
+    }
+
+    private sealed class BatchGenerator : BaseExporter<Metric>
+    {
+        public Batch<Metric> Batch { get; private set; }
+
+        public override ExportResult Export(in Batch<Metric> batch)
+        {
+            this.Batch = batch;
+            return ExportResult.Success;
+        }
+    }
+
+    private sealed class CapturedBatch : IDisposable
+    {
+        private readonly Meter meter;
+        private readonly MeterProvider meterProvider;
+
+        public CapturedBatch(Meter meter, MeterProvider meterProvider, Batch<Metric> batch)
+        {
+            this.meter = meter;
+            this.meterProvider = meterProvider;
+            this.Batch = batch;
+        }
+
+        public Batch<Metric> Batch { get; }
+
+        public void Dispose()
+        {
+            this.meterProvider.Dispose();
+            this.meter.Dispose();
+        }
+    }
+
+    private sealed class TestMetricsWriter : IMetricsWriter
+    {
+        public void Write(Metric metric, OpenTelemetry.Resources.Resource? resource, ICollection<string> lineProtocol)
+        {
+            lineProtocol.Add("test-counter counter=1i");
+        }
+    }
+
+    private sealed class BlockingPayloadWriter : IInfluxDBExportPayloadWriter, IDisposable
+    {
+        private readonly ManualResetEventSlim gate;
+        private readonly TaskCompletionSource<bool> firstWriteStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public BlockingPayloadWriter(ManualResetEventSlim gate)
+        {
+            this.gate = gate;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public Task WaitForFirstWriteAsync() => this.firstWriteStarted.Task;
+
+        public Task WriteAsync(IReadOnlyCollection<string> lineProtocol, CancellationToken cancellationToken)
+        {
+            this.firstWriteStarted.TrySetResult(true);
+            this.gate.Wait(cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingPayloadWriter : IInfluxDBExportPayloadWriter, IDisposable
+    {
+        private readonly TaskCompletionSource<bool> writeAttempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Dispose()
+        {
+        }
+
+        public Task WaitForWriteAttemptAsync() => this.writeAttempted.Task;
+
+        public Task WriteAsync(IReadOnlyCollection<string> lineProtocol, CancellationToken cancellationToken)
+        {
+            this.writeAttempted.TrySetResult(true);
+            throw new InvalidOperationException("Simulated export failure.");
+        }
     }
 }

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
@@ -13,10 +13,12 @@ internal class InfluxDBFakeServer : IDisposable
     private static readonly char[] SplitChars = Environment.NewLine.ToCharArray();
     private readonly IDisposable httpServer;
     private readonly BlockingCollection<string> lines;
+    private readonly ManualResetEventSlim? responseGate;
 
-    public InfluxDBFakeServer()
+    public InfluxDBFakeServer(ManualResetEventSlim? responseGate = null)
     {
         this.lines = [];
+        this.responseGate = responseGate;
         this.httpServer = TestHttpServer.RunServer(
             context =>
             {
@@ -28,6 +30,7 @@ internal class InfluxDBFakeServer : IDisposable
                     this.lines.Add(line);
                 }
 
+                this.responseGate?.Wait(TimeSpan.FromSeconds(10));
                 context.Response.StatusCode = (int)HttpStatusCode.OK;
                 context.Response.Close();
             },


### PR DESCRIPTION
Fixes #4473

## Changes

### Add backpressure support to the InfluxDB metrics exporter

In production environments with a high volume of OpenTelemetry metrics, the InfluxDB exporter can become a bottleneck when the remote endpoint cannot accept data as fast as the instrumented application produces it. The existing exporter enqueues into an unbounded internal buffer on each export call using the InfluxDB client's internally buffered WriteApi, which provides no mechanism to limit how much data accumulates in memory. One of our production deployments is actively affected by this: metrics are collected at a rate the InfluxDB backend cannot sustain, causing unbounded memory growth until the process is restarted.

This change introduces a configurable backpressure mechanism. When `MaxPendingExports` is set to a value greater than zero, the exporter switches from the synchronous buffered write path to an asynchronous background worker that holds a bounded queue of pending metric batches and writes them one at a time using `IWriteApiAsync`. The caller can choose how the exporter behaves when the queue is full by setting `BackpressureMode` to one of three options: 
* block the exporting thread until space is available (Wait), 
* silently discard the current batch (DropNewest), 
* or evict the oldest queued batch and enqueue the current one instead (DropOldest). 

The default behavior when MaxPendingExports is zero remains unchanged, preserving full backwards compatibility.

`IMetricsWriter` was changed to collect line protocol strings in a caller-provided buffer rather than writing directly to WriteApi. This makes the serialization step reusable for both the existing synchronous path and the new backpressure worker.

The background worker uses a lock to keep queue updates and semaphore signaling consistent. Write failures are captured and returned from ForceFlush and Shutdown. In Wait mode, Flush also waits for blocked enqueue operations to finish before reporting success. Timeout handling uses 64-bit arithmetic to avoid overflow on large values. Disposal is idempotent and waits for the worker to stop cleanly.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
