### PR TITLE
[release] core-1.16.0 release updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
   <!-- OpenTelemetry packages -->
   <PropertyGroup>
-    <OpenTelemetryCoreLatestVersion>1.15.3</OpenTelemetryCoreLatestVersion>
+    <OpenTelemetryCoreLatestVersion>1.16.0</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreUnstableLatestVersion>1.15.3-beta.1</OpenTelemetryCoreUnstableLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>1.14.0-rc.1</OpenTelemetryCoreLatestPrereleaseVersion>
     <OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>1.15.2</OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -546,7 +546,7 @@ function GetCoreDependenciesForProjects {
     foreach ($project in $projects)
     {
         # Note: dotnet restore may fail if the core packages aren't available yet but that is fine, we just want to generate project.assets.json for these projects.
-        dotnet restore $project
+        dotnet restore $project | Out-Null
 
         $projectDir = $project | Split-Path -Parent
         $projectDirName = $projectDir | Split-Path -Leaf

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.0.0-alpha.8
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.0.0-alpha.8
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -12,7 +12,7 @@
   ([#4442](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4442))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Fix `IndexOutOfRangeException` if the extension key limit is reached.
   ([#4442](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4442))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#4396](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4396))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fix sampling behaviour to be compatible with .NET 11.
   ([#4396](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4396))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.0-beta.1
 

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.0-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -10,6 +10,9 @@
   telemetry processing failures do not escape request stop processing.
   ([#4344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4344))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#4344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4344))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#4344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4344))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -10,6 +10,9 @@
   `null` defaults.
   ([#4344](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4344))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -15,7 +15,7 @@
   ([#4015](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4015))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Fix enrich methods being called multiple times.
   ([#4015](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4015))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.0.0-beta.6
 

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.0.0-beta.6
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 0.1.0-alpha.7
 
 Released 2026-May-29

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 0.1.0-alpha.7
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Update `System.Text.Json` for `netstandard2.0` and `net8.0` to `8.0.5`.
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Fix `SqlConnectionDetails` to parse PostgreSQL data source URIs correctly.
   ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -17,7 +17,7 @@
   ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -7,7 +7,7 @@
   ([#4031](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4031))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-alpha.1
 

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -6,6 +6,9 @@
   configured via `AddEventSources`.
   ([#4031](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4031))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-alpha.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add instrumentation scope version and schema URL to traces.
   ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.0.0-beta.11
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -9,7 +9,7 @@
   ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.0.0-beta.11
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -9,7 +9,7 @@
   ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add instrumentation scope version and schema URL to traces.
   ([#4338](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4338))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -7,7 +7,7 @@
   ([#4288](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4288))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -6,6 +6,9 @@
   the previous ambient baggage is restored after job completion.
   ([#4288](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4288))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -9,7 +9,7 @@
   ([#4082](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4082))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1
 

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add instrumentation scope version and schema URL to metrics and traces.
   ([#4082](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4082))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add instrumentation scope version and schema URL to metrics and traces.
   ([#4375](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4375))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -9,7 +9,7 @@
   ([#4375](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4375))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -11,6 +11,9 @@
   metric as an alternative.
   ([#4088](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4088))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -12,7 +12,7 @@
   ([#4088](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4088))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Remoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Remoting/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 0.1.0-alpha.1
 

--- a/src/OpenTelemetry.Instrumentation.Remoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Remoting/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 0.1.0-alpha.1
 
 Released 2026-Jun-01

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1
 

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -27,6 +27,9 @@
 * Fix `SqlConnectionDetails` to parse PostgreSQL data source URIs correctly.
   ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -28,7 +28,7 @@
   ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4444))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.2
 
 Released 2026-May-27

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -19,7 +19,7 @@
   ([#4378](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4378))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -18,6 +18,9 @@
   `ExecutionContext` flow was suppressed.
   ([#4378](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4378))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.2
 
 Released 2026-Apr-22

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1
 

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Update `System.Text.Json` for `netstandard2.0` to `8.0.5`.
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Update `System.Text.Json` for `netstandard2.0` to `8.0.5`.
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Update `System.Text.Json` for `netstandard2.0` to `8.0.5`.
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.0.0-alpha.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#4154](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4154))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.0.0-alpha.1
 

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.2
 

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.2
 
 Released 2026-May-06

--- a/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 1.15.1-beta.1
 

--- a/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -10,7 +10,7 @@
   ([#4316](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4316))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
 ## 0.1.0-alpha.9
 

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -9,6 +9,9 @@
   missing or null `Attributes`.
   ([#4316](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4316))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 0.1.0-alpha.9
 
 Released 2026-Apr-21

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorLoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorLoggerProviderBuilderExtensionsTests.cs
@@ -22,6 +22,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                 configure => configure.ConfigureBatchOptions(o => configurationInvocations++));
         });
 
+        _ = loggerFactory.CreateLogger("TestLogger");
+
         Assert.Equal(1, configurationInvocations);
     }
 
@@ -36,6 +38,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                 "InstrumentationKey=token-extrainformation",
                 configure => configure.ConfigureExporter(exporter => exporterInstance = exporter));
         });
+
+        _ = loggerFactory.CreateLogger("TestLogger");
 
         Assert.NotNull(exporterInstance);
 
@@ -60,6 +64,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                 configure => configure.ConfigureSerializationOptions(o => configurationInvocations++));
         });
 
+        _ = loggerFactory.CreateLogger("TestLogger");
+
         Assert.Equal(1, configurationInvocations);
     }
 
@@ -74,6 +80,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                 "InstrumentationKey=token-extrainformation",
                 configure => configure.ConfigureTransportOptions(o => configurationInvocations++));
         });
+
+        _ = loggerFactory.CreateLogger("TestLogger");
 
         Assert.Equal(1, configurationInvocations);
     }
@@ -90,6 +98,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                     configure => configure.SetConnectionString("InstrumentationKey=token-extrainformation"));
             },
             services => services.Configure<OneCollectorLogExporterOptions>(o => options = o));
+
+        _ = loggerFactory.CreateLogger("TestLogger");
 
         Assert.NotNull(options);
         Assert.Equal("InstrumentationKey=token-extrainformation", options.ConnectionString);
@@ -114,6 +124,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
             },
             services => services.Configure<OneCollectorLogExporterOptions>(o => options = o));
 
+        _ = loggerFactory.CreateLogger("TestLogger");
+
         Assert.NotNull(options);
         Assert.Equal(mappings, options.EventFullNameMappings);
     }
@@ -132,6 +144,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
             },
             services => services.Configure<OneCollectorLogExporterOptions>(o => options = o));
 
+        _ = loggerFactory.CreateLogger("TestLogger");
+
         Assert.NotNull(options);
         Assert.Equal("MyDefaultEventNamespace", options.DefaultEventNamespace);
     }
@@ -149,6 +163,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                     configure => configure.SetDefaultEventName("MyDefaultEventName"));
             },
             services => services.Configure<OneCollectorLogExporterOptions>(o => options = o));
+
+        _ = loggerFactory.CreateLogger("TestLogger");
 
         Assert.NotNull(options);
         Assert.Equal("MyDefaultEventName", options.DefaultEventName);
@@ -179,6 +195,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                 services.Configure<OneCollectorLogExporterOptions>(name, o => exporterOptions = o);
                 services.Configure<BatchExportLogRecordProcessorOptions>(name, o => batchOptions = o);
             });
+
+        _ = loggerFactory.CreateLogger("TestLogger");
 
         Assert.NotNull(exporterOptions);
         Assert.NotNull(batchOptions);
@@ -212,6 +230,7 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
             {
                 builder.AddOneCollectorExporter(configure => { });
             });
+            _ = loggerFactory.CreateLogger("TestLogger");
         });
 
         Assert.Throws<OneCollectorExporterValidationException>(() =>
@@ -220,6 +239,7 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
             {
                 builder.AddOneCollectorExporter("InstrumentationKey=invalidinstrumentationkey");
             });
+            _ = loggerFactory.CreateLogger("TestLogger");
         });
 
         Assert.Throws<OneCollectorExporterValidationException>(() =>
@@ -228,6 +248,7 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
             {
                 builder.AddOneCollectorExporter("UnknownKey=invalidinstrumentationkey");
             });
+            _ = loggerFactory.CreateLogger("TestLogger");
         });
     }
 
@@ -253,6 +274,8 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                 services.Configure<BatchExportLogRecordProcessorOptions>(
                     o => configurationInvocations++);
             });
+
+        _ = loggerFactory.CreateLogger("TestLogger");
 
         Assert.Equal(2, configurationInvocations);
     }
@@ -286,14 +309,15 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
                     o => configurationInvocations++);
             });
 
+        _ = loggerFactory.CreateLogger("TestLogger");
+
         Assert.Equal(2, configurationInvocations);
     }
 
     private static ILoggerFactory CreateLoggerFactoryWithOneCollectorExporter(
         Action<LoggerProviderBuilder> configureLogging,
-        Action<IServiceCollection>? configureServices = null)
-    {
-        return LoggerFactory.Create(builder =>
+        Action<IServiceCollection>? configureServices = null) =>
+        LoggerFactory.Create(builder =>
         {
             builder.AddOpenTelemetry();
 
@@ -301,5 +325,4 @@ public class OneCollectorLoggerProviderBuilderExtensionsTests
 
             configureServices?.Invoke(builder.Services);
         });
-    }
 }

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorOpenTelemetryLoggerOptionsExtensionsTests.cs
@@ -21,6 +21,8 @@ public class OneCollectorOpenTelemetryLoggerOptionsExtensionsTests
                     configure => configure.ConfigureExporter(exporter => exporterInstance = exporter));
             }));
 
+        _ = loggerFactory.CreateLogger("TestLogger");
+
         Assert.NotNull(exporterInstance);
 
         using var payloadTransmittedRegistration = exporterInstance.RegisterPayloadTransmittedCallback(OnPayloadTransmitted);
@@ -58,6 +60,7 @@ public class OneCollectorOpenTelemetryLoggerOptionsExtensionsTests
                 {
                     builder.AddOneCollectorExporter(configure => { });
                 }));
+            _ = loggerFactory.CreateLogger("TestLogger");
         });
 
         Assert.Throws<OneCollectorExporterValidationException>(() =>
@@ -67,6 +70,7 @@ public class OneCollectorOpenTelemetryLoggerOptionsExtensionsTests
                 {
                     builder.AddOneCollectorExporter("InstrumentationKey=invalidinstrumentationkey");
                 }));
+            _ = loggerFactory.CreateLogger("TestLogger");
         });
 
         Assert.Throws<OneCollectorExporterValidationException>(() =>
@@ -76,6 +80,7 @@ public class OneCollectorOpenTelemetryLoggerOptionsExtensionsTests
                 {
                     builder.AddOneCollectorExporter("UnknownKey=invalidinstrumentationkey");
                 }));
+            _ = loggerFactory.CreateLogger("TestLogger");
         });
     }
 }


### PR DESCRIPTION
## Changes

- Sets `OpenTelemetryCoreLatestVersion` in `Directory.Packages.props` to `1.16.0`.
- Update CHANGELOGs.
- Fix issue that cause automatic PR generation to fail.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
