### PR TITLE
[EFCore] Fix test flakiness

### DIFF
--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Changes

Avoid [flaky EFCore tests](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/27744673048/job/82080005392) from concurrent activity listeners by disabling tests in the same collection from running in parallel with each other like we already do with AWS and ASP.NET.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
