### PR TITLE
[Repo] Add workflow to check for SDK releases

### DIFF
--- a/.github/workflows/check-for-new-sdk-releases.yml
+++ b/.github/workflows/check-for-new-sdk-releases.yml
@@ -1,0 +1,46 @@
+name: Check for new SDK releases
+
+on:
+  schedule:
+  - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  automation:
+    uses: ./.github/workflows/automation.yml
+    permissions:
+      contents: read
+    secrets:
+      OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
+
+  check-for-core-version-update:
+    name: Check for SDK releases
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    if: (github.event_name != 'schedule' || github.event.repository.fork == false) && needs.automation.outputs.enabled
+
+    needs: automation
+
+    permissions:
+      actions: write # Needed to trigger the core-version-update workflow
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
+
+    - name: Check for SDK releases and trigger update workflow
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: .\build\scripts\check-for-new-sdk-releases.ps1

--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.tag }}
   cancel-in-progress: false
 
 jobs:

--- a/build/scripts/check-for-new-sdk-releases.ps1
+++ b/build/scripts/check-for-new-sdk-releases.ps1
@@ -1,0 +1,169 @@
+#!/usr/bin/env pwsh
+
+#Requires -PSEdition Core
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+Checks whether the OpenTelemetry core package versions used by this repository are
+up to date with the latest releases in the opentelemetry-dotnet repository and, if
+not, triggers the "Core version update" workflow to open a pull request updating them.
+
+.DESCRIPTION
+The OpenTelemetry core package versions are pinned in Directory.Packages.props using
+three properties, each of which corresponds to a release tag in the
+opentelemetry-dotnet repository:
+
+  * OpenTelemetryCoreLatestVersion           -> latest stable release            (e.g. core-1.16.0)
+  * OpenTelemetryCoreLatestPrereleaseVersion -> latest release candidate release (e.g. core-1.16.0-rc.1)
+  * OpenTelemetryCoreUnstableLatestVersion   -> latest unstable (beta) release   (e.g. coreunstable-1.16.0-beta.1)
+
+For each property the script finds the latest matching release in the
+opentelemetry-dotnet repository and, if it does not match the version pinned in
+Directory.Packages.props, runs the core-version-update workflow with the
+corresponding tag as the input as described in the opentelemetry-dotnet releasing
+documentation.
+
+.EXAMPLE
+./build/scripts/check-for-new-sdk-releases.ps1
+#>
+
+param(
+  [Parameter()][string]$repoRoot = (Get-Item $PSScriptRoot).Parent.Parent.FullName,
+  [Parameter()][string]$coreRepository = "open-telemetry/opentelemetry-dotnet",
+  [Parameter()][string]$contribRepository,
+  [Parameter()][string]$workflow = "core-version-update.yml"
+)
+
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
+# Maps each version property in Directory.Packages.props to the release tag prefix
+# used in the opentelemetry-dotnet repository and the kind of release it tracks.
+# Stable and release-candidate releases both use the 'core-' tag prefix and are
+# distinguished by whether the version has a prerelease suffix; unstable (beta)
+# releases use the 'coreunstable-' tag prefix.
+$propertyMappings = @(
+  [PSCustomObject]@{ Property = "OpenTelemetryCoreLatestVersion";           TagPrefix = "core-";         Kind = "stable" }
+  [PSCustomObject]@{ Property = "OpenTelemetryCoreLatestPrereleaseVersion"; TagPrefix = "core-";         Kind = "prerelease" }
+  [PSCustomObject]@{ Property = "OpenTelemetryCoreUnstableLatestVersion";   TagPrefix = "coreunstable-"; Kind = "unstable" }
+)
+
+function GetPropertyVersions {
+  param([string]$propsPath)
+
+  $content = Get-Content -Path $propsPath -Raw
+
+  $versions = @{}
+  foreach ($mapping in $propertyMappings) {
+    $match = [regex]::Match($content, "<$($mapping.Property)>(?<version>[^<]+)</$($mapping.Property)>")
+    if ($match.Success -eq $false) {
+      throw "Could not find property '$($mapping.Property)' in '$propsPath'."
+    }
+    $versions[$mapping.Property] = $match.Groups["version"].Value.Trim()
+  }
+
+  return $versions
+}
+
+function GetLatestCoreVersion {
+  param(
+    [object[]]$releases,
+    [string]$tagPrefix,
+    [string]$kind
+  )
+
+  # Releases are ordered most-recent first, so the first match for each kind is the
+  # latest release of that kind.
+  foreach ($release in $releases) {
+    $tag = $release.tagName
+
+    if ($tag.StartsWith($tagPrefix) -eq $false) {
+      continue
+    }
+
+    # 'core-' is also a prefix of 'coreunstable-' so make sure unstable releases are
+    # not mistaken for stable or release candidate releases.
+    if ($tagPrefix -eq "core-" -and $tag.StartsWith("coreunstable-") -eq $true) {
+      continue
+    }
+
+    $version = $tag.Substring($tagPrefix.Length)
+
+    # A release is treated as a prerelease if either its version has a prerelease
+    # suffix (e.g. core-1.16.0-rc.1) or the GitHub release itself is flagged as a
+    # prerelease. Stable releases (e.g. core-1.16.0) have neither, whereas release
+    # candidate and unstable (beta) releases have both.
+    $isPrerelease = $version.Contains("-") -or ($release.isPrerelease -eq $true)
+
+    $isMatch =
+      ($kind -eq "stable" -and $isPrerelease -eq $false) -or
+      ($kind -eq "prerelease" -and $isPrerelease -eq $true) -or
+      ($kind -eq "unstable")
+
+    if ($isMatch -eq $true) {
+      return $version
+    }
+  }
+
+  return $null
+}
+
+if ([string]::IsNullOrEmpty($contribRepository) -eq $true) {
+  $contribRepository = if ([string]::IsNullOrEmpty($env:GITHUB_REPOSITORY) -eq $true) {
+    "open-telemetry/opentelemetry-dotnet-contrib"
+  }
+  else {
+    $env:GITHUB_REPOSITORY
+  }
+}
+
+$propsPath = Join-Path -Path $repoRoot -ChildPath "Directory.Packages.props"
+$versions = GetPropertyVersions -propsPath $propsPath
+
+$releasesJson = gh release list `
+  --repo $coreRepository `
+  --exclude-drafts `
+  --limit 100 `
+  --json isPrerelease,publishedAt,tagName
+
+if ($LASTEXITCODE -gt 0) {
+  throw "Failed to list releases for '$coreRepository'."
+}
+
+$releases = @($releasesJson | ConvertFrom-Json | Sort-Object -Property publishedAt -Descending)
+
+$triggered = $false
+
+foreach ($mapping in $propertyMappings) {
+  $currentVersion = $versions[$mapping.Property]
+  $latestVersion = GetLatestCoreVersion -releases $releases -tagPrefix $mapping.TagPrefix -kind $mapping.Kind
+
+  if ([string]::IsNullOrEmpty($latestVersion) -eq $true) {
+    Write-Warning "Could not find a $($mapping.Kind) release in '$coreRepository' for property '$($mapping.Property)'."
+    continue
+  }
+
+  if ($latestVersion -eq $currentVersion) {
+    Write-Information "$($mapping.Property) is up to date ($currentVersion)."
+    continue
+  }
+
+  $tag = "$($mapping.TagPrefix)$latestVersion"
+
+  Write-Information "$($mapping.Property) is out of date (current: $currentVersion, latest: $latestVersion). Triggering '$workflow' for tag '$tag'."
+
+  gh workflow run $workflow `
+    --repo $contribRepository `
+    --field tag=$tag
+
+  if ($LASTEXITCODE -gt 0) {
+    throw "Failed to trigger '$workflow' for tag '$tag'."
+  }
+
+  $triggered = $true
+}
+
+if ($triggered -eq $false) {
+  Write-Information "All OpenTelemetry core package versions are up to date."
+}

--- a/build/scripts/check-for-new-sdk-releases.ps1
+++ b/build/scripts/check-for-new-sdk-releases.ps1
@@ -90,11 +90,14 @@ function GetLatestCoreVersion {
 
     $version = $tag.Substring($tagPrefix.Length)
 
-    # A release is treated as a prerelease if either its version has a prerelease
-    # suffix (e.g. core-1.16.0-rc.1) or the GitHub release itself is flagged as a
-    # prerelease. Stable releases (e.g. core-1.16.0) have neither, whereas release
-    # candidate and unstable (beta) releases have both.
-    $isPrerelease = $version.Contains("-") -or ($release.isPrerelease -eq $true)
+    # A release is treated as a prerelease if its version has a prerelease suffix
+    # (e.g. core-1.16.0-rc.1). Stable releases (e.g. core-1.16.0) do not. The GitHub
+    # 'isPrerelease' flag is deliberately not consulted here so that this classifier
+    # matches the one used by the core-version-update workflow, which decides whether
+    # to update the stable or prerelease property based solely on the version suffix.
+    # If the two disagreed, this script could dispatch a tag as a prerelease that the
+    # target workflow would then apply to the stable property (or vice versa).
+    $isPrerelease = $version.Contains("-")
 
     $isMatch =
       ($kind -eq "stable" -and $isPrerelease -eq $false) -or
@@ -107,6 +110,22 @@ function GetLatestCoreVersion {
   }
 
   return $null
+}
+
+function TestUpdateBranchExists {
+  param(
+    [string]$repository,
+    [string]$branch
+  )
+
+  # The core-version-update workflow pushes to a fixed branch and does not force
+  # push, so if a branch (and its pull request) from a previous run still exists the
+  # workflow would fail. Query the branch directly rather than open pull requests so
+  # that a lingering branch left behind by a closed pull request is also detected,
+  # and so that only the already-granted 'contents: read' permission is required.
+  gh api "repos/$repository/branches/$branch" --silent 2>$null
+
+  return $LASTEXITCODE -eq 0
 }
 
 if ([string]::IsNullOrEmpty($contribRepository) -eq $true) {
@@ -125,7 +144,7 @@ $releasesJson = gh release list `
   --repo $coreRepository `
   --exclude-drafts `
   --limit 100 `
-  --json isPrerelease,publishedAt,tagName
+  --json publishedAt,tagName
 
 if ($LASTEXITCODE -gt 0) {
   throw "Failed to list releases for '$coreRepository'."
@@ -150,6 +169,16 @@ foreach ($mapping in $propertyMappings) {
   }
 
   $tag = "$($mapping.TagPrefix)$latestVersion"
+
+  # The core-version-update workflow creates this branch for the update. If it already
+  # exists then an update for this version is already in progress (a pull request is
+  # open or was recently closed), so skip dispatching to avoid the workflow failing to
+  # push to the existing branch and to avoid dispatching the same update every hour.
+  $branch = "otelbot/post-core-$latestVersion-update"
+  if ((TestUpdateBranchExists -repository $contribRepository -branch $branch) -eq $true) {
+    Write-Information "$($mapping.Property) is out of date (current: $currentVersion, latest: $latestVersion) but branch '$branch' already exists, so '$workflow' will not be triggered."
+    continue
+  }
 
   Write-Information "$($mapping.Property) is out of date (current: $currentVersion, latest: $latestVersion). Triggering '$workflow' for tag '$tag'."
 

--- a/build/scripts/check-for-new-sdk-releases.ps1
+++ b/build/scripts/check-for-new-sdk-releases.ps1
@@ -174,7 +174,7 @@ foreach ($mapping in $propertyMappings) {
   # exists then an update for this version is already in progress (a pull request is
   # open or was recently closed), so skip dispatching to avoid the workflow failing to
   # push to the existing branch and to avoid dispatching the same update every hour.
-  $branch = "otelbot/post-core-$latestVersion-update"
+  $branch = "otelbot/post-$tag-update"
   if ((TestUpdateBranchExists -repository $contribRepository -branch $branch) -eq $true) {
     Write-Information "$($mapping.Property) is out of date (current: $currentVersion, latest: $latestVersion) but branch '$branch' already exists, so '$workflow' will not be triggered."
     continue

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -330,7 +330,7 @@ function CreateOpenTelemetryCoreLatestVersionUpdatePullRequest {
     Return
   }
 
-  $branch="otelbot/post-core-${version}-update"
+  $branch="otelbot/post-${tag}-update"
 
   if ([string]::IsNullOrEmpty($gitUserName) -eq $false)
   {

--- a/build/scripts/tests/RunTests.ps1
+++ b/build/scripts/tests/RunTests.ps1
@@ -59,6 +59,7 @@ $testsDirectory = $PSScriptRoot
 $coveragePaths = @(
     "add-labels.psm1",
     "build.psm1",
+    "check-for-new-sdk-releases.ps1",
     "finalize-publicapi.ps1",
     "post-release.psm1",
     "prepare-release.psm1",

--- a/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
+++ b/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
@@ -83,6 +83,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         )
 
         Mock -CommandName "gh" -MockWith {
+            $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
 
@@ -105,6 +106,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         )
 
         Mock -CommandName "gh" -MockWith {
+            $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
 
@@ -133,6 +135,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         )
 
         Mock -CommandName "gh" -MockWith {
+            $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
 
@@ -159,6 +162,7 @@ Describe "check-for-new-sdk-releases.ps1" {
             -Prereleases @{ "core-2.0.0" = $true }
 
         Mock -CommandName "gh" -MockWith {
+            $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
 
@@ -179,6 +183,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         $releasesJson = NewReleasesJson -Tags @("core-1.16.0")
 
         Mock -CommandName "gh" -MockWith {
+            $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
 
@@ -203,6 +208,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         $releasesJson = NewReleasesJson -Tags @("core-1.15.0")
 
         Mock -CommandName "gh" -MockWith {
+            $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
 
@@ -223,7 +229,7 @@ Describe "check-for-new-sdk-releases.ps1" {
             -Path (Join-Path -Path $work -ChildPath "Directory.Packages.props") `
             -Value "<Project><PropertyGroup><OpenTelemetryCoreLatestVersion>1.16.0</OpenTelemetryCoreLatestVersion></PropertyGroup></Project>"
 
-        Mock -CommandName "gh" -MockWith { }
+        Mock -CommandName "gh" -MockWith { $global:LASTEXITCODE = 0 }
 
         { & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null } |
             Should -Throw "*OpenTelemetryCoreLatestPrereleaseVersion*"

--- a/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
+++ b/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
@@ -128,6 +128,42 @@ Describe "check-for-new-sdk-releases.ps1" {
         } -Because "the unstable version should be updated using the 'coreunstable-' prefixed tag"
     }
 
+    It "uses distinct update branches when core and coreunstable releases have the same version" {
+        $work = NewRepositoryFixture -StableVersion "1.8.0" -PrereleaseVersion "1.8.0-rc.1" -UnstableVersion "1.8.0-alpha.1"
+
+        # Core and coreunstable releases can share the same version, but they update
+        # different properties and therefore must not target the same remote branch.
+        $releasesJson = NewReleasesJson -Tags @(
+            "core-1.8.0",
+            "core-1.9.0-alpha.1",
+            "coreunstable-1.9.0-alpha.1"
+        )
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 1; return }
+            $global:LASTEXITCODE = 0
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "api" -and ($args -join " ") -match "branches/otelbot/post-core-1\.9\.0-alpha\.1-update"
+        } -Because "the core prerelease should use a branch containing the full core tag"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "api" -and ($args -join " ") -match "branches/otelbot/post-coreunstable-1\.9\.0-alpha\.1-update"
+        } -Because "the unstable release should use a distinct branch containing the full coreunstable tag"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=core-1.9.0-alpha.1"
+        } -Because "the core prerelease update should be dispatched"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=coreunstable-1.9.0-alpha.1"
+        } -Because "the unstable update should be dispatched independently"
+    }
+
     It "only triggers the update workflow for the versions that are out of date" {
         $work = NewRepositoryFixture -StableVersion "1.15.0" -PrereleaseVersion "1.16.0-rc.1" -UnstableVersion "1.16.0-beta.1"
 

--- a/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
+++ b/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
@@ -1,0 +1,231 @@
+#Requires -PSEdition Core
+#Requires -Version 7
+
+BeforeAll {
+    $script:scriptPath = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath "check-for-new-sdk-releases.ps1"
+
+    # Define a stub for the GitHub CLI if it is not installed so that Pester is
+    # always able to mock it. The real 'gh' is never invoked by these tests.
+    if (-not (Get-Command -Name "gh" -ErrorAction SilentlyContinue)) {
+        function global:gh { throw "The 'gh' command should have been mocked but was invoked with: $args" }
+    }
+
+    # Creates an isolated repository fixture containing a Directory.Packages.props
+    # with the three OpenTelemetry core version properties set to the supplied
+    # values and returns its root path. The script only reads the file.
+    function script:NewRepositoryFixture {
+        param(
+            [string]$StableVersion,
+            [string]$PrereleaseVersion,
+            [string]$UnstableVersion
+        )
+
+        $work = Join-Path -Path $TestDrive -ChildPath (New-Guid)
+        New-Item -Path $work -ItemType Directory -Force | Out-Null
+        Set-Content `
+            -Path (Join-Path -Path $work -ChildPath "Directory.Packages.props") `
+            -Value @"
+<Project>
+  <PropertyGroup>
+    <OpenTelemetryCoreLatestVersion>$StableVersion</OpenTelemetryCoreLatestVersion>
+    <OpenTelemetryCoreUnstableLatestVersion>$UnstableVersion</OpenTelemetryCoreUnstableLatestVersion>
+    <OpenTelemetryCoreLatestPrereleaseVersion>$PrereleaseVersion</OpenTelemetryCoreLatestPrereleaseVersion>
+  </PropertyGroup>
+</Project>
+"@
+        return $work
+    }
+
+    # Builds the JSON payload returned by 'gh release list
+    # --json isPrerelease,publishedAt,tagName' for a set of tags, assigning each an
+    # increasing publishedAt timestamp so the later entries are treated as the most
+    # recent releases. By default a release is flagged as a prerelease when its tag
+    # has a prerelease suffix, matching how the opentelemetry-dotnet repository marks
+    # its releases; the isPrerelease flag can be overridden for a specific tag via
+    # the -Prereleases hashtable to exercise the prerelease handling explicitly.
+    function script:NewReleasesJson {
+        param(
+            [string[]]$Tags,
+            [hashtable]$Prereleases = @{}
+        )
+
+        $index = 0
+        $releases = foreach ($tag in $Tags) {
+            $index++
+            $version = $tag -replace '^(coreunstable-|core-)', ''
+            $isPrerelease = if ($Prereleases.ContainsKey($tag)) { [bool]$Prereleases[$tag] } else { $version.Contains("-") }
+            [PSCustomObject]@{
+                tagName      = $tag
+                isPrerelease = $isPrerelease
+                publishedAt  = "2024-01-{0:D2}T00:00:00Z" -f $index
+            }
+        }
+
+        return ConvertTo-Json -InputObject @($releases) -Depth 5
+    }
+}
+
+AfterAll {
+    Remove-Item -Path "function:gh" -Force -ErrorAction SilentlyContinue
+}
+
+Describe "check-for-new-sdk-releases.ps1" {
+
+    It "does not trigger the update workflow when all versions are up to date" {
+        $work = NewRepositoryFixture -StableVersion "1.16.0" -PrereleaseVersion "1.16.0-rc.1" -UnstableVersion "1.16.0-beta.1"
+
+        $releasesJson = NewReleasesJson -Tags @(
+            "core-1.15.0",
+            "coreunstable-1.15.0-beta.1",
+            "core-1.16.0-rc.1",
+            "coreunstable-1.16.0-beta.1",
+            "core-1.16.0"
+        )
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 0 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run"
+        } -Because "no version is out of date so the update workflow should not be triggered"
+    }
+
+    It "triggers the update workflow with the correct tag for each out-of-date version" {
+        $work = NewRepositoryFixture -StableVersion "1.15.0" -PrereleaseVersion "1.15.0-rc.1" -UnstableVersion "1.15.0-beta.1"
+
+        $releasesJson = NewReleasesJson -Tags @(
+            "core-1.15.0",
+            "coreunstable-1.15.0-beta.1",
+            "core-1.16.0-rc.1",
+            "coreunstable-1.16.0-beta.1",
+            "core-1.16.0"
+        )
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=core-1.16.0"
+        } -Because "the stable version should be updated using the 'core-' prefixed tag"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=core-1.16.0-rc.1"
+        } -Because "the prerelease version should be updated using the 'core-' prefixed release candidate tag"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=coreunstable-1.16.0-beta.1"
+        } -Because "the unstable version should be updated using the 'coreunstable-' prefixed tag"
+    }
+
+    It "only triggers the update workflow for the versions that are out of date" {
+        $work = NewRepositoryFixture -StableVersion "1.15.0" -PrereleaseVersion "1.16.0-rc.1" -UnstableVersion "1.16.0-beta.1"
+
+        $releasesJson = NewReleasesJson -Tags @(
+            "core-1.16.0-rc.1",
+            "coreunstable-1.16.0-beta.1",
+            "core-1.16.0"
+        )
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run"
+        } -Because "only the stable version is out of date"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=core-1.16.0"
+        } -Because "the out-of-date stable version should be updated and not mistaken for a 'coreunstable-' release"
+    }
+
+    It "treats a release flagged as a prerelease as a prerelease even without a prerelease version suffix" {
+        $work = NewRepositoryFixture -StableVersion "1.16.0" -PrereleaseVersion "1.15.0-rc.1" -UnstableVersion "1.16.0-beta.1"
+
+        # 'core-2.0.0' has no prerelease suffix but is flagged as a prerelease, so it
+        # must not be treated as the latest stable release. The latest stable release
+        # remains 'core-1.16.0' (which matches the props) and the prerelease lookup
+        # should instead resolve to 'core-2.0.0'.
+        $releasesJson = NewReleasesJson `
+            -Tags @("core-1.16.0", "coreunstable-1.16.0-beta.1", "core-2.0.0") `
+            -Prereleases @{ "core-2.0.0" = $true }
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run"
+        } -Because "only the prerelease version is out of date once the prerelease flag is honoured"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=core-2.0.0"
+        } -Because "the prerelease lookup should pick the release flagged as a prerelease"
+    }
+
+    It "uses the GITHUB_REPOSITORY environment variable to determine the repository to dispatch to" {
+        $work = NewRepositoryFixture -StableVersion "1.15.0" -PrereleaseVersion "1.16.0-rc.1" -UnstableVersion "1.16.0-beta.1"
+
+        $releasesJson = NewReleasesJson -Tags @("core-1.16.0")
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        $originalRepository = $env:GITHUB_REPOSITORY
+        $env:GITHUB_REPOSITORY = "open-telemetry/my-fork"
+        try {
+            & $scriptPath -repoRoot $work 6>$null
+        }
+        finally {
+            $env:GITHUB_REPOSITORY = $originalRepository
+        }
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run" -and $args -contains "open-telemetry/my-fork"
+        } -Because "the workflow should be dispatched to the repository named by GITHUB_REPOSITORY"
+    }
+
+    It "warns and does not trigger the update workflow when no matching release can be found" {
+        $work = NewRepositoryFixture -StableVersion "1.15.0" -PrereleaseVersion "1.15.0-rc.1" -UnstableVersion "1.15.0-beta.1"
+
+        # Only stable releases exist, so no release candidate or unstable release can be found.
+        $releasesJson = NewReleasesJson -Tags @("core-1.15.0")
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        $warnings = & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 3>&1 6>$null
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 0 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run"
+        } -Because "no version is out of date and the missing release kinds should be skipped"
+
+        ($warnings -join "`n") | Should -Match "Could not find a prerelease release" -Because "a warning should be emitted when a matching release is missing"
+        ($warnings -join "`n") | Should -Match "Could not find an? unstable release" -Because "a warning should be emitted when a matching release is missing"
+    }
+
+    It "throws when an expected version property is missing from Directory.Packages.props" {
+        $work = Join-Path -Path $TestDrive -ChildPath (New-Guid)
+        New-Item -Path $work -ItemType Directory -Force | Out-Null
+        Set-Content `
+            -Path (Join-Path -Path $work -ChildPath "Directory.Packages.props") `
+            -Value "<Project><PropertyGroup><OpenTelemetryCoreLatestVersion>1.16.0</OpenTelemetryCoreLatestVersion></PropertyGroup></Project>"
+
+        Mock -CommandName "gh" -MockWith { }
+
+        { & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null } |
+            Should -Throw "*OpenTelemetryCoreLatestPrereleaseVersion*"
+    }
+}

--- a/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
+++ b/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
@@ -41,8 +41,9 @@ BeforeAll {
     # increasing publishedAt timestamp so the later entries are treated as the most
     # recent releases. By default a release is flagged as a prerelease when its tag
     # has a prerelease suffix, matching how the opentelemetry-dotnet repository marks
-    # its releases; the isPrerelease flag can be overridden for a specific tag via
-    # the -Prereleases hashtable to exercise the prerelease handling explicitly.
+    # its releases; the isPrerelease flag can be overridden for a specific tag via the
+    # -Prereleases hashtable to verify that the script classifies releases by version
+    # suffix alone and deliberately ignores the GitHub prerelease flag.
     function script:NewReleasesJson {
         param(
             [string[]]$Tags,
@@ -83,6 +84,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         )
 
         Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 1; return }
             $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
@@ -106,6 +108,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         )
 
         Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 1; return }
             $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
@@ -135,6 +138,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         )
 
         Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 1; return }
             $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
@@ -150,18 +154,22 @@ Describe "check-for-new-sdk-releases.ps1" {
         } -Because "the out-of-date stable version should be updated and not mistaken for a 'coreunstable-' release"
     }
 
-    It "treats a release flagged as a prerelease as a prerelease even without a prerelease version suffix" {
-        $work = NewRepositoryFixture -StableVersion "1.16.0" -PrereleaseVersion "1.15.0-rc.1" -UnstableVersion "1.16.0-beta.1"
+    It "classifies releases by version suffix and not the GitHub prerelease flag so it agrees with the core version update workflow" {
+        $work = NewRepositoryFixture -StableVersion "1.16.0" -PrereleaseVersion "2.1.0-rc.1" -UnstableVersion "1.16.0-beta.1"
 
-        # 'core-2.0.0' has no prerelease suffix but is flagged as a prerelease, so it
-        # must not be treated as the latest stable release. The latest stable release
-        # remains 'core-1.16.0' (which matches the props) and the prerelease lookup
-        # should instead resolve to 'core-2.0.0'.
+        # 'core-2.0.0' has no prerelease version suffix but is flagged as a prerelease
+        # by GitHub. The core-version-update workflow decides whether a tag updates the
+        # stable or prerelease property based solely on the version suffix, so this
+        # script must ignore the flag and treat 'core-2.0.0' as the latest *stable*
+        # release. If the flag were honoured instead, 'core-2.0.0' would be classified
+        # as a prerelease (which is already up to date at 'core-2.1.0-rc.1') and the
+        # stable property would be left behind at '1.16.0'.
         $releasesJson = NewReleasesJson `
-            -Tags @("core-1.16.0", "coreunstable-1.16.0-beta.1", "core-2.0.0") `
+            -Tags @("core-1.16.0", "coreunstable-1.16.0-beta.1", "core-2.0.0", "core-2.1.0-rc.1") `
             -Prereleases @{ "core-2.0.0" = $true }
 
         Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 1; return }
             $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
@@ -170,11 +178,35 @@ Describe "check-for-new-sdk-releases.ps1" {
 
         Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
             $args -contains "workflow" -and $args -contains "run"
-        } -Because "only the prerelease version is out of date once the prerelease flag is honoured"
+        } -Because "only the stable version is out of date once the prerelease flag is ignored"
 
         Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
             $args -contains "workflow" -and $args -contains "run" -and $args -contains "tag=core-2.0.0"
-        } -Because "the prerelease lookup should pick the release flagged as a prerelease"
+        } -Because "'core-2.0.0' has no version suffix so it must update the stable property despite the prerelease flag"
+    }
+
+    It "does not trigger the update workflow when the update branch already exists" {
+        $work = NewRepositoryFixture -StableVersion "1.15.0" -PrereleaseVersion "1.16.0-rc.1" -UnstableVersion "1.16.0-beta.1"
+
+        # Only the stable version is out of date; the prerelease and unstable releases
+        # match the props so the branch guard is only exercised for the stable update.
+        $releasesJson = NewReleasesJson -Tags @("core-1.16.0", "core-1.16.0-rc.1", "coreunstable-1.16.0-beta.1")
+
+        Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 0; return }
+            $global:LASTEXITCODE = 0
+            if ($args -contains "list") { return $releasesJson }
+        }
+
+        & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "api" -and ($args -join " ") -match "branches/otelbot/post-core-1\.16\.0-update"
+        } -Because "the script should check whether the update branch already exists before dispatching"
+
+        Should -Invoke -CommandName "gh" -Exactly -Times 0 -ParameterFilter {
+            $args -contains "workflow" -and $args -contains "run"
+        } -Because "an update for this version is already in progress so it should not be dispatched again"
     }
 
     It "uses the GITHUB_REPOSITORY environment variable to determine the repository to dispatch to" {
@@ -183,6 +215,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         $releasesJson = NewReleasesJson -Tags @("core-1.16.0")
 
         Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 1; return }
             $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }
@@ -208,6 +241,7 @@ Describe "check-for-new-sdk-releases.ps1" {
         $releasesJson = NewReleasesJson -Tags @("core-1.15.0")
 
         Mock -CommandName "gh" -MockWith {
+            if ($args -contains "api") { $global:LASTEXITCODE = 1; return }
             $global:LASTEXITCODE = 0
             if ($args -contains "list") { return $releasesJson }
         }

--- a/build/scripts/tests/post-release.Tests.ps1
+++ b/build/scripts/tests/post-release.Tests.ps1
@@ -270,6 +270,10 @@ Released 2024-01-01
             $args -contains "pr" -and $args -contains "create" -and $args -contains "--label" -and $args -contains "release"
         } -Because "a labelled pull request should be opened for the core update"
 
+        Should -Invoke -CommandName "git" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "switch" -and $args -contains "otelbot/post-core-1.2.3-update"
+        } -Because "the update branch should contain the full core tag"
+
         (Get-Content -Path (Join-Path -Path $project -ChildPath "CHANGELOG.md") -Raw) |
             Should -Match "Updated OpenTelemetry core component version\(s\) to ``1\.2\.3``" -Because "the CHANGELOG of an affected project should be updated"
     }
@@ -309,6 +313,10 @@ Released 2024-01-01
         Should -Invoke -CommandName "gh" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
             $args -contains "pr" -and $args -contains "create" -and $args -contains "--label" -and $args -contains "release"
         } -Because "a labelled pull request should be opened for the core unstable update"
+
+        Should -Invoke -CommandName "git" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
+            $args -contains "switch" -and $args -contains "otelbot/post-coreunstable-1.1.0-beta.1-update"
+        } -Because "the update branch should contain the full coreunstable tag"
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/6556

## Changes

Add a GitHub Actions workflow to check for new main SDK releases to trigger version updates.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
