### PR TITLE
[Instrumentation.AspNetCore] Fix missing grpc.method tag when empty tracestate header is present

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -113,7 +113,7 @@ internal class HttpInListener : ListenerHandler
             if (ctx.ActivityContext.IsValid()
                 && !((ctx.ActivityContext.TraceId == activity.TraceId)
                     && (ctx.ActivityContext.SpanId == activity.ParentSpanId)
-                    && (ctx.ActivityContext.TraceState == activity.TraceStateString)))
+                    && ((ctx.ActivityContext.TraceState ?? string.Empty) == (activity.TraceStateString ?? string.Empty))))
             {
                 // Create a new activity with its parent set from the extracted context.
                 // This makes the new activity as a "sibling" of the activity created by


### PR DESCRIPTION
Fixes #4501

## Changes

Normalize `null` and empty string `TraceState` comparison in `HttpInListener.OnStartActivity` to prevent sibling activity creation when an empty `tracestate:` header is present.

The .NET runtime's `W3CPropagator` sets `activity.TraceStateString = null` for an empty tracestate header, while OpenTelemetry's `CompositeTextMapPropagator` extracts `TraceState = ""`. Both represent absent tracestate but`==` comparison treats them as different, triggering unnecessary sibling activity creation. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)