### PR TITLE
[Exporter.Geneva] Add per-table CustomFields via CustomFieldsMappings 

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+#nullable enable
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFieldsMappings.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IEnumerable<string!>!>?
+OpenTelemetry.Exporter.Geneva.GenevaExporterOptions.CustomFieldsMappings.set -> void

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Added `CustomFieldsMappings` to `GenevaExporterOptions` which allows
+  configuring `CustomFields` per table. Custom fields are resolved by the final
+  (physical) table name a record is routed to (after applying
+  `TableNameMappings`), so multiple categories mapping to the same table share
+  the same custom fields. `CustomFields` continues to act as the default for
+  tables without a more specific mapping.
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/GenevaExporterOptions.cs
@@ -15,6 +15,8 @@ public class GenevaExporterOptions
 
     private IReadOnlyDictionary<string, string>? tableNameMappings;
 
+    private IReadOnlyDictionary<string, IEnumerable<string>>? customFieldsMappings;
+
     /// <summary>
     /// Gets or sets the connection string.
     /// </summary>
@@ -27,8 +29,69 @@ public class GenevaExporterOptions
     ///
     /// Any user-defined fields not in CustomFields are moved to the 'properties' column.
     /// If CustomFields is not provided, all user-defined fields will be made into dedicated fields.
+    ///
+    /// CustomFields acts as the default for any table that does not have a dedicated entry in
+    /// <see cref="CustomFieldsMappings"/>.
     /// </summary>
     public IEnumerable<string>? CustomFields { get; set; }
+
+    /// <summary>
+    /// Gets or sets per-table CustomFields mappings.
+    ///
+    /// CustomFieldsMappings allows specifying CustomFields per table so that each table can have its
+    /// own set of dedicated fields (table columns).
+    ///
+    /// Resolution is performed against the <b>final (physical) table name</b> a record is routed to
+    /// (ie., the table produced by applying <see cref="TableNameMappings"/>), not the incoming log
+    /// category. Multiple categories that map to the same table therefore share the same custom fields.
+    ///
+    /// Each key is an exact (final) table name. The wildcard key "*" is not supported here: use
+    /// <see cref="CustomFields"/> to configure the global default that applies to any table without
+    /// a dedicated entry.
+    /// </summary>
+    public IReadOnlyDictionary<string, IEnumerable<string>>? CustomFieldsMappings
+    {
+        get => this.customFieldsMappings;
+        set
+        {
+            Guard.ThrowIfNull(value);
+
+            var copy = new Dictionary<string, IEnumerable<string>>(value.Count, StringComparer.Ordinal);
+
+            foreach (var entry in value)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Key))
+                {
+                    throw new ArgumentException("A custom fields mapping key was null, empty, or consisted only of white-space characters.", nameof(this.CustomFieldsMappings));
+                }
+
+                if (entry.Key == "*")
+                {
+                    throw new ArgumentException("The wildcard key '*' is not supported in CustomFieldsMappings. Use CustomFields to configure the global default.", nameof(this.CustomFieldsMappings));
+                }
+
+                if (entry.Value == null)
+                {
+                    throw new ArgumentException($"The custom fields collection provided for key '{entry.Key}' was null.", nameof(this.CustomFieldsMappings));
+                }
+
+                var fields = new List<string>();
+                foreach (var fieldName in entry.Value)
+                {
+                    if (string.IsNullOrWhiteSpace(fieldName))
+                    {
+                        throw new ArgumentException($"A custom field name provided for key '{entry.Key}' was null, empty, or consisted only of white-space characters.", nameof(this.CustomFieldsMappings));
+                    }
+
+                    fields.Add(fieldName);
+                }
+
+                copy[entry.Key] = fields;
+            }
+
+            this.customFieldsMappings = copy;
+        }
+    }
 
     /// <summary>
     /// Gets or sets ResourceFieldNames.

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/CustomFieldsLookup.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/CustomFieldsLookup.cs
@@ -1,0 +1,226 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Collections.Frozen;
+using CustomFieldSet = System.Collections.Frozen.FrozenSet<string>;
+using TableLookup = System.Collections.Frozen.FrozenDictionary<string, System.Collections.Frozen.FrozenSet<string>>;
+#else
+using CustomFieldSet = System.Collections.Generic.HashSet<string>;
+using TableLookup = System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>;
+#endif
+using System.Text;
+
+// CustomFieldSet/TableLookup are TFM-specific aliases (Frozen* on .NET, mutable
+// collections otherwise). On the non-.NET target an alias resolves to the same
+// concrete type used to build the collection, so the analyzer suggests collapsing
+// the construction onto the alias. Doing so would break the .NET build where the
+// alias is an abstract Frozen type, so name simplification is intentionally
+// disabled in this file.
+#pragma warning disable IDE0001 // Name can be simplified
+
+namespace OpenTelemetry.Exporter.Geneva;
+
+/// <summary>
+/// Resolves the set of custom fields that applies to a given physical table.
+/// Custom fields can be configured globally (via
+/// <see cref="GenevaExporterOptions.CustomFields"/>) and/or per table (via
+/// <see cref="GenevaExporterOptions.CustomFieldsMappings"/>).
+///
+/// Resolution is performed against the <b>final table name</b> a record is
+/// routed to (ie., the table produced by
+/// <see cref="GenevaExporterOptions.TableNameMappings"/>), not the incoming log
+/// category. Multiple categories that map to the same table therefore share the
+/// same custom fields.
+///
+/// The set of tables with a dedicated configuration is fully known at
+/// construction time, so the lookup is precomputed into hash tables (no
+/// per-record resolution or caching). Callers pass the already-resolved final
+/// table name (the exporters compute it anyway when serializing the table name).
+/// </summary>
+internal sealed class CustomFieldsLookup
+{
+    private readonly CustomFieldSet? defaultFields;
+
+    // The per-table configuration is stored twice, once keyed by the table name
+    // as a string and once keyed by its ASCII bytes, so that each Resolve
+    // overload can match without converting between string and bytes on the hot
+    // path. Duplicating the (tiny) configuration is intentional: the number of
+    // tables with a dedicated mapping is small, so the extra memory is negligible.
+    private readonly TableLookup? perTableFieldsByName;
+#if NET
+    private readonly FrozenDictionary<Utf8TableName, CustomFieldSet>? perTableFieldsByUtf8;
+#else
+    private readonly Dictionary<Utf8TableName, CustomFieldSet>? perTableFieldsByUtf8;
+#endif
+#if NET9_0_OR_GREATER
+    private readonly FrozenDictionary<Utf8TableName, CustomFieldSet>.AlternateLookup<ReadOnlySpan<byte>> perTableFieldsByUtf8Span;
+#endif
+    private readonly bool hasConfiguration;
+
+    public CustomFieldsLookup(
+        IEnumerable<string>? globalCustomFields,
+        IReadOnlyDictionary<string, IEnumerable<string>>? customFieldsMappings)
+    {
+        var defaultSet = globalCustomFields != null
+            ? new HashSet<string>(globalCustomFields, StringComparer.Ordinal)
+            : null;
+
+#if NET
+        this.defaultFields = defaultSet?.ToFrozenSet(StringComparer.Ordinal);
+#else
+        this.defaultFields = defaultSet;
+#endif
+
+        Dictionary<string, CustomFieldSet>? byName = null;
+        Dictionary<Utf8TableName, CustomFieldSet>? byUtf8 = null;
+        if (customFieldsMappings != null)
+        {
+            foreach (var kv in customFieldsMappings)
+            {
+                var set = new HashSet<string>(kv.Value, StringComparer.Ordinal);
+#if NET
+                var fields = set.ToFrozenSet(StringComparer.Ordinal);
+#else
+                var fields = set;
+#endif
+                byName ??= new Dictionary<string, CustomFieldSet>(StringComparer.Ordinal);
+                byName[kv.Key] = fields;
+
+                byUtf8 ??= new Dictionary<Utf8TableName, CustomFieldSet>(Utf8TableNameComparer.Instance);
+                byUtf8[new Utf8TableName(Encoding.ASCII.GetBytes(kv.Key))] = fields;
+            }
+        }
+
+        if (byName != null)
+        {
+#if NET
+            this.perTableFieldsByName = byName.ToFrozenDictionary(StringComparer.Ordinal);
+            this.perTableFieldsByUtf8 = byUtf8!.ToFrozenDictionary(Utf8TableNameComparer.Instance);
+#else
+            this.perTableFieldsByName = byName;
+            this.perTableFieldsByUtf8 = byUtf8;
+#endif
+#if NET9_0_OR_GREATER
+            // Ordinal byte-keyed FrozenDictionary supports a span-based alternate
+            // lookup, letting the hot path resolve the table name straight from
+            // its already-serialized ASCII bytes without any heap allocation.
+            this.perTableFieldsByUtf8Span = this.perTableFieldsByUtf8.GetAlternateLookup<ReadOnlySpan<byte>>();
+#endif
+        }
+
+        this.hasConfiguration = this.defaultFields != null || this.perTableFieldsByName != null;
+    }
+
+    /// <summary>
+    /// Resolves the custom fields configured for <paramref name="tableName"/>.
+    /// </summary>
+    /// <param name="tableName">The final (physical) table name.</param>
+    /// <returns>
+    /// The set of custom field names, or <see langword="null"/> when no custom
+    /// fields are configured for the table (in which case all user-defined
+    /// fields are made into dedicated fields).
+    /// </returns>
+    public CustomFieldSet? Resolve(string tableName)
+    {
+        if (!this.hasConfiguration)
+        {
+            return null;
+        }
+
+        if (this.perTableFieldsByName != null && this.perTableFieldsByName.TryGetValue(tableName, out var fields))
+        {
+            return fields;
+        }
+
+        return this.defaultFields;
+    }
+
+    /// <summary>
+    /// Resolves the custom fields configured for the table whose name is encoded
+    /// in <paramref name="tableNameStr8"/>. This overload avoids decoding the
+    /// table name to a heap string on the hot path.
+    /// </summary>
+    /// <param name="tableNameStr8">
+    /// The final (physical) table name as a MessagePack str8 value (a 2-byte
+    /// header followed by the ASCII table name).
+    /// </param>
+    /// <returns>
+    /// The set of custom field names, or <see langword="null"/> when no custom
+    /// fields are configured for the table.
+    /// </returns>
+    public CustomFieldSet? Resolve(ReadOnlySpan<byte> tableNameStr8)
+    {
+        if (!this.hasConfiguration)
+        {
+            return null;
+        }
+
+        if (this.perTableFieldsByUtf8 != null && tableNameStr8.Length > 2)
+        {
+            // Skip the 2-byte str8 header to get the ASCII table name payload.
+            var payload = tableNameStr8.Slice(2);
+#if NET9_0_OR_GREATER
+            if (this.perTableFieldsByUtf8Span.TryGetValue(payload, out var fields))
+            {
+                return fields;
+            }
+#else
+            if (this.perTableFieldsByUtf8.TryGetValue(new Utf8TableName(payload.ToArray()), out var fields))
+            {
+                return fields;
+            }
+#endif
+        }
+
+        return this.defaultFields;
+    }
+
+    private readonly struct Utf8TableName
+    {
+        public readonly byte[] Bytes;
+
+        public Utf8TableName(byte[] bytes)
+        {
+            this.Bytes = bytes;
+        }
+    }
+
+    private sealed class Utf8TableNameComparer :
+#if NET9_0_OR_GREATER
+        IAlternateEqualityComparer<ReadOnlySpan<byte>, Utf8TableName>,
+#endif
+        IEqualityComparer<Utf8TableName>
+    {
+        public static readonly Utf8TableNameComparer Instance = new();
+
+        private const uint Fnv1aOffsetBasis = 2166136261;
+        private const uint Fnv1aPrime = 16777619;
+
+        public bool Equals(Utf8TableName x, Utf8TableName y)
+            => x.Bytes.AsSpan().SequenceEqual(y.Bytes);
+
+        public int GetHashCode(Utf8TableName obj) => Hash(obj.Bytes);
+
+#if NET9_0_OR_GREATER
+        public bool Equals(ReadOnlySpan<byte> alternate, Utf8TableName other)
+            => alternate.SequenceEqual(other.Bytes);
+
+        public int GetHashCode(ReadOnlySpan<byte> alternate) => Hash(alternate);
+
+        public Utf8TableName Create(ReadOnlySpan<byte> alternate)
+            => new(alternate.ToArray());
+#endif
+
+        private static int Hash(ReadOnlySpan<byte> bytes)
+        {
+            var hash = Fnv1aOffsetBasis;
+            foreach (var b in bytes)
+            {
+                hash = (hash ^ b) * Fnv1aPrime;
+            }
+
+            return (int)hash;
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/EventHeader/EventHeaderLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/EventHeader/EventHeaderLogExporter.cs
@@ -112,19 +112,9 @@ internal class EventHeaderLogExporter : TldLogCommon, IDisposable
 
         var categoryName = logRecord.CategoryName ?? this.defaultEventName;
 
-        // If user configured explicit TableName, use it.
-        if (this.tableMappings?.TryGetValue(categoryName, out var eventName) != true)
-        {
-            if (!this.shouldPassThruTableMappings)
-            {
-                eventName = this.defaultEventName;
-            }
-            else
-            {
-                // TODO: Avoid allocation
-                eventName = GetSanitizedCategoryName(categoryName);
-            }
-        }
+        var eventName = this.ResolveEventNameForCategoryName(categoryName);
+
+        var customFields = this.customFieldsLookup.Resolve(eventName);
 
         var eb = EventBuilder.Value ??= new EventHeaderDynamicBuilder(); // TODO: make sure it can be reused with a reset
 
@@ -249,7 +239,7 @@ internal class EventHeaderLogExporter : TldLogCommon, IDisposable
                 bodyPopulated = true;
                 continue;
             }
-            else if (this.customFields == null || this.customFields.Contains(entry.Key))
+            else if (customFields == null || customFields.Contains(entry.Key))
             {
                 // TODO: the above null check can be optimized and avoided inside foreach.
                 if (entry.Value != null)
@@ -306,6 +296,7 @@ internal class EventHeaderLogExporter : TldLogCommon, IDisposable
 
         dataForScopes.HasEnvProperties = hasEnvProperties;
         dataForScopes.PartCFieldsCountFromState = partCFieldsCountFromState;
+        dataForScopes.CustomFields = customFields;
 
         logRecord.ForEachScope(ProcessScopeForIndividualColumnsAction, this);
 
@@ -341,10 +332,13 @@ internal class EventHeaderLogExporter : TldLogCommon, IDisposable
     protected override void Dispose(bool disposing) => base.Dispose(disposing);
 
     private static void OnProcessScopeForIndividualColumns(LogRecordScope scope, EventHeaderLogExporter state)
-        => OnProcessScopeForIndividualColumns(
+    {
+        var stateData = state.serializationData.Value!;
+        OnProcessScopeForIndividualColumns(
             scope,
-            state.serializationData.Value!,
-            state.customFields);
+            stateData,
+            stateData.CustomFields);
+    }
 }
 
 #endif

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackLogExporter.cs
@@ -3,6 +3,9 @@
 
 #if NET
 using System.Collections.Frozen;
+using CustomFieldSet = System.Collections.Frozen.FrozenSet<string>;
+#else
+using CustomFieldSet = System.Collections.Generic.HashSet<string>;
 #endif
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -32,13 +35,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
     private readonly ThreadLocal<byte[]> buffer = new();
     private readonly bool shouldExportEventName;
     private readonly TableNameSerializer tableNameSerializer;
-
-#if NET
-    private readonly FrozenSet<string>? customFields;
-#else
-    private readonly HashSet<string>? customFields;
-#endif
-
+    private readonly CustomFieldsLookup customFieldsLookup;
     private readonly ExceptionStackExportMode exportExceptionStack;
     private readonly bool userProvidedPrepopulatedFields;
     private readonly IEnumerable<string>? resourceFieldNames;
@@ -134,20 +131,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
         }
 
         // TODO: Validate custom fields (reserved name? etc).
-        if (options.CustomFields != null)
-        {
-            var customFields = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var name in options.CustomFields)
-            {
-                customFields.Add(name);
-            }
-
-#if NET
-            this.customFields = customFields.ToFrozenSet(StringComparer.Ordinal);
-#else
-            this.customFields = customFields;
-#endif
-        }
+        this.customFieldsLookup = new CustomFieldsLookup(options.CustomFields, options.CustomFieldsMappings);
 
         var buffer = new byte[BUFFER_SIZE];
         var cursor = MessagePackSerializer.Serialize(buffer, 0, new Dictionary<string, object> { { "TimeFormat", "DateTime" } });
@@ -352,6 +336,8 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
 
         cursor = this.tableNameSerializer.ResolveAndSerializeTableNameForCategoryName(buffer, cursor, categoryName, out var eventName);
 
+        var customFields = this.customFieldsLookup.Resolve(eventName);
+
         cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 1);
         cursor = MessagePackSerializer.WriteArrayHeader(buffer, cursor, 2);
         cursor = MessagePackSerializer.SerializeUtcDateTime(buffer, cursor, timestamp);
@@ -442,7 +428,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
                 bodyPopulated = true;
                 continue;
             }
-            else if (this.customFields == null || this.customFields.Contains(entry.Key))
+            else if (customFields == null || customFields.Contains(entry.Key))
             {
                 // TODO: the above null check can be optimized and avoided inside foreach.
                 if (entry.Value != null)
@@ -491,6 +477,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
         dataForScopes.Cursor = cursor;
         dataForScopes.FieldsCount = cntFields;
         dataForScopes.HasEnvProperties = hasEnvProperties;
+        dataForScopes.CustomFields = customFields;
 
         logRecord.ForEachScope(ProcessScopeForIndividualColumnsAction, this);
 
@@ -510,7 +497,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
             for (var i = 0; i < logFields!.Count; i++)
             {
                 var entry = logFields[i];
-                if (entry.Key == "{OriginalFormat}" || this.customFields!.Contains(entry.Key))
+                if (entry.Key == "{OriginalFormat}" || customFields!.Contains(entry.Key))
                 {
                     continue;
                 }
@@ -613,7 +600,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
 #pragma warning disable IDE0370 // Suppression is unnecessary
         var stateData = state.serializationData.Value!;
 #pragma warning restore IDE0370 // Suppression is unnecessary
-        var customFields = state.customFields;
+        var customFields = stateData.CustomFields;
 
         foreach (var scopeItem in scope)
         {
@@ -642,7 +629,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
     private static void OnProcessScopeForEnvProperties(LogRecordScope scope, MsgPackLogExporter state)
     {
         var stateData = state.serializationData.Value!;
-        var customFields = state.customFields;
+        var customFields = stateData.CustomFields;
 
         foreach (var scopeItem in scope)
         {
@@ -673,6 +660,7 @@ internal sealed class MsgPackLogExporter : MsgPackExporter, IDisposable
         public ushort FieldsCount;
         public bool HasEnvProperties;
         public ushort EnvPropertiesCount;
+        public CustomFieldSet? CustomFields;
 
         public SerializationDataForScopes(byte[] buffer)
         {

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -163,7 +163,9 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         }
 
         // TODO: Validate custom fields (reserved name? etc).
-        if (options.CustomFields != null)
+        var customFieldsLookup = new CustomFieldsLookup(options.CustomFields, options.CustomFieldsMappings);
+        var spanCustomFields = customFieldsLookup.Resolve(this.partAName);
+        if (spanCustomFields != null)
         {
             var customFields = new HashSet<string>(StringComparer.Ordinal);
             var dedicatedFields = new HashSet<string>(StringComparer.Ordinal);
@@ -178,7 +180,7 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
                 dedicatedFields.Add(name);
             }
 
-            foreach (var name in options.CustomFields)
+            foreach (var name in spanCustomFields)
             {
                 customFields.Add(name);
                 dedicatedFields.Add(name);

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
@@ -1,6 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
+using CustomFieldSet = System.Collections.Frozen.FrozenSet<string>;
+#else
+using CustomFieldSet = System.Collections.Generic.HashSet<string>;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
@@ -24,7 +29,7 @@ internal abstract class TldLogCommon : IDisposable
     protected readonly byte partAFieldsCount = 1; // At least one field: time
     protected readonly bool shouldPassThruTableMappings;
     protected readonly string defaultEventName = "Log";
-    protected readonly HashSet<string>? customFields;
+    protected readonly CustomFieldsLookup customFieldsLookup;
     protected readonly Dictionary<string, string>? tableMappings;
     protected readonly ExceptionStackExportMode exceptionStackExportMode;
 
@@ -61,16 +66,7 @@ internal abstract class TldLogCommon : IDisposable
         }
 
         // TODO: Validate custom fields (reserved name? etc).
-        if (options.CustomFields != null)
-        {
-            var customFields = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var name in options.CustomFields)
-            {
-                customFields.Add(name);
-            }
-
-            this.customFields = customFields;
-        }
+        this.customFieldsLookup = new CustomFieldsLookup(options.CustomFields, options.CustomFieldsMappings);
 
         if (options.PrepopulatedFields != null)
         {
@@ -155,7 +151,7 @@ internal abstract class TldLogCommon : IDisposable
     protected static void OnProcessScopeForIndividualColumns(
         LogRecordScope scope,
         SerializationDataForScopes stateDataValue,
-        HashSet<string>? customFields)
+        CustomFieldSet? customFields)
     {
         Debug.Assert(stateDataValue != null, "state.serializationData was null");
         Debug.Assert(PartCFields.Value != null, "PartCFields.Value was null");
@@ -197,6 +193,25 @@ internal abstract class TldLogCommon : IDisposable
         }
     }
 
+    protected string ResolveEventNameForCategoryName(string categoryName)
+    {
+        // If user configured explicit TableName, use it.
+        if (this.tableMappings?.TryGetValue(categoryName, out var eventName) != true)
+        {
+            if (!this.shouldPassThruTableMappings)
+            {
+                eventName = this.defaultEventName;
+            }
+            else
+            {
+                // TODO: Avoid allocation
+                eventName = GetSanitizedCategoryName(categoryName);
+            }
+        }
+
+        return eventName!;
+    }
+
     protected virtual void Dispose(bool disposing)
     {
         if (this.isDisposed)
@@ -224,5 +239,6 @@ internal abstract class TldLogCommon : IDisposable
     {
         public byte HasEnvProperties;
         public byte PartCFieldsCountFromState;
+        public CustomFieldSet? CustomFields;
     }
 }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogExporter.cs
@@ -110,19 +110,9 @@ internal sealed class TldLogExporter : TldLogCommon, IDisposable
 
         var categoryName = logRecord.CategoryName ?? this.defaultEventName;
 
-        // If user configured explicit TableName, use it.
-        if (this.tableMappings?.TryGetValue(categoryName, out var eventName) != true)
-        {
-            if (!this.shouldPassThruTableMappings)
-            {
-                eventName = this.defaultEventName;
-            }
-            else
-            {
-                // TODO: Avoid allocation
-                eventName = GetSanitizedCategoryName(categoryName);
-            }
-        }
+        var eventName = this.ResolveEventNameForCategoryName(categoryName);
+
+        var customFields = this.customFieldsLookup.Resolve(eventName);
 
         var eb = EventBuilder.Value ??= new EventBuilder(UncheckedASCIIEncoding.SharedInstance);
 
@@ -238,7 +228,7 @@ internal sealed class TldLogExporter : TldLogCommon, IDisposable
                 bodyPopulated = true;
                 continue;
             }
-            else if (this.customFields == null || this.customFields.Contains(entry.Key))
+            else if (customFields == null || customFields.Contains(entry.Key))
             {
                 // TODO: the above null check can be optimized and avoided inside foreach.
                 if (entry.Value != null)
@@ -295,6 +285,7 @@ internal sealed class TldLogExporter : TldLogCommon, IDisposable
 
         dataForScopes.HasEnvProperties = hasEnvProperties;
         dataForScopes.PartCFieldsCountFromState = partCFieldsCountFromState;
+        dataForScopes.CustomFields = customFields;
 
         logRecord.ForEachScope(ProcessScopeForIndividualColumnsAction, this);
 
@@ -355,9 +346,12 @@ internal sealed class TldLogExporter : TldLogCommon, IDisposable
 
 #pragma warning disable IDE0370 // Suppression is unnecessary
     private static void OnProcessScopeForIndividualColumns(LogRecordScope scope, TldLogExporter state)
-        => OnProcessScopeForIndividualColumns(
+    {
+        var stateData = state.serializationData.Value!;
+        OnProcessScopeForIndividualColumns(
             scope,
-            state.serializationData.Value!,
-            state.customFields);
+            stateData,
+            stateData.CustomFields);
+    }
 #pragma warning restore IDE0370 // Suppression is unnecessary
 }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldTraceExporter.cs
@@ -59,7 +59,9 @@ internal sealed class TldTraceExporter : IDisposable
         }
 
         // TODO: Validate custom fields (reserved name? etc).
-        if (options.CustomFields != null)
+        var customFieldsLookup = new CustomFieldsLookup(options.CustomFields, options.CustomFieldsMappings);
+        var spanCustomFields = customFieldsLookup.Resolve(this.partAName);
+        if (spanCustomFields != null)
         {
             var customFields = new HashSet<string>(StringComparer.Ordinal)
             {
@@ -72,7 +74,7 @@ internal sealed class TldTraceExporter : IDisposable
                 customFields.Add(mapping.Key);
             }
 
-            foreach (var name in options.CustomFields)
+            foreach (var name in spanCustomFields)
             {
                 customFields.Add(name);
             }

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -119,6 +119,59 @@ A list of fields which should be stored as individual table columns.
 * If non-null, only those fields named in the list will be stored as individual
   columns.
 
+`CustomFields` is applied to every table. To configure dedicated fields per
+table (for example a different set for each log category or for Traces), use
+[`CustomFieldsMappings`](#customfieldsmappings-optional) instead. `CustomFields`
+acts as the default for any table that does not have a more specific entry in
+`CustomFieldsMappings`.
+
+#### `CustomFieldsMappings` (optional)
+
+This allows configuring `CustomFields` per table. Resolution is performed against
+the **final (physical) table name** a record is routed to (ie., the table
+produced by applying [`TableNameMappings`](#tablenamemappings-optional)), not the
+incoming log category. Multiple categories that map to the same table therefore
+share the same custom fields.
+
+Each key is an exact (final) table name. The value is the list of fields which
+should be stored as individual table columns for that table.
+
+* For any table that matches an entry, the associated list of fields is used.
+* For any table that does not match an entry, the value of `CustomFields` is
+  used.
+
+The wildcard key `*` is not supported here. To configure the global default that
+applies to any table without a dedicated entry, use
+[`CustomFields`](#customfields-optional).
+
+For example, given the configuration...
+
+```csharp
+var options = new GenevaExporterOptions
+{
+    TableNameMappings = new Dictionary<string, string>()
+    {
+        ["MyCompany.Product1"] = "ProductLogs",
+        ["MyCompany.Product2"] = "ProductLogs",
+        ["Span"] = "MySpans",
+    },
+
+    // Global default applied to any table without a dedicated entry below.
+    CustomFields = new[] { "environment" },
+    CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>()
+    {
+        ["ProductLogs"] = new[] { "requestId", "userId" },
+        ["MySpans"] = new[] { "clientRequestId" },
+    },
+};
+```
+
+...both the `MyCompany.Product1` and `MyCompany.Product2` categories route to the
+`ProductLogs` table and store `requestId` and `userId` as dedicated columns,
+Traces (routed to the `MySpans` table) store `clientRequestId` (in addition to
+the always-dedicated Part B fields) as a dedicated column, and everything else
+stores `environment` (the `CustomFields` default) as a dedicated column.
+
 #### `ResourceFieldNames` (optional)
 
 A list of resource attribute keys which should be sent to Geneva.

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/CustomFieldsLookupBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/CustomFieldsLookupBenchmarks.cs
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter.Geneva.MsgPack;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+
+/*
+Compares the cost of MsgPack log serialization when custom fields are configured
+globally (the pre-existing behavior, "before") versus per table (the new
+CustomFieldsMappings feature, "after") for 10 tables each carrying 20 custom
+fields. The per-table path is expected to be slightly slower because it performs
+a dictionary lookup keyed by the final table name on the hot path, whereas the
+global path returns the single shared field set directly.
+
+Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 16 logical and 8 physical cores
+
+.NET 10.0.8 (zero-alloc byte-span alternate lookup):
+| Method                                  | Mean     | Ratio | Allocated |
+|---------------------------------------- |---------:|------:|----------:|
+| SerializeLogRecord_GlobalCustomFields   | 293.5 ns |  1.00 |         - |
+| SerializeLogRecord_PerTableCustomFields | 319.6 ns |  1.09 |         - |
+
+.NET 8.0.27 (key-construction fallback, no ReadOnlySpan<byte> alternate lookup):
+| Method                                  | Mean     | Ratio | Allocated |
+|---------------------------------------- |---------:|------:|----------:|
+| SerializeLogRecord_GlobalCustomFields   | 380.2 ns |  1.00 |         - |
+| SerializeLogRecord_PerTableCustomFields | 409.4 ns |  1.08 |      40 B |
+*/
+
+namespace OpenTelemetry.Exporter.Geneva.Benchmarks;
+
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+
+[MemoryDiagnoser]
+public class CustomFieldsLookupBenchmarks
+{
+    private const int TableCount = 10;
+    private const int FieldsPerTable = 20;
+
+    private readonly MsgPackLogExporter globalExporter;
+    private readonly MsgPackLogExporter perTableExporter;
+    private readonly LogRecord logRecord;
+
+    public CustomFieldsLookupBenchmarks()
+    {
+        // The 20 custom fields applied to the record. Two of them match the
+        // structured-logging template attributes so the serialized output is
+        // identical for both exporters; only the resolution mechanism differs.
+        var fields = new List<string> { "Food", "Price" };
+        for (var i = fields.Count; i < FieldsPerTable; i++)
+        {
+            fields.Add("Field" + i);
+        }
+
+        // "Before": a single global CustomFields set shared by every table.
+        this.globalExporter = new MsgPackLogExporter(
+            new GenevaExporterOptions
+            {
+                ConnectionString = "EtwSession=OpenTelemetry",
+                CustomFields = fields.ToArray(),
+            },
+            () => Resource.Empty);
+
+        // "After": 10 tables, each with its own 20 custom fields. The benchmark
+        // record maps to BenchTable5; the other nine entries simply make the
+        // lookup non-trivial.
+        var tableMappings = new Dictionary<string, string>();
+        var customFieldsMappings = new Dictionary<string, IEnumerable<string>>();
+        for (var t = 0; t < TableCount; t++)
+        {
+            var table = "BenchTable" + t;
+            tableMappings["BenchCategory" + t] = table;
+            customFieldsMappings[table] = fields.ToArray();
+        }
+
+        this.perTableExporter = new MsgPackLogExporter(
+            new GenevaExporterOptions
+            {
+                ConnectionString = "EtwSession=OpenTelemetry",
+                TableNameMappings = tableMappings,
+                CustomFieldsMappings = customFieldsMappings,
+            },
+            () => Resource.Empty);
+
+        this.logRecord = GenerateTestLogRecord("BenchCategory5");
+    }
+
+    [Benchmark(Baseline = true)]
+    public void SerializeLogRecord_GlobalCustomFields()
+        => this.globalExporter.SerializeLogRecord(this.logRecord);
+
+    [Benchmark]
+    public void SerializeLogRecord_PerTableCustomFields()
+        => this.perTableExporter.SerializeLogRecord(this.logRecord);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        this.globalExporter.Dispose();
+        this.perTableExporter.Dispose();
+    }
+
+    private static LogRecord GenerateTestLogRecord(string categoryName)
+    {
+        var items = new List<LogRecord>(1);
+        using var factory = LoggerFactory.Create(builder => builder
+            .AddOpenTelemetry(loggerOptions =>
+            {
+                loggerOptions.AddInMemoryExporter(items);
+            }));
+
+        var logger = factory.CreateLogger(categoryName);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
+        return items[0];
+    }
+}

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaLogExporterTests.cs
@@ -1824,6 +1824,332 @@ public class GenevaLogExporterTests
 #endif
     }
 
+    [Fact]
+    public void PerTableCustomFieldsAreResolvedByFinalTableName()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions
+            {
+                // Two categories route to the same physical table and therefore must
+                // share the same custom fields. A category without a mapping falls back
+                // to the default "Log" table (and the global CustomFields default).
+                TableNameMappings = new Dictionary<string, string>
+                {
+                    ["CategoryA1"] = "TableA",
+                    ["CategoryA2"] = "TableA",
+                    ["CategoryB"] = "TableB",
+                },
+
+                // Global default that should only apply to tables without a more specific mapping.
+                CustomFields = ["GlobalField"],
+
+                // Custom fields are keyed by the final (physical) table name, not the category.
+                CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+                {
+                    ["TableA"] = ["FieldA"],
+                    ["TableB"] = ["FieldB"],
+                },
+            };
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GenerateTempFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            var resource = ResourceBuilder.CreateEmpty().Build();
+            var logRecordList = new List<LogRecord>();
+
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecordList);
+                })
+                .AddFilter("CategoryA1", LogLevel.Trace)
+                .AddFilter("CategoryA2", LogLevel.Trace)
+                .AddFilter("CategoryB", LogLevel.Trace)
+                .AddFilter("CategoryC", LogLevel.Trace));
+
+            using var exporter = new MsgPackLogExporter(exporterOptions, () => resource);
+
+            var loggerA1 = loggerFactory.CreateLogger("CategoryA1");
+            var loggerA2 = loggerFactory.CreateLogger("CategoryA2");
+            var loggerB = loggerFactory.CreateLogger("CategoryB");
+            var loggerC = loggerFactory.CreateLogger("CategoryC");
+
+            loggerA1.LogInformation("Log {FieldA} and {FieldB} and {GlobalField}.", "A", "B", "G");
+            loggerA2.LogInformation("Log {FieldA} and {FieldB} and {GlobalField}.", "A", "B", "G");
+            loggerB.LogInformation("Log {FieldA} and {FieldB} and {GlobalField}.", "A", "B", "G");
+            loggerC.LogInformation("Log {FieldA} and {FieldB} and {GlobalField}.", "A", "B", "G");
+
+            Assert.Equal(4, logRecordList.Count);
+
+            // CategoryA1 -> TableA: only fieldA is a dedicated column.
+            var mappingA1 = SerializeAndGetMapping(exporter, logRecordList[0]);
+            Assert.Equal("A", mappingA1["FieldA"]);
+            Assert.False(mappingA1.ContainsKey("FieldB"));
+            Assert.False(mappingA1.ContainsKey("GlobalField"));
+            var envA1 = mappingA1["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("B", envA1["FieldB"]);
+            Assert.Equal("G", envA1["GlobalField"]);
+            Assert.False(envA1.ContainsKey("FieldA"));
+
+            // CategoryA2 -> TableA: shares the same custom fields as CategoryA1 (resolved by table, not category).
+            var mappingA2 = SerializeAndGetMapping(exporter, logRecordList[1]);
+            Assert.Equal("A", mappingA2["FieldA"]);
+            Assert.False(mappingA2.ContainsKey("FieldB"));
+            Assert.False(mappingA2.ContainsKey("GlobalField"));
+            var envA2 = mappingA2["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("B", envA2["FieldB"]);
+            Assert.Equal("G", envA2["GlobalField"]);
+            Assert.False(envA2.ContainsKey("FieldA"));
+
+            // CategoryB -> TableB: only fieldB is a dedicated column.
+            var mappingB = SerializeAndGetMapping(exporter, logRecordList[2]);
+            Assert.Equal("B", mappingB["FieldB"]);
+            Assert.False(mappingB.ContainsKey("FieldA"));
+            Assert.False(mappingB.ContainsKey("GlobalField"));
+            var envB = mappingB["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("A", envB["FieldA"]);
+            Assert.Equal("G", envB["GlobalField"]);
+            Assert.False(envB.ContainsKey("FieldB"));
+
+            // CategoryC -> default "Log" table: no specific mapping, so the global CustomFields default applies.
+            var mappingC = SerializeAndGetMapping(exporter, logRecordList[3]);
+            Assert.Equal("G", mappingC["GlobalField"]);
+            Assert.False(mappingC.ContainsKey("FieldA"));
+            Assert.False(mappingC.ContainsKey("FieldB"));
+            var envC = mappingC["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("A", envC["FieldA"]);
+            Assert.Equal("B", envC["FieldB"]);
+            Assert.False(envC.ContainsKey("GlobalField"));
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public void GlobalCustomFieldsAppliesToTablesWithoutMapping()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions
+            {
+                // The global default is configured via CustomFields (the wildcard "*"
+                // key is not supported in CustomFieldsMappings).
+                CustomFields = ["GlobalField"],
+                CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+                {
+                    ["TableA"] = ["FieldA"],
+                },
+            };
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GenerateTempFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            var resource = ResourceBuilder.CreateEmpty().Build();
+            var logRecordList = new List<LogRecord>();
+
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecordList);
+                })
+                .AddFilter("AnyCategory", LogLevel.Trace));
+
+            using var exporter = new MsgPackLogExporter(exporterOptions, () => resource);
+
+            var logger = loggerFactory.CreateLogger("AnyCategory");
+            logger.LogInformation("Log {FieldA} and {GlobalField}.", "A", "G");
+
+            Assert.Single(logRecordList);
+
+            // "AnyCategory" routes to the default "Log" table, which has no dedicated
+            // mapping, so the global CustomFields default applies (only GlobalField).
+            var mapping = SerializeAndGetMapping(exporter, logRecordList[0]);
+            Assert.Equal("G", mapping["GlobalField"]);
+            Assert.False(mapping.ContainsKey("FieldA"));
+            var env = mapping["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("A", env["FieldA"]);
+            Assert.False(env.ContainsKey("GlobalField"));
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public void PerTableCustomFieldsResolvedForPassthroughTableNames()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions
+            {
+                // Pass-through: the final table name is the sanitized category name,
+                // which is not known at configuration time. Custom fields keyed by the
+                // resulting table name must still resolve.
+                TableNameMappings = new Dictionary<string, string>
+                {
+                    ["*"] = "*",
+                },
+                CustomFields = ["GlobalField"],
+                CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+                {
+                    ["TableX"] = ["FieldX"],
+                },
+            };
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GenerateTempFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            var resource = ResourceBuilder.CreateEmpty().Build();
+            var logRecordList = new List<LogRecord>();
+
+            using var loggerFactory = LoggerFactory.Create(builder => builder
+                .AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecordList);
+                })
+                .AddFilter("TableX", LogLevel.Trace)
+                .AddFilter("TableY", LogLevel.Trace));
+
+            using var exporter = new MsgPackLogExporter(exporterOptions, () => resource);
+
+            // "TableX" sanitizes to the table "TableX" (matches the mapping);
+            // "TableY" sanitizes to "TableY" (no mapping -> global default).
+            var loggerX = loggerFactory.CreateLogger("TableX");
+            var loggerY = loggerFactory.CreateLogger("TableY");
+
+            loggerX.LogInformation("Log {FieldX} and {GlobalField}.", "X", "G");
+            loggerY.LogInformation("Log {FieldX} and {GlobalField}.", "X", "G");
+
+            Assert.Equal(2, logRecordList.Count);
+
+            var mappingX = SerializeAndGetMapping(exporter, logRecordList[0]);
+            Assert.Equal("X", mappingX["FieldX"]);
+            Assert.False(mappingX.ContainsKey("GlobalField"));
+            var envX = mappingX["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("G", envX["GlobalField"]);
+            Assert.False(envX.ContainsKey("FieldX"));
+
+            var mappingY = SerializeAndGetMapping(exporter, logRecordList[1]);
+            Assert.Equal("G", mappingY["GlobalField"]);
+            Assert.False(mappingY.ContainsKey("FieldX"));
+            var envY = mappingY["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("X", envY["FieldX"]);
+            Assert.False(envY.ContainsKey("GlobalField"));
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public void CustomFieldsMappingsValidation()
+    {
+        var options = new GenevaExporterOptions();
+
+        // Null dictionary.
+        Assert.Throws<ArgumentNullException>(() => options.CustomFieldsMappings = null);
+
+        // Null, empty, or white-space key.
+        Assert.Throws<ArgumentException>(() => options.CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+        {
+            [" "] = ["FieldA"],
+        });
+
+        // Wildcard "*" key is not supported (use CustomFields for the global default).
+        Assert.Throws<ArgumentException>(() => options.CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+        {
+            ["*"] = ["FieldA"],
+        });
+
+        // Null value collection.
+        Assert.Throws<ArgumentException>(() => options.CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+        {
+            ["TableA"] = null,
+        });
+
+        // Null, empty, or white-space field name.
+        Assert.Throws<ArgumentException>(() => options.CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+        {
+            ["TableA"] = ["validField", " "],
+        });
+
+        // Valid mappings should round-trip and be defensively copied.
+        var source = new Dictionary<string, IEnumerable<string>>
+        {
+            ["TableA"] = ["FieldA"],
+        };
+        options.CustomFieldsMappings = source;
+
+        Assert.NotNull(options.CustomFieldsMappings);
+        Assert.True(options.CustomFieldsMappings.ContainsKey("TableA"));
+        Assert.NotSame(source, options.CustomFieldsMappings);
+    }
+
     private static string GenerateTempFilePath()
     {
         while (true)
@@ -1838,6 +2164,14 @@ public class GenevaLogExporterTests
 
     private static string GetTestMethodName([CallerMemberName] string callingMethodName = "")
         => callingMethodName;
+
+    private static Dictionary<object, object> SerializeAndGetMapping(MsgPackLogExporter exporter, LogRecord logRecord)
+    {
+        var serializedLog = exporter.SerializeLogRecord(logRecord);
+        var fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(serializedLog, MessagePack.Resolvers.ContractlessStandardResolver.Options);
+        var timeStampAndMappings = ((fluentdData as object[])[1] as object[])[0];
+        return (timeStampAndMappings as object[])[1] as Dictionary<object, object>;
+    }
 
     private static object GetField(object fluentdData, string key)
     {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaTraceExporterTests.cs
@@ -1345,6 +1345,92 @@ public class GenevaTraceExporterTests : IDisposable
         }
     }
 
+    [Fact]
+    public void CustomFieldsMappingsForSpanTable()
+    {
+        var path = string.Empty;
+        Socket server = null;
+        try
+        {
+            var exporterOptions = new GenevaExporterOptions
+            {
+                // The Span table is renamed, so custom fields must be keyed by the
+                // final table name ("MySpanTable"), not the literal "Span".
+                TableNameMappings = new Dictionary<string, string>
+                {
+                    ["Span"] = "MySpanTable",
+                },
+
+                // Global default that should be overridden by the table-specific mapping for traces.
+                CustomFields = ["globalField"],
+                CustomFieldsMappings = new Dictionary<string, IEnumerable<string>>
+                {
+                    ["MySpanTable"] = ["spanField"],
+                },
+            };
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "EtwSession=OpenTelemetry";
+            }
+            else
+            {
+                path = GetRandomFilePath();
+                exporterOptions.ConnectionString = "Endpoint=unix:" + path;
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
+
+            using var exporter = new MsgPackTraceExporter(exporterOptions, () => Resource.Empty);
+            var m_buffer = exporter.Buffer;
+
+            Dictionary<object, object> mapping = null;
+
+            var sourceName = GetTestMethodName();
+
+            using var listener = new ActivityListener();
+            listener.ShouldListenTo = (activitySource) => activitySource.Name == sourceName;
+            listener.Sample = (ref options) => ActivitySamplingResult.AllDataAndRecorded;
+            listener.ActivityStopped = (activity) =>
+            {
+                _ = exporter.SerializeActivity(activity);
+                var fluentdData = MessagePack.MessagePackSerializer.Deserialize<object>(m_buffer.Value, MessagePack.Resolvers.ContractlessStandardResolver.Options);
+                var timeStampAndMappings = ((fluentdData as object[])[1] as object[])[0];
+                mapping = (timeStampAndMappings as object[])[1] as Dictionary<object, object>;
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            using var source = new ActivitySource(sourceName);
+            using (var activity = source.StartActivity("SpanActivity"))
+            {
+                activity?.SetTag("spanField", "S");
+                activity?.SetTag("globalField", "G");
+            }
+
+            Assert.NotNull(mapping);
+
+            // The table-specific mapping takes precedence over the global CustomFields, so only spanField is a dedicated column.
+            Assert.Equal("S", mapping["spanField"]);
+            Assert.False(mapping.ContainsKey("globalField"));
+            var env = mapping["env_properties"] as Dictionary<object, object>;
+            Assert.Equal("G", env["globalField"]);
+            Assert.False(env.ContainsKey("spanField"));
+        }
+        finally
+        {
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
     private static string GetRandomFilePath()
     {
         while (true)


### PR DESCRIPTION
Add per-table CustomFields via CustomFieldsMappings 

Fixes #4476 

## Changes

Add CustomFieldsMappings to GenevaExporterOptions so custom fields can be configured per table in addition to the global CustomFields. 

Resolution is keyed by the final (physical) table name a record is routed to (after TableNameMappings), so categories mapping to the same table share the same custom fields. CustomFields remains the default for tables without a mapping.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
