### PR TITLE
[AspNetCore] Clarify timing scope

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -334,6 +334,11 @@ The time ends when:
 * All response data has been sent.
 * The context data structures for the request are being disposed.
 
+Because this window spans the entire handler pipeline, the measurement
+includes the time spent reading the request payload (for example, model
+binding or reading a large request body via `HttpRequest.Body`) as well as the
+time spent sending the response.
+
 ## Experimental support for gRPC requests
 
 gRPC instrumentation can be enabled by setting


### PR DESCRIPTION
Fixes #2015

## Changes

Clarify exactly what is timed by `http.server.request.duration` by the ASP.NET Core instrumentation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
