### PR TITLE
[OpAMP] Add full state report

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -15,16 +15,16 @@ OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.Content.get -> System.Re
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.ContentType.get -> string!
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.EffectiveConfigFile(System.ReadOnlyMemory<byte> content, string! contentType, string! fileName) -> void
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.FileName.get -> string!
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.CustomCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.CustomCapabilities.set -> void
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.EffectiveConfigFiles.get -> System.Collections.Generic.IEnumerable<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>?
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.EffectiveConfigFiles.set -> void
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.FullStateReport() -> void
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.RemoteConfigStatus.get -> OpenTelemetry.OpAmp.Client.Messages.RemoteConfigStatusReport?
-OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.RemoteConfigStatus.set -> void
 OpenTelemetry.OpAmp.Client.Messages.FlagsMessage
 OpenTelemetry.OpAmp.Client.Messages.FlagsMessage.Flags.get -> OpenTelemetry.OpAmp.Client.Messages.ServerSentFlags
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport.CustomCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport.CustomCapabilities.set -> void
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport.EffectiveConfigFiles.get -> System.Collections.Generic.IEnumerable<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>?
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport.EffectiveConfigFiles.set -> void
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport.FullStateReport() -> void
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport.RemoteConfigStatus.get -> OpenTelemetry.OpAmp.Client.Messages.RemoteConfigStatusReport?
+OpenTelemetry.OpAmp.Client.Messages.FullStateReport.RemoteConfigStatus.set -> void
 OpenTelemetry.OpAmp.Client.Messages.OpAmpMessage
 OpenTelemetry.OpAmp.Client.Messages.OpAmpMessage.OpAmpMessage() -> void
 OpenTelemetry.OpAmp.Client.Messages.RemoteConfigMessage
@@ -61,7 +61,7 @@ OpenTelemetry.OpAmp.Client.OpAmpClient.OpAmpClient(System.Action<OpenTelemetry.O
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendCustomCapabilitiesAsync(System.Collections.Generic.IEnumerable<string!>! capabilities, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendCustomMessageAsync(string! capability, string! type, System.ReadOnlyMemory<byte> data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendEffectiveConfigAsync(System.Collections.Generic.IEnumerable<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>! files, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-OpenTelemetry.OpAmp.Client.OpAmpClient.SendFullStateReportAsync(OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+OpenTelemetry.OpAmp.Client.OpAmpClient.SendFullStateReportAsync(OpenTelemetry.OpAmp.Client.Messages.FullStateReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendRemoteConfigStatusAsync(OpenTelemetry.OpAmp.Client.Messages.RemoteConfigStatusReport! statusReport, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.StartAsync(System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.StopAsync(System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -15,6 +15,14 @@ OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.Content.get -> System.Re
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.ContentType.get -> string!
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.EffectiveConfigFile(System.ReadOnlyMemory<byte> content, string! contentType, string! fileName) -> void
 OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile.FileName.get -> string!
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.CustomCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.CustomCapabilities.set -> void
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.EffectiveConfigFiles.get -> System.Collections.Generic.IEnumerable<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>?
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.EffectiveConfigFiles.set -> void
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.FullStateReport() -> void
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.RemoteConfigStatus.get -> OpenTelemetry.OpAmp.Client.Messages.RemoteConfigStatusReport?
+OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport.RemoteConfigStatus.set -> void
 OpenTelemetry.OpAmp.Client.Messages.FlagsMessage
 OpenTelemetry.OpAmp.Client.Messages.FlagsMessage.Flags.get -> OpenTelemetry.OpAmp.Client.Messages.ServerSentFlags
 OpenTelemetry.OpAmp.Client.Messages.OpAmpMessage
@@ -53,6 +61,7 @@ OpenTelemetry.OpAmp.Client.OpAmpClient.OpAmpClient(System.Action<OpenTelemetry.O
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendCustomCapabilitiesAsync(System.Collections.Generic.IEnumerable<string!>! capabilities, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendCustomMessageAsync(string! capability, string! type, System.ReadOnlyMemory<byte> data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendEffectiveConfigAsync(System.Collections.Generic.IEnumerable<OpenTelemetry.OpAmp.Client.Messages.EffectiveConfigFile!>! files, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+OpenTelemetry.OpAmp.Client.OpAmpClient.SendFullStateReportAsync(OpenTelemetry.OpAmp.Client.Messages.Flags.FullStateReport! report, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.SendRemoteConfigStatusAsync(OpenTelemetry.OpAmp.Client.Messages.RemoteConfigStatusReport! statusReport, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.StartAsync(System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 OpenTelemetry.OpAmp.Client.OpAmpClient.StopAsync(System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add support for reporting full state.
+  ([#4633](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4633))
+
 ## 0.5.0-alpha.1
 
 Released 2026-Jul-01

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
@@ -145,19 +145,19 @@ internal sealed class FrameDispatcher : IDisposable
                 .AddCapabilities();
 
             // TODO: Add here features when they become available and are necessary to restore the full state in the server if requested.
-            if (report.EffectiveConfigFiles != null)
+            if (report.EffectiveConfigFiles is { } effectiveConfig)
             {
-                message.AddEffectiveConfig(report.EffectiveConfigFiles);
+                message.AddEffectiveConfig(effectiveConfig);
             }
 
-            if (report.RemoteConfigStatus != null)
+            if (report.RemoteConfigStatus is { } remoteConfigStatus)
             {
-                message.AddRemoteConfigStatus(report.RemoteConfigStatus);
+                message.AddRemoteConfigStatus(remoteConfigStatus);
             }
 
-            if (report.CustomCapabilities != null)
+            if (report.CustomCapabilities is { } customCapabilities)
             {
-                message.AddCustomCapabilities(report.CustomCapabilities);
+                message.AddCustomCapabilities(customCapabilities);
             }
 
             return message.Build();

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
@@ -6,6 +6,7 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Internal.Transport;
 using OpenTelemetry.OpAmp.Client.Messages;
+using OpenTelemetry.OpAmp.Client.Messages.Flags;
 using OpenTelemetry.OpAmp.Client.Settings;
 
 namespace OpenTelemetry.OpAmp.Client.Internal;
@@ -125,6 +126,41 @@ internal sealed class FrameDispatcher : IDisposable
         AgentToServer BuildCustomMessageMessage(FrameBuilder fb)
         {
             return fb.StartBaseMessage().AddCustomMessage(capability, type, data).Build();
+        }
+    }
+
+    public async Task DispatchFullStateReportAsync(FullStateReport report, CancellationToken token)
+    {
+        await this.DispatchFrameAsync(
+            BuildFullStateReportMessage,
+            OpAmpClientEventSource.Log.SendingFullStateReportMessage,
+            OpAmpClientEventSource.Log.SendFullStateReportMessageException,
+            token).ConfigureAwait(false);
+
+        AgentToServer BuildFullStateReportMessage(FrameBuilder fb)
+        {
+            // Start message with basic partials.
+            var message = fb.StartBaseMessage()
+                .AddAgentDescription()
+                .AddCapabilities();
+
+            // TODO: Add here features when they become available and are necessary to restore the full state in the server if requested.
+            if (report.EffectiveConfigFiles != null)
+            {
+                message.AddEffectiveConfig(report.EffectiveConfigFiles);
+            }
+
+            if (report.RemoteConfigStatus != null)
+            {
+                message.AddRemoteConfigStatus(report.RemoteConfigStatus);
+            }
+
+            if (report.CustomCapabilities != null)
+            {
+                message.AddCustomCapabilities(report.CustomCapabilities);
+            }
+
+            return message.Build();
         }
     }
 

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
@@ -145,6 +145,7 @@ internal sealed class FrameDispatcher : IDisposable
                 .AddCapabilities();
 
             // TODO: Add here features when they become available and are necessary to restore the full state in the server if requested.
+            // See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/4634
             if (report.EffectiveConfigFiles is { } effectiveConfig)
             {
                 message.AddEffectiveConfig(effectiveConfig);

--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameDispatcher.cs
@@ -6,7 +6,6 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Internal.Transport;
 using OpenTelemetry.OpAmp.Client.Messages;
-using OpenTelemetry.OpAmp.Client.Messages.Flags;
 using OpenTelemetry.OpAmp.Client.Settings;
 
 namespace OpenTelemetry.OpAmp.Client.Internal;

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientEventSource.cs
@@ -34,6 +34,7 @@ internal sealed class OpAmpClientEventSource : EventSource
     private const int EventIdSendingCustomCapabilitiesMessage = 1_004;
     private const int EventIdSendingCustomMessageMessage = 1_005;
     private const int EventIdSendingRemoteConfigStatusMessage = 1_006;
+    private const int EventIdSendingFullStateReportMessage = 1_007;
 
     // FrameDispatcher error messages 1100-1199
     private const int EventIdFailedToSendIdentificationMessage = 1_100;
@@ -43,6 +44,7 @@ internal sealed class OpAmpClientEventSource : EventSource
     private const int EventIdFailedToSendCustomCapabilitiesMessage = 1_104;
     private const int EventIdFailedToSendCustomMessageMessage = 1_105;
     private const int EventIdFailedToSendRemoteConfigStatusMessage = 1_106;
+    private const int EventIdFailedToSendFullStateReportMessage = 1_107;
 
     [Event(EventIdInvalidWsFrame, Message = "Received invalid WebSocket frame header: {0}. Dropping the frame.", Level = EventLevel.Warning)]
     public void InvalidWsFrame(string errorMessage)
@@ -217,6 +219,12 @@ internal sealed class OpAmpClientEventSource : EventSource
         this.WriteEvent(EventIdSendingRemoteConfigStatusMessage);
     }
 
+    [Event(EventIdSendingFullStateReportMessage, Message = "Sending full state report message.", Level = EventLevel.Informational)]
+    public void SendingFullStateReportMessage()
+    {
+        this.WriteEvent(EventIdSendingFullStateReportMessage);
+    }
+
     [NonEvent]
     public void SendIdentificationMessageException(Exception ex)
     {
@@ -320,5 +328,20 @@ internal sealed class OpAmpClientEventSource : EventSource
     public void FailedToSendRemoteConfigStatusMessage(string exception)
     {
         this.WriteEvent(EventIdFailedToSendRemoteConfigStatusMessage, exception);
+    }
+
+    [NonEvent]
+    public void SendFullStateReportMessageException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.FailedToSendFullStateReportMessage(ex.ToInvariantString());
+        }
+    }
+
+    [Event(EventIdFailedToSendFullStateReportMessage, Message = "Failed to send full state report message: {0}", Level = EventLevel.Error)]
+    public void FailedToSendFullStateReportMessage(string exception)
+    {
+        this.WriteEvent(EventIdFailedToSendFullStateReportMessage, exception);
     }
 }

--- a/src/OpenTelemetry.OpAmp.Client/Messages/Flags/FullStateReport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Messages/Flags/FullStateReport.cs
@@ -6,7 +6,7 @@ namespace OpenTelemetry.OpAmp.Client.Messages.Flags;
 /// <summary>
 /// Contains all parts that are necessary to restore the full state in the server.
 /// </summary>
-public class FullStateReport
+public sealed class FullStateReport
 {
     /// <summary>
     /// Gets or sets the effective configuration.

--- a/src/OpenTelemetry.OpAmp.Client/Messages/Flags/FullStateReport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Messages/Flags/FullStateReport.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-namespace OpenTelemetry.OpAmp.Client.Messages.Flags;
+namespace OpenTelemetry.OpAmp.Client.Messages;
 
 /// <summary>
 /// Contains all parts that are necessary to restore the full state in the server.

--- a/src/OpenTelemetry.OpAmp.Client/Messages/Flags/FullStateReport.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Messages/Flags/FullStateReport.cs
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Messages.Flags;
+
+/// <summary>
+/// Contains all parts that are necessary to restore the full state in the server.
+/// </summary>
+public class FullStateReport
+{
+    /// <summary>
+    /// Gets or sets the effective configuration.
+    /// </summary>
+    public IEnumerable<EffectiveConfigFile>? EffectiveConfigFiles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the custom capabilities.
+    /// </summary>
+    public IEnumerable<string>? CustomCapabilities { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last remote config status.
+    /// </summary>
+    public RemoteConfigStatusReport? RemoteConfigStatus { get; set; }
+}

--- a/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
@@ -10,6 +10,7 @@ using OpenTelemetry.OpAmp.Client.Internal.Transport.Http;
 using OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 using OpenTelemetry.OpAmp.Client.Listeners;
 using OpenTelemetry.OpAmp.Client.Messages;
+using OpenTelemetry.OpAmp.Client.Messages.Flags;
 using OpenTelemetry.OpAmp.Client.Settings;
 
 namespace OpenTelemetry.OpAmp.Client;
@@ -203,6 +204,20 @@ public sealed class OpAmpClient : IDisposable
         this.ThrowIfDisposed();
 
         return this.dispatcher.DispatchCustomMessageAsync(capability, type, data, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends full state report message to restore the lost state in the server.
+    /// </summary>
+    /// <param name="report">Report that contains supported partials.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that represents the asynchronous send operation.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the client has already been disposed.</exception>
+    public Task SendFullStateReportAsync(FullStateReport report, CancellationToken cancellationToken = default)
+    {
+        this.ThrowIfDisposed();
+
+        return this.dispatcher.DispatchFullStateReportAsync(report, cancellationToken);
     }
 
     /// <summary>

--- a/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
@@ -10,7 +10,6 @@ using OpenTelemetry.OpAmp.Client.Internal.Transport.Http;
 using OpenTelemetry.OpAmp.Client.Internal.Transport.WebSocket;
 using OpenTelemetry.OpAmp.Client.Listeners;
 using OpenTelemetry.OpAmp.Client.Messages;
-using OpenTelemetry.OpAmp.Client.Messages.Flags;
 using OpenTelemetry.OpAmp.Client.Settings;
 
 namespace OpenTelemetry.OpAmp.Client;
@@ -216,6 +215,17 @@ public sealed class OpAmpClient : IDisposable
     public Task SendFullStateReportAsync(FullStateReport report, CancellationToken cancellationToken = default)
     {
         this.ThrowIfDisposed();
+        Guard.ThrowIfNull(report);
+
+        if (report.EffectiveConfigFiles != null && !this.settings.EffectiveConfigurationReporting.EnableReporting)
+        {
+            throw new InvalidOperationException("Effective configuration reporting is not enabled in settings.");
+        }
+
+        if (report.RemoteConfigStatus != null && !this.settings.RemoteConfiguration.ReportsRemoteConfigStatus)
+        {
+            throw new InvalidOperationException("Remote configuration status reporting is not enabled in settings.");
+        }
 
         return this.dispatcher.DispatchFullStateReportAsync(report, cancellationToken);
     }

--- a/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
+++ b/src/OpenTelemetry.OpAmp.Client/OpAmpClient.cs
@@ -207,7 +207,7 @@ public sealed class OpAmpClient : IDisposable
     }
 
     /// <summary>
-    /// Sends full state report message to restore the lost state in the server.
+    /// Sends a full state report message to restore the lost state in the server.
     /// </summary>
     /// <param name="report">Report that contains supported partials.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -10,7 +10,6 @@ using System.Text;
 using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Messages;
-using OpenTelemetry.OpAmp.Client.Messages.Flags;
 using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.DataGenerators;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
@@ -492,6 +491,8 @@ public class OpAmpClientTests
 
             o.Identification.AddIdentifyingAttribute("test", "value");
             o.RemoteConfiguration.AcceptsRemoteConfig = true;
+            o.RemoteConfiguration.ReportsRemoteConfigStatus = true;
+            o.EffectiveConfigurationReporting.EnableReporting = true;
         });
 
         // Setup content

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using OpAmp.Proto.V1;
 using OpenTelemetry.OpAmp.Client.Internal.Services.Heartbeat;
 using OpenTelemetry.OpAmp.Client.Messages;
+using OpenTelemetry.OpAmp.Client.Messages.Flags;
 using OpenTelemetry.OpAmp.Client.Settings;
 using OpenTelemetry.OpAmp.Client.Tests.DataGenerators;
 using OpenTelemetry.OpAmp.Client.Tests.Mocks;
@@ -476,6 +477,46 @@ public class OpAmpClientTests
         Assert.Equal(capability, actualCapability);
         Assert.Equal(type, actualType);
         Assert.Equal(messageContent, actualMessageContent);
+    }
+
+    [Fact]
+    internal async Task SendsFullStateReport()
+    {
+        // Setup OpAMP server
+        using var opAmpServer = new OpAmpFakeHttpServer(false);
+        var opAmpEndpoint = opAmpServer.Endpoint;
+
+        using var client = new OpAmpClient(o =>
+        {
+            o.ServerUrl = opAmpEndpoint;
+
+            o.Identification.AddIdentifyingAttribute("test", "value");
+            o.RemoteConfiguration.AcceptsRemoteConfig = true;
+        });
+
+        // Setup content
+        var content = "test"u8.ToArray();
+        var report = new FullStateReport()
+        {
+            EffectiveConfigFiles = [new EffectiveConfigFile(content, "text/plain", "test")],
+            CustomCapabilities = ["test-capability"],
+            RemoteConfigStatus = new RemoteConfigStatusReport(content, RemoteConfigStatusCode.Applied),
+        };
+
+        // Act
+        await client.StartAsync();
+        await client.SendFullStateReportAsync(report);
+        await client.StopAsync();
+
+        // Assert received frames
+        var frames = opAmpServer.GetFrames();
+
+        Assert.NotNull(frames[1].AgentDescription);
+        Assert.NotNull(frames[1].EffectiveConfig);
+        Assert.NotNull(frames[1].CustomCapabilities);
+        Assert.NotNull(frames[1].RemoteConfigStatus);
+
+        Assert.True(frames[1].Capabilities > 0);
     }
 
     internal class CapabilityTestData


### PR DESCRIPTION
Towards #4634

## Changes

Adds a response option after receiving `FlagsMessage` with `ReportFullState`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
