### PR TITLE
[infra] cleanup zizmor configuration

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,5 +2,3 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
-  secrets-outside-env:
-    disable: true


### PR DESCRIPTION
## Changes

[infra] cleanup zizmor configuration
secrets-outside-env is part only of auditor persona, pedantic not longer include this check

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
