### PR TITLE
[OneCollector.Tests] Use fake endpoint for OneCollector PR tests

### DIFF
--- a/.github/workflows/ci-Exporter.OneCollector-Integration.yml
+++ b/.github/workflows/ci-Exporter.OneCollector-Integration.yml
@@ -1,34 +1,17 @@
-name: Integration Build OpenTelemetry.Exporter.OneCollector
+name: Live Integration Build OpenTelemetry.Exporter.OneCollector
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers] Code is gated on maintainer approval for forks
-    branches: [ 'main*', 'exporter*' ]
-    paths:
-    - '*/OpenTelemetry.Exporter.OneCollector*/**'
-    - 'src/Shared/**'
-    - 'build/**'
-    - '!**.md'
+  workflow_dispatch:
 
 jobs:
-  authorize:
-    name: Authorize external PR
-    environment: # Run external PRs from forks on the "external" environment which requires approval
-      ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      'external' || 'internal' }}
-    runs-on: ubuntu-24.04
-    steps:
-    - run: echo ✓
-
-  build-integration-test:
-    needs: authorize
+  build-live-integration-test:
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +31,5 @@ jobs:
       version: ${{ matrix.version }}
       test-filter: OneCollectorIntegrationTests
       env-var-name: OTEL_ONECOLLECTOR_INSTRUMENTATION_KEY
-      checkout-ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
     secrets:
       instrumentation-key: ${{ secrets.OTEL_ONECOLLECTOR_INSTRUMENTATION_KEY }}

--- a/.github/workflows/integration-test-reusable.yml
+++ b/.github/workflows/integration-test-reusable.yml
@@ -31,11 +31,6 @@ on:
         required: false
         type: string
         default: 'INSTRUMENTATION_KEY'
-      checkout-ref:
-        description: 'Git ref to checkout'
-        required: false
-        type: string
-        default: ''
     secrets:
       instrumentation-key:
         description: 'Instrumentation key for testing'
@@ -48,15 +43,10 @@ jobs:
     env:
       BUILD_COMPONENT: ${{ inputs.component }}
     steps:
-    # Security: When called from pull_request_target with untrusted PR code,
-    # this checkout requires prior approval via the 'authorize' job environment.
-    # The workflow has limited permissions (contents: read) and uses persist-credentials: false
-    # to prevent credential theft.
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
-        ref: ${{ inputs.checkout-ref }}
         show-progress: false
 
     - name: Setup .NET

--- a/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OneCollector.Tests/OneCollectorIntegrationTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.IO.Compression;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -23,7 +25,7 @@ public class OneCollectorIntegrationTests
         this.testOutputHelper = output;
     }
 
-    [SkipUnlessEnvVarFoundFact(OneCollectorInstrumentationKeyEnvName)]
+    [Fact]
     public void LogWithEventIdAndNameIntegrationTest()
     {
         this.RunIntegrationTest(
@@ -54,7 +56,7 @@ public class OneCollectorIntegrationTests
             });
     }
 
-    [SkipUnlessEnvVarFoundFact(OneCollectorInstrumentationKeyEnvName)]
+    [Fact]
     public void LogWithEventNameOnlyIntegrationTest()
     {
         this.RunIntegrationTest(
@@ -85,7 +87,7 @@ public class OneCollectorIntegrationTests
             });
     }
 
-    [SkipUnlessEnvVarFoundFact(OneCollectorInstrumentationKeyEnvName)]
+    [Fact]
     public void LogWithDataIntegrationTest()
     {
 #pragma warning disable CA1873 // Avoid potentially expensive logging
@@ -113,7 +115,7 @@ public class OneCollectorIntegrationTests
             });
     }
 
-    [SkipUnlessEnvVarFoundTheory(OneCollectorInstrumentationKeyEnvName)]
+    [Theory]
     [InlineData(false)]
     [InlineData(true)]
     public void LogWithExceptionIntegrationTest(bool includeStackTrace)
@@ -172,7 +174,7 @@ public class OneCollectorIntegrationTests
             });
     }
 
-    [SkipUnlessEnvVarFoundFact(OneCollectorInstrumentationKeyEnvName)]
+    [Fact]
     public void LogWithActivityIntegrationTest()
     {
         using var activity = new Activity("TestOperation");
@@ -262,25 +264,45 @@ public class OneCollectorIntegrationTests
     {
         var innerSucceeded = false;
         string? innerActualJson = null;
+        var instrumentationKey = Environment.GetEnvironmentVariable(OneCollectorInstrumentationKeyEnvName);
+        FakeOneCollectorEndpoint? fakeEndpoint = null;
 
-        using (var loggerFactory = LoggerFactory.Create(logging => logging
-            .AddOpenTelemetry(options =>
-            {
-                options
-                    .SetResourceBuilder(ResourceBuilder.CreateEmpty())
-                    .AddOneCollectorExporter(builder =>
-                    {
-                        builder.SetConnectionString($"InstrumentationKey={Environment.GetEnvironmentVariable(OneCollectorInstrumentationKeyEnvName)}");
-
-                        builder.ConfigureExporter(e => e.RegisterPayloadTransmittedCallback(OneCollectorExporterPayloadTransmittedCallbackAction, includeFailures: true));
-
-                        configureBuilderAction?.Invoke(builder);
-                    });
-
-                configureOptionsAction?.Invoke(options);
-            })))
+        if (string.IsNullOrWhiteSpace(instrumentationKey))
         {
+            instrumentationKey = "test-token";
+            fakeEndpoint = new();
+        }
+
+        try
+        {
+            using var loggerFactory = LoggerFactory.Create(logging => logging
+                .AddOpenTelemetry(options =>
+                {
+                    options
+                        .SetResourceBuilder(ResourceBuilder.CreateEmpty())
+                        .AddOneCollectorExporter(builder =>
+                        {
+                            builder.SetConnectionString($"InstrumentationKey={instrumentationKey}");
+
+                            if (fakeEndpoint != null)
+                            {
+                                var endpoint = fakeEndpoint.Endpoint;
+                                builder.ConfigureTransportOptions(options => options.Endpoint = endpoint);
+                            }
+
+                            builder.ConfigureExporter(e => e.RegisterPayloadTransmittedCallback(OneCollectorExporterPayloadTransmittedCallbackAction, includeFailures: true));
+
+                            configureBuilderAction?.Invoke(builder);
+                        });
+
+                    configureOptionsAction?.Invoke(options);
+                }));
+
             testAction(loggerFactory.CreateLogger(nameof(OneCollectorIntegrationTests)));
+        }
+        finally
+        {
+            fakeEndpoint?.Dispose();
         }
 
         succeeded = innerSucceeded;
@@ -295,6 +317,56 @@ public class OneCollectorIntegrationTests
             using var memoryStream = new MemoryStream();
             args.CopyPayloadToStream(memoryStream);
             innerActualJson = Encoding.UTF8.GetString(memoryStream.ToArray());
+        }
+    }
+
+    private sealed class FakeOneCollectorEndpoint : IDisposable
+    {
+        private readonly IDisposable server;
+
+        public FakeOneCollectorEndpoint()
+        {
+            this.server = TestHttpServer.RunServer(this.HandleRequest, out var endpoint);
+            this.Endpoint = endpoint;
+        }
+
+        public Uri Endpoint { get; }
+
+        public void Dispose() => this.server.Dispose();
+
+        private static int GetResponseStatusCode(string requestPayload)
+        {
+            using var document = JsonDocument.Parse(requestPayload);
+
+            return document.RootElement.TryGetProperty("ext", out var extensions)
+                && extensions.TryGetProperty("ex", out _)
+                ? 400
+                : 200;
+        }
+
+        private static string ReadRequestPayload(HttpListenerRequest request)
+        {
+            using var requestBody = new MemoryStream();
+
+            request.InputStream.CopyTo(requestBody);
+            requestBody.Position = 0;
+
+            if (string.Equals(request.Headers["Content-Encoding"], "deflate", StringComparison.OrdinalIgnoreCase))
+            {
+                using var deflateStream = new DeflateStream(requestBody, CompressionMode.Decompress);
+                using var reader = new StreamReader(deflateStream, Encoding.UTF8);
+
+                return reader.ReadToEnd();
+            }
+
+            return Encoding.UTF8.GetString(requestBody.ToArray());
+        }
+
+        private void HandleRequest(HttpListenerContext context)
+        {
+            var requestPayload = ReadRequestPayload(context.Request);
+
+            context.Response.StatusCode = GetResponseStatusCode(requestPayload);
         }
     }
 }


### PR DESCRIPTION
## Changes

> [!IMPORTANT]
> With this changes we lose possibility to execute integration tests before merge, but the projects seems to be stable right now. Manual execution is possible after merge


This PR removes the unsafe `pull_request_target` OneCollector integration workflow path that checked out PR code while exposing live backend secrets.

OneCollector integration tests now run by default against an in-process fake OneCollector endpoint, so they can execute safely as part of normal PR CI through `build-test-exporter-onecollector` in `ci.yml`.

The dedicated OneCollector integration workflow is now manual-only via `workflow_dispatch` and is retained for live backend validation. When `OTEL_ONECOLLECTOR_INSTRUMENTATION_KEY` is provided, the same tests use the real OneCollector backend; otherwise they use the fake endpoint.

## Why

* actions/checkout@7+ blocks possibility to checkout code by default for such scenarios, ref: https://github.com/actions/checkout/pull/2454 - not tested this TBH
* Make the zizmor analysis happy
* Make at least one other tool I have marked it manually that it is exactly as safe as merging it first, I do not remember exact name.
* Already received _security_ message that it is not safe, even if it is safe. I do not want to handle this more time.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
~~* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
~~* [ ] Changes in public API reviewed (if applicable)~~