### PR TITLE
[Redis] Update semantic conventions to 1.42.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -9,7 +9,7 @@
   `OTEL_SEMCONV_STABILITY_OPT_IN` is set to `database` or `database/dup` to
   [v1.42.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/db/database-spans.md)
   of the Semantic Conventions for Database Client Calls.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4519](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4519))
 
 ## 1.15.1-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Updated the new database semantic conventions emitted when
+  `OTEL_SEMCONV_STABILITY_OPT_IN` is set to `database` or `database/dup` to
+  [v1.42.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/db/database-spans.md)
+  of the Semantic Conventions for Database Client Calls.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.2
 
 Released 2026-May-27

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -123,11 +123,11 @@ internal static class RedisProfilerEntryToActivityConverter
 
         if (activity.IsAllDataRequested)
         {
-            // see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md
+            // See https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/db/database-spans.md
 
             // Timing example:
-            // command.CommandCreated; //2019-01-10 22:18:28Z
 
+            // command.CommandCreated;          // 2019-01-10 22:18:28Z
             // command.CreationToEnqueued;      // 00:00:32.4571995
             // command.EnqueuedToSending;       // 00:00:00.0352838
             // command.SentToResponse;          // 00:00:00.0060586

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
@@ -17,7 +17,7 @@ and collects traces about outgoing calls to Redis.
 
 > [!NOTE]
 > This component is based on the OpenTelemetry semantic conventions for
-[traces](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/redis.md).
+[traces](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/db/redis.md).
 These conventions are
 [Experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md),
 and hence, this package is a [pre-release](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#pre-releases).

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -21,7 +21,7 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
     internal static readonly Version SemanticConventionsVersion = new(1, 23, 0);
     internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(SemanticConventionsVersion);
 
-    internal static readonly Version SemanticConventionsVersionNew = new(1, 28, 0);
+    internal static readonly Version SemanticConventionsVersionNew = new(1, 42, 0);
     internal static readonly ActivitySource ActivitySourceNew = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(SemanticConventionsVersionNew);
 
     internal static readonly ActivitySource ActivitySourceBoth = ActivitySourceFactory.Create<StackExchangeRedisConnectionInstrumentation>(null);

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -164,7 +164,7 @@ public class StackExchangeRedisCallsInstrumentationTests(RedisXunitFixture fixtu
 
         var expectedSchemaUrl = (emitOldAttributes, emitNewAttributes) switch
         {
-            (false, true) => "https://opentelemetry.io/schemas/1.28.0",
+            (false, true) => "https://opentelemetry.io/schemas/1.42.0",
             (true, false) => "https://opentelemetry.io/schemas/1.23.0",
             _ => null,
         };


### PR DESCRIPTION
## Changes

Update semantic conventions version when the opt-in is enabled to v1.42.0 and update some out-of-date links.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
