### PR TITLE
[Infra] Fix hanging benchmarks

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -301,7 +301,8 @@ try {
             "--"
         ) + $additionalArgs
 
-        $p = Start-Process -FilePath "dotnet" -ArgumentList $dotnetArgs -NoNewWindow -Wait -PassThru
+        $p = Start-Process -FilePath "dotnet" -ArgumentList $dotnetArgs -NoNewWindow -PassThru
+        $p.WaitForExit()
 
         if ($p.ExitCode -ne 0) {
             throw "Benchmarks failed with exit code $($p.ExitCode)."


### PR DESCRIPTION
## Changes

If dotnet spawned any reusable MSBuild servers when invoked the script would hang due to the still running child processes. Instead, just wait for dotnet itself to exit rather than the whole process tree.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
