### PR TITLE
[EntityFrameworkCore] Add benchmarks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,4 +3,8 @@
     <ArtifactsPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'artifacts'))</ArtifactsPath>
     <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
+  <!-- TODO remove when https://github.com/dotnet/efcore/issues/38463 is fixed by: https://github.com/dotnet/efcore/pull/38402 -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>

--- a/opentelemetry-dotnet-contrib.slnx
+++ b/opentelemetry-dotnet-contrib.slnx
@@ -266,6 +266,7 @@
     <Project Path="test/OpenTelemetry.Instrumentation.Cassandra.Tests/OpenTelemetry.Instrumentation.Cassandra.Tests.csproj" />
     <Project Path="test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetry.Instrumentation.ConfluentKafka.Tests.csproj" />
     <Project Path="test/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests/OpenTelemetry.Instrumentation.ElasticsearchClient.Tests.csproj" />
+    <Project Path="test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks.csproj" />
     <Project Path="test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj" />
     <Project Path="test/OpenTelemetry.Instrumentation.EventCounters.Tests/OpenTelemetry.Instrumentation.EventCounters.Tests.csproj" />
     <Project Path="test/OpenTelemetry.Instrumentation.GrpcCore.Tests/OpenTelemetry.Instrumentation.GrpcCore.Tests.csproj" />

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/BenchmarkContext.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/BenchmarkContext.cs
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.EntityFrameworkCore;
+
+namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks;
+
+internal sealed class BenchmarkContext(DbContextOptions<BenchmarkContext> options)
+    : DbContext(options)
+{
+    public DbSet<BenchmarkItem> Items { get; set; } = null!;
+}

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/BenchmarkItem.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/BenchmarkItem.cs
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks;
+
+public sealed class BenchmarkItem
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = default!;
+}

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Data;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the EFCore instrumentation that can be used to guard against
+/// regressions and to guide future optimisations.
+/// </summary>
+/// <remarks>
+/// The benchmarks use an SQLite in-memory database to exercise the full
+/// diagnostic listener lifecycle (CommandCreated → CommandExecuting →
+/// CommandExecuted) without needing an external database server.
+/// </remarks>
+[MemoryDiagnoser]
+public class EntityFrameworkCoreBenchmarks
+{
+    private SqliteConnection? connection;
+    private DbContextOptions<BenchmarkContext>? contextOptions;
+    private TracerProvider? tracerProvider;
+
+    /// <summary>
+    /// Controls how the EFCore instrumentation is configured for each benchmark run.
+    /// </summary>
+    public enum InstrumentationScenario
+    {
+        /// <summary>
+        /// No TracerProvider is configured: the diagnostic events fired by EF Core
+        /// are ignored. This is the baseline cost.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Tracing is enabled with default options. This covers the core
+        /// CommandCreated / CommandExecuting / CommandExecuted path.
+        /// </summary>
+        Traces,
+
+        /// <summary>
+        /// Tracing is enabled with an <see cref="EntityFrameworkInstrumentationOptions.EnrichWithIDbCommand"/>
+        /// callback, measuring the additional overhead of user-defined enrichment.
+        /// </summary>
+        TracesWithEnrichment,
+
+        /// <summary>
+        /// Tracing is enabled with a <see cref="EntityFrameworkInstrumentationOptions.Filter"/>
+        /// callback that accepts all commands, measuring the overhead of filter evaluation.
+        /// </summary>
+        TracesWithFilter,
+    }
+
+    [Params(
+        InstrumentationScenario.None,
+        InstrumentationScenario.Traces,
+        InstrumentationScenario.TracesWithEnrichment,
+        InstrumentationScenario.TracesWithFilter)]
+    public InstrumentationScenario Scenario { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.connection = new SqliteConnection("Filename=:memory:");
+        this.connection.Open();
+
+        this.contextOptions = new DbContextOptionsBuilder<BenchmarkContext>()
+            .UseSqlite(this.connection)
+            .Options;
+
+        using var context = new BenchmarkContext(this.contextOptions);
+        context.Database.EnsureCreated();
+
+        context.Items.AddRange(
+            new() { Name = "Alpha" },
+            new() { Name = "Beta" },
+            new() { Name = "Gamma" });
+
+        context.SaveChanges();
+
+        this.tracerProvider = this.Scenario switch
+        {
+            InstrumentationScenario.Traces => Sdk.CreateTracerProviderBuilder()
+                .AddEntityFrameworkCoreInstrumentation()
+                .Build(),
+
+            InstrumentationScenario.TracesWithEnrichment => Sdk.CreateTracerProviderBuilder()
+                .AddEntityFrameworkCoreInstrumentation(
+                    (options) => options.EnrichWithIDbCommand = static (activity, _) => activity.SetTag("benchmark.enriched", true))
+                .Build(),
+
+            InstrumentationScenario.TracesWithFilter => Sdk.CreateTracerProviderBuilder()
+                .AddEntityFrameworkCoreInstrumentation(
+                    (options) => options.Filter = static (_, command) => command.CommandType == CommandType.Text)
+                .Build(),
+
+            _ => null,
+        };
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        this.tracerProvider?.Dispose();
+        this.connection?.Dispose();
+    }
+
+    [Benchmark]
+    public int SelectItems()
+    {
+        using var context = new BenchmarkContext(this.contextOptions!);
+        return context.Items.OrderBy((p) => p.Name).ToList().Count;
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks;
 /// </summary>
 /// <remarks>
 /// The benchmarks use an SQLite in-memory database to exercise the full
-/// diagnostic listener lifecycle (CommandCreated → CommandExecuting →
+/// diagnostic listener lifecycle (CommandCreated => CommandExecuting =>
 /// CommandExecuted) without needing an external database server.
 /// </remarks>
 [MemoryDiagnoser]

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
@@ -110,7 +110,7 @@ public class EntityFrameworkCoreBenchmarks
     }
 
     [Benchmark]
-    public int SelectItems()
+    public int Query()
     {
         using var context = new BenchmarkContext(this.contextOptions!);
         return context.Items.OrderBy((p) => p.Name).ToList().Count;

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks.csproj
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="OpenTelemetry" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.EntityFrameworkCore\OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+  <!-- TODO remove when https://github.com/dotnet/efcore/issues/38463 is fixed by: https://github.com/dotnet/efcore/pull/38402 -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks.csproj
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks.csproj
@@ -15,9 +15,4 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.EntityFrameworkCore\OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
-  <!-- TODO remove when https://github.com/dotnet/efcore/issues/38463 is fixed by: https://github.com/dotnet/efcore/pull/38402 -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-  </ItemGroup>
-
 </Project>

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/Program.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/Program.cs
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using BenchmarkDotNet.Running;
+using OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks;
+
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(EntityFrameworkCoreBenchmarks).Assembly).Run(args);
+return summaries.SelectMany(p => p.Reports).Any((p) => !p.Success) ? 1 : 0;

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/README.md
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/README.md
@@ -1,0 +1,8 @@
+# OpenTelemetry EFCore Instrumentation Benchmarks
+
+Navigate to the `./test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks`
+directory and run the following command to run all of the benchmarks:
+
+```sh
+dotnet run --configuration Release --framework net10.0 -- --filter "*"
+```

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests/OpenTelemetry.Instrumentation.EntityFrameworkCore.Tests.csproj
@@ -39,9 +39,4 @@
     <EmbeddedResource Include="*.Dockerfile" LogicalName="%(FileName)%(Extension)" />
     <EmbeddedResource Include="$(RepoRoot)\test\OpenTelemetry.Instrumentation.SqlClient.Tests\sqlserver.Dockerfile" LogicalName="sqlserver.Dockerfile" />
   </ItemGroup>
-
-  <!-- TODO remove when https://github.com/dotnet/efcore/issues/38463 is fixed by: https://github.com/dotnet/efcore/pull/38402 -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Changes

Add a benchmark project for EFCore to help with any possible future optimisation work and for manual use to detect regressions.

### Results

```text
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8655/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.301
  [Host]    : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
  .NET 10.0 : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3

Job=.NET 10.0  Runtime=.NET 10.0  Toolchain=net10.0  
```

| Method | Scenario             | Mean     | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|------- |--------------------- |---------:|---------:|---------:|-------:|-------:|----------:|
| **Query**  | **None**                 | **28.79 μs** | **0.351 μs** | **0.311 μs** | **3.4180** | **0.2441** |  **43.96 KB** |
| **Query**  | **Traces**               | **32.58 μs** | **0.365 μs** | **0.285 μs** | **3.6621** | **0.2441** |  **47.33 KB** |
| **Query**  | **TracesWithEnrichment** | **32.93 μs** | **0.627 μs** | **0.556 μs** | **3.6621** | **0.2441** |  **47.39 KB** |
| **Query**  | **TracesWithFilter**     | **33.66 μs** | **0.298 μs** | **0.264 μs** | **3.6621** | **0.2441** |  **47.33 KB** |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
