### PR TITLE
[Repo] Add review guidelines for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,8 @@ Every behavioural change needs a CHANGELOG entry in the affected component's
 Instrumentation `src/` projects must reference only the minimal OpenTelemetry
 packages needed:
 
-- Use `OpenTelemetry.Api` or `OpenTelemetry.Api.ProviderBuilderExtensions`.
+- Use `OpenTelemetry.Api` or `OpenTelemetry.Api.ProviderBuilderExtensions` when
+  adding or editing existing code.
 - Do **not** add new references to `OpenTelemetry` (the SDK) wherever possible.
 
 ## Code Conventions
@@ -174,7 +175,7 @@ packages needed:
 - Use `<para/>` as the paragraph break inside `///` XML doc comments - not a
   blank line.
 - For property setters, the `paramName` in any `ArgumentException` should be
-  `"value"`, not the property name.
+  `nameof(value)`, not the property name.
 
 ### Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,3 +133,55 @@ Component owners are defined in `.github/component_owners.yml` (not `CODEOWNERS`
 3. Add both projects to `opentelemetry-dotnet-contrib.slnx` (hand-maintained).
 4. Add the component path to `.github/component_owners.yml`.
 5. Add path filters for the new component to `.github/workflows/ci.yml`.
+
+## CHANGELOG Entries
+
+Every behavioural change needs a CHANGELOG entry in the affected component's
+`CHANGELOG.md` under `## Unreleased`. Format:
+
+```markdown
+* Description of the change (sentence case, ends with a period).
+  ([#NNNN](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/NNNN))
+```
+
+- New entries go at the **end** of `## Unreleased`, not the top.
+- Do **not** add a new version header — that is added automatically during
+  release.
+- No CHANGELOG entry is needed for pure infrastructure changes (CI workflows,
+  Renovate config, editor config).
+- When a PR touches multiple components, add an entry to each component's
+  `CHANGELOG.md`.
+
+## NuGet References in Source Projects
+
+Instrumentation `src/` projects must reference only the minimal OpenTelemetry
+packages needed:
+
+- Use `OpenTelemetry.Api` or `OpenTelemetry.Api.ProviderBuilderExtensions`.
+- Do **not** add new references to `OpenTelemetry` (the SDK) wherever possible.
+
+## Code Conventions
+
+### Banned APIs (enforced by `build/BannedSymbols.txt`)
+
+- Use `string.Equals(a, b, StringComparison)` (**static**), not the instance
+  method `a.Equals(b, StringComparison)`.
+- All `TryParse` overloads on numeric/date types must pass
+  `CultureInfo.InvariantCulture`.
+
+### XML Documentation
+
+- Use `<para/>` as the paragraph break inside `///` XML doc comments — not a
+  blank line.
+- For property setters, the `paramName` in any `ArgumentException` should be
+  `"value"`, not the property name.
+
+### Tests
+
+- Use `[Obsolete("...")]` on a test method that exercises an obsolete API
+  rather than suppressing the compiler warning with `#pragma`.
+
+## Code Review Instructions
+
+See [`REVIEW.md`](./REVIEW.md) for guidance used by automated code review
+agents when reviewing pull requests in this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Every behavioural change needs a CHANGELOG entry in the affected component's
 ```
 
 - New entries go at the **end** of `## Unreleased`, not the top.
-- Do **not** add a new version header — that is added automatically during
+- Do **not** add a new version header - that is added automatically during
   release.
 - No CHANGELOG entry is needed for pure infrastructure changes (CI workflows,
   Renovate config, editor config).
@@ -171,7 +171,7 @@ packages needed:
 
 ### XML Documentation
 
-- Use `<para/>` as the paragraph break inside `///` XML doc comments — not a
+- Use `<para/>` as the paragraph break inside `///` XML doc comments - not a
   blank line.
 - For property setters, the `paramName` in any `ArgumentException` should be
   `"value"`, not the property name.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -54,7 +54,6 @@ required OpenTelemetry packages:
   `#nullable enable`) and all initial surface goes in `Unshipped.txt`. Entries
   are moved to `Shipped.txt` automatically during the release process.
 
-
 ## XML Documentation Comments
 
 - Use `<para/>` as the paragraph separator in XML doc comments - not a

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,269 @@
+# OpenTelemetry .NET Contrib - Code Review Instructions
+
+This file provides guidance for reviewing pull requests and local changes in this
+repository. It also helps guide AI coding and review agents to make them more effective.
+
+> [!NOTE]
+> The primary audience for this document is Copilot for automated pull request reviews.
+
+---
+
+## CHANGELOG
+
+CHANGELOG updates are one of the most frequently corrected review items.
+
+- Every behavioural change (bug fix, new feature, breaking change) must
+  have a `CHANGELOG.md` entry in the affected component's `CHANGELOG.md` file.
+- New entries go at the end of the `## Unreleased` section, after all
+  existing entries.
+- The required format is:
+
+  ```markdown
+  * Description of the change (sentence case, ends with a period).
+    ([#NNNN](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/NNNN))
+  ```
+
+- Do not add CHANGELOG entries for purely infrastructure changes (CI
+  workflow updates, documentation-only fixes, test changes, etc.).
+- If a single PR modifies multiple components, each affected component's
+  `CHANGELOG.md` needs its own entry with the same PR link.
+- "Breaking change" entries should be prefixed with `**Breaking Change**:`.
+
+---
+
+## NuGet Package References
+
+Instrumentation packages' source projects must reference only the minimal
+required OpenTelemetry packages:
+
+- Source packages (`src/`) should reference `OpenTelemetry.Api` or
+  `OpenTelemetry.Api.ProviderBuilderExtensions` **only**. Avoid references to
+  `OpenTelemetry` (the SDK) from a library source project.
+- All package versions are centralized in `Directory.Packages.props`. Flag any
+  `Version="..."` attribute on a `<PackageReference>` in a src or test `.csproj`
+  (`VersionOverride` is allowed only for intentional version-range pinning
+  exceptions and should be rare).
+- Never add `<Version>` to a project file; use `Directory.Packages.props`.
+
+---
+
+## Public API Surface
+
+- Any new or modified public type or member must be declared in the component's
+  `.publicApi/PublicAPI.Unshipped.txt` file. A build error is raised if this is
+  missing.
+- Flag public API changes that are not reflected in `PublicAPI.Unshipped.txt`.
+- Breaking API changes (removals, signature changes, type moves) are not allowed
+  without an explicit maintainer decision and a breaking-change CHANGELOG entry.
+- For a new component, `PublicAPI.Shipped.txt` should be empty (contains only
+  `#nullable enable`) and all initial surface goes in `Unshipped.txt`. Entries
+  are moved to `Shipped.txt` automatically during the release process.
+
+---
+
+## XML Documentation Comments
+
+- Use `<para/>` as the paragraph separator in XML doc comments - not a
+  blank line inside the `///` block.
+- For `ArgumentException`/`ArgumentNullException`/`ArgumentOutOfRangeException`
+  thrown from a property setter, the `paramName` argument should be `nameof(value)`,
+  not the property's name.
+- When writing XML doc comments for manually authored code, write idiomatic,
+  readable English rather than copying specification text verbatim. If the
+  underlying spec text is not self-explanatory to a consumer of the library,
+  rephrase it. Include links to specification documents where appropriate using
+  permalinks (i.e. to tags or git SHAs - avoid branch names like `main`).
+- Use `<c>TypeName</c>` for type/member references inline in text when not using
+  a `<see cref="..."/>` link.
+
+---
+
+## String Comparisons and Culture-Sensitive Parsing
+
+The repository enforces these via `build/BannedSymbols.txt` (a Roslyn analyzer
+will catch them, but flag them in review too):
+
+- **Do not use** the instance `string.Equals(string)` or
+  `string.Equals(string, StringComparison)` methods - use the **static**
+  `string.Equals(a, b)` / `string.Equals(a, b, StringComparison)` overloads to
+  avoid potential `NullReferenceException`.
+- **Do not use** the culture-sensitive `TryParse(string, out T)` or
+  `TryParse(ReadOnlySpan<char>, out T)` overloads on numeric/date types - always
+  pass `CultureInfo.InvariantCulture` (or `NumberStyles` + `IFormatProvider`).
+
+---
+
+## Code Correctness
+
+### Infinite loops
+
+`while (true)` loops that do not have a provably finite exit path must include a
+safety mechanism - a `maxAttempts` counter, a `Stopwatch`-based timeout, or
+similar - and throw an exception if the limit is exceeded. This prevents the
+code from hanging forever if an assumption is found to be invalid.
+
+### Error handling in OpenTelemetry components
+
+- For exporters: document (and where possible test) what happens when internal
+  buffer or size limits are exceeded.
+
+### TODO comments
+
+Do not leave `// TODO` comments in code under review unless there is a
+corresponding tracking issue. The comment should reference the issue number.
+
+---
+
+## OpenTelemetry Semantic Conventions
+
+- Sampling-sensitive span attributes (identifiers like `rpc.method`, network
+  addresses, request method, etc.) must be set **before** `Activity.Start()` is
+  called so that custom samplers can observe them.
+- Attribute values must match the type specified in the semantic convention
+  specification (e.g. a status code attribute defined as a string must not be
+  written as an integer).
+- Instrumentation scope must include both a `Version` and a `SchemaUrl`.
+- Links to the semantic convention specification should be added where relevant
+  using permalinks (i.e. to tags or git SHAs - avoid branch names like `main`).
+
+---
+
+## Instrumentation Package Conventions
+
+- Instrumentation packages should only add tags/attributes to an activity that
+  is **already started** - do not start new activities from within an
+  instrumentation library unless that is its explicit purpose.
+- When migrating between semantic convention versions, the
+  `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable controls opt-in.
+  Check that both old and new attribute names are handled correctly for each
+  opt-in mode.
+- Schema URLs and instrumentation scope versions should be updated when semantic
+  convention version support changes.
+
+---
+
+## Performance
+
+- When making performance optimizations, measure before and after to ensure the
+  change has the desired effect rather than making assumptions. The `benchmark.ps1`
+  script in the root of the repository can be used to run benchmarks locally to
+  consistently compare the impact of a change in a branch against the main branch.
+- Any PR that claims a performance improvement should include benchmark results
+  (BenchmarkDotNet output is preferred) to substantiate any claims.
+- For hot-path string or value formatting, consider returning cached constant
+  results for well-known common values before falling back to a runtime
+  formatting call.
+- Avoid unnecessary allocations in instrumentation code that runs on every
+  request.
+
+---
+
+## Testing
+
+- When using `Assert.NotNull(x)` or similar null-guard assertions, do not add
+  the null-forgiving `!` operator on the same value in subsequent assertions
+  - the guard already expresses the contract.
+- Include the actual value in assertion failure messages where appropriate,
+  e.g. `Assert.True(condition, $"Expected ... but got {actualValue}")`.
+- Use `[Obsolete("...")]` on test methods that exercise obsolete APIs instead of
+  suppressing the compiler warning via `#pragma`.
+- When testing a refactoring (e.g. moving types between files), prefer testing
+  behavior through the public API rather than testing that internal types still
+  exist.
+- Where relevant, prefer Verify-style tests that assert the entire output of a
+  method rather than asserting individual properties of the output. This ensures
+  that the output is correct as a whole and helps guard against unexpected changes
+  to output. This is particularly important for serialization related tests.
+
+---
+
+## Line Length and Readability
+
+- Lines that wrap in the GitHub web view (roughly >120 characters) should be
+  broken at a logical boundary. This applies equally to code, XML doc comments,
+  and CHANGELOG entries.
+- Method signatures with many parameters are easier to read when each parameter
+  is on its own line.
+
+---
+
+## API Design Patterns
+
+- Prefer `ReadOnlySpan<byte>` over `ReadOnlyMemory<byte>` for constructor
+  parameters when the data is only needed at construction time and is
+  snapshotted internally (avoids a forced heap allocation at the call site).
+- Use `left` and `right` as parameter names for `==`/`!=` operator overloads
+  and `Equals(T other)` methods.
+- On .NET targets (`#if NET`), use `System.HashCode` (the struct API with
+  `HashCode.Combine(...)` or `Add`/`ToHashCode`) rather than the manual
+  `unchecked { h1 * 31 ^ h2 }` pattern.
+- `[Flags]` enums whose name represents a set of flags should have a `Flags`
+  suffix in their type name.
+
+---
+
+## New Components
+
+- A brand-new component must be introduced in at least two PRs: the first PR
+  sets up the infrastructure (directory structure, `.csproj`, empty public API
+  files, CHANGELOG, README, `.github/component_owners.yml` entry, CI path
+  filter, solution file entry) and the second PR adds the implementation.
+- Discuss the design, naming, and necessity of new components in a GitHub issue
+  **before** opening a PR. New components increase the maintenance burden for all
+  maintainers so there must be broad consensus on need before proceeding.
+- New packages need `<MinVerTagPrefix>` and `<PackageValidationBaselineVersion>`
+  set in the `.csproj` (baseline can be omitted only for brand-new packages that
+  have never shipped).
+
+---
+
+## Pull Request Hygiene
+
+- PRs should be focused and small. Thousands of changed lines in a single PR
+  make meaningful review impractical; suggest splitting by concern.
+- Do not merge upstream/main into a PR branch repeatedly just to stay current -
+  this generates unnecessary notifications for reviewers.
+- All contributors must have signed the [EasyCLA](https://easycla.lfx.linuxfoundation.org/)
+  agreement before a PR can be merged. Flag any PR where the CLA check has not
+  passed. Maintainers will usually not review changes at all before the CLA is signed.
+
+---
+
+## PowerShell Scripts
+
+- Use `Write-Warning` for non-fatal advisory output, and `Write-Error` (or
+  throw) for failures, rather than plain `Write-Host`. This allows callers and
+  CI to distinguish severity.
+- Cross-platform PowerShell scripts should start with `#!/usr/bin/env pwsh`.
+- When new scripts are added, ensure they are executable (`chmod +x script.ps1`)
+  so that they can be run on Linux/macOS without requiring `pwsh script.ps1`.
+- Aggregate errors and report them at the end of a script (fail-at-end pattern)
+  rather than stopping at the first warning, so that all issues are visible in
+  one run.
+
+---
+
+## What NOT to Flag
+
+To maintain a high signal-to-noise ratio, **do not comment on**:
+
+- Code style, formatting, or whitespace that is already enforced by
+  `dotnet format` / StyleCop / `.editorconfig` - the CI will catch those
+  automatically.
+- Renovate-managed dependency updates - those PRs are auto-generated.
+- `otelbot` automated PRs (semantic-conventions sync) unless there is an
+  obvious functional defect.
+- Comments suggesting code that will not compile - the compiler will enforce this
+  as part of continuous integration and this will avoid false-positive comments
+  where new language features are used that AI models may not yet be aware of.
+
+---
+
+## Miscellaneous
+
+- When reviewing changes related to OpenTelemetry semantic conventions, refer to
+  the official specification repository for specific guidance and provide citations
+  to justify suggestions wherever possible. The specification repository is located
+  at <https://github.com/open-telemetry/semantic-conventions>. Do not provide
+  speculative feedback without referencing the official specification, as it may
+  lead to incorrect assumptions or misunderstandings.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,9 +4,7 @@ This file provides guidance for reviewing pull requests and local changes in thi
 repository. It also helps guide AI coding and review agents to make them more effective.
 
 > [!NOTE]
-> The primary audience for this document is Copilot for automated pull request reviews.
-
----
+> The primary audience for this document is for automated pull request reviews agents.
 
 ## CHANGELOG
 
@@ -29,23 +27,20 @@ CHANGELOG updates are one of the most frequently corrected review items.
   `CHANGELOG.md` needs its own entry with the same PR link.
 - "Breaking change" entries should be prefixed with `**Breaking Change**:`.
 
----
-
 ## NuGet Package References
 
 Instrumentation packages' source projects must reference only the minimal
 required OpenTelemetry packages:
 
 - Source packages (`src/`) should reference `OpenTelemetry.Api` or
-  `OpenTelemetry.Api.ProviderBuilderExtensions` **only**. Avoid references to
-  `OpenTelemetry` (the SDK) from a library source project.
+- `OpenTelemetry.Api.ProviderBuilderExtensions` **only**. Avoid references to
+  `OpenTelemetry` (the SDK) from a library source project when adding or editing
+  existing code.
 - All package versions are centralized in `Directory.Packages.props`. Flag any
   `Version="..."` attribute on a `<PackageReference>` in a src or test `.csproj`
   (`VersionOverride` is allowed only for intentional version-range pinning
   exceptions and should be rare).
-- Never add `<Version>` to a project file; use `Directory.Packages.props`.
-
----
+- Never add `<Version>` to a project file; use `Directory.Packages.props`
 
 ## Public API Surface
 
@@ -54,12 +49,11 @@ required OpenTelemetry packages:
   missing.
 - Flag public API changes that are not reflected in `PublicAPI.Unshipped.txt`.
 - Breaking API changes (removals, signature changes, type moves) are not allowed
-  without an explicit maintainer decision and a breaking-change CHANGELOG entry.
+  without an explicit maintainer decision and a breaking-change CHANGELOG entry
 - For a new component, `PublicAPI.Shipped.txt` should be empty (contains only
   `#nullable enable`) and all initial surface goes in `Unshipped.txt`. Entries
   are moved to `Shipped.txt` automatically during the release process.
 
----
 
 ## XML Documentation Comments
 
@@ -76,8 +70,6 @@ required OpenTelemetry packages:
 - Use `<c>TypeName</c>` for type/member references inline in text when not using
   a `<see cref="..."/>` link.
 
----
-
 ## String Comparisons and Culture-Sensitive Parsing
 
 The repository enforces these via `build/BannedSymbols.txt` (a Roslyn analyzer
@@ -90,8 +82,6 @@ will catch them, but flag them in review too):
 - **Do not use** the culture-sensitive `TryParse(string, out T)` or
   `TryParse(ReadOnlySpan<char>, out T)` overloads on numeric/date types - always
   pass `CultureInfo.InvariantCulture` (or `NumberStyles` + `IFormatProvider`).
-
----
 
 ## Code Correctness
 
@@ -112,8 +102,6 @@ code from hanging forever if an assumption is found to be invalid.
 Do not leave `// TODO` comments in code under review unless there is a
 corresponding tracking issue. The comment should reference the issue number.
 
----
-
 ## OpenTelemetry Semantic Conventions
 
 - Sampling-sensitive span attributes (identifiers like `rpc.method`, network
@@ -126,8 +114,6 @@ corresponding tracking issue. The comment should reference the issue number.
 - Links to the semantic convention specification should be added where relevant
   using permalinks (i.e. to tags or git SHAs - avoid branch names like `main`).
 
----
-
 ## Instrumentation Package Conventions
 
 - Instrumentation packages should only add tags/attributes to an activity that
@@ -139,8 +125,6 @@ corresponding tracking issue. The comment should reference the issue number.
   opt-in mode.
 - Schema URLs and instrumentation scope versions should be updated when semantic
   convention version support changes.
-
----
 
 ## Performance
 
@@ -155,8 +139,6 @@ corresponding tracking issue. The comment should reference the issue number.
   formatting call.
 - Avoid unnecessary allocations in instrumentation code that runs on every
   request.
-
----
 
 ## Testing
 
@@ -175,8 +157,6 @@ corresponding tracking issue. The comment should reference the issue number.
   that the output is correct as a whole and helps guard against unexpected changes
   to output. This is particularly important for serialization related tests.
 
----
-
 ## Line Length and Readability
 
 - Lines that wrap in the GitHub web view (roughly >120 characters) should be
@@ -184,8 +164,6 @@ corresponding tracking issue. The comment should reference the issue number.
   and CHANGELOG entries.
 - Method signatures with many parameters are easier to read when each parameter
   is on its own line.
-
----
 
 ## API Design Patterns
 
@@ -200,8 +178,6 @@ corresponding tracking issue. The comment should reference the issue number.
 - `[Flags]` enums whose name represents a set of flags should have a `Flags`
   suffix in their type name.
 
----
-
 ## New Components
 
 - A brand-new component must be introduced in at least two PRs: the first PR
@@ -215,8 +191,6 @@ corresponding tracking issue. The comment should reference the issue number.
   set in the `.csproj` (baseline can be omitted only for brand-new packages that
   have never shipped).
 
----
-
 ## Pull Request Hygiene
 
 - PRs should be focused and small. Thousands of changed lines in a single PR
@@ -226,8 +200,6 @@ corresponding tracking issue. The comment should reference the issue number.
 - All contributors must have signed the [EasyCLA](https://easycla.lfx.linuxfoundation.org/)
   agreement before a PR can be merged. Flag any PR where the CLA check has not
   passed. Maintainers will usually not review changes at all before the CLA is signed.
-
----
 
 ## PowerShell Scripts
 
@@ -240,8 +212,6 @@ corresponding tracking issue. The comment should reference the issue number.
 - Aggregate errors and report them at the end of a script (fail-at-end pattern)
   rather than stopping at the first warning, so that all issues are visible in
   one run.
-
----
 
 ## What NOT to Flag
 
@@ -257,8 +227,6 @@ To maintain a high signal-to-noise ratio, **do not comment on**:
   as part of continuous integration and this will avoid false-positive comments
   where new language features are used that AI models may not yet be aware of.
 
----
-
 ## Miscellaneous
 
 - When reviewing changes related to OpenTelemetry semantic conventions, refer to
@@ -267,3 +235,8 @@ To maintain a high signal-to-noise ratio, **do not comment on**:
   at <https://github.com/open-telemetry/semantic-conventions>. Do not provide
   speculative feedback without referencing the official specification, as it may
   lead to incorrect assumptions or misunderstandings.
+- Where possible, use more performant APIs added in newer releases of .NET and use
+  pre-processor directives to maintain compatibility with older versions of .NET,
+  provided that this does not introduce too much code complexity relative to the
+  advantages gained by doing so. For example, Use `FrozenSet<T>` instead of `HashSet<T>`
+  when targeting .NET 8 or later if the hash set's values are not changed once created.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -240,3 +240,7 @@ To maintain a high signal-to-noise ratio, **do not comment on**:
   provided that this does not introduce too much code complexity relative to the
   advantages gained by doing so. For example, Use `FrozenSet<T>` instead of `HashSet<T>`
   when targeting .NET 8 or later if the hash set's values are not changed once created.
+- Where appropriate, links to external documentation, such as for Microsoft Learn
+  and GitHub, should not include language-specific slugs (e.g. `/en/`, `/en-us/`)
+  in the URL path so that documentation is shown to the reader in their preferred
+  browser language when available.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -103,6 +103,9 @@ corresponding tracking issue. The comment should reference the issue number.
 
 ## OpenTelemetry Semantic Conventions
 
+[Semantic Conventions](https://github.com/open-telemetry/semantic-conventions)
+for OpenTelemetry are definitions for how telemetry should work.
+
 - Sampling-sensitive span attributes (identifiers like `rpc.method`, network
   addresses, request method, etc.) must be set **before** `Activity.Start()` is
   called so that custom samplers can observe them.


### PR DESCRIPTION
## Changes

Add code review documents synthesised from the last 90 days of pull request review in the repository to make AI code review comments more effective.

The documents were originally generated by Copilot from the following prompt:

> I would like to add instructions to this repository for code review agents, like Copilot, Claude, and Codex, to use to make code reviews of pull requests (and local changes) more effective. Go through all pull requests both merged and closed opened in the last 90 days for review comments from `@martincostello`, `@alanwest`, `@Kielek`, `@rajkumar-rangaraj` and `@cijothomas`. Synthesise common comments, themes, suggestions, requirements etc. from their comments into generic repository-level notes for reviewing code in this repository that are not already catered for by the AGENTS.md file for working on the code in the repository. Where relevant, also add any missing instructions for generating code too.

I then manually reviewed the output and made adjustments.

Feedback welcome.

Post-merge I'll do the same process in [opentelemetry-dotnet](https://github.com/open-telemetry/opentelemetry-dotnet).

/cc @pellared

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
