### PR TITLE
[Geneva] Use frozen collections for TLD exporter and table name lookups

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Internal/TableNameSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/TableNameSerializer.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
+using System.Collections.Frozen;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -24,7 +27,11 @@ internal sealed class TableNameSerializer
     private static readonly StringComparer DictionaryKeyComparer = StringComparer.Ordinal;
 
     private readonly byte[] defaultTableName;
+#if NET
+    private readonly FrozenDictionary<string, byte[]>? tableMappings;
+#else
     private readonly Dictionary<string, byte[]>? tableMappings;
+#endif
     private readonly bool shouldPassThruTableMappings;
     private readonly Lock lockObject = new();
     private TableNameCacheDictionary tableNameCache = new();
@@ -58,7 +65,12 @@ internal sealed class TableNameSerializer
                 }
             }
 
-            this.tableMappings = tempTableMappings;
+            this.tableMappings = tempTableMappings
+#if NET
+                .ToFrozenDictionary(DictionaryKeyComparer);
+#else
+                ;
+#endif
         }
     }
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldExporter.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
+using System.Collections.Frozen;
+#endif
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -11,7 +14,8 @@ namespace OpenTelemetry.Exporter.Geneva.Tld;
 internal static class TldExporter
 {
     internal const int StringLengthLimit = (1 << 14) - 1; // 16 * 1024 - 1 = 16383
-    internal static readonly IReadOnlyDictionary<string, string> V40_PART_A_TLD_MAPPING = new Dictionary<string, string>
+
+    internal static readonly Dictionary<string, string> V40_PART_A_TLD_MAPPING_DICTIONARY = new()
     {
         // Part A
         [Schema.V40.PartA.IKey] = "iKey",
@@ -31,6 +35,12 @@ internal static class TldExporter
         [Schema.V40.PartA.Extensions.Os.Name] = "ext_os_name",
         [Schema.V40.PartA.Extensions.Os.Ver] = "ext_os_ver",
     };
+
+#if NET
+    internal static readonly FrozenDictionary<string, string> V40_PART_A_TLD_MAPPING = V40_PART_A_TLD_MAPPING_DICTIONARY.ToFrozenDictionary();
+#else
+    internal static readonly Dictionary<string, string> V40_PART_A_TLD_MAPPING = V40_PART_A_TLD_MAPPING_DICTIONARY;
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Serialize(EventBuilder eb, string key, object value)

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
+using System.Collections.Frozen;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
@@ -24,8 +27,13 @@ internal abstract class TldLogCommon : IDisposable
     protected readonly byte partAFieldsCount = 1; // At least one field: time
     protected readonly bool shouldPassThruTableMappings;
     protected readonly string defaultEventName = "Log";
+#if NET
+    protected readonly FrozenSet<string>? customFields;
+    protected readonly FrozenDictionary<string, string>? tableMappings;
+#else
     protected readonly HashSet<string>? customFields;
     protected readonly Dictionary<string, string>? tableMappings;
+#endif
     protected readonly ExceptionStackExportMode exceptionStackExportMode;
 
     private bool isDisposed;
@@ -57,7 +65,12 @@ internal abstract class TldLogCommon : IDisposable
                 }
             }
 
-            this.tableMappings = tempTableMappings;
+            this.tableMappings = tempTableMappings
+#if NET
+                .ToFrozenDictionary(StringComparer.Ordinal);
+#else
+                ;
+#endif
         }
 
         // TODO: Validate custom fields (reserved name? etc).
@@ -69,7 +82,11 @@ internal abstract class TldLogCommon : IDisposable
                 customFields.Add(name);
             }
 
+#if NET
+            this.customFields = customFields.ToFrozenSet(StringComparer.Ordinal);
+#else
             this.customFields = customFields;
+#endif
         }
 
         if (options.PrepopulatedFields != null)
@@ -155,7 +172,11 @@ internal abstract class TldLogCommon : IDisposable
     protected static void OnProcessScopeForIndividualColumns(
         LogRecordScope scope,
         SerializationDataForScopes stateDataValue,
+#if NET
+        FrozenSet<string>? customFields)
+#else
         HashSet<string>? customFields)
+#endif
     {
         Debug.Assert(stateDataValue != null, "state.serializationData was null");
         Debug.Assert(PartCFields.Value != null, "PartCFields.Value was null");

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldTraceExporter.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
+using System.Collections.Frozen;
+#endif
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -18,7 +21,7 @@ internal sealed class TldTraceExporter : IDisposable
 
     private static readonly string INVALID_SPAN_ID = default(ActivitySpanId).ToHexString();
 
-    private static readonly Dictionary<string, string> CS40_PART_B_MAPPING = new()
+    private static readonly Dictionary<string, string> CS40_PART_B_MAPPING_DICTIONARY = new()
     {
         ["db.system"] = "dbSystem",
         ["db.name"] = "dbName",
@@ -36,9 +39,19 @@ internal sealed class TldTraceExporter : IDisposable
         ["messaging.url"] = "messagingUrl",
     };
 
+#if NET
+    private static readonly FrozenDictionary<string, string> CS40_PART_B_MAPPING = CS40_PART_B_MAPPING_DICTIONARY.ToFrozenDictionary();
+#else
+    private static readonly Dictionary<string, string> CS40_PART_B_MAPPING = CS40_PART_B_MAPPING_DICTIONARY;
+#endif
+
     private readonly string partAName = "Span";
     private readonly byte partAFieldsCount = 3; // At least three fields: time, ext_dt_traceId, ext_dt_spanId
+#if NET
+    private readonly FrozenSet<string>? customFields;
+#else
     private readonly HashSet<string>? customFields;
+#endif
     private readonly Tuple<byte[], byte[]>? repeatedPartAFields;
     private readonly bool shouldIncludeTraceState;
     private readonly EventProvider eventProvider;
@@ -77,7 +90,11 @@ internal sealed class TldTraceExporter : IDisposable
                 customFields.Add(name);
             }
 
+#if NET
+            this.customFields = customFields.ToFrozenSet(StringComparer.Ordinal);
+#else
             this.customFields = customFields;
+#endif
         }
 
         if (options.PrepopulatedFields != null)


### PR DESCRIPTION
Convert ctor/startup-built, read-many lookup collections in the TLD exporters and TableNameSerializer to FrozenDictionary/FrozenSet (guarded by #if NET with Dictionary/HashSet fallback for net462/netstandard2.0), mirroring the existing MsgPack exporter pattern.


## Changes

If-deffed usage of frozen collections for read heavy stuff (mainly hashtables and hashsets). Should be functionally equivalent, with some perf benefit (loads of internal MSFT services using this exporter).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
