### PR TITLE
[release] coreunstable-1.16.0-beta.1 release updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <OpenTelemetryCoreLatestVersion>1.16.0</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreUnstableLatestVersion>1.16.0-beta.1</OpenTelemetryCoreUnstableLatestVersion>
-    <OpenTelemetryCoreLatestPrereleaseVersion>1.14.0-rc.1</OpenTelemetryCoreLatestPrereleaseVersion>
+    <OpenTelemetryCoreLatestPrereleaseVersion>1.16.0-rc.1</OpenTelemetryCoreLatestPrereleaseVersion>
     <OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>1.15.2</OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>
     <OpenTelemetryInstrumentationHttpLatestStableVersion>1.15.1</OpenTelemetryInstrumentationHttpLatestStableVersion>
     <OpenTelemetryInstrumentationRuntimeLatestStableVersion>1.15.1</OpenTelemetryInstrumentationRuntimeLatestStableVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   <!-- OpenTelemetry packages -->
   <PropertyGroup>
     <OpenTelemetryCoreLatestVersion>1.15.3</OpenTelemetryCoreLatestVersion>
-    <OpenTelemetryCoreUnstableLatestVersion>1.15.3-beta.1</OpenTelemetryCoreUnstableLatestVersion>
+    <OpenTelemetryCoreUnstableLatestVersion>1.16.0-beta.1</OpenTelemetryCoreUnstableLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>1.14.0-rc.1</OpenTelemetryCoreLatestPrereleaseVersion>
     <OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>1.15.2</OpenTelemetryInstrumentationAspNetCoreLatestStableVersion>
     <OpenTelemetryInstrumentationHttpLatestStableVersion>1.15.1</OpenTelemetryInstrumentationHttpLatestStableVersion>


### PR DESCRIPTION
## Changes

Sets `OpenTelemetryCoreUnstableLatestVersion` in `Directory.Packages.props` to `1.16.0-beta.1`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
