### PR TITLE
[infra] Avoid NuGet API keys in process arguments

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -180,11 +180,11 @@ jobs:
         working-directory: ./artifacts/package/release
         env:
           MYGET_TOKEN_EXISTS: ${{ secrets.MYGET_TOKEN != '' }}
-          API_KEY: ${{ secrets.MYGET_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.MYGET_TOKEN }}
           SOURCE: https://www.myget.org/F/opentelemetry/api/v3/index.json
         if: env.MYGET_TOKEN_EXISTS == 'true' # Skip MyGet publish if run on a fork without the secret
         shell: pwsh
-        run: dotnet nuget push *.nupkg --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
+        run: dotnet nuget push *.nupkg --skip-duplicate --source ${env:SOURCE}
 
       - name: NuGet log in
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
@@ -199,11 +199,11 @@ jobs:
         working-directory: ./artifacts/package/release
         env:
           NUGET_TOKEN_EXISTS: ${{ steps.nuget-login.outputs.NUGET_API_KEY != '' }}
-          API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
           SOURCE: https://api.nuget.org/v3/index.json
         if: github.ref_type == 'tag' && env.NUGET_TOKEN_EXISTS == 'true' # Skip NuGet publish for scheduled nightly builds or if run on a fork without the secret
         shell: pwsh
-        run: dotnet nuget push *.nupkg --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
+        run: dotnet nuget push *.nupkg --skip-duplicate --source ${env:SOURCE}
 
   post-build:
     name: Post build release tasks


### PR DESCRIPTION
## Changes

This PR updates package publishing in `.github/workflows/publish-packages.yml` so NuGet API keys are no longer passed as command-line arguments to `dotnet nuget push`.

The MyGet and NuGet.org publish steps now provide the key through the `NUGET_API_KEY` environment variable and invoke `dotnet nuget push` without `--api-key`. This follows the NuGet CLI environment variable documentation, which describes `NUGET_API_KEY` as the API key used when pushing packages: https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables

This reduces exposure of publishing secrets through process command-line arguments while keeping the keys scoped to the individual publish steps.

Not tested in the wild, but based on the description it should be fine. In case of any issues, we can restore previous behavior. When tested, we can propagate to the sdk repo.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
