### PR TITLE
[Infra] .NET 11 preparation

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -74,6 +74,12 @@ jobs:
         persist-credentials: false
         show-progress: false
 
+    - name: Get Git commit timestamp
+      id: get-commit-timestamp
+      shell: pwsh
+      run: |
+        "epoch=$(git log -1 --pretty=%ct)" >> ${env:GITHUB_OUTPUT}
+
     - name: Resolve project
       id: resolve-project
       shell: pwsh
@@ -183,6 +189,7 @@ jobs:
       shell: pwsh
       env:
         PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
+        SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.epoch }}
 
     - name: Install dotnet-coverage
       if: inputs.run-tests

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -55,6 +55,12 @@ jobs:
           persist-credentials: false
           show-progress: false
 
+      - name: Get Git commit timestamp
+        id: get-commit-timestamp
+        shell: pwsh
+        run: |
+          "epoch=$(git log -1 --pretty=%ct)" >> ${env:GITHUB_OUTPUT}
+
       - name: Resolve project
         id: resolve-project
         shell: pwsh
@@ -115,6 +121,8 @@ jobs:
       - name: dotnet pack ${{ steps.resolve-project.outputs.title }}
         shell: pwsh
         run: dotnet pack ${env:PROJECT_PATH} --configuration Release --no-restore --no-build  -p:"PackTag=${env:TAG}"
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.epoch }}
 
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/examples/InfluxDB/Examples.InfluxDB/Program.cs
+++ b/examples/InfluxDB/Examples.InfluxDB/Program.cs
@@ -6,13 +6,8 @@ using OpenTelemetry.Exporter.InfluxDB;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 
-Action<ResourceBuilder> configureResource = r => r.AddService(
-    serviceName: "influx-exporter-test",
-    serviceVersion: typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown",
-    serviceInstanceId: Environment.MachineName);
-
 using var meterProvider = Sdk.CreateMeterProviderBuilder()
-    .ConfigureResource(configureResource)
+    .ConfigureResource(ConfigureResource)
     .AddRuntimeInstrumentation()
     .AddInfluxDBMetricsExporter(options =>
     {
@@ -27,3 +22,11 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
 meterProvider.ForceFlush();
 
 await Task.Delay(TimeSpan.FromSeconds(10));
+
+static void ConfigureResource(ResourceBuilder builder)
+{
+    builder.AddService(
+        serviceName: "influx-exporter-test",
+        serviceVersion: typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown",
+        serviceInstanceId: Environment.MachineName);
+}

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializationState.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/Serialization/CommonSchemaJsonSerializationState.cs
@@ -46,7 +46,9 @@ internal sealed class CommonSchemaJsonSerializationState
         Debug.Assert(fieldInformation?.FieldName != null, "fieldInformation.FieldName was null");
         Debug.Assert(fieldInformation?.EncodedFieldName.EncodedUtf8Bytes.Length > 0, "fieldInformation.EncodedFieldName was empty");
 
+#pragma warning disable IDE0370 // Remove unnecessary suppression
         var extensionName = fieldInformation!.ExtensionName!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
 #if NET
         ref var lookupIndexRef = ref CollectionsMarshal.GetValueRefOrAddDefault(this.keys, extensionName, out var existed);

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineHandler.cs
@@ -248,7 +248,11 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
 
             if (topicArn is string arn && TryGetLastSplitItem(arn, ':', out var topicName))
             {
+#if NET
+                this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingDestinationName(activity, topicName);
+#else
                 this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingDestinationName(activity, topicName!);
+#endif
             }
 
             var operationName = AWSServiceHelper.GetAWSOperationName(requestContext);
@@ -273,7 +277,11 @@ internal sealed class AWSTracingPipelineHandler : PipelineHandler
 
                 if (uri.GetLeftPart(UriPartial.Path) is { Length: > 0 } path && TryGetLastSplitItem(path, '/', out var queueName))
                 {
+#if NET
+                    this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingDestinationName(activity, queueName);
+#else
                     this.awsSemanticConventions.TagBuilder.SetTagAttributeMessagingDestinationName(activity, queueName!);
+#endif
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/HttpContextExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/HttpContextExtensions.cs
@@ -21,7 +21,6 @@ internal static class HttpContextExtensions
         var endpoint = GetOriginalEndpoint(context);
         var route = endpoint?.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route;
 
-#if !NET11_0_OR_GREATER
         if (string.IsNullOrEmpty(route))
         {
             // For Razor Pages, the route template may be empty (e.g., for the Index page mapped to root "/").
@@ -32,7 +31,6 @@ internal static class HttpContextExtensions
                 return pageValue;
             }
         }
-#endif
 
         return route is not null ? ResolveHttpRoute(route) : null;
     }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -112,6 +112,14 @@ internal class HttpInListener : ListenerHandler
             return;
         }
 
+        string? path = null;
+
+        // Tracks whether the instrumentation created a sibling Activity. When it does,
+        // ASP.NET Core 11+ writes its native OpenTelemetry tags to the framework Activity
+        // (which is no longer sampled) rather than to the exported sibling, so the
+        // instrumentation must set those tags itself instead of deferring to the framework.
+        var createdSibling = false;
+
         // Ensure context extraction irrespective of sampling decision
         var request = context.Request;
         var textMapPropagator = Propagators.DefaultTextMapPropagator;
@@ -157,6 +165,7 @@ internal class HttpInListener : ListenerHandler
                 // Set IsAllDataRequested to false for the activity created by the framework to only export the sibling activity and not the framework activity
                 activity.IsAllDataRequested = false;
                 activity = newOne;
+                createdSibling = true;
             }
 
             Baggage.Current = ctx.Baggage;
@@ -197,12 +206,19 @@ internal class HttpInListener : ListenerHandler
                 ActivityInstrumentationHelper.SetKindProperty(activity, ActivityKind.Server);
             }
 
+            // ASP.NET Core does not support OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS so we
+            // still need to set the display name and HTTP method tag so that any override
+            // by the user is honoured. See https://github.com/dotnet/aspnetcore/issues/65873.
+            TelemetryHelper.RequestDataHelper.SetActivityDisplayName(activity, request.Method);
+
             // ASP.NET Core 10 does not support OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS so we
             // still need to set the HTTP method tag so that any override by the user is honoured.
             // See https://github.com/dotnet/aspnetcore/issues/65873.
             TelemetryHelper.RequestDataHelper.SetActivityDisplayNameAndHttpMethodTag(activity, request.Method);
 
-            if (!Net10OrGreater || !this.nativeAspNetCoreOpenTelemetryEnabled)
+            // When a sibling Activity was created the framework's native tags land on the
+            // (now unsampled) framework Activity, so set them here on the exported sibling.
+            if (!Net10OrGreater || !this.nativeAspNetCoreOpenTelemetryEnabled || createdSibling)
             {
                 if (request.Host.HasValue)
                 {
@@ -225,9 +241,7 @@ internal class HttpInListener : ListenerHandler
 
                 activity.SetTag(SemanticConventions.AttributeUrlScheme, request.Scheme);
 
-                // See the spec: https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/http/http-spans.md
-                var path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
-                activity.SetTag(SemanticConventions.AttributeUrlPath, path);
+                SetUrlPathAttribute(request, activity);
             }
 
             if (request.QueryString.HasValue)
@@ -256,6 +270,13 @@ internal class HttpInListener : ListenerHandler
                 }
             }
         }
+
+        void SetUrlPathAttribute(HttpRequest request, Activity activity)
+        {
+            // See the spec: https://github.com/open-telemetry/semantic-conventions/blob/v1.40.0/docs/http/http-spans.md
+            path ??= (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
+            activity.SetTag(SemanticConventions.AttributeUrlPath, path);
+        }
     }
 
     public void OnStopActivity(Activity activity, object? payload)
@@ -269,17 +290,32 @@ internal class HttpInListener : ListenerHandler
             }
 
             var response = context.Response;
+            var statusCodeSet = false;
 
-#if !NETSTANDARD
-            var routePattern = context.GetHttpRoute();
-            if (!string.IsNullOrEmpty(routePattern))
+            // When the instrumentation created a sibling Activity, ASP.NET Core 11+ wrote its
+            // native tags (route, display name, status code) to the unsampled framework Activity,
+            // so the instrumentation must set them on the exported sibling instead.
+            var createdSibling = ReferenceEquals(activity.GetCustomProperty(CreatedByInstrumentationPropertyName), CreatedByInstrumentationMarker);
+
+            if (!Net11OrGreater || !this.nativeAspNetCoreOpenTelemetryEnabled || createdSibling)
             {
-                TelemetryHelper.RequestDataHelper.SetActivityDisplayName(activity, context.Request.Method, routePattern);
-                activity.SetTag(SemanticConventions.AttributeHttpRoute, routePattern);
-            }
+#if NET
+                var routePattern = context.GetHttpRoute();
+                if (!string.IsNullOrEmpty(routePattern))
+                {
+                    TelemetryHelper.RequestDataHelper.SetActivityDisplayName(activity, context.Request.Method, routePattern);
+                    activity.SetTag(SemanticConventions.AttributeHttpRoute, routePattern);
+                }
 #endif
 
-            activity.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode));
+                activity.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode));
+                statusCodeSet = true;
+
+                if (activity.Status == ActivityStatusCode.Unset)
+                {
+                    activity.SetStatus(SpanHelper.ResolveActivityStatusForHttpStatusCode(activity.Kind, response.StatusCode));
+                }
+            }
 
             // If the instrumentation created a sibling Activity, the gRPC .NET library may
             // have added its grpc.* tags to the original (framework) Activity instead of to
@@ -314,12 +350,20 @@ internal class HttpInListener : ListenerHandler
                     }
                 }
 
-                AddGrpcAttributes(
-                    activity,
-                    grpcMethod,
-                    context,
-                    grpcStatusCode,
-                    hasGrpcStatusCode);
+                if (grpcMethod is { Length: > 0 })
+                {
+                    if (!statusCodeSet)
+                    {
+                        activity.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode));
+                    }
+
+                    AddGrpcAttributes(
+                        activity,
+                        grpcMethod,
+                        context,
+                        grpcStatusCode,
+                        hasGrpcStatusCode);
+                }
             }
 
             if (activity.Status == ActivityStatusCode.Unset)

--- a/test/OpenTelemetry.OpAmp.Client.Tests/DataGenerators/FrameBuilderTestData.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/DataGenerators/FrameBuilderTestData.cs
@@ -21,8 +21,8 @@ internal class FrameBuilderTestData
 
         this.Add(fb => fb.AddCapabilities(), m => m.Capabilities);
 
-        this.Add(fb => fb.AddRemoteConfigStatus(new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, RemoteConfigStatusCode.Applied)), m => m.RemoteConfigStatus);
-        this.Add(fb => fb.AddRemoteConfigStatus(new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, RemoteConfigStatusCode.Applying)), m => m.RemoteConfigStatus);
-        this.Add(fb => fb.AddRemoteConfigStatus(new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, RemoteConfigStatusCode.Unset)), m => m.RemoteConfigStatus);
+        this.Add(fb => fb.AddRemoteConfigStatus(new RemoteConfigStatusReport([1, 2, 3], RemoteConfigStatusCode.Applied)), m => m.RemoteConfigStatus);
+        this.Add(fb => fb.AddRemoteConfigStatus(new RemoteConfigStatusReport([1, 2, 3], RemoteConfigStatusCode.Applying)), m => m.RemoteConfigStatus);
+        this.Add(fb => fb.AddRemoteConfigStatus(new RemoteConfigStatusReport([1, 2, 3], RemoteConfigStatusCode.Unset)), m => m.RemoteConfigStatus);
     }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -25,7 +25,7 @@ public class OpAmpClientTests
         using var listener = new MockListener();
         var client = new OpAmpClient(o => o.Heartbeat.IsEnabled = false);
         var configFile = new EffectiveConfigFile(Encoding.UTF8.GetBytes("test"), "plain/text", "config.txt");
-        var remoteConfigStatus = new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, RemoteConfigStatusCode.Applied);
+        var remoteConfigStatus = new RemoteConfigStatusReport([1, 2, 3], RemoteConfigStatusCode.Applied);
 
         client.Dispose();
 
@@ -326,7 +326,7 @@ public class OpAmpClientTests
     internal async Task SendsRemoteConfigStatus_IsDisabledAndThrows()
     {
         using var client = new OpAmpClient(o => o.Heartbeat.IsEnabled = false);
-        var statusReport = new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, RemoteConfigStatusCode.Applied);
+        var statusReport = new RemoteConfigStatusReport([1, 2, 3], RemoteConfigStatusCode.Applied);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendRemoteConfigStatusAsync(statusReport));
     }
@@ -344,13 +344,13 @@ public class OpAmpClientTests
         });
 
         await client.StartAsync();
-        await client.SendRemoteConfigStatusAsync(new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, RemoteConfigStatusCode.Failed, "apply failed"));
+        await client.SendRemoteConfigStatusAsync(new RemoteConfigStatusReport([1, 2, 3], RemoteConfigStatusCode.Failed, "apply failed"));
         await client.StopAsync();
 
         var frames = opAmpServer.GetFrames();
         Assert.Equal(3, frames.Count); // 3 frames: 1 identification, 2 remote config status, 3 disconnect
         var actualStatus = frames[1].RemoteConfigStatus;
-        Assert.Equal(new byte[] { 1, 2, 3 }, actualStatus.LastRemoteConfigHash.ToByteArray());
+        Assert.Equal([1, 2, 3], actualStatus.LastRemoteConfigHash.ToByteArray());
         Assert.Equal(RemoteConfigStatuses.Failed, actualStatus.Status);
         Assert.Equal("apply failed", actualStatus.ErrorMessage);
     }
@@ -367,7 +367,7 @@ public class OpAmpClientTests
             o.RemoteConfiguration.ReportsRemoteConfigStatus = true;
         });
 
-        var status = new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, RemoteConfigStatusCode.Applied);
+        var status = new RemoteConfigStatusReport([1, 2, 3], RemoteConfigStatusCode.Applied);
 
         await client.StartAsync();
         await client.SendRemoteConfigStatusAsync(status);
@@ -391,14 +391,14 @@ public class OpAmpClientTests
         var status = new RemoteConfigStatusReport(hash, RemoteConfigStatusCode.Applied);
         hash[0] = 4;
 
-        Assert.Equal(new byte[] { 1, 2, 3 }, status.LastRemoteConfigHash.ToArray());
+        Assert.Equal([1, 2, 3], status.LastRemoteConfigHash.ToArray());
     }
 
     [Fact]
     internal void RemoteConfigStatusReport_ThrowsOnEmptyHash()
     {
         var exception = Assert.Throws<ArgumentException>(() =>
-            new RemoteConfigStatusReport(Array.Empty<byte>(), RemoteConfigStatusCode.Applied));
+            new RemoteConfigStatusReport([], RemoteConfigStatusCode.Applied));
 
         Assert.Equal("lastRemoteConfigHash", exception.ParamName);
     }
@@ -410,7 +410,7 @@ public class OpAmpClientTests
     internal void RemoteConfigStatusReport_ThrowsWhenErrorMessageIsSetForNonFailedStatus(RemoteConfigStatusCode status)
     {
         var exception = Assert.Throws<ArgumentException>(() =>
-            new RemoteConfigStatusReport(new byte[] { 1, 2, 3 }, status, "apply failed"));
+            new RemoteConfigStatusReport([1, 2, 3], status, "apply failed"));
 
         Assert.Equal("errorMessage", exception.ParamName);
     }

--- a/test/Shared/WeaverTelemetryVerifier.cs
+++ b/test/Shared/WeaverTelemetryVerifier.cs
@@ -342,6 +342,7 @@ public static class WeaverTelemetryVerifier
         {
             ActivityStatusCode.Error => "error",
             ActivityStatusCode.Ok => "ok",
+            ActivityStatusCode.Unset => null,
             _ => null,
         };
 
@@ -557,6 +558,9 @@ public static class WeaverTelemetryVerifier
 
                     break;
 
+                case MetricType.DoubleSumNonMonotonic:
+                case MetricType.ExponentialHistogram:
+                case MetricType.LongSumNonMonotonic:
                 default:
                     if (TryGetMetricPointValue(point) is { } fallback)
                     {


### PR DESCRIPTION
## Changes

Cherry-pick changes out of #3867 to reduce its size:

- Fix new code analysis warnings.
- Update `HttpInListener` to handle sibling-created activities better.
- Set `SOURCE_DATE_EPOCH` during package publishing (to support NuGet's new [DeterministicTimestamp](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/nuget.md#deterministic-pack-support-is-restored) feature).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
