### PR TITLE
[Exporter.Geneva] Reduce per-record allocations

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -5,6 +5,13 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Reduced per-log-record and per-span allocations in the Geneva exporter:
+  cache sanitized logger category names (with a fast path that reuses already
+  valid names) and freeze the cache on .NET 8+, serialize metric base-128
+  strings and HTTP url spans directly into the output buffer instead of via
+  temporary arrays/strings.
+  ([#4498](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4498))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -5,14 +5,15 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Log error when telemetry data exceeds the serialization buffer capacity.
+  ([#4027](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4027))
+
 * Reduced per-log-record and per-span allocations in the Geneva exporter:
   cache sanitized logger category names (with a fast path that reuses already
   valid names) and freeze the cache on .NET 8+, serialize metric base-128
   strings and HTTP url spans directly into the output buffer instead of via
   temporary arrays/strings.
   ([#4498](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4498))
-* Log error when telemetry data exceeds the serialization buffer capacity.
-  ([#4027](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4027))
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/EventHeader/EventHeaderLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/EventHeader/EventHeaderLogExporter.cs
@@ -121,8 +121,7 @@ internal class EventHeaderLogExporter : TldLogCommon, IDisposable
             }
             else
             {
-                // TODO: Avoid allocation
-                eventName = GetSanitizedCategoryName(categoryName);
+                eventName = this.GetSanitizedCategoryName(categoryName);
             }
         }
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/MsgPack/MsgPackTraceExporter.cs
@@ -313,6 +313,97 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
         return urlStringBuilder.ToString();
     }
 
+    // Serializes the composed HTTP url (scheme://address:port/path?query) for a
+    // server span directly into the msgpack buffer, avoiding the intermediate
+    // interpolated strings, StringBuilder, and ToString() that GetHttpUrl
+    // allocates. The fast path writes each url segment's UTF-8 straight into the
+    // buffer and back-patches the STR16 length header (exactly mirroring
+    // MessagePackSerializer.SerializeUnicodeString's wire format). The rare
+    // over-limit case delegates to GetHttpUrl + SerializeUnicodeString so the
+    // existing char-count truncation semantics are preserved byte-for-byte.
+    internal static int SerializeHttpUrl(byte[] buffer, int cursor, object?[] httpUrlParts, ref ushort fieldCount)
+    {
+        static int WriteUtf8(byte[] target, int at, string value)
+        {
+            if (value.Length == 0)
+            {
+                return 0;
+            }
+#if NETSTANDARD2_1_OR_GREATER || NET
+            return Encoding.UTF8.GetBytes(value, target.AsSpan(at));
+#else
+            return Encoding.UTF8.GetBytes(value, 0, value.Length, target, at);
+#endif
+        }
+
+        var scheme = httpUrlParts[0]?.ToString() ?? string.Empty;   // url.scheme
+        var address = httpUrlParts[1]?.ToString() ?? string.Empty;  // server.address
+        var port = httpUrlParts[2]?.ToString();                     // server.port (null => no ':' prefix, even for "")
+        var path = httpUrlParts[3]?.ToString() ?? string.Empty;     // url.path
+        var query = httpUrlParts[4]?.ToString();                    // url.query
+
+        var hasQuery = !string.IsNullOrEmpty(query);
+        var queryNeedsPrefix = hasQuery && query![0] != '?';
+
+        // Combined char count, mirroring GetHttpUrl's `length` exactly so the
+        // empty-detection and the over-limit threshold stay consistent.
+        var combinedCharCount = scheme.Length
+            + Uri.SchemeDelimiter.Length
+            + address.Length
+            + (port != null ? 1 + port.Length : 0)
+            + path.Length
+            + (hasQuery ? (queryNeedsPrefix ? 1 + query!.Length : query!.Length) : 0);
+
+        // No URL elements found (only "://").
+        if (combinedCharCount == Uri.SchemeDelimiter.Length)
+        {
+            return cursor;
+        }
+
+        cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "httpUrl");
+
+        if (combinedCharCount > MessagePackSerializer.DEFAULT_STRING_SIZE_LIMIT_CHAR_COUNT)
+        {
+            // Rare: preserve the exact truncation + "..." semantics by reusing
+            // the original builder and serializer.
+            cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, GetHttpUrl(httpUrlParts));
+            fieldCount += 1;
+            return cursor;
+        }
+
+        var start = cursor;
+        cursor += 3; // Reserve the STR16 header; back-patched once the byte length is known.
+
+        cursor += WriteUtf8(buffer, cursor, scheme);
+        buffer[cursor++] = (byte)':';
+        buffer[cursor++] = (byte)'/';
+        buffer[cursor++] = (byte)'/';
+        cursor += WriteUtf8(buffer, cursor, address);
+        if (port != null)
+        {
+            buffer[cursor++] = (byte)':';
+            cursor += WriteUtf8(buffer, cursor, port);
+        }
+
+        cursor += WriteUtf8(buffer, cursor, path);
+        if (hasQuery)
+        {
+            if (queryNeedsPrefix)
+            {
+                buffer[cursor++] = (byte)'?';
+            }
+
+            cursor += WriteUtf8(buffer, cursor, query!);
+        }
+
+        var cb = cursor - start - 3;
+        buffer[start] = MessagePackSerializer.STR16;
+        buffer[start + 1] = unchecked((byte)(cb >> 8));
+        buffer[start + 2] = unchecked((byte)cb);
+        fieldCount += 1;
+        return cursor;
+    }
+
     /// <summary>
     /// Populates this.bufferPrologue and this.bufferEpilogue.
     /// </summary>
@@ -611,14 +702,9 @@ internal sealed class MsgPackTraceExporter : MsgPackExporter, IDisposable
 
         if (isServerActivity)
         {
-            var httpUrl = GetHttpUrl(httpUrlParts);
-            if (httpUrl != null)
-            {
-                // If the activity is a server activity and has http.url, we need to add it as a dedicated field.
-                cursor = MessagePackSerializer.SerializeAsciiString(buffer, cursor, "httpUrl");
-                cursor = MessagePackSerializer.SerializeUnicodeString(buffer, cursor, httpUrl);
-                cntFields += 1;
-            }
+            // Serializes the "httpUrl" field directly into the buffer (no
+            // intermediate URL string) when the server span carries url parts.
+            cursor = SerializeHttpUrl(buffer, cursor, httpUrlParts, ref cntFields);
         }
 
         if (hasEnvProperties)

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NET
+using System.Buffers;
 using System.Collections.Frozen;
 #endif
 using System.Diagnostics;
@@ -14,6 +15,7 @@ namespace OpenTelemetry.Exporter.Geneva.Tld;
 internal abstract class TldLogCommon : IDisposable
 {
     protected const int MaxSanitizedEventNameLength = 50;
+    protected const int MaxCachedSanitizedCategoryNames = 10000;
 
     protected static readonly ThreadLocal<List<KeyValuePair<string, object?>>> EnvProperties = new();
     protected static readonly ThreadLocal<KeyValuePair<string, object>[]> PartCFields = new(); // This is used to temporarily store the PartC fields from tags
@@ -36,6 +38,16 @@ internal abstract class TldLogCommon : IDisposable
 #endif
     protected readonly ExceptionStackExportMode exceptionStackExportMode;
 
+#if NET
+    private static readonly SearchValues<char> AlphanumericChars = SearchValues.Create(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+
+#endif
+#if NET
+    private FrozenDictionary<string, string> sanitizedCategoryNameCache = FrozenDictionary<string, string>.Empty;
+#else
+    private Dictionary<string, string> sanitizedCategoryNameCache = new(StringComparer.Ordinal);
+#endif
     private bool isDisposed;
 
     protected TldLogCommon(GenevaExporterOptions options)
@@ -120,55 +132,6 @@ internal abstract class TldLogCommon : IDisposable
         _ => 1,
     };
 
-    // This method would map the logger category to a table name which only contains alphanumeric values with the following additions:
-    // Any character that is not allowed will be removed.
-    // If the resulting string is longer than 50 characters, only the first 50 characters will be taken.
-    // If the first character in the resulting string is a lower-case alphabet, it will be converted to the corresponding upper-case.
-    // If the resulting string still does not comply with Rule, the category name will not be serialized.
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected static string GetSanitizedCategoryName(string categoryName)
-    {
-        var validNameLength = 0;
-        Span<char> result = stackalloc char[MaxSanitizedEventNameLength];
-
-        // Special treatment for the first character.
-        var firstChar = categoryName[0];
-        if (firstChar is >= 'A' and <= 'Z')
-        {
-            result[0] = firstChar;
-            ++validNameLength;
-        }
-        else if (firstChar is >= 'a' and <= 'z')
-        {
-            // If the first character in the resulting string is a lower-case alphabet,
-            // it will be converted to the corresponding upper-case.
-            result[0] = (char)(firstChar - 32);
-            ++validNameLength;
-        }
-        else
-        {
-            // Not a valid name.
-            return string.Empty;
-        }
-
-        for (var i = 1; i < categoryName.Length; i++)
-        {
-            if (validNameLength == MaxSanitizedEventNameLength)
-            {
-                break;
-            }
-
-            var cur = categoryName[i];
-            if (cur is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9'))
-            {
-                result[validNameLength] = cur;
-                ++validNameLength;
-            }
-        }
-
-        return result.Slice(0, validNameLength).ToString();
-    }
-
     protected static void OnProcessScopeForIndividualColumns(
         LogRecordScope scope,
         SerializationDataForScopes stateDataValue,
@@ -218,6 +181,29 @@ internal abstract class TldLogCommon : IDisposable
         }
     }
 
+    // Maps the logger category to a table/event name. The set of logger
+    // category names in a process is small and stable, so the sanitized result
+    // is cached (copy-on-write, keeping the happy path lockless) instead of
+    // being recomputed and reallocated on every log record. This mirrors the
+    // caching the MsgPack TableNameSerializer already performs.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected string GetSanitizedCategoryName(string categoryName)
+    {
+        // Fast path: when the category name is already a valid event name we can
+        // return the original string reference as-is, avoiding both the cache
+        // lookup and any allocation. The check is an accelerated character scan.
+        if (IsAlreadySanitized(categoryName))
+        {
+            return categoryName;
+        }
+
+        var cache = Volatile.Read(ref this.sanitizedCategoryNameCache);
+
+        return cache.TryGetValue(categoryName, out var sanitized)
+            ? sanitized
+            : this.GetSanitizedCategoryNameRare(categoryName);
+    }
+
     protected virtual void Dispose(bool disposing)
     {
         if (this.isDisposed)
@@ -239,6 +225,150 @@ internal abstract class TldLogCommon : IDisposable
         }
 
         this.isDisposed = true;
+    }
+
+    // Returns true when SanitizeCategoryName(categoryName) would produce a string
+    // identical to categoryName, i.e. the name is non-empty, starts with an
+    // upper-case ASCII letter, is no longer than MaxSanitizedEventNameLength, and
+    // contains only ASCII alphanumeric characters. In that case the original
+    // string can be reused verbatim with no allocation.
+    private static bool IsAlreadySanitized(string categoryName)
+    {
+        var length = categoryName.Length;
+        if (length == 0 || length > MaxSanitizedEventNameLength)
+        {
+            return false;
+        }
+
+        // The first character must already be an upper-case letter (a lower-case
+        // first character would be up-cased by sanitization, changing the string).
+        if (categoryName[0] is not (>= 'A' and <= 'Z'))
+        {
+            return false;
+        }
+
+#if NET
+        return !categoryName.AsSpan(1).ContainsAnyExcept(AlphanumericChars);
+#else
+        for (var i = 1; i < length; i++)
+        {
+            var cur = categoryName[i];
+            if (cur is not ((>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9')))
+            {
+                return false;
+            }
+        }
+
+        return true;
+#endif
+    }
+
+    private static string SanitizeCategoryName(string categoryName)
+    {
+        var validNameLength = 0;
+        Span<char> result = stackalloc char[MaxSanitizedEventNameLength];
+
+        // Special treatment for the first character.
+        var firstChar = categoryName[0];
+        if (firstChar is >= 'A' and <= 'Z')
+        {
+            result[0] = firstChar;
+            ++validNameLength;
+        }
+        else if (firstChar is >= 'a' and <= 'z')
+        {
+            // If the first character in the resulting string is a lower-case alphabet,
+            // it will be converted to the corresponding upper-case.
+            result[0] = (char)(firstChar - 32);
+            ++validNameLength;
+        }
+        else
+        {
+            // Not a valid name.
+            return string.Empty;
+        }
+
+        for (var i = 1; i < categoryName.Length; i++)
+        {
+            if (validNameLength == MaxSanitizedEventNameLength)
+            {
+                break;
+            }
+
+            var cur = categoryName[i];
+            if (cur is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9'))
+            {
+                result[validNameLength] = cur;
+                ++validNameLength;
+            }
+        }
+
+        return result.Slice(0, validNameLength).ToString();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private string GetSanitizedCategoryNameRare(string categoryName)
+    {
+        var sanitized = SanitizeCategoryName(categoryName);
+
+        // Lock-free copy-on-write update. The cache is a pure memoization of a
+        // deterministic, side-effect-free function, so a lost race is harmless:
+        // the worst case is that the value is recomputed and re-inserted later.
+        // We use compare-and-swap (rather than a plain write) so the update is
+        // guaranteed to make progress and never overwrite a concurrent insert
+        // with a stale snapshot.
+        //
+        // The CAS loop only ever retries when it loses a race to a concurrent
+        // writer (i.e. another thread made progress), so it is provably finite.
+        // We still cap the attempts as a safety net: rather than risk spinning
+        // forever if that reasoning is ever wrong, we simply stop caching and
+        // return the freshly computed value uncached. Failing to memoize is a
+        // benign performance degradation, so we degrade gracefully instead of
+        // throwing on a telemetry hot path.
+        const int maxAttempts = 64;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            var cache = Volatile.Read(ref this.sanitizedCategoryNameCache);
+
+            // Another thread may have inserted the entry already.
+            if (cache.TryGetValue(categoryName, out var existing))
+            {
+                return existing;
+            }
+
+            // Bound the cache to guard against unbounded growth from
+            // pathological/adversarial category-name churn.
+            if (cache.Count >= MaxCachedSanitizedCategoryNames)
+            {
+                return sanitized;
+            }
+
+            // On modern runtimes the published snapshot is a FrozenDictionary,
+            // which trades a higher one-time build cost for faster lookups - a
+            // good fit for this read-mostly, rarely-mutated cache.
+#if NET
+            var newCache = new Dictionary<string, string>(cache, StringComparer.Ordinal)
+            {
+                [categoryName] = sanitized,
+            }.ToFrozenDictionary(StringComparer.Ordinal);
+#else
+            var newCache = new Dictionary<string, string>(cache, StringComparer.Ordinal)
+            {
+                [categoryName] = sanitized,
+            };
+#endif
+
+            if (Interlocked.CompareExchange(ref this.sanitizedCategoryNameCache, newCache, cache) == cache)
+            {
+                return sanitized;
+            }
+
+            // Lost the race against a concurrent update; re-read and retry.
+        }
+
+        // Exceeded the retry budget under pathological contention: return the
+        // computed value without caching it.
+        return sanitized;
     }
 
     internal sealed class SerializationDataForScopes

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogExporter.cs
@@ -119,8 +119,7 @@ internal sealed class TldLogExporter : TldLogCommon, IDisposable
             }
             else
             {
-                // TODO: Avoid allocation
-                eventName = GetSanitizedCategoryName(categoryName);
+                eventName = this.GetSanitizedCategoryName(categoryName);
             }
         }
 

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/MetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/MetricSerializer.cs
@@ -351,10 +351,17 @@ internal static class MetricSerializer
     {
         if (!string.IsNullOrEmpty(value))
         {
-            var encodedValue = Encoding.UTF8.GetBytes(value);
-            SerializeUInt64AsBase128(buffer, ref bufferIndex, (ulong)encodedValue.Length);
-            Array.Copy(encodedValue, 0, buffer, bufferIndex, encodedValue.Length);
-            bufferIndex += encodedValue.Length;
+#if NETSTANDARD2_1_OR_GREATER || NET
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            SerializeUInt64AsBase128(buffer, ref bufferIndex, (ulong)byteCount);
+            var lengthWritten = Encoding.UTF8.GetBytes(value, buffer.AsSpan(bufferIndex));
+            bufferIndex += lengthWritten;
+#else
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            SerializeUInt64AsBase128(buffer, ref bufferIndex, (ulong)byteCount);
+            var lengthWritten = Encoding.UTF8.GetBytes(value!, 0, value!.Length, buffer, bufferIndex);
+            bufferIndex += lengthWritten;
+#endif
         }
         else
         {

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/SerializationBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/SerializationBenchmarks.cs
@@ -40,6 +40,15 @@ public class SerializationBenchmarks
     private readonly EventBuilder eventBuilder = new(UncheckedASCIIEncoding.SharedInstance);
     private readonly byte[] buffer = new byte[65360];
 
+    private readonly object?[] httpUrlParts =
+    [
+        "https",                       // url.scheme
+        "example.contoso.com",         // server.address
+        "443",                         // server.port
+        "/api/v2/items/search",        // url.path
+        "?q=opentelemetry&limit=50",   // url.query
+    ];
+
     [Benchmark]
     public void TLD_SerializeUInt8()
     {
@@ -107,5 +116,34 @@ public class SerializationBenchmarks
     public void TLD_Reset()
     {
         this.eventBuilder.Reset("test");
+    }
+
+    [Benchmark]
+    public void Metric_SerializeBase128String()
+    {
+        // Mirrors one dimension (key + value) in the TLV metric path, where
+        // SerializeBase128String is called twice per dimension/exemplar-tag,
+        // per metric data point.
+        var index = 0;
+        MetricSerializer.SerializeBase128String(this.buffer, ref index, Key);
+        MetricSerializer.SerializeBase128String(this.buffer, ref index, Value);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void Trace_HttpUrl_Before()
+    {
+        // Original approach: GetHttpUrl composes the url via interpolated strings
+        // + StringBuilder + ToString(), then it is serialized into the buffer.
+        var cursor = MessagePackSerializer.SerializeAsciiString(this.buffer, 0, "httpUrl");
+        MessagePackSerializer.SerializeUnicodeString(this.buffer, cursor, MsgPackTraceExporter.GetHttpUrl(this.httpUrlParts));
+    }
+
+    [Benchmark]
+    public void Trace_HttpUrl_After()
+    {
+        // New approach: SerializeHttpUrl writes each segment directly into the
+        // buffer, avoiding the intermediate strings/StringBuilder allocations.
+        ushort cntFields = 0;
+        MsgPackTraceExporter.SerializeHttpUrl(this.buffer, 0, this.httpUrlParts, ref cntFields);
     }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TldSanitizationBenchmarks.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Benchmarks/Exporter/TldSanitizationBenchmarks.cs
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter.Geneva.Tld;
+using OpenTelemetry.Logs;
+
+namespace OpenTelemetry.Exporter.Geneva.Benchmarks;
+
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+
+// This benchmark isolates the cost of category-name handling in the TLD log
+// exporter when running in pass-through table-mapping mode ("*" -> "*").
+//
+// In that mode TldLogExporter calls GetSanitizedCategoryName(categoryName) for
+// every single log record. The method allocates a brand new string on each
+// call (Span<char>.Slice(...).ToString()). Because the set of logger category
+// names in a process is small and stable, the sanitized value could be cached
+// the way MsgPack's TableNameSerializer already does, turning a per-event
+// sanitize+allocate into a dictionary lookup.
+[MemoryDiagnoser]
+public class TldSanitizationBenchmarks
+{
+    private TldLogExporter passthroughExporter = null!;
+    private CategorySanitizerProbe sanitizerProbe = null!;
+    private LogRecord logRecord = null!;
+    private Batch<LogRecord> batch;
+
+    // "AlreadyNormalized" exercises the accelerated fast path that returns the
+    // category name verbatim. "NeedsNormalization" (contains '.') exercises the
+    // sanitize + copy-on-write cache path.
+    [Params("TestLogger", "TestCompany.TestNamespace.TestLogger")]
+    public string CategoryName { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // "*" -> "*" turns on shouldPassThruTableMappings, which is the path
+        // that sanitizes the category name on every record.
+        this.passthroughExporter = new TldLogExporter(new GenevaExporterOptions()
+        {
+            ConnectionString = "EtwSession=OpenTelemetry;PrivatePreviewEnableTraceLoggingDynamic=true",
+            TableNameMappings = new Dictionary<string, string>
+            {
+                ["*"] = "*",
+            },
+            PrepopulatedFields = new Dictionary<string, object>
+            {
+                ["cloud.role"] = "BusyWorker",
+                ["cloud.roleInstance"] = "CY1SCH030021417",
+                ["cloud.roleVer"] = "9.0.15289.2",
+            },
+        });
+
+        this.sanitizerProbe = new CategorySanitizerProbe(new GenevaExporterOptions()
+        {
+            ConnectionString = "EtwSession=OpenTelemetry;PrivatePreviewEnableTraceLoggingDynamic=true",
+            TableNameMappings = new Dictionary<string, string>
+            {
+                ["*"] = "*",
+            },
+        });
+
+        this.logRecord = GenerateTestLogRecord(this.CategoryName);
+        this.batch = GenerateTestLogRecordBatch(this.CategoryName);
+    }
+
+    // Isolates just the category-name handling (the rest of serialization adds
+    // ~350 ns of fixed cost that hides the difference at the end-to-end level).
+    [Benchmark]
+    public string TLD_GetSanitizedCategoryName()
+        => this.sanitizerProbe.Sanitize(this.CategoryName);
+
+    [Benchmark]
+    public void TLD_SerializeLogRecord_Passthrough()
+        => this.passthroughExporter.SerializeLogRecord(this.logRecord);
+
+    [Benchmark]
+    public void TLD_ExportLogRecord_Passthrough()
+        => this.passthroughExporter.Export(this.batch);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        this.batch.Dispose();
+        this.passthroughExporter.Dispose();
+        this.sanitizerProbe.Dispose();
+    }
+
+    private static LogRecord GenerateTestLogRecord(string categoryName)
+    {
+        var exportedItems = new List<LogRecord>(1);
+        using var factory = LoggerFactory.Create(builder => builder
+            .AddOpenTelemetry(loggerOptions =>
+            {
+                loggerOptions.AddInMemoryExporter(exportedItems);
+            }));
+
+        var logger = factory.CreateLogger(categoryName);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
+        return exportedItems[0];
+    }
+
+    private static Batch<LogRecord> GenerateTestLogRecordBatch(string categoryName)
+    {
+        var items = new List<LogRecord>(1);
+        using var batchGeneratorExporter = new BatchGeneratorExporter();
+        using var factory = LoggerFactory.Create(builder => builder
+            .AddOpenTelemetry(loggerOptions =>
+            {
+                loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(batchGeneratorExporter));
+            }));
+
+        var logger = factory.CreateLogger(categoryName);
+        logger.LogInformation("Hello from {Food} {Price}.", "artichoke", 3.99);
+        return batchGeneratorExporter.Batch;
+    }
+
+    private sealed class BatchGeneratorExporter : BaseExporter<LogRecord>
+    {
+        public Batch<LogRecord> Batch { get; set; }
+
+        public override ExportResult Export(in Batch<LogRecord> batch)
+        {
+            this.Batch = batch;
+            return ExportResult.Success;
+        }
+    }
+
+    // Minimal TldLogCommon subclass that exposes the protected sanitization entry
+    // point so the cache + fast-path can be benchmarked in isolation.
+    private sealed class CategorySanitizerProbe : TldLogCommon
+    {
+        public CategorySanitizerProbe(GenevaExporterOptions options)
+            : base(options)
+        {
+        }
+
+        public string Sanitize(string categoryName)
+            => this.GetSanitizedCategoryName(categoryName);
+    }
+}

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/MsgPackTraceExporterTests.cs
@@ -114,4 +114,58 @@ public class MsgPackTraceExporterTests
         var url = MsgPackTraceExporter.GetHttpUrl(arr);
         Assert.Null(url);
     }
+
+    [Fact]
+    public void SerializeHttpUrl_MatchesGetHttpUrlPlusSerializer_ByteForByte()
+    {
+        var count = MsgPackTraceExporter.CS40_PART_B_HTTPURL_MAPPING.Count;
+
+        object?[] Parts(object? scheme, object? address, object? port, object? path, object? query)
+        {
+            var arr = new object?[count];
+            arr[0] = scheme;
+            arr[1] = address;
+            arr[2] = port;
+            arr[3] = path;
+            arr[4] = query;
+            return arr;
+        }
+
+        var cases = new[]
+        {
+            Parts(null, null, null, null, null),                          // no parts => nothing written
+            Parts("http", "host", null, null, null),                      // scheme + address only
+            Parts("http", "host", "8080", "/x", "y=1"),                   // query without '?'
+            Parts("http", "host", "8080", "/x", "?y=1"),                  // query with leading '?'
+            Parts("http", "host", "8080", "/x", "?"),                     // query is just '?'
+            Parts("http", "host", "8080", "/x", string.Empty),           // empty query => omitted
+            Parts("http", "host", string.Empty, "/x", "a=b"),             // port "" (non-null) => ':' still emitted
+            Parts("http", "host", 8080, "/x", "a=b"),                     // numeric (boxed) port
+            Parts("https", "\u00FCn\u00EE\u00E7\u00F8d\u00E9.example", "443", "/p\u00E2th/\u00E7", "q=\u00FC"), // unicode
+            Parts(null, "host", null, "/p", null),                        // missing scheme
+            Parts("http", null, "80", null, null),                        // missing address/path
+            Parts("http", new string('a', 20000), null, null, null),      // > 16383 chars => truncation fallback path
+        };
+
+        foreach (var parts in cases)
+        {
+            var url = MsgPackTraceExporter.GetHttpUrl(parts);
+
+            var expected = new byte[65360];
+            var expectedCursor = 0;
+            if (url != null)
+            {
+                expectedCursor = MessagePackSerializer.SerializeAsciiString(expected, expectedCursor, "httpUrl");
+                expectedCursor = MessagePackSerializer.SerializeUnicodeString(expected, expectedCursor, url);
+            }
+
+            var actual = new byte[65360];
+            ushort cntFields = 0;
+            var actualCursor = MsgPackTraceExporter.SerializeHttpUrl(actual, 0, parts, ref cntFields);
+
+            Assert.Equal(expectedCursor, actualCursor);
+            Assert.Equal(url != null ? 1 : 0, cntFields);
+            Assert.Equal(expected.AsSpan(0, expectedCursor).ToArray(), actual.AsSpan(0, actualCursor).ToArray());
+        }
+    }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/TldLogCommonSanitizationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/TldLogCommonSanitizationTests.cs
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Exporter.Geneva.Tld;
+
+namespace OpenTelemetry.Exporter.Geneva.Tests;
+
+public class TldLogCommonSanitizationTests
+{
+    // categoryName -> expected sanitized event name:
+    //  - lower-case first character is upper-cased,
+    //  - non-alphanumeric characters are stripped,
+    //  - a non-letter first character yields an empty name.
+    [Theory]
+    [InlineData("testLogger", "TestLogger")]
+    [InlineData("TestCompany.TestNamespace.TestLogger", "TestCompanyTestNamespaceTestLogger")]
+    [InlineData("Foo-Bar_Baz 123", "FooBarBaz123")]
+    [InlineData("123abc", "")]
+    [InlineData("_invalid", "")]
+    [InlineData(".dotted", "")]
+    public void GetSanitizedCategoryName_SanitizesAsExpected(string categoryName, string expected)
+    {
+        using var probe = CreateProbe();
+
+        Assert.Equal(expected, probe.Sanitize(categoryName));
+    }
+
+    // Already-valid names (start with an upper-case letter, alphanumeric only,
+    // <= 50 chars) take the allocation-free fast path and are returned verbatim.
+    [Theory]
+    [InlineData("TestLogger")]
+    [InlineData("ABC123")]
+    [InlineData("A")]
+    public void GetSanitizedCategoryName_AlreadyValid_ReturnsSameReference(string categoryName)
+    {
+        using var probe = CreateProbe();
+
+        var result = probe.Sanitize(categoryName);
+
+        Assert.Same(categoryName, result);
+    }
+
+    [Fact]
+    public void GetSanitizedCategoryName_TruncatesToMaxLength()
+    {
+        using var probe = CreateProbe();
+
+        // 60 characters, with a lower-case leading char that forces the slower
+        // sanitize path (and is itself up-cased).
+        var categoryName = "a" + new string('b', 59);
+        var expected = "A" + new string('b', 49); // 50 characters total.
+
+        var result = probe.Sanitize(categoryName);
+
+        Assert.Equal(50, result.Length);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetSanitizedCategoryName_ExactlyMaxLengthValidName_ReturnsSameReference()
+    {
+        using var probe = CreateProbe();
+
+        var categoryName = "A" + new string('B', 49); // 50 characters, all valid.
+
+        var result = probe.Sanitize(categoryName);
+
+        Assert.Same(categoryName, result);
+    }
+
+    [Fact]
+    public void GetSanitizedCategoryName_CachesSanitizedResult()
+    {
+        using var probe = CreateProbe();
+
+        const string categoryName = "Test.Namespace.Logger";
+
+        var first = probe.Sanitize(categoryName);
+        var second = probe.Sanitize(categoryName);
+
+        Assert.Equal("TestNamespaceLogger", first);
+
+        // The second lookup must hit the cache and return the very same string
+        // instance produced by the first call rather than re-sanitizing.
+        Assert.Same(first, second);
+    }
+
+    private static CategorySanitizerProbe CreateProbe()
+    {
+        return new CategorySanitizerProbe(new GenevaExporterOptions
+        {
+            ConnectionString = "EtwSession=OpenTelemetry;PrivatePreviewEnableTraceLoggingDynamic=true",
+            TableNameMappings = new Dictionary<string, string>
+            {
+                ["*"] = "*",
+            },
+        });
+    }
+
+    // Minimal TldLogCommon subclass that exposes the protected sanitization entry
+    // point so the cache + fast-path can be exercised in isolation, independent of
+    // the platform-specific TLD transport.
+    private sealed class CategorySanitizerProbe : TldLogCommon
+    {
+        public CategorySanitizerProbe(GenevaExporterOptions options)
+            : base(options)
+        {
+        }
+
+        public string Sanitize(string categoryName)
+            => this.GetSanitizedCategoryName(categoryName);
+    }
+}


### PR DESCRIPTION
## Changes

Cut hot-path allocations in the Geneva exporter:

* Cache sanitized logger category names with a lock-free copy-on-write (CAS) cache, plus an accelerated fast path that returns the original string when it is already a valid event name. The cache snapshot is a FrozenDictionary on .NET 8+ and a Dictionary elsewhere.
* MetricSerializer.SerializeBase128String now writes UTF-8 directly into the buffer via GetByteCount/GetBytes instead of allocating a temp byte[] and copying.
* MsgPackTraceExporter.SerializeHttpUrl writes the composed HTTP url segments straight into the msgpack buffer (back-patching the STR16 header) instead of building interpolated strings + StringBuilder; the rare >16383-char case still delegates to GetHttpUrl for byte-identical truncation.

Adds byte-for-byte equivalence tests for SerializeHttpUrl and before/after allocation benchmarks for each optimization.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
