### PR TITLE
[Instrumentation.Kusto] Match the EXC_CTOR exception source id family

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Kusto/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Kusto/CHANGELOG.md
@@ -4,3 +4,8 @@
 
 * Initial implementation.
   ([#3591](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3591))
+
+* Recognized the `EXC_CTOR.<ExceptionType>` exception source id introduced in
+  `Microsoft.Azure.Kusto.Data` 14.1.2 so `error.type` continues to be recorded
+  for failed queries.
+  ([#4630](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4630))

--- a/src/OpenTelemetry.Instrumentation.Kusto/Implementation/TraceRecordExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Kusto/Implementation/TraceRecordExtensions.cs
@@ -8,8 +8,8 @@ namespace OpenTelemetry.Instrumentation.Kusto.Implementation;
 /// <summary>
 /// Classifies a Kusto client <see cref="KustoUtils.TraceRecord"/> by the markers the
 /// client writes into its trace output: RestClient2 writes "$$HTTPREQUEST[", the activity layer writes
-/// "MonitoredActivityCompleted", and exceptions are traced under the "EXC_CTOR" source id. There is no public
-/// reference to link, so they are matched by string.
+/// "MonitoredActivityCompleted", and exceptions are traced under a source that is "EXC_CTOR" or begins with
+/// "EXC_CTOR.". There is no public reference to link, so they are matched by string.
 /// </summary>
 internal static class TraceRecordExtensions
 {
@@ -20,7 +20,9 @@ internal static class TraceRecordExtensions
 
     public static bool IsException(this KustoUtils.TraceRecord record)
     {
-        return record.SourceId == "EXC_CTOR";
+        var sourceId = record.SourceId;
+        return sourceId == "EXC_CTOR"
+            || sourceId?.StartsWith("EXC_CTOR.", StringComparison.Ordinal) == true;
     }
 
     public static bool IsActivityComplete(this KustoUtils.TraceRecord record)

--- a/test/OpenTelemetry.Instrumentation.Kusto.Tests/TraceRecordExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Kusto.Tests/TraceRecordExtensionsTests.cs
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Instrumentation.Kusto.Implementation;
+using KustoUtils = Kusto.Cloud.Platform.Utils;
+
+namespace OpenTelemetry.Instrumentation.Kusto.Tests;
+
+public class TraceRecordExtensionsTests
+{
+    [Theory]
+
+    // Bare constant version.
+    [InlineData("EXC_CTOR", true)]
+
+    // Prefix version.
+    [InlineData("EXC_CTOR.SemanticException", true)]
+    [InlineData("EXC_CTOR.KustoClientStreamReadException", true)]
+
+    [InlineData("EXC_CTORX", false)]
+    [InlineData("EXC_CTOR_SemanticException", false)]
+
+    [InlineData("SOMETHING_ELSE", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsException(string? sourceId, bool expected)
+    {
+        var record = new KustoUtils.TraceRecord { SourceId = sourceId };
+
+        Assert.Equal(expected, record.IsException());
+    }
+
+    [Theory]
+    [InlineData("$$HTTPREQUEST[RestClient2]: Verb=POST, Uri=http://localhost/v1/rest/query", true)]
+    [InlineData("MonitoredActivityCompleted: KD.RestClient.ExecuteQuery", false)]
+    [InlineData("Exception object created: Kusto.Data.Exceptions.SemanticException", false)]
+    public void IsRequestStart(string message, bool expected)
+    {
+        var record = new KustoUtils.TraceRecord { Message = message };
+
+        Assert.Equal(expected, record.IsRequestStart());
+    }
+
+    [Theory]
+    [InlineData("MonitoredActivityCompleted: KD.RestClient.ExecuteQuery", true)]
+    [InlineData("$$HTTPREQUEST[RestClient2]: Verb=POST, Uri=http://localhost/v1/rest/query", false)]
+    public void IsActivityComplete(string message, bool expected)
+    {
+        var record = new KustoUtils.TraceRecord { Message = message };
+
+        Assert.Equal(expected, record.IsActivityComplete());
+    }
+}


### PR DESCRIPTION
## Changes

`Microsoft.Azure.Kusto.Data` 14.1.2 changed the source id used for the
exception-construction trace record from the bare `EXC_CTOR` to
`EXC_CTOR.<ExceptionType>` (for example `EXC_CTOR.SemanticException`).
`TraceRecordExtensions.IsException` matched that source id by exact equality, so
on 14.1.2 and later a failed query was no longer classified as an exception:
`error.type` was not recorded on the `db.client.operation.duration` metric and
the span status was not set to `Error`.

This relaxes the classifier to recognize a source id that is `EXC_CTOR` or begins
with `EXC_CTOR.`, so both the previous and current client versions are handled,
and adds unit tests for the trace-record classifiers.

Surfaced by the dependency bump in #4621: that update currently fails the
`Instrumentation.Kusto` integration tests on Linux for this reason, and will pass
once rebased on this fix. This is a source-only change and does not itself bump
the pinned `Microsoft.Azure.Kusto.Data` version.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable) - no public API changes
