### PR TITLE
[ServiceFabricRemoting] Bump Service Fabric dependencies to 8.4.268

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,8 +84,8 @@
     <PackageVersion Include="Confluent.Kafka" Version="[2.4.0,)" />
     <PackageVersion Include="Grpc.Core.Api" Version="[2.46.6,)" />
     <PackageVersion Include="InfluxDB.Client" Version="[4.18.0,)" />
-    <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="[7.1.2448,)" />
-    <PackageVersion Include="Microsoft.ServiceFabric.Services.Remoting" Version="[7.1.2448,)" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="[8.4.268,)" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Services.Remoting" Version="[8.4.268,)" />
     <PackageVersion Include="Quartz" Version="[3.6.3,)" />
     <PackageVersion Include="StackExchange.Redis" Version="[2.6.122,)" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Raised the minimum required version of `Microsoft.ServiceFabric.Actors` and
   `Microsoft.ServiceFabric.Services.Remoting` from `7.1.2448` to `8.4.268`, as the
   `7.1` Service Fabric runtime is going out of support.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#4510](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4510))
 
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))

--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Raised the minimum required version of `Microsoft.ServiceFabric.Actors` and
+  `Microsoft.ServiceFabric.Services.Remoting` from `7.1.2448` to `8.4.268`, as the
+  `7.1` Service Fabric runtime is going out of support.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 

--- a/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/App.config
+++ b/test/OpenTelemetry.Instrumentation.ServiceFabricRemoting.Tests/App.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <!--
+        Service Fabric runtime assembly. ServiceFabric.Mocks and the Microsoft.ServiceFabric.*
+        packages are built against different System.Fabric versions, so an explicit redirect is
+        required for the mock state providers/managers to type-load correctly on .NET Framework.
+        Only relevant for the net462 target; binding redirects are ignored on .NET Core/5+.
+      -->
+      <dependentAssembly>
+        <assemblyIdentity name="System.Fabric" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Fixes #

## Changes

Raises the minimum required version of `Microsoft.ServiceFabric.Actors` and
`Microsoft.ServiceFabric.Services.Remoting` from `7.1.2448` to `8.4.268`. The
Service Fabric `7.1` runtime is going out of support, so the library should
floor at a supported runtime version.

The library's remoting adapter surface (`IServiceRemotingClient`,
`IServiceRemotingClientFactory`, `IServiceRemotingMessageDispatcher`, etc.) is
unchanged between 7.1 and 8.4 and recompiles cleanly.

Also adds an explicit `System.Fabric` binding redirect to the test project's
`App.config`. With the old `7.1` floor, MSBuild auto-generated this redirect to
resolve a version conflict between `ServiceFabric.Mocks` and the
`Microsoft.ServiceFabric.*` packages. The `8.4` floor removes that conflict (and
therefore the auto-generated redirect), which exposed a latent
`TypeLoadException` in the `ServiceFabric.Mocks` state provider/manager on the
`net462` target. Declaring the redirect explicitly makes the tests
deterministic regardless of the resolved package graph. The redirect is ignored
on the `net8.0`/`net9.0`/`net10.0` targets.

Validated: all four target frameworks (`net462`, `net8.0`, `net9.0`,
`net10.0`) build clean and pass 6/6 tests.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated (n/a - no behavior change; existing tests pass)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (n/a - no public API change)
