### PR TITLE
[Infra] Fix new code analyis warnings

### DIFF
--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -58,6 +58,10 @@
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>

--- a/examples/wcf/server-aspnetframework/Web.config
+++ b/examples/wcf/server-aspnetframework/Web.config
@@ -41,6 +41,14 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.ComponentModel.Annotations" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
       </dependentAssembly>

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
@@ -235,7 +235,7 @@ internal abstract class TldLogCommon : IDisposable
     private static bool IsAlreadySanitized(string categoryName)
     {
         var length = categoryName.Length;
-        if (length == 0 || length > MaxSanitizedEventNameLength)
+        if (length is 0 or > MaxSanitizedEventNameLength)
         {
             return false;
         }

--- a/src/OpenTelemetry.Exporter.OneCollector/Internal/EventNameManager.cs
+++ b/src/OpenTelemetry.Exporter.OneCollector/Internal/EventNameManager.cs
@@ -137,10 +137,10 @@ internal sealed partial class EventNameManager
     }
 
 #if NET
-    [GeneratedRegex(@"^[A-Za-z](?:\.?[A-Za-z0-9]+?)*$", RegexOptions.Compiled)]
+    [GeneratedRegex(@"^[A-Za-z](?:\.?[A-Za-z0-9]+?)*$")]
     private static partial Regex EventNamespaceValidationRegex();
 
-    [GeneratedRegex(@"^[A-Za-z][A-Za-z0-9]*$", RegexOptions.Compiled)]
+    [GeneratedRegex(@"^[A-Za-z][A-Za-z0-9]*$")]
 
     private static partial Regex EventNameValidationRegex();
 #else

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/SnsRequestContextHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/SnsRequestContextHelper.cs
@@ -15,8 +15,7 @@ internal class SnsRequestContextHelper
 
     internal static void AddAttributes(IRequestContext context, IReadOnlyDictionary<string, string> attributes)
     {
-        var originalRequest = context.OriginalRequest as PublishRequest;
-        if (originalRequest == null)
+        if (context.OriginalRequest is not PublishRequest originalRequest)
         {
             return;
         }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
@@ -15,8 +15,7 @@ internal class SqsRequestContextHelper
 
     internal static void AddAttributes(IRequestContext context, IReadOnlyDictionary<string, string> attributes)
     {
-        var originalRequest = context.OriginalRequest as SendMessageRequest;
-        if (originalRequest == null)
+        if (context.OriginalRequest is not SendMessageRequest originalRequest)
         {
             return;
         }

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
@@ -128,7 +128,7 @@ internal partial class ElasticsearchRequestPipelineDiagnosticListener : Listener
     }
 
 #if NET
-    [GeneratedRegex(RequestRegexPattern, RegexOptions.Compiled | RegexOptions.Singleline)]
+    [GeneratedRegex(RequestRegexPattern, RegexOptions.Singleline)]
     private static partial Regex RequestParser();
 #else
     private static Regex RequestParser() => ParseRequest;

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -108,7 +108,7 @@ public class HttpInMetricsListenerTests
         }
 
         Assert.Equal(expectedTagCount, metricPoints[0].Tags.Count);
-        Dictionary<string, object?> tags = new(metricPoint.Tags.Count);
+        var tags = new Dictionary<string, object?>(metricPoint.Tags.Count);
         foreach (var tag in metricPoint.Tags)
         {
             tags.Add(tag.Key, tag.Value);

--- a/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
+++ b/test/OpenTelemetry.Instrumentation.EntityFrameworkCore.Benchmarks/EntityFrameworkCoreBenchmarks.cs
@@ -98,6 +98,7 @@ public class EntityFrameworkCoreBenchmarks
                     (options) => options.Filter = static (_, command) => command.CommandType == CommandType.Text)
                 .Build(),
 
+            InstrumentationScenario.None => null,
             _ => null,
         };
     }

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestRateLimiter.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestRateLimiter.cs
@@ -118,7 +118,7 @@ public class TestRateLimiter
         var clock = new TestClock();
         var limiter = new RateLimiter(1, numWorkers * creditsPerWorker, clock);
         var count = 0;
-        List<Task> tasks = new(numWorkers);
+        var tasks = new List<Task>(numWorkers);
 
         for (var w = 0; w < numWorkers; ++w)
         {

--- a/test/Shared/PerfTracepointListener.cs
+++ b/test/Shared/PerfTracepointListener.cs
@@ -13,12 +13,11 @@ namespace OpenTelemetry.Tests;
 // this can be removed if/when
 // https://github.com/microsoft/LinuxTracepoints-Net/ has listening bits or
 // dotnet/runtime supports user_events (both reading & writing) directly.
-internal sealed class PerfTracepointListener : IDisposable
+internal sealed partial class PerfTracepointListener : IDisposable
 {
     private readonly string name;
     private readonly PerfTracepoint tracepoint;
     private readonly ConsoleCommand catCommand;
-    private readonly Regex eventRegex = new("(\\w+?)=([\\w\\(\\) .,-]*)( |$)", RegexOptions.Compiled);
 
     public PerfTracepointListener(string name, string nameArgs)
     {
@@ -100,6 +99,9 @@ internal sealed class PerfTracepointListener : IDisposable
         }
     }
 
+    [GeneratedRegex("(\\w+?)=([\\w\\(\\) .,-]*)( |$)", RegexOptions.Compiled)]
+    private static partial Regex EventRegex();
+
     private void OnCatOutputReceived(string output)
     {
         var name = $": {this.name}:";
@@ -112,7 +114,7 @@ internal sealed class PerfTracepointListener : IDisposable
 
         startingPosition += name.Length;
 
-        var matches = this.eventRegex.Matches(output, startingPosition);
+        var matches = EventRegex().Matches(output, startingPosition);
 
         if (matches.Count > 0)
         {

--- a/test/Shared/PerfTracepointListener.cs
+++ b/test/Shared/PerfTracepointListener.cs
@@ -99,7 +99,7 @@ internal sealed partial class PerfTracepointListener : IDisposable
         }
     }
 
-    [GeneratedRegex("(\\w+?)=([\\w\\(\\) .,-]*)( |$)", RegexOptions.Compiled)]
+    [GeneratedRegex("(\\w+?)=([\\w\\(\\) .,-]*)( |$)")]
     private static partial Regex EventRegex();
 
     private void OnCatOutputReceived(string output)


### PR DESCRIPTION
## Changes

- Fix new code analysis warnings identified in #3867 when using C# 15.
- Update binding redirects to avoid warnings in Visual Studio.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
