### PR TITLE
[ConfluentKafka] Update Semantic Conventions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -28,6 +28,9 @@
     `messaging.kafka.destination.partition`)
   * `messaging.kafka.offset` (replacing `messaging.kafka.message.offset`)
 
+  `messaging.kafka.message.key` is now emitted as a string when the key has an
+  unambiguous canonical representation; otherwise, the attribute is omitted.
+
   The metrics were renamed to:
 
   * `messaging.client.operation.duration`

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -31,10 +31,10 @@
       (replacing `messaging.receive.messages`).
   `error.type` is now reported as the language-agnostic Kafka error code and
   the exception message is recorded in the span status description.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4636](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4636))
 
 * Metrics and traces now include a telemetry schema URL.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4636](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4636))
 
 ## 0.1.0-alpha.7
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -15,20 +15,24 @@
   The producer `send` span (previously `publish`) and the consumer `poll`
   span (previously `receive`, and now emitted with `ActivityKind.Client`) now
   set:
-    * `messaging.operation.name` and `messaging.operation.type`
-      (replacing `messaging.operation`)
-    * `messaging.client.id` (replacing `messaging.client_id`)
-    * `messaging.consumer.group.name` (replacing
-      `messaging.kafka.consumer.group`)
-    * `messaging.destination.partition.id` (a string) (replacing
-      `messaging.kafka.destination.partition`)
-    * `messaging.kafka.offset` (replacing `messaging.kafka.message.offset`)
+
+  * `messaging.operation.name` and `messaging.operation.type`
+    (replacing `messaging.operation`)
+  * `messaging.client.id` (replacing `messaging.client_id`)
+  * `messaging.consumer.group.name` (replacing
+    `messaging.kafka.consumer.group`)
+  * `messaging.destination.partition.id` (a string) (replacing
+    `messaging.kafka.destination.partition`)
+  * `messaging.kafka.offset` (replacing `messaging.kafka.message.offset`)
+
   The metrics were renamed to:
+
     * `messaging.client.operation.duration`
       (replacing `messaging.publish.duration` and `messaging.receive.duration`)
     * `messaging.client.sent.messages` (replacing `messaging.publish.messages`)
     * `messaging.client.consumed.messages`
       (replacing `messaging.receive.messages`).
+
   `error.type` is now reported as the language-agnostic Kafka error code and
   the exception message is recorded in the span status description.
   ([#4636](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4636))

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -9,6 +9,30 @@
   and producers created outside a DI container.
   ([#4545](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4545))
 
+* **Breaking change**: Updated the traces and metrics emitted by the Kafka
+  producer and consumer to follow the
+  [v1.42.0 messaging semantic conventions](https://github.com/open-telemetry/semantic-conventions/tree/v1.42.0/docs/messaging).
+  The producer `send` span (previously `publish`) and the consumer `poll`
+  span (previously `receive`, and now emitted with `ActivityKind.Client`) now
+  set:
+    * `messaging.operation.name` and `messaging.operation.type`
+      (replacing `messaging.operation`)
+    * `messaging.client.id` (replacing `messaging.client_id`)
+    * `messaging.consumer.group.name` (replacing
+      `messaging.kafka.consumer.group`)
+    * `messaging.destination.partition.id` (a string) (replacing
+      `messaging.kafka.destination.partition`)
+    * `messaging.kafka.offset` (replacing `messaging.kafka.message.offset`)
+  The metrics were renamed to:
+    * `messaging.client.operation.duration`
+      (replacing `messaging.publish.duration` and `messaging.receive.duration`)
+    * `messaging.client.sent.messages` (replacing `messaging.publish.messages`)
+    * `messaging.client.consumed.messages`
+      (replacing `messaging.receive.messages`).
+  `error.type` is now reported as the language-agnostic Kafka error code and
+  the exception message is recorded in the span status description.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 0.1.0-alpha.7
 
 Released 2026-May-29

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -33,6 +33,9 @@
   the exception message is recorded in the span status description.
   ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
 
+* Metrics and traces now include a telemetry schema URL.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 0.1.0-alpha.7
 
 Released 2026-May-29

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -27,11 +27,11 @@
 
   The metrics were renamed to:
 
-    * `messaging.client.operation.duration`
-      (replacing `messaging.publish.duration` and `messaging.receive.duration`)
-    * `messaging.client.sent.messages` (replacing `messaging.publish.messages`)
-    * `messaging.client.consumed.messages`
-      (replacing `messaging.receive.messages`).
+  * `messaging.client.operation.duration`
+    (replacing `messaging.publish.duration` and `messaging.receive.duration`)
+  * `messaging.client.sent.messages` (replacing `messaging.publish.messages`)
+  * `messaging.client.consumed.messages`
+    (replacing `messaging.receive.messages`).
 
   `error.type` is now reported as the language-agnostic Kafka error code and
   the exception message is recorded in the span status description.

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 * **Breaking change**: Updated the traces and metrics emitted by the Kafka
   producer and consumer to follow the
-  [v1.42.0 messaging semantic conventions](https://github.com/open-telemetry/semantic-conventions/tree/v1.42.0/docs/messaging).
+  [v1.43.0 messaging semantic conventions](https://github.com/open-telemetry/semantic-conventions/tree/v1.43.0/docs/messaging).
   The producer `send` span (previously `publish`) and the consumer `poll`
   span (previously `receive`, and now emitted with `ActivityKind.Client`) now
   set:

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -33,8 +33,10 @@
   * `messaging.client.consumed.messages`
     (replacing `messaging.receive.messages`).
 
-  `error.type` is now reported as the language-agnostic Kafka error code and
-  the exception message is recorded in the span status description.
+  `error.type` is now reported as the language-agnostic Kafka error code for
+  Kafka errors (`ProduceException`/`ConsumeException`), or the exception type
+  name for other failures (such as an `ArgumentException` from the producer or
+  an exception thrown by a message handler).
   ([#4636](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4636))
 
 * Metrics and traces now include a telemetry schema URL.

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -3,41 +3,50 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using OpenTelemetry.Internal;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka;
 
+/// <summary>
+/// Contains common constants and static members used by the Confluent Kafka instrumentation.
+/// </summary>
+/// <remarks>
+/// Follows the v1.42.0 messaging semantic conventions:
+/// https://github.com/open-telemetry/semantic-conventions/tree/v1.42.0/docs/messaging.
+/// </remarks>
 internal static class ConfluentKafkaCommon
 {
-    internal const string ReceiveOperationName = "receive";
-    internal const string ProcessOperationName = "process";
     internal const string KafkaMessagingSystem = "kafka";
-    internal const string PublishOperationName = "publish";
 
-#pragma warning disable IDE0370 // Suppression is unnecessary
-    internal static readonly string InstrumentationName = typeof(ConfluentKafkaCommon).Assembly.GetName().Name!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
-    internal static readonly string InstrumentationVersion = typeof(ConfluentKafkaCommon).Assembly.GetPackageVersion();
-    internal static readonly ActivitySource ActivitySource = new(InstrumentationName, InstrumentationVersion);
-    internal static readonly Meter Meter = new(InstrumentationName, InstrumentationVersion);
-    internal static readonly Counter<long> ReceiveMessagesCounter = Meter.CreateCounter<long>(
-        SemanticConventions.MetricMessagingReceiveMessages,
-        description: "Measures the number of received messages.");
+    // messaging.operation.name values (system-specific operation names).
+    internal const string SendOperationName = "send";
+    internal const string PollOperationName = "poll";
+    internal const string ProcessOperationName = "process";
 
-    internal static readonly Histogram<double> ReceiveDurationHistogram = Meter.CreateHistogram(
-        SemanticConventions.MetricMessagingReceiveDuration,
+    // messaging.operation.type values.
+    internal const string SendOperationType = "send";
+    internal const string ReceiveOperationType = "receive";
+    internal const string ProcessOperationType = "process";
+
+    internal static readonly Version SemanticConventionsVersion = new(1, 42, 0);
+
+    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create(typeof(ConfluentKafkaCommon), SemanticConventionsVersion);
+    internal static readonly Meter Meter = MeterFactory.Create(typeof(ConfluentKafkaCommon), SemanticConventionsVersion);
+
+    internal static readonly Histogram<double> OperationDurationHistogram = Meter.CreateHistogram(
+        SemanticConventions.MetricMessagingClientOperationDuration,
         unit: "s",
-        description: "Measures the duration of receive operation.",
+        description: "Duration of messaging operation initiated by a producer or consumer client.",
         advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
 
-    internal static readonly Counter<long> PublishMessagesCounter = Meter.CreateCounter<long>(
-        SemanticConventions.MetricMessagingPublishMessages,
-        description: "Measures the number of published messages.");
+    internal static readonly Counter<long> SentMessagesCounter = Meter.CreateCounter<long>(
+        SemanticConventions.MetricMessagingClientSentMessages,
+        unit: "{message}",
+        description: "Number of messages producer attempted to send to the broker.");
 
-    internal static readonly Histogram<double> PublishDurationHistogram = Meter.CreateHistogram(
-        SemanticConventions.MetricMessagingPublishDuration,
-        unit: "s",
-        description: "Measures the duration of publish operation.",
-        advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10] });
+    internal static readonly Counter<long> ConsumedMessagesCounter = Meter.CreateCounter<long>(
+        SemanticConventions.MetricMessagingClientConsumedMessages,
+        unit: "{message}",
+        description: "Number of messages that were delivered to the application.");
 }

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Globalization;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -49,4 +50,21 @@ internal static class ConfluentKafkaCommon
         SemanticConventions.MetricMessagingClientConsumedMessages,
         unit: "{message}",
         description: "Number of messages that were delivered to the application.");
+
+    /// <summary>
+    /// Normalizes a Kafka message key to the string representation required by the
+    /// <c>messaging.kafka.message.key</c> attribute in the Semantic Conventions.
+    /// </summary>
+    /// <param name="key">The message key, which may be <see langword="null"/>.</param>
+    /// <returns>
+    /// The string representation of <paramref name="key"/>, or <see langword="null"/> when the key
+    /// is absent or has no unambiguous, canonical string form (e.g. a <see cref="byte"/> array),
+    /// in which case the attribute must be omitted.
+    /// </returns>
+    internal static string? FormatMessageKey(object? key) => key switch
+    {
+        string value => value,
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => null,
+    };
 }

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -53,18 +53,34 @@ internal static class ConfluentKafkaCommon
 
     /// <summary>
     /// Normalizes a Kafka message key to the string representation required by the
-    /// <c>messaging.kafka.message.key</c> attribute in the Semantic Conventions.
+    /// <see href="https://github.com/open-telemetry/semantic-conventions/blob/ae3a98640194ed405c4c797281502e4d3bd258b3/docs/messaging/kafka.md#L119"><c>messaging.kafka.message.key</c> semantic convention</see>.
     /// </summary>
     /// <param name="key">The message key, which may be <see langword="null"/>.</param>
     /// <returns>
-    /// The string representation of <paramref name="key"/>, or <see langword="null"/> when the key
-    /// is absent or has no unambiguous, canonical string form (e.g. a <see cref="byte"/> array),
-    /// in which case the attribute must be omitted.
+    /// The canonical string representation of <paramref name="key"/>, or <see langword="null"/>
+    /// when the key is absent or has no unambiguous, canonical string form (e.g. a
+    /// <see cref="byte"/> array), in which case the attribute must be omitted.
     /// </returns>
     internal static string? FormatMessageKey(object? key) => key switch
     {
         string value => value,
-        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        char value => value.ToString(),
+        bool value => value.ToString(),
+        byte value => value.ToString(CultureInfo.InvariantCulture),
+        sbyte value => value.ToString(CultureInfo.InvariantCulture),
+        short value => value.ToString(CultureInfo.InvariantCulture),
+        ushort value => value.ToString(CultureInfo.InvariantCulture),
+        int value => value.ToString(CultureInfo.InvariantCulture),
+        uint value => value.ToString(CultureInfo.InvariantCulture),
+        long value => value.ToString(CultureInfo.InvariantCulture),
+        ulong value => value.ToString(CultureInfo.InvariantCulture),
+        float value when !float.IsNaN(value) => value.ToString("R", CultureInfo.InvariantCulture),
+        double value when !double.IsNaN(value) => value.ToString("R", CultureInfo.InvariantCulture),
+        decimal value => value.ToString(CultureInfo.InvariantCulture),
+        Guid value => value.ToString("D"),
+        DateTime value => value.ToString("O", CultureInfo.InvariantCulture),
+        DateTimeOffset value => value.ToString("O", CultureInfo.InvariantCulture),
+        TimeSpan value => value.ToString("c", CultureInfo.InvariantCulture),
         _ => null,
     };
 }

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -13,8 +13,8 @@ namespace OpenTelemetry.Instrumentation.ConfluentKafka;
 /// Contains common constants and static members used by the Confluent Kafka instrumentation.
 /// </summary>
 /// <remarks>
-/// Follows the v1.42.0 messaging semantic conventions:
-/// https://github.com/open-telemetry/semantic-conventions/tree/v1.42.0/docs/messaging.
+/// Follows the v1.43.0 messaging semantic conventions:
+/// https://github.com/open-telemetry/semantic-conventions/tree/v1.43.0/docs/messaging.
 /// </remarks>
 internal static class ConfluentKafkaCommon
 {
@@ -30,7 +30,7 @@ internal static class ConfluentKafkaCommon
     internal const string ReceiveOperationType = "receive";
     internal const string ProcessOperationType = "process";
 
-    internal static readonly Version SemanticConventionsVersion = new(1, 42, 0);
+    internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
 
     internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create(typeof(ConfluentKafkaCommon), SemanticConventionsVersion);
     internal static readonly Meter Meter = MeterFactory.Create(typeof(ConfluentKafkaCommon), SemanticConventionsVersion);
@@ -53,7 +53,7 @@ internal static class ConfluentKafkaCommon
 
     /// <summary>
     /// Normalizes a Kafka message key to the string representation required by the
-    /// <see href="https://github.com/open-telemetry/semantic-conventions/blob/ae3a98640194ed405c4c797281502e4d3bd258b3/docs/messaging/kafka.md#L119"><c>messaging.kafka.message.key</c> semantic convention</see>.
+    /// <see href="https://github.com/open-telemetry/semantic-conventions/blob/89aae438b3b3b0a8dd33003c9d70592baf7dbd0d/docs/messaging/kafka.md#L119"><c>messaging.kafka.message.key</c> semantic convention</see>.
     /// </summary>
     /// <param name="key">The message key, which may be <see langword="null"/>.</param>
     /// <returns>

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
@@ -218,14 +218,14 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
     {
         null => new ConsumeResult(null, null),
         { Message: null } => new ConsumeResult(result.TopicPartitionOffset, null),
-        _ => new ConsumeResult(result.TopicPartitionOffset, result.Message.Headers, result.Message.Key),
+        _ => new ConsumeResult(result.TopicPartitionOffset, result.Message.Headers, result.Message.Key, result.Message.Value is null),
     };
 
     private static (ConsumeResult ConsumeResult, string ErrorType) ExtractConsumeResult(ConsumeException exception) => exception switch
     {
         { ConsumerRecord: null } => (new ConsumeResult(null, null), FormatConsumeException(exception)),
         { ConsumerRecord.Message: null } => (new ConsumeResult(exception.ConsumerRecord.TopicPartitionOffset, null), FormatConsumeException(exception)),
-        _ => (new ConsumeResult(exception.ConsumerRecord.TopicPartitionOffset, exception.ConsumerRecord.Message.Headers, exception.ConsumerRecord.Message.Key), FormatConsumeException(exception)),
+        _ => (new ConsumeResult(exception.ConsumerRecord.TopicPartitionOffset, exception.ConsumerRecord.Message.Headers, exception.ConsumerRecord.Message.Key, exception.ConsumerRecord.Message.Value is null), FormatConsumeException(exception)),
     };
 
     private static void GetTags(string? topic, string? groupId, out TagList tags, int? partition = null, string? errorType = null)
@@ -292,7 +292,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
                 ? OpenTelemetryConsumeResultExtensions.ExtractPropagationContext(consumeResult.Headers)
                 : default;
 
-            using var activity = this.StartReceiveActivity(propagationContext, startTime, consumeResult.TopicPartitionOffset, consumeResult.Key);
+            using var activity = this.StartReceiveActivity(propagationContext, startTime, consumeResult.TopicPartitionOffset, consumeResult.Key, consumeResult.IsTombstone);
             if (activity != null)
             {
                 if (errorType != null)
@@ -315,7 +315,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
     }
 
-    private Activity? StartReceiveActivity(PropagationContext propagationContext, DateTimeOffset start, TopicPartitionOffset? topicPartitionOffset, object? key)
+    private Activity? StartReceiveActivity(PropagationContext propagationContext, DateTimeOffset start, TopicPartitionOffset? topicPartitionOffset, object? key, bool isTombstone)
     {
 #pragma warning disable IDE0370 // Suppression is unnecessary
         var spanName = string.IsNullOrEmpty(topicPartitionOffset?.Topic)
@@ -350,6 +350,11 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, key);
             }
+
+            if (isTombstone)
+            {
+                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageTombstone, true);
+            }
         }
 
         return activity;
@@ -358,12 +363,15 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
     private readonly record struct ConsumeResult(
         TopicPartitionOffset? TopicPartitionOffset,
         Headers? Headers,
-        object? Key = null)
+        object? Key = null,
+        bool IsTombstone = false)
     {
         public object? Key { get; } = Key;
 
         public Headers? Headers { get; } = Headers;
 
         public TopicPartitionOffset? TopicPartitionOffset { get; } = TopicPartitionOffset;
+
+        public bool IsTombstone { get; } = IsTombstone;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
@@ -276,15 +276,29 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
     }
 
-    private static void RecordReceive(TopicPartition? topicPartition, string? groupId, TimeSpan duration, string? errorType = null)
+    private static void RecordReceive(
+        TopicPartition? topicPartition,
+        string? groupId,
+        TimeSpan duration,
+        bool messageConsumed,
+        string? errorType = null)
     {
         GetTags(topicPartition?.Topic, groupId, out var tags, partition: topicPartition?.Partition, errorType);
 
-        ConfluentKafkaCommon.ConsumedMessagesCounter.Add(1, in tags);
+        if (messageConsumed)
+        {
+            ConfluentKafkaCommon.ConsumedMessagesCounter.Add(1, in tags);
+        }
+
         ConfluentKafkaCommon.OperationDurationHistogram.Record(duration.TotalSeconds, in tags);
     }
 
-    private void InstrumentConsumption(DateTimeOffset startTime, DateTimeOffset endTime, ConsumeResult consumeResult, string? errorType, string? errorMessage)
+    private void InstrumentConsumption(
+        DateTimeOffset startTime,
+        DateTimeOffset endTime,
+        ConsumeResult consumeResult,
+        string? errorType,
+        string? errorMessage)
     {
         if (this.options.Traces)
         {
@@ -311,11 +325,23 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         if (this.options.Metrics)
         {
             var duration = endTime - startTime;
-            RecordReceive(consumeResult.TopicPartitionOffset?.TopicPartition, this.GroupId, duration, errorType);
+            var messageConsumed = consumeResult.TopicPartitionOffset is not null;
+
+            RecordReceive(
+                consumeResult.TopicPartitionOffset?.TopicPartition,
+                this.GroupId,
+                duration,
+                messageConsumed,
+                errorType);
         }
     }
 
-    private Activity? StartReceiveActivity(PropagationContext propagationContext, DateTimeOffset start, TopicPartitionOffset? topicPartitionOffset, object? key, bool isTombstone)
+    private Activity? StartReceiveActivity(
+        PropagationContext propagationContext,
+        DateTimeOffset start,
+        TopicPartitionOffset? topicPartitionOffset,
+        object? key,
+        bool isTombstone)
     {
 #pragma warning disable IDE0370 // Suppression is unnecessary
         var spanName = string.IsNullOrEmpty(topicPartitionOffset?.Topic)
@@ -327,28 +353,48 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             ? [new ActivityLink(propagationContext.ActivityContext)]
             : [];
 
-        // Per the v1.42.0 conventions the "poll" span has a CLIENT kind (the CONSUMER kind is
-        // reserved for the "process" span that embraces message handling).
-        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Client, links: activityLinks, startTime: start, parentContext: default);
+        // Provide the attributes that can influence sampling decisions at span creation time
+        var initialTags = new ActivityTagsCollection
+        {
+            [SemanticConventions.AttributeMessagingOperationName] = ConfluentKafkaCommon.PollOperationName,
+            [SemanticConventions.AttributeMessagingOperationType] = ConfluentKafkaCommon.ReceiveOperationType,
+            [SemanticConventions.AttributeMessagingSystem] = ConfluentKafkaCommon.KafkaMessagingSystem,
+        };
+
+        if (this.GroupId is { Length: > 0 } groupId)
+        {
+            initialTags.Add(SemanticConventions.AttributeMessagingConsumerGroupName, groupId);
+        }
+
+        // messaging.destination.name is only set for actual topics; it must be omitted when unknown.
+        if (topicPartitionOffset?.Topic is { Length: > 0 } topic)
+        {
+            initialTags.Add(SemanticConventions.AttributeMessagingDestinationName, topic);
+
+            if (topicPartitionOffset.Partition is { } partition)
+            {
+                initialTags.Add(SemanticConventions.AttributeMessagingDestinationPartitionId, partition.Value.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        // Per the Semantic Conventions the "poll" span has a CLIENT kind (the CONSUMER
+        // kind is reserved for the "process" span that embraces message handling).
+        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(
+            spanName,
+            kind: ActivityKind.Client,
+            parentContext: default,
+            tags: initialTags,
+            links: activityLinks,
+            startTime: start);
+
         if (activity?.IsAllDataRequested == true)
         {
-            activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, this.Name);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.PollOperationName);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.ReceiveOperationType);
-            activity.SetTag(SemanticConventions.AttributeMessagingConsumerGroupName, this.GroupId);
             activity.SetTag(SemanticConventions.AttributeMessagingKafkaOffset, topicPartitionOffset?.Offset.Value);
 
-            // messaging.destination.name is only set for actual topics; it must be omitted when unknown.
-            if (!string.IsNullOrEmpty(topicPartitionOffset?.Topic))
+            if (ConfluentKafkaCommon.FormatMessageKey(key) is { Length: > 0 } messageKey)
             {
-                activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topicPartitionOffset!.Topic);
-                activity.SetTag(SemanticConventions.AttributeMessagingDestinationPartitionId, topicPartitionOffset.Partition.Value.ToString(CultureInfo.InvariantCulture));
-            }
-
-            if (key != null)
-            {
-                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, key);
+                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, messageKey);
             }
 
             if (isTombstone)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
@@ -392,7 +392,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, this.Name);
             activity.SetTag(SemanticConventions.AttributeMessagingKafkaOffset, topicPartitionOffset?.Offset.Value);
 
-            if (ConfluentKafkaCommon.FormatMessageKey(key) is { Length: > 0 } messageKey)
+            if (ConfluentKafkaCommon.FormatMessageKey(key) is { } messageKey)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, messageKey);
             }

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using Confluent.Kafka;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
@@ -48,6 +49,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         ConsumeResult<TKey, TValue>? result = null;
         ConsumeResult consumeResult = default;
         string? errorType = null;
+        string? errorMessage = null;
         try
         {
             result = this.consumer.Consume(millisecondsTimeout);
@@ -57,6 +59,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         catch (ConsumeException e)
         {
             (consumeResult, errorType) = ExtractConsumeResult(e);
+            errorMessage = e.Message;
             throw;
         }
         finally
@@ -64,7 +67,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             if (ShouldInstrument(result, errorType))
             {
                 var end = DateTimeOffset.UtcNow;
-                this.InstrumentConsumption(start, end, consumeResult, errorType);
+                this.InstrumentConsumption(start, end, consumeResult, errorType, errorMessage);
             }
         }
     }
@@ -75,6 +78,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         ConsumeResult<TKey, TValue>? result = null;
         ConsumeResult consumeResult = default;
         string? errorType = null;
+        string? errorMessage = null;
         try
         {
             result = this.consumer.Consume(cancellationToken);
@@ -84,6 +88,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         catch (ConsumeException e)
         {
             (consumeResult, errorType) = ExtractConsumeResult(e);
+            errorMessage = e.Message;
             throw;
         }
         finally
@@ -91,7 +96,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             if (ShouldInstrument(result, errorType))
             {
                 var end = DateTimeOffset.UtcNow;
-                this.InstrumentConsumption(start, end, consumeResult, errorType);
+                this.InstrumentConsumption(start, end, consumeResult, errorType, errorMessage);
             }
         }
     }
@@ -102,6 +107,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         ConsumeResult<TKey, TValue>? result = null;
         ConsumeResult consumeResult = default;
         string? errorType = null;
+        string? errorMessage = null;
         try
         {
             result = this.consumer.Consume(timeout);
@@ -111,6 +117,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         catch (ConsumeException e)
         {
             (consumeResult, errorType) = ExtractConsumeResult(e);
+            errorMessage = e.Message;
             throw;
         }
         finally
@@ -118,7 +125,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             if (ShouldInstrument(result, errorType))
             {
                 var end = DateTimeOffset.UtcNow;
-                this.InstrumentConsumption(start, end, consumeResult, errorType);
+                this.InstrumentConsumption(start, end, consumeResult, errorType, errorMessage);
             }
         }
     }
@@ -205,7 +212,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         (result is null && errorType is not null);
 
     private static string FormatConsumeException(ConsumeException consumeException) =>
-        $"ConsumeException: {consumeException.Error}";
+        consumeException.Error.Code.ToString();
 
     private static ConsumeResult ExtractConsumeResult(ConsumeResult<TKey, TValue> result) => result switch
     {
@@ -221,13 +228,16 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         _ => (new ConsumeResult(exception.ConsumerRecord.TopicPartitionOffset, exception.ConsumerRecord.Message.Headers, exception.ConsumerRecord.Message.Key), FormatConsumeException(exception)),
     };
 
-    private static void GetTags(string? topic, out TagList tags, int? partition = null, string? errorType = null)
+    private static void GetTags(string? topic, string? groupId, out TagList tags, int? partition = null, string? errorType = null)
     {
         tags = new TagList()
         {
             new KeyValuePair<string, object?>(
-                SemanticConventions.AttributeMessagingOperation,
-                ConfluentKafkaCommon.ReceiveOperationName),
+                SemanticConventions.AttributeMessagingOperationName,
+                ConfluentKafkaCommon.PollOperationName),
+            new KeyValuePair<string, object?>(
+                SemanticConventions.AttributeMessagingOperationType,
+                ConfluentKafkaCommon.ReceiveOperationType),
             new KeyValuePair<string, object?>(
                 SemanticConventions.AttributeMessagingSystem,
                 ConfluentKafkaCommon.KafkaMessagingSystem),
@@ -245,8 +255,16 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         {
             tags.Add(
                 new KeyValuePair<string, object?>(
-                    SemanticConventions.AttributeMessagingKafkaDestinationPartition,
-                    partition));
+                    SemanticConventions.AttributeMessagingDestinationPartitionId,
+                    partition.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (groupId is not null)
+        {
+            tags.Add(
+                new KeyValuePair<string, object?>(
+                    SemanticConventions.AttributeMessagingConsumerGroupName,
+                    groupId));
         }
 
         if (errorType is not null)
@@ -258,15 +276,15 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         }
     }
 
-    private static void RecordReceive(TopicPartition? topicPartition, TimeSpan duration, string? errorType = null)
+    private static void RecordReceive(TopicPartition? topicPartition, string? groupId, TimeSpan duration, string? errorType = null)
     {
-        GetTags(topicPartition?.Topic, out var tags, partition: topicPartition?.Partition, errorType);
+        GetTags(topicPartition?.Topic, groupId, out var tags, partition: topicPartition?.Partition, errorType);
 
-        ConfluentKafkaCommon.ReceiveMessagesCounter.Add(1, in tags);
-        ConfluentKafkaCommon.ReceiveDurationHistogram.Record(duration.TotalSeconds, in tags);
+        ConfluentKafkaCommon.ConsumedMessagesCounter.Add(1, in tags);
+        ConfluentKafkaCommon.OperationDurationHistogram.Record(duration.TotalSeconds, in tags);
     }
 
-    private void InstrumentConsumption(DateTimeOffset startTime, DateTimeOffset endTime, ConsumeResult consumeResult, string? errorType)
+    private void InstrumentConsumption(DateTimeOffset startTime, DateTimeOffset endTime, ConsumeResult consumeResult, string? errorType, string? errorMessage)
     {
         if (this.options.Traces)
         {
@@ -279,7 +297,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             {
                 if (errorType != null)
                 {
-                    activity.SetStatus(ActivityStatusCode.Error);
+                    activity.SetStatus(ActivityStatusCode.Error, errorMessage);
                     if (activity.IsAllDataRequested)
                     {
                         activity.SetTag(SemanticConventions.AttributeErrorType, errorType);
@@ -293,7 +311,7 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         if (this.options.Metrics)
         {
             var duration = endTime - startTime;
-            RecordReceive(consumeResult.TopicPartitionOffset?.TopicPartition, duration, errorType);
+            RecordReceive(consumeResult.TopicPartitionOffset?.TopicPartition, this.GroupId, duration, errorType);
         }
     }
 
@@ -301,24 +319,33 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
     {
 #pragma warning disable IDE0370 // Suppression is unnecessary
         var spanName = string.IsNullOrEmpty(topicPartitionOffset?.Topic)
-            ? ConfluentKafkaCommon.ReceiveOperationName
-            : string.Concat(topicPartitionOffset!.Topic, " ", ConfluentKafkaCommon.ReceiveOperationName);
+            ? ConfluentKafkaCommon.PollOperationName
+            : string.Concat(ConfluentKafkaCommon.PollOperationName, " ", topicPartitionOffset!.Topic);
 #pragma warning restore IDE0370 // Suppression is unnecessary
 
         ActivityLink[] activityLinks = propagationContext.ActivityContext.IsValid()
             ? [new ActivityLink(propagationContext.ActivityContext)]
             : [];
 
-        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Consumer, links: activityLinks, startTime: start, parentContext: default);
+        // Per the v1.42.0 conventions the "poll" span has a CLIENT kind (the CONSUMER kind is
+        // reserved for the "process" span that embraces message handling).
+        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Client, links: activityLinks, startTime: start, parentContext: default);
         if (activity?.IsAllDataRequested == true)
         {
             activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, this.Name);
-            activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topicPartitionOffset?.Topic);
-            activity.SetTag(SemanticConventions.AttributeMessagingKafkaDestinationPartition, topicPartitionOffset?.Partition.Value);
-            activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageOffset, topicPartitionOffset?.Offset.Value);
-            activity.SetTag(SemanticConventions.AttributeMessagingKafkaConsumerGroup, this.GroupId);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperation, ConfluentKafkaCommon.ReceiveOperationName);
+            activity.SetTag(SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.PollOperationName);
+            activity.SetTag(SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.ReceiveOperationType);
+            activity.SetTag(SemanticConventions.AttributeMessagingConsumerGroupName, this.GroupId);
+            activity.SetTag(SemanticConventions.AttributeMessagingKafkaOffset, topicPartitionOffset?.Offset.Value);
+
+            // messaging.destination.name is only set for actual topics; it must be omitted when unknown.
+            if (!string.IsNullOrEmpty(topicPartitionOffset?.Topic))
+            {
+                activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topicPartitionOffset!.Topic);
+                activity.SetTag(SemanticConventions.AttributeMessagingDestinationPartitionId, topicPartitionOffset.Partition.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
             if (key != null)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, key);

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
@@ -348,7 +348,7 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         {
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, this.Name);
 
-            if (ConfluentKafkaCommon.FormatMessageKey(message.Key) is { Length: > 0 } messageKey)
+            if (ConfluentKafkaCommon.FormatMessageKey(message.Key) is { } messageKey)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, messageKey);
             }

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
@@ -316,7 +316,29 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
 
         var spanName = string.Concat(ConfluentKafkaCommon.SendOperationName, " ", topic);
-        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(name: spanName, kind: ActivityKind.Producer, startTime: start);
+
+        // Provide the attributes that can influence sampling decisions at span creation time
+        var initialTags = new ActivityTagsCollection
+        {
+            [SemanticConventions.AttributeMessagingDestinationName] = topic,
+            [SemanticConventions.AttributeMessagingOperationName] = ConfluentKafkaCommon.SendOperationName,
+            [SemanticConventions.AttributeMessagingOperationType] = ConfluentKafkaCommon.SendOperationType,
+            [SemanticConventions.AttributeMessagingSystem] = ConfluentKafkaCommon.KafkaMessagingSystem,
+        };
+
+        if (partition is { } partitionValue)
+        {
+            initialTags.Add(SemanticConventions.AttributeMessagingDestinationPartitionId, partitionValue.ToString(CultureInfo.InvariantCulture));
+        }
+
+        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(
+            spanName,
+            kind: ActivityKind.Producer,
+            parentContext: default,
+            tags: initialTags,
+            links: null,
+            startTime: start);
+
         if (activity == null)
         {
             return null;
@@ -324,25 +346,16 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
 
         if (activity.IsAllDataRequested)
         {
-            activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, this.Name);
-            activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topic);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.SendOperationName);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.SendOperationType);
 
-            if (message.Key != null)
+            if (ConfluentKafkaCommon.FormatMessageKey(message.Key) is { Length: > 0 } messageKey)
             {
-                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, message.Key);
+                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, messageKey);
             }
 
             if (message.Value is null)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageTombstone, true);
-            }
-
-            if (partition is not null)
-            {
-                activity.SetTag(SemanticConventions.AttributeMessagingDestinationPartitionId, partition.Value.ToString(CultureInfo.InvariantCulture));
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
@@ -335,6 +335,11 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, message.Key);
             }
 
+            if (message.Value is null)
+            {
+                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageTombstone, true);
+            }
+
             if (partition is not null)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingDestinationPartitionId, partition.Value.ToString(CultureInfo.InvariantCulture));

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using Confluent.Kafka;
 using OpenTelemetry.Context.Propagation;
@@ -28,14 +29,10 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
     public string Name => this.producer.Name;
 
     public int AddBrokers(string brokers)
-    {
-        return this.producer.AddBrokers(brokers);
-    }
+        => this.producer.AddBrokers(brokers);
 
     public void SetSaslCredentials(string username, string password)
-    {
-        this.producer.SetSaslCredentials(username, password);
-    }
+        => this.producer.SetSaslCredentials(username, password);
 
     public async Task<DeliveryResult<TKey, TValue>> ProduceAsync(
         string topic,
@@ -57,15 +54,17 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         catch (ProduceException<TKey, TValue> produceException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatProduceException(produceException));
+            errorType = FormatProduceException(produceException);
+            activity?.SetStatus(ActivityStatusCode.Error, produceException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
         catch (ArgumentException argumentException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatArgumentException(argumentException));
+            errorType = FormatArgumentException(argumentException);
+            activity?.SetStatus(ActivityStatusCode.Error, argumentException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
@@ -104,15 +103,17 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         catch (ProduceException<TKey, TValue> produceException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatProduceException(produceException));
+            errorType = FormatProduceException(produceException);
+            activity?.SetStatus(ActivityStatusCode.Error, produceException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
         catch (ArgumentException argumentException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatArgumentException(argumentException));
+            errorType = FormatArgumentException(argumentException);
+            activity?.SetStatus(ActivityStatusCode.Error, argumentException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
@@ -147,15 +148,17 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         catch (ProduceException<TKey, TValue> produceException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatProduceException(produceException));
+            errorType = FormatProduceException(produceException);
+            activity?.SetStatus(ActivityStatusCode.Error, produceException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
         catch (ArgumentException argumentException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatArgumentException(argumentException));
+            errorType = FormatArgumentException(argumentException);
+            activity?.SetStatus(ActivityStatusCode.Error, argumentException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
@@ -188,15 +191,17 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         }
         catch (ProduceException<TKey, TValue> produceException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatProduceException(produceException));
+            errorType = FormatProduceException(produceException);
+            activity?.SetStatus(ActivityStatusCode.Error, produceException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
         catch (ArgumentException argumentException)
         {
-            activity?.SetStatus(ActivityStatusCode.Error);
-            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType = FormatArgumentException(argumentException));
+            errorType = FormatArgumentException(argumentException);
+            activity?.SetStatus(ActivityStatusCode.Error, argumentException.Message);
+            activity?.SetTag(SemanticConventions.AttributeErrorType, errorType);
 
             throw;
         }
@@ -214,73 +219,54 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
     }
 
     public int Poll(TimeSpan timeout)
-    {
-        return this.producer.Poll(timeout);
-    }
+         => this.producer.Poll(timeout);
 
     public int Flush(TimeSpan timeout)
-    {
-        return this.producer.Flush(timeout);
-    }
+         => this.producer.Flush(timeout);
 
-    public void Flush(CancellationToken cancellationToken = default)
-    {
+    public void Flush(CancellationToken cancellationToken = default) =>
         this.producer.Flush(cancellationToken);
-    }
 
-    public void InitTransactions(TimeSpan timeout)
-    {
+    public void InitTransactions(TimeSpan timeout) =>
         this.producer.InitTransactions(timeout);
-    }
 
-    public void BeginTransaction()
-    {
+    public void BeginTransaction() =>
         this.producer.BeginTransaction();
-    }
 
-    public void CommitTransaction(TimeSpan timeout)
-    {
+    public void CommitTransaction(TimeSpan timeout) =>
         this.producer.CommitTransaction(timeout);
-    }
 
-    public void CommitTransaction()
-    {
+    public void CommitTransaction() =>
         this.producer.CommitTransaction();
-    }
 
-    public void AbortTransaction(TimeSpan timeout)
-    {
+    public void AbortTransaction(TimeSpan timeout) =>
         this.producer.AbortTransaction(timeout);
-    }
 
-    public void AbortTransaction()
-    {
+    public void AbortTransaction() =>
         this.producer.AbortTransaction();
-    }
 
-    public void SendOffsetsToTransaction(IEnumerable<TopicPartitionOffset> offsets, IConsumerGroupMetadata groupMetadata, TimeSpan timeout)
-    {
+    public void SendOffsetsToTransaction(IEnumerable<TopicPartitionOffset> offsets, IConsumerGroupMetadata groupMetadata, TimeSpan timeout) =>
         this.producer.SendOffsetsToTransaction(offsets, groupMetadata, timeout);
-    }
 
-    public void Dispose()
-    {
+    public void Dispose() =>
         this.producer.Dispose();
-    }
 
     private static string FormatProduceException(ProduceException<TKey, TValue> produceException) =>
-        $"ProduceException: {produceException.Error.Code}";
+        produceException.Error.Code.ToString();
 
     private static string FormatArgumentException(ArgumentException argumentException) =>
-        $"ArgumentException: {argumentException.ParamName}";
+        argumentException.GetType().FullName!;
 
     private static void GetTags(string topic, out TagList tags, int? partition = null, string? errorType = null)
     {
         tags = new TagList()
         {
             new KeyValuePair<string, object?>(
-                SemanticConventions.AttributeMessagingOperation,
-                ConfluentKafkaCommon.PublishOperationName),
+                SemanticConventions.AttributeMessagingOperationName,
+                ConfluentKafkaCommon.SendOperationName),
+            new KeyValuePair<string, object?>(
+                SemanticConventions.AttributeMessagingOperationType,
+                ConfluentKafkaCommon.SendOperationType),
             new KeyValuePair<string, object?>(
                 SemanticConventions.AttributeMessagingSystem,
                 ConfluentKafkaCommon.KafkaMessagingSystem),
@@ -293,8 +279,8 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         {
             tags.Add(
                 new KeyValuePair<string, object?>(
-                    SemanticConventions.AttributeMessagingKafkaDestinationPartition,
-                    partition));
+                    SemanticConventions.AttributeMessagingDestinationPartitionId,
+                    partition.Value.ToString(CultureInfo.InvariantCulture)));
         }
 
         if (errorType is not null)
@@ -310,16 +296,16 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
     {
         GetTags(topic, out var tags, partition: null, errorType);
 
-        ConfluentKafkaCommon.PublishMessagesCounter.Add(1, in tags);
-        ConfluentKafkaCommon.PublishDurationHistogram.Record(duration.TotalSeconds, in tags);
+        ConfluentKafkaCommon.SentMessagesCounter.Add(1, in tags);
+        ConfluentKafkaCommon.OperationDurationHistogram.Record(duration.TotalSeconds, in tags);
     }
 
     private static void RecordPublish(TopicPartition topicPartition, TimeSpan duration, string? errorType = null)
     {
         GetTags(topicPartition.Topic, out var tags, partition: topicPartition.Partition, errorType);
 
-        ConfluentKafkaCommon.PublishMessagesCounter.Add(1, in tags);
-        ConfluentKafkaCommon.PublishDurationHistogram.Record(duration.TotalSeconds, in tags);
+        ConfluentKafkaCommon.SentMessagesCounter.Add(1, in tags);
+        ConfluentKafkaCommon.OperationDurationHistogram.Record(duration.TotalSeconds, in tags);
     }
 
     private Activity? StartPublishActivity(DateTimeOffset start, string topic, Message<TKey, TValue> message, int? partition = null)
@@ -329,7 +315,7 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
             return null;
         }
 
-        var spanName = string.Concat(topic, " ", ConfluentKafkaCommon.PublishOperationName);
+        var spanName = string.Concat(ConfluentKafkaCommon.SendOperationName, " ", topic);
         var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(name: spanName, kind: ActivityKind.Producer, startTime: start);
         if (activity == null)
         {
@@ -341,7 +327,8 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
             activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, this.Name);
             activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topic);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperation, ConfluentKafkaCommon.PublishOperationName);
+            activity.SetTag(SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.SendOperationName);
+            activity.SetTag(SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.SendOperationType);
 
             if (message.Key != null)
             {
@@ -350,17 +337,15 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
 
             if (partition is not null)
             {
-                activity.SetTag(SemanticConventions.AttributeMessagingKafkaDestinationPartition, partition);
+                activity.SetTag(SemanticConventions.AttributeMessagingDestinationPartitionId, partition.Value.ToString(CultureInfo.InvariantCulture));
             }
         }
 
         return activity;
     }
 
-    private void InjectActivity(Activity? activity, Message<TKey, TValue> message)
-    {
+    private void InjectActivity(Activity? activity, Message<TKey, TValue> message) =>
         this.propagator.Inject(new PropagationContext(activity?.Context ?? default, Baggage.Current), message, this.InjectTraceContext);
-    }
 
     private void InjectTraceContext(Message<TKey, TValue> message, string key, string value)
     {

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/MeterProviderBuilderExtensions.Consumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/MeterProviderBuilderExtensions.Consumer.cs
@@ -70,7 +70,7 @@ public static partial class MeterProviderBuilderExtensions
         Guard.ThrowIfNull(builder);
 
         return builder
-            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
+            .AddMeter(ConfluentKafkaCommon.Meter.Name)
             .AddInstrumentation(sp =>
             {
                 if (name == null)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/MeterProviderBuilderExtensions.Producer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/MeterProviderBuilderExtensions.Producer.cs
@@ -70,7 +70,7 @@ public static partial class MeterProviderBuilderExtensions
         Guard.ThrowIfNull(builder);
 
         return builder
-            .AddMeter(ConfluentKafkaCommon.InstrumentationName)
+            .AddMeter(ConfluentKafkaCommon.Meter.Name)
             .AddInstrumentation(sp =>
             {
                 if (name == null)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
@@ -14,8 +14,10 @@
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
@@ -113,7 +114,7 @@ public static class OpenTelemetryConsumeResultExtensions
         }
         catch (Exception ex)
         {
-            processActivity?.SetStatus(ActivityStatusCode.Error);
+            processActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             processActivity?.SetTag(SemanticConventions.AttributeErrorType, ex.GetType().FullName);
             throw;
         }
@@ -133,7 +134,7 @@ public static class OpenTelemetryConsumeResultExtensions
 #pragma warning disable IDE0370 // Suppression is unnecessary
         var spanName = string.IsNullOrEmpty(topicPartitionOffset?.Topic)
             ? ConfluentKafkaCommon.ProcessOperationName
-            : string.Concat(topicPartitionOffset!.Topic, " ", ConfluentKafkaCommon.ProcessOperationName);
+            : string.Concat(ConfluentKafkaCommon.ProcessOperationName, " ", topicPartitionOffset!.Topic);
 #pragma warning restore IDE0370 // Suppression is unnecessary
 
         ActivityLink[] activityLinks = propagationContext != default && propagationContext.ActivityContext.IsValid()
@@ -145,11 +146,18 @@ public static class OpenTelemetryConsumeResultExtensions
         {
             activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, clientId);
-            activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topicPartitionOffset?.Topic);
-            activity.SetTag(SemanticConventions.AttributeMessagingKafkaDestinationPartition, topicPartitionOffset?.Partition.Value);
-            activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageOffset, topicPartitionOffset?.Offset.Value);
-            activity.SetTag(SemanticConventions.AttributeMessagingKafkaConsumerGroup, groupId);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperation, ConfluentKafkaCommon.ProcessOperationName);
+            activity.SetTag(SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.ProcessOperationName);
+            activity.SetTag(SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.ProcessOperationType);
+            activity.SetTag(SemanticConventions.AttributeMessagingConsumerGroupName, groupId);
+            activity.SetTag(SemanticConventions.AttributeMessagingKafkaOffset, topicPartitionOffset?.Offset.Value);
+
+            // messaging.destination.name is only set for actual topics; it must be omitted when unknown.
+            if (!string.IsNullOrEmpty(topicPartitionOffset?.Topic))
+            {
+                activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topicPartitionOffset!.Topic);
+                activity.SetTag(SemanticConventions.AttributeMessagingDestinationPartitionId, topicPartitionOffset.Partition.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
             if (key != null)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, key);

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -177,7 +177,7 @@ public static class OpenTelemetryConsumeResultExtensions
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, clientId);
             activity.SetTag(SemanticConventions.AttributeMessagingKafkaOffset, topicPartitionOffset?.Offset.Value);
 
-            if (ConfluentKafkaCommon.FormatMessageKey(key) is { Length: > 0 } messageKey)
+            if (ConfluentKafkaCommon.FormatMessageKey(key) is { } messageKey)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, messageKey);
             }

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -106,7 +106,7 @@ public static class OpenTelemetryConsumeResultExtensions
             return consumeResult;
         }
 
-        var processActivity = StartProcessActivity(TryExtractPropagationContext(consumeResult, out var propagationContext) ? propagationContext : default, consumeResult.TopicPartitionOffset, consumeResult.Message.Key, instrumentedConsumer.Name, instrumentedConsumer.GroupId!);
+        var processActivity = StartProcessActivity(TryExtractPropagationContext(consumeResult, out var propagationContext) ? propagationContext : default, consumeResult.TopicPartitionOffset, consumeResult.Message.Key, consumeResult.Message.Value is null, instrumentedConsumer.Name, instrumentedConsumer.GroupId!);
 
         try
         {
@@ -129,7 +129,7 @@ public static class OpenTelemetryConsumeResultExtensions
     internal static PropagationContext ExtractPropagationContext(Headers? headers)
         => Propagators.DefaultTextMapPropagator.Extract(default, headers, ExtractTraceContext);
 
-    private static Activity? StartProcessActivity<TKey>(PropagationContext propagationContext, TopicPartitionOffset? topicPartitionOffset, TKey? key, string clientId, string groupId)
+    private static Activity? StartProcessActivity<TKey>(PropagationContext propagationContext, TopicPartitionOffset? topicPartitionOffset, TKey? key, bool isTombstone, string clientId, string groupId)
     {
 #pragma warning disable IDE0370 // Suppression is unnecessary
         var spanName = string.IsNullOrEmpty(topicPartitionOffset?.Topic)
@@ -161,6 +161,11 @@ public static class OpenTelemetryConsumeResultExtensions
             if (key != null)
             {
                 activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, key);
+            }
+
+            if (isTombstone)
+            {
+                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageTombstone, true);
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -141,26 +141,45 @@ public static class OpenTelemetryConsumeResultExtensions
             ? [new ActivityLink(propagationContext.ActivityContext)]
             : [];
 
-        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(spanName, kind: ActivityKind.Consumer, links: activityLinks, parentContext: default);
+        // Provide the attributes that can influence sampling decisions at span creation time
+        var initialTags = new ActivityTagsCollection
+        {
+            [SemanticConventions.AttributeMessagingOperationName] = ConfluentKafkaCommon.ProcessOperationName,
+            [SemanticConventions.AttributeMessagingOperationType] = ConfluentKafkaCommon.ProcessOperationType,
+            [SemanticConventions.AttributeMessagingSystem] = ConfluentKafkaCommon.KafkaMessagingSystem,
+        };
+
+        if (groupId is { Length: > 0 })
+        {
+            initialTags.Add(SemanticConventions.AttributeMessagingConsumerGroupName, groupId);
+        }
+
+        // messaging.destination.name is only set for actual topics; it must be omitted when unknown.
+        if (topicPartitionOffset?.Topic is { Length: > 0 } topic)
+        {
+            initialTags.Add(SemanticConventions.AttributeMessagingDestinationName, topic);
+
+            if (topicPartitionOffset?.Partition is { } partition)
+            {
+                initialTags.Add(SemanticConventions.AttributeMessagingDestinationPartitionId, partition.Value.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        var activity = ConfluentKafkaCommon.ActivitySource.StartActivity(
+            spanName,
+            kind: ActivityKind.Consumer,
+            parentContext: default,
+            tags: initialTags,
+            links: activityLinks);
+
         if (activity?.IsAllDataRequested == true)
         {
-            activity.SetTag(SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem);
             activity.SetTag(SemanticConventions.AttributeMessagingClientId, clientId);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.ProcessOperationName);
-            activity.SetTag(SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.ProcessOperationType);
-            activity.SetTag(SemanticConventions.AttributeMessagingConsumerGroupName, groupId);
             activity.SetTag(SemanticConventions.AttributeMessagingKafkaOffset, topicPartitionOffset?.Offset.Value);
 
-            // messaging.destination.name is only set for actual topics; it must be omitted when unknown.
-            if (!string.IsNullOrEmpty(topicPartitionOffset?.Topic))
+            if (ConfluentKafkaCommon.FormatMessageKey(key) is { Length: > 0 } messageKey)
             {
-                activity.SetTag(SemanticConventions.AttributeMessagingDestinationName, topicPartitionOffset!.Topic);
-                activity.SetTag(SemanticConventions.AttributeMessagingDestinationPartitionId, topicPartitionOffset.Partition.Value.ToString(CultureInfo.InvariantCulture));
-            }
-
-            if (key != null)
-            {
-                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, key);
+                activity.SetTag(SemanticConventions.AttributeMessagingKafkaMessageKey, messageKey);
             }
 
             if (isTombstone)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/TracerProviderBuilderExtensions.Consumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/TracerProviderBuilderExtensions.Consumer.cs
@@ -70,7 +70,7 @@ public static partial class TracerProviderBuilderExtensions
         Guard.ThrowIfNull(builder);
 
         return builder
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .AddInstrumentation(sp =>
             {
                 if (name == null)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/TracerProviderBuilderExtensions.Producer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/TracerProviderBuilderExtensions.Producer.cs
@@ -70,7 +70,7 @@ public static partial class TracerProviderBuilderExtensions
         Guard.ThrowIfNull(builder);
 
         return builder
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .AddInstrumentation(sp =>
             {
                 if (name == null)

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -128,7 +128,6 @@ internal static class SemanticConventions
     public const string AttributeMessagingConsumerGroupName = "messaging.consumer.group.name"; // replaces: "messaging.kafka.consumer.group"
     public const string AttributeMessagingDestinationName = "messaging.destination.name";
     public const string AttributeMessagingDestinationPartitionId = "messaging.destination.partition.id"; // replaces: "messaging.kafka.destination.partition"
-    public const string AttributeMessagingMessageBodySize = "messaging.message.body.size";
     public const string AttributeMessagingOperationName = "messaging.operation.name"; // replaces: "messaging.operation"
     public const string AttributeMessagingOperationType = "messaging.operation.type";
 
@@ -137,12 +136,10 @@ internal static class SemanticConventions
     public const string MetricMessagingClientOperationDuration = "messaging.client.operation.duration"; // replaces: "messaging.publish.duration" and "messaging.receive.duration"
     public const string MetricMessagingClientSentMessages = "messaging.client.sent.messages"; // replaces: "messaging.publish.messages"
     public const string MetricMessagingClientConsumedMessages = "messaging.client.consumed.messages"; // replaces: "messaging.receive.messages"
-    public const string MetricMessagingProcessDuration = "messaging.process.duration";
 
     // v1.42.0 Messaging (Kafka)
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/messaging/kafka.md
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
-    public const string AttributeMessagingKafkaMessageTombstone = "messaging.kafka.message.tombstone";
     public const string AttributeMessagingKafkaOffset = "messaging.kafka.offset"; // replaces: "messaging.kafka.message.offset"
 
     // v1.36.0 database conventions:

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -140,6 +140,7 @@ internal static class SemanticConventions
     // v1.42.0 Messaging (Kafka)
     // https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/messaging/kafka.md
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
+    public const string AttributeMessagingKafkaMessageTombstone = "messaging.kafka.message.tombstone";
     public const string AttributeMessagingKafkaOffset = "messaging.kafka.offset"; // replaces: "messaging.kafka.message.offset"
 
     // v1.36.0 database conventions:

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -122,24 +122,28 @@ internal static class SemanticConventions
     public const string AttributeNetworkPeerAddress = "network.peer.address"; // replaces: "net.peer.ip" (AttributeNetPeerIp)
     public const string AttributeNetworkPeerPort = "network.peer.port"; // replaces: "net.peer.port" (AttributeNetPeerPort)
 
-    // v1.24.0 Messaging spans
-    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-spans.md
-    public const string AttributeMessagingClientId = "messaging.client_id";
+    // v1.42.0 Messaging spans
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/messaging/messaging-spans.md
+    public const string AttributeMessagingClientId = "messaging.client.id"; // replaces: "messaging.client_id"
+    public const string AttributeMessagingConsumerGroupName = "messaging.consumer.group.name"; // replaces: "messaging.kafka.consumer.group"
     public const string AttributeMessagingDestinationName = "messaging.destination.name";
+    public const string AttributeMessagingDestinationPartitionId = "messaging.destination.partition.id"; // replaces: "messaging.kafka.destination.partition"
+    public const string AttributeMessagingMessageBodySize = "messaging.message.body.size";
+    public const string AttributeMessagingOperationName = "messaging.operation.name"; // replaces: "messaging.operation"
+    public const string AttributeMessagingOperationType = "messaging.operation.type";
 
-    // v1.24.0 Messaging metrics
-    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-metrics.md
-    public const string MetricMessagingPublishDuration = "messaging.publish.duration";
-    public const string MetricMessagingPublishMessages = "messaging.publish.messages";
-    public const string MetricMessagingReceiveDuration = "messaging.receive.duration";
-    public const string MetricMessagingReceiveMessages = "messaging.receive.messages";
+    // v1.42.0 Messaging metrics
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/messaging/messaging-metrics.md
+    public const string MetricMessagingClientOperationDuration = "messaging.client.operation.duration"; // replaces: "messaging.publish.duration" and "messaging.receive.duration"
+    public const string MetricMessagingClientSentMessages = "messaging.client.sent.messages"; // replaces: "messaging.publish.messages"
+    public const string MetricMessagingClientConsumedMessages = "messaging.client.consumed.messages"; // replaces: "messaging.receive.messages"
+    public const string MetricMessagingProcessDuration = "messaging.process.duration";
 
-    // v1.24.0 Messaging (Kafka)
-    // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/kafka.md
-    public const string AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer.group";
-    public const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
+    // v1.42.0 Messaging (Kafka)
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/messaging/kafka.md
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
-    public const string AttributeMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
+    public const string AttributeMessagingKafkaMessageTombstone = "messaging.kafka.message.tombstone";
+    public const string AttributeMessagingKafkaOffset = "messaging.kafka.offset"; // replaces: "messaging.kafka.message.offset"
 
     // v1.36.0 database conventions:
     // https://github.com/open-telemetry/semantic-conventions/tree/v1.36.0/docs/database

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/ConfluentKafkaCommonTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/ConfluentKafkaCommonTests.cs
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
+
+public class ConfluentKafkaCommonTests
+{
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("message-key", "message-key")]
+    [InlineData(42, "42")]
+    [InlineData(true, "True")]
+    public void FormatMessageKey_ReturnsCanonicalValue(object key, string expected)
+    {
+        var actual = ConfluentKafkaCommon.FormatMessageKey(key);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void FormatMessageKey_UsesRoundTripDateTimeFormat()
+    {
+        var key = new DateTime(2026, 7, 7, 12, 34, 56, 789, DateTimeKind.Utc).AddTicks(1234);
+
+        var actual = ConfluentKafkaCommon.FormatMessageKey(key);
+
+        Assert.Equal("2026-07-07T12:34:56.7891234Z", actual);
+    }
+
+    [Fact]
+    public void FormatMessageKey_OmitsKeyWithoutCanonicalFormat()
+    {
+        var actual = ConfluentKafkaCommon.FormatMessageKey(new DisplayOnlyKey());
+
+        Assert.Null(actual);
+    }
+
+    private sealed class DisplayOnlyKey : IFormattable
+    {
+        public string ToString(string? format, IFormatProvider? formatProvider) => "display-value";
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedMeteringTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedMeteringTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 
@@ -96,6 +97,11 @@ public class HostedMeteringTests(KafkaFixture fixture, ITestOutputHelper outputH
 
         groups = [.. metrics.GroupBy(x => x.Name)];
 
-        Assert.Equal(4, groups.Length);
+        // messaging.client.operation.duration is shared by the producer (send) and consumer (poll),
+        // so producing and consuming yields three distinct metric names.
+        Assert.Contains(SemanticConventions.MetricMessagingClientSentMessages, groups.Select(x => x.Key));
+        Assert.Contains(SemanticConventions.MetricMessagingClientConsumedMessages, groups.Select(x => x.Key));
+        Assert.Contains(SemanticConventions.MetricMessagingClientOperationDuration, groups.Select(x => x.Key));
+        Assert.Equal(3, groups.Length);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedTracingAndMeteringTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/HostedTracingAndMeteringTests.cs
@@ -242,24 +242,30 @@ public class HostedTracingAndMeteringTests(KafkaFixture fixture, ITestOutputHelp
 
         if (enableProducerMetrics)
         {
-            Assert.Contains("messaging.publish.messages", groups.Select(x => x.Key));
-            Assert.Contains("messaging.publish.duration", groups.Select(x => x.Key));
+            Assert.Contains("messaging.client.sent.messages", groups.Select(x => x.Key));
         }
         else
         {
-            Assert.DoesNotContain("messaging.publish.messages", groups.Select(x => x.Key));
-            Assert.DoesNotContain("messaging.publish.duration", groups.Select(x => x.Key));
+            Assert.DoesNotContain("messaging.client.sent.messages", groups.Select(x => x.Key));
         }
 
         if (enableConsumerMetrics)
         {
-            Assert.Contains("messaging.receive.messages", groups.Select(x => x.Key));
-            Assert.Contains("messaging.receive.duration", groups.Select(x => x.Key));
+            Assert.Contains("messaging.client.consumed.messages", groups.Select(x => x.Key));
         }
         else
         {
-            Assert.DoesNotContain("messaging.receive.messages", groups.Select(x => x.Key));
-            Assert.DoesNotContain("messaging.receive.duration", groups.Select(x => x.Key));
+            Assert.DoesNotContain("messaging.client.consumed.messages", groups.Select(x => x.Key));
+        }
+
+        // messaging.client.operation.duration is emitted by both producers (send) and consumers (poll).
+        if (enableProducerMetrics || enableConsumerMetrics)
+        {
+            Assert.Contains("messaging.client.operation.duration", groups.Select(x => x.Key));
+        }
+        else
+        {
+            Assert.DoesNotContain("messaging.client.operation.duration", groups.Select(x => x.Key));
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -34,13 +34,16 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.Single(a => a.DisplayName == "consume-topic receive");
-        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        var activity = activities.Single(a => a.DisplayName == "poll consume-topic");
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+        Assert.Equal("https://opentelemetry.io/schemas/1.42.0", activity.Source.TelemetrySchemaUrl);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal("consume-topic", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
-        Assert.Equal(42L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
-        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
+        Assert.Equal("1", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
+        Assert.Equal(42L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingConsumerGroupName));
         Assert.Equal("msg-key", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
     }
 
@@ -74,7 +77,7 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        Assert.DoesNotContain(activities, a => a.DisplayName == "disabled-traces-topic receive");
+        Assert.DoesNotContain(activities, a => a.DisplayName == "poll disabled-traces-topic");
     }
 
     [Fact]
@@ -100,7 +103,7 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        Assert.DoesNotContain(activities, a => a.DisplayName == "eof-topic receive");
+        Assert.DoesNotContain(activities, a => a.DisplayName == "poll eof-topic");
     }
 
     [Fact]
@@ -134,7 +137,7 @@ public class InstrumentedConsumerTests
         }
 
         var snapshot = activities.ToList();
-        var activity = snapshot.Single(a => a.DisplayName == "linked-topic receive");
+        var activity = snapshot.Single(a => a.DisplayName == "poll linked-topic");
 
         // The extracted producer context should be linked (not parented) per messaging conventions
         Assert.NotEmpty(activity.Links);
@@ -164,18 +167,19 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.FirstOrDefault(a => a.DisplayName == "receive");
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "poll");
         Assert.NotNull(activity);
-        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
-        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingConsumerGroupName));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
+        Assert.Equal(exception.Error.Code.ToString(), activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
-        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
-        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
         Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
     }
 
@@ -207,18 +211,19 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.FirstOrDefault(a => a.DisplayName == "error-topic receive");
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "poll error-topic");
         Assert.NotNull(activity);
-        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
-        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingConsumerGroupName));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
+        Assert.Equal(exception.Error.Code.ToString(), activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Equal("error-topic", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
-        Assert.Equal(2, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
-        Assert.Equal(100L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Equal("2", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
+        Assert.Equal(100L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
         Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
     }
 
@@ -254,18 +259,19 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.FirstOrDefault(a => a.DisplayName == "error-topic-no-headers receive");
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "poll error-topic-no-headers");
         Assert.NotNull(activity);
-        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
-        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingConsumerGroupName));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
+        Assert.Equal(exception.Error.Code.ToString(), activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Equal("error-topic-no-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
-        Assert.Equal(3, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
-        Assert.Equal(150L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Equal("3", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
+        Assert.Equal(150L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
         Assert.Equal("error-key", Encoding.UTF8.GetString((byte[])activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey)!));
     }
 
@@ -309,20 +315,21 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.FirstOrDefault(a => a.DisplayName == "error-topic-with-headers receive");
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "poll error-topic-with-headers");
         Assert.NotNull(activity);
         Assert.NotEmpty(activity.Links);
         Assert.Equal("0af7651916cd43dd8448eb211c80319c", activity.Links.First().Context.TraceId.ToHexString());
-        Assert.Equal(ActivityKind.Consumer, activity.Kind);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
         Assert.Equal("fake-consumer-1", activity.GetTagValue(SemanticConventions.AttributeMessagingClientId));
-        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaConsumerGroup));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
-        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingConsumerGroupName));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
+        Assert.Equal(exception.Error.Code.ToString(), activity.GetTagValue(SemanticConventions.AttributeErrorType));
         Assert.Equal("error-topic-with-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
-        Assert.Equal(5, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
-        Assert.Equal(200L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageOffset));
+        Assert.Equal("5", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
+        Assert.Equal(200L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
         Assert.Equal("error-key-with-headers", Encoding.UTF8.GetString((byte[])activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey)!));
     }
 
@@ -364,10 +371,10 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.FirstOrDefault(a => a.DisplayName == "timeout-topic receive");
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "poll timeout-topic");
         Assert.NotNull(activity);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
-        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal(exception.Error.Code.ToString(), activity.GetTagValue(SemanticConventions.AttributeErrorType));
     }
 
     [Fact]
@@ -408,10 +415,10 @@ public class InstrumentedConsumerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.FirstOrDefault(a => a.DisplayName == "broker-error-topic receive");
+        var activity = activities.FirstOrDefault(a => a.DisplayName == "poll broker-error-topic");
         Assert.NotNull(activity);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
-        Assert.Equal($"ConsumeException: {exception.Error}", activity.GetTagValue(SemanticConventions.AttributeErrorType));
+        Assert.Equal(exception.Error.Code.ToString(), activity.GetTagValue(SemanticConventions.AttributeErrorType));
     }
 
     [Fact]
@@ -435,23 +442,23 @@ public class InstrumentedConsumerTests
             meterProvider.EnsureMetricsAreFlushed();
         }
 
-        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientConsumedMessages);
         AssertMetric(
             actualMetric: receiveMessagesMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: null,
             expectedKafkaDestinationPartition: null,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedErrorType: exception.Error.Code.ToString());
 
-        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientOperationDuration);
         AssertMetric(
             actualMetric: receiveDurationMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: null,
             expectedKafkaDestinationPartition: null,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedErrorType: exception.Error.Code.ToString());
     }
 
     [Fact]
@@ -482,23 +489,23 @@ public class InstrumentedConsumerTests
             meterProvider.EnsureMetricsAreFlushed();
         }
 
-        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientConsumedMessages);
         AssertMetric(
             actualMetric: receiveMessagesMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic",
-            expectedKafkaDestinationPartition: 2,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedKafkaDestinationPartition: "2",
+            expectedErrorType: exception.Error.Code.ToString());
 
-        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientOperationDuration);
         AssertMetric(
             actualMetric: receiveDurationMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic",
-            expectedKafkaDestinationPartition: 2,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedKafkaDestinationPartition: "2",
+            expectedErrorType: exception.Error.Code.ToString());
     }
 
     [Fact]
@@ -533,23 +540,23 @@ public class InstrumentedConsumerTests
             meterProvider.EnsureMetricsAreFlushed();
         }
 
-        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientConsumedMessages);
         AssertMetric(
             actualMetric: receiveMessagesMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-no-headers",
-            expectedKafkaDestinationPartition: 3,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedKafkaDestinationPartition: "3",
+            expectedErrorType: exception.Error.Code.ToString());
 
-        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientOperationDuration);
         AssertMetric(
             actualMetric: receiveDurationMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-no-headers",
-            expectedKafkaDestinationPartition: 3,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedKafkaDestinationPartition: "3",
+            expectedErrorType: exception.Error.Code.ToString());
     }
 
     [Fact]
@@ -591,34 +598,34 @@ public class InstrumentedConsumerTests
             meterProvider.EnsureMetricsAreFlushed();
         }
 
-        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveMessages);
+        var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientConsumedMessages);
         AssertMetric(
             actualMetric: receiveMessagesMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-with-headers",
-            expectedKafkaDestinationPartition: 5,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedKafkaDestinationPartition: "5",
+            expectedErrorType: exception.Error.Code.ToString());
 
-        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingReceiveDuration);
+        var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientOperationDuration);
         AssertMetric(
             actualMetric: receiveDurationMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.ReceiveOperationName,
+            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
             expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
             expectedKafkaDestinationName: "error-topic-with-headers",
-            expectedKafkaDestinationPartition: 5,
-            expectedErrorType: $"ConsumeException: {exception.Error}");
+            expectedKafkaDestinationPartition: "5",
+            expectedErrorType: exception.Error.Code.ToString());
     }
 
     private static TracerProvider CreateTraceProvider(List<Activity> activities) => Sdk.CreateTracerProviderBuilder()
-                .AddSource(ConfluentKafkaCommon.InstrumentationName)
-                .AddInMemoryExporter(activities)
-                .Build();
+        .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
+        .AddInMemoryExporter(activities)
+        .Build();
 
     private static MeterProvider CreateMeterProvider(List<Metric> metrics) => Sdk.CreateMeterProviderBuilder()
-                .AddMeter(ConfluentKafkaCommon.InstrumentationName)
-                .AddInMemoryExporter(metrics)
-                .Build();
+        .AddMeter(ConfluentKafkaCommon.Meter.Name)
+        .AddInMemoryExporter(metrics)
+        .Build();
 
     private static void ConsumeEventAndCaptureTraces(IConsumer<string, string> fakeConsumer)
     {
@@ -657,10 +664,11 @@ public class InstrumentedConsumerTests
        string? expectedMessagingOperation,
        string? expectedMessagingSystem,
        string? expectedKafkaDestinationName,
-       int? expectedKafkaDestinationPartition,
+       string? expectedKafkaDestinationPartition,
        string? expectedErrorType)
     {
         Assert.NotNull(actualMetric);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", actualMetric.MeterSchemaUrl, StringComparison.Ordinal);
 
         var metricPoint = GetMetricPoint(actualMetric);
 
@@ -672,7 +680,7 @@ public class InstrumentedConsumerTests
 
         foreach (var tag in metricPoint!.Value.Tags)
         {
-            if (tag.Key == SemanticConventions.AttributeMessagingOperation)
+            if (tag.Key == SemanticConventions.AttributeMessagingOperationName)
             {
                 Assert.Equal(expectedMessagingOperation, tag.Value?.ToString());
                 messagingOperationFound = true;
@@ -690,9 +698,9 @@ public class InstrumentedConsumerTests
                 destinationNameFound = true;
             }
 
-            if (tag.Key == SemanticConventions.AttributeMessagingKafkaDestinationPartition)
+            if (tag.Key == SemanticConventions.AttributeMessagingDestinationPartitionId)
             {
-                Assert.Equal(expectedKafkaDestinationPartition, tag.Value);
+                Assert.Equal(expectedKafkaDestinationPartition, tag.Value?.ToString());
                 destinationPartitionFound = true;
             }
 
@@ -763,34 +771,13 @@ public class InstrumentedConsumerTests
         }
 
         public ConsumeResult<TKey, TValue>? Consume(int millisecondsTimeout)
-        {
-            if (this.ConsumerExceptionToThrow != null)
-            {
-                throw this.ConsumerExceptionToThrow;
-            }
-
-            return this.ConsumeResult;
-        }
+            => this.ConsumerExceptionToThrow != null ? throw this.ConsumerExceptionToThrow : this.ConsumeResult;
 
         public ConsumeResult<TKey, TValue>? Consume(CancellationToken cancellationToken = default)
-        {
-            if (this.ConsumerExceptionToThrow != null)
-            {
-                throw this.ConsumerExceptionToThrow;
-            }
-
-            return this.ConsumeResult;
-        }
+            => this.ConsumerExceptionToThrow != null ? throw this.ConsumerExceptionToThrow : this.ConsumeResult;
 
         public ConsumeResult<TKey, TValue>? Consume(TimeSpan timeout)
-        {
-            if (this.ConsumerExceptionToThrow != null)
-            {
-                throw this.ConsumerExceptionToThrow;
-            }
-
-            return this.ConsumeResult;
-        }
+            => this.ConsumerExceptionToThrow != null ? throw this.ConsumerExceptionToThrow : this.ConsumeResult;
 
         public void Subscribe(IEnumerable<string> topics)
         {

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -45,6 +45,34 @@ public class InstrumentedConsumerTests
         Assert.Equal(42L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
         Assert.Equal("test-group", activity.GetTagValue(SemanticConventions.AttributeMessagingConsumerGroupName));
         Assert.Equal("msg-key", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageTombstone));
+    }
+
+    [Fact]
+    public void Consume_TombstoneMessage_SetsTombstoneTag()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = CreateTraceProvider(activities))
+        {
+            var fakeConsumer = new FakeConsumer<string, string>
+            {
+                ConsumeResult = new ConsumeResult<string, string>
+                {
+                    Topic = "tombstone-topic",
+                    Partition = new Partition(0),
+                    Offset = new Offset(3),
+                    Message = new Message<string, string> { Key = "msg-key", Value = null! },
+                },
+            };
+
+            ConsumeEventAndCaptureTraces(fakeConsumer);
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.Single(a => a.DisplayName == "poll tombstone-topic");
+        Assert.Equal(true, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageTombstone));
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -36,7 +36,7 @@ public class InstrumentedConsumerTests
 
         var activity = activities.Single(a => a.DisplayName == "poll consume-topic");
         Assert.Equal(ActivityKind.Client, activity.Kind);
-        Assert.Equal("https://opentelemetry.io/schemas/1.42.0", activity.Source.TelemetrySchemaUrl);
+        Assert.Equal("https://opentelemetry.io/schemas/1.43.0", activity.Source.TelemetrySchemaUrl);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
         Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
         Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -300,7 +300,7 @@ public class InstrumentedConsumerTests
         Assert.Equal("error-topic-no-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
         Assert.Equal("3", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
         Assert.Equal(150L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
-        Assert.Equal("error-key", Encoding.UTF8.GetString((byte[])activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey)!));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
     }
 
     [Fact]
@@ -358,7 +358,7 @@ public class InstrumentedConsumerTests
         Assert.Equal("error-topic-with-headers", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
         Assert.Equal("5", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
         Assert.Equal(200L, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaOffset));
-        Assert.Equal("error-key-with-headers", Encoding.UTF8.GetString((byte[])activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey)!));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
     }
 
     [Fact]
@@ -470,14 +470,9 @@ public class InstrumentedConsumerTests
             meterProvider.EnsureMetricsAreFlushed();
         }
 
+        // The ConsumeException carried no ConsumerRecord, so no message was pulled from the broker.
         var receiveMessagesMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientConsumedMessages);
-        AssertMetric(
-            actualMetric: receiveMessagesMetric,
-            expectedMessagingOperation: ConfluentKafkaCommon.PollOperationName,
-            expectedMessagingSystem: ConfluentKafkaCommon.KafkaMessagingSystem,
-            expectedKafkaDestinationName: null,
-            expectedKafkaDestinationPartition: null,
-            expectedErrorType: exception.Error.Code.ToString());
+        Assert.Null(receiveMessagesMetric);
 
         var receiveDurationMetric = metrics.FirstOrDefault(m => m.Name == SemanticConventions.MetricMessagingClientOperationDuration);
         AssertMetric(

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
@@ -74,6 +74,35 @@ public class InstrumentedProducerTests
     }
 
     [Fact]
+    public async Task ProduceAsync_EmptyKey_SetsKeyTag()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var fakeProducer = new FakeProducer<string, string>();
+            var options = new ConfluentKafkaProducerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedProducer = new InstrumentedProducer<string, string>(fakeProducer, options);
+
+            await instrumentedProducer.ProduceAsync(
+                "empty-key-topic",
+                new Message<string, string> { Key = string.Empty, Value = "hello" });
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.Single(a => a.DisplayName == "send empty-key-topic");
+        Assert.Equal(string.Empty, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
+    }
+
+    [Fact]
     public async Task ProduceAsync_TombstoneMessage_SetsTombstoneTag()
     {
         var activities = new List<Activity>();

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
@@ -70,6 +70,34 @@ public class InstrumentedProducerTests
         var activity = activities.Single(a => a.DisplayName == "send partition-topic");
         Assert.Equal("3", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
         Assert.Equal("msg-key", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageTombstone));
+    }
+
+    [Fact]
+    public async Task ProduceAsync_TombstoneMessage_SetsTombstoneTag()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var fakeProducer = new FakeProducer<string, string>();
+            var options = new ConfluentKafkaProducerInstrumentationOptions<string, string>
+            {
+                Traces = true,
+                Metrics = false,
+            };
+            var instrumentedProducer = new InstrumentedProducer<string, string>(fakeProducer, options);
+
+            await instrumentedProducer.ProduceAsync("tombstone-topic", new Message<string, string> { Key = "msg-key", Value = null! });
+
+            tracerProvider.ForceFlush();
+        }
+
+        var activity = activities.Single(a => a.DisplayName == "send tombstone-topic");
+        Assert.Equal(true, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageTombstone));
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedProducerTests.cs
@@ -15,7 +15,7 @@ public class InstrumentedProducerTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .AddInMemoryExporter(activities)
             .Build())
         {
@@ -32,11 +32,13 @@ public class InstrumentedProducerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.Single(a => a.DisplayName == "unit-test-topic publish");
+        var activity = activities.Single(a => a.DisplayName == "send unit-test-topic");
 
         Assert.Equal(ActivityKind.Producer, activity.Kind);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", activity.Source.TelemetrySchemaUrl, StringComparison.Ordinal);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("publish", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal("unit-test-topic", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationName));
     }
 
@@ -46,7 +48,7 @@ public class InstrumentedProducerTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .AddInMemoryExporter(activities)
             .Build())
         {
@@ -65,8 +67,8 @@ public class InstrumentedProducerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.Single(a => a.DisplayName == "partition-topic publish");
-        Assert.Equal(3, activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaDestinationPartition));
+        var activity = activities.Single(a => a.DisplayName == "send partition-topic");
+        Assert.Equal("3", activity.GetTagValue(SemanticConventions.AttributeMessagingDestinationPartitionId));
         Assert.Equal("msg-key", activity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageKey));
     }
 
@@ -76,7 +78,7 @@ public class InstrumentedProducerTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .AddInMemoryExporter(activities)
             .Build())
         {
@@ -93,7 +95,7 @@ public class InstrumentedProducerTests
             tracerProvider.ForceFlush();
         }
 
-        Assert.DoesNotContain(activities, a => a.DisplayName == "disabled-traces-topic publish");
+        Assert.DoesNotContain(activities, a => a.DisplayName == "send disabled-traces-topic");
     }
 
     [Fact]
@@ -102,7 +104,7 @@ public class InstrumentedProducerTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .AddInMemoryExporter(activities)
             .Build())
         {
@@ -123,7 +125,7 @@ public class InstrumentedProducerTests
             tracerProvider.ForceFlush();
         }
 
-        var activity = activities.Single(a => a.DisplayName == "error-topic publish");
+        var activity = activities.Single(a => a.DisplayName == "send error-topic");
 
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
 
@@ -136,7 +138,7 @@ public class InstrumentedProducerTests
     public async Task ProduceAsync_InjectsTraceContextIntoMessageHeaders()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .Build();
 
         var fakeProducer = new FakeProducer<string, string>();
@@ -162,7 +164,7 @@ public class InstrumentedProducerTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .AddInMemoryExporter(activities)
             .Build())
         {
@@ -179,7 +181,7 @@ public class InstrumentedProducerTests
             tracerProvider.ForceFlush();
         }
 
-        Assert.Contains(activities, a => a.DisplayName == "sync-topic publish");
+        Assert.Contains(activities, a => a.DisplayName == "send sync-topic");
     }
 
     private sealed class FakeProducer<TKey, TValue> : IProducer<TKey, TValue>

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/MeteringTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/MeteringTests.cs
@@ -4,6 +4,7 @@
 using Confluent.Kafka;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka.Tests;
 
@@ -42,6 +43,9 @@ public class MeteringTests(KafkaFixture fixture)
         var groups = metrics.GroupBy(m => m.Name).ToArray();
 
         Assert.Equal(2, groups.Length);
+        Assert.Contains(SemanticConventions.MetricMessagingClientSentMessages, groups.Select(g => g.Key));
+        Assert.Contains(SemanticConventions.MetricMessagingClientOperationDuration, groups.Select(g => g.Key));
+        AssertOperation(metrics, SemanticConventions.MetricMessagingClientOperationDuration, expectedOperationName: "send", expectedOperationType: "send");
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -73,6 +77,9 @@ public class MeteringTests(KafkaFixture fixture)
         var groups = metrics.GroupBy(m => m.Name).ToArray();
 
         Assert.Equal(2, groups.Length);
+        Assert.Contains(SemanticConventions.MetricMessagingClientSentMessages, groups.Select(g => g.Key));
+        Assert.Contains(SemanticConventions.MetricMessagingClientOperationDuration, groups.Select(g => g.Key));
+        AssertOperation(metrics, SemanticConventions.MetricMessagingClientOperationDuration, expectedOperationName: "send", expectedOperationType: "send");
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -122,5 +129,56 @@ public class MeteringTests(KafkaFixture fixture)
         var groups = metrics.GroupBy(m => m.Name).ToArray();
 
         Assert.Equal(2, groups.Length);
+        Assert.Contains(SemanticConventions.MetricMessagingClientConsumedMessages, groups.Select(g => g.Key));
+        Assert.Contains(SemanticConventions.MetricMessagingClientOperationDuration, groups.Select(g => g.Key));
+        AssertOperation(metrics, SemanticConventions.MetricMessagingClientOperationDuration, expectedOperationName: "poll", expectedOperationType: "receive");
+    }
+
+    private static void AssertOperation(
+        IEnumerable<Metric> metrics,
+        string metricName,
+        string expectedOperationName,
+        string expectedOperationType)
+    {
+        // The in-memory exporter may emit the same instrument more than once (e.g. on flush and on
+        // dispose), so inspect every matching metric rather than expecting a single instance.
+        var matching = metrics.Where(m => m.Name == metricName).ToList();
+        Assert.NotEmpty(matching);
+        Assert.All(matching, m => Assert.StartsWith("https://opentelemetry.io/schemas/", m.MeterSchemaUrl, StringComparison.Ordinal));
+
+        string? operationName = null;
+        string? operationType = null;
+        string? system = null;
+
+        foreach (var metric in matching)
+        {
+            foreach (ref readonly var metricPoint in metric.GetMetricPoints())
+            {
+                foreach (var tag in metricPoint.Tags)
+                {
+                    switch (tag.Key)
+                    {
+                        case SemanticConventions.AttributeMessagingOperationName:
+                            operationName = tag.Value?.ToString();
+                            break;
+
+                        case SemanticConventions.AttributeMessagingOperationType:
+                            operationType = tag.Value?.ToString();
+                            break;
+
+                        case SemanticConventions.AttributeMessagingSystem:
+                            system = tag.Value?.ToString();
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+
+        Assert.Equal(expectedOperationName, operationName);
+        Assert.Equal(expectedOperationType, operationType);
+        Assert.Equal(ConfluentKafkaCommon.KafkaMessagingSystem, system);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
@@ -63,7 +63,7 @@ public class OpenTelemetryConsumeResultExtensionsTests
 
         // TracerProvider registers the W3C TraceContext propagator as the default
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(ConfluentKafkaCommon.InstrumentationName)
+            .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
             .Build();
 
         var result = consumeResult.TryExtractPropagationContext(out var propagationContext);
@@ -153,7 +153,7 @@ public class OpenTelemetryConsumeResultExtensionsTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                                       .AddSource(ConfluentKafkaCommon.InstrumentationName)
+                                       .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
                                        .AddInMemoryExporter(activities)
                                        .Build())
         {
@@ -172,7 +172,7 @@ public class OpenTelemetryConsumeResultExtensionsTests
             tracerProvider.ForceFlush();
         }
 
-        var processActivity = Assert.Single(activities, a => a.DisplayName.EndsWith("process", StringComparison.Ordinal));
+        var processActivity = Assert.Single(activities, a => a.DisplayName == "process error-topic");
         Assert.Equal(ActivityStatusCode.Error, processActivity.Status);
     }
 
@@ -182,7 +182,7 @@ public class OpenTelemetryConsumeResultExtensionsTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                                       .AddSource(ConfluentKafkaCommon.InstrumentationName)
+                                       .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
                                        .AddInMemoryExporter(activities)
                                        .Build())
         {
@@ -199,11 +199,12 @@ public class OpenTelemetryConsumeResultExtensionsTests
             tracerProvider.ForceFlush();
         }
 
-        var processActivity = Assert.Single(activities, a => a.DisplayName == "process-topic process");
+        var processActivity = Assert.Single(activities, a => a.DisplayName == "process process-topic");
 
         Assert.Equal(ActivityKind.Consumer, processActivity.Kind);
         Assert.Equal("kafka", processActivity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
     }
 
     private static InstrumentedConsumer<TKey, TValue> BuildInstrumentedConsumer<TKey, TValue>(

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/OpenTelemetryConsumeResultExtensionsTests.cs
@@ -205,6 +205,34 @@ public class OpenTelemetryConsumeResultExtensionsTests
         Assert.Equal("kafka", processActivity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
         Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
         Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
+        Assert.Null(processActivity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageTombstone));
+    }
+
+    [Fact]
+    public async Task ConsumeAndProcessMessageAsync_TombstoneMessage_SetsTombstoneTag()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                                       .AddSource(ConfluentKafkaCommon.ActivitySource.Name)
+                                       .AddInMemoryExporter(activities)
+                                       .Build())
+        {
+            var consumer = BuildInstrumentedConsumer(new ConsumeResult<string, string>
+            {
+                Topic = "tombstone-topic",
+                Partition = new Partition(0),
+                Offset = new Offset(5),
+                Message = new Message<string, string> { Key = "msg-key", Value = null! },
+            });
+
+            await consumer.ConsumeAndProcessMessageAsync(NoOpHandler);
+
+            tracerProvider.ForceFlush();
+        }
+
+        var processActivity = Assert.Single(activities, a => a.DisplayName == "process tombstone-topic");
+        Assert.Equal(true, processActivity.GetTagValue(SemanticConventions.AttributeMessagingKafkaMessageTombstone));
     }
 
     private static InstrumentedConsumer<TKey, TValue> BuildInstrumentedConsumer<TKey, TValue>(

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/TracingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/TracingTests.cs
@@ -38,10 +38,12 @@ public class TracingTests(KafkaFixture fixture)
             });
         }
 
-        Assert.Contains(activities, activity => activity.DisplayName == topic + " publish");
+        Assert.Contains(activities, activity => activity.DisplayName == "send " + topic);
         var activity = Assert.Single(activities);
+        Assert.Equal(ActivityKind.Producer, activity.Kind);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("publish", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, activity.GetTagValue("messaging.destination.name"));
     }
 
@@ -69,12 +71,13 @@ public class TracingTests(KafkaFixture fixture)
             });
         }
 
-        Assert.Contains(activities, activity => activity.DisplayName == topic + " publish");
+        Assert.Contains(activities, activity => activity.DisplayName == "send " + topic);
         var activity = Assert.Single(activities);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("publish", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, activity.GetTagValue("messaging.destination.name"));
-        Assert.Equal(0, activity.GetTagValue("messaging.kafka.destination.partition"));
+        Assert.Equal("0", activity.GetTagValue("messaging.destination.partition.id"));
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -101,10 +104,11 @@ public class TracingTests(KafkaFixture fixture)
             });
         }
 
-        Assert.Contains(activities, activity => activity.DisplayName == topic + " publish");
+        Assert.Contains(activities, activity => activity.DisplayName == "send " + topic);
         var activity = Assert.Single(activities);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("publish", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, activity.GetTagValue("messaging.destination.name"));
     }
 
@@ -132,12 +136,13 @@ public class TracingTests(KafkaFixture fixture)
             });
         }
 
-        Assert.Contains(activities, activity => activity.DisplayName == topic + " publish");
+        Assert.Contains(activities, activity => activity.DisplayName == "send " + topic);
         var activity = Assert.Single(activities);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("publish", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("send", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, activity.GetTagValue("messaging.destination.name"));
-        Assert.Equal(0, activity.GetTagValue("messaging.kafka.destination.partition"));
+        Assert.Equal("0", activity.GetTagValue("messaging.destination.partition.id"));
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -180,14 +185,16 @@ public class TracingTests(KafkaFixture fixture)
             consumer.Close();
         }
 
-        Assert.Contains(activities, activity => activity.DisplayName == topic + " receive");
+        Assert.Contains(activities, activity => activity.DisplayName == "poll " + topic);
         var activity = Assert.Single(activities);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, activity.GetTagValue("messaging.destination.name"));
-        Assert.Equal(0, activity.GetTagValue("messaging.kafka.destination.partition"));
-        Assert.Equal(0L, activity.GetTagValue("messaging.kafka.message.offset"));
-        Assert.Equal("test-consumer-group", activity.GetTagValue("messaging.kafka.consumer.group"));
+        Assert.Equal("0", activity.GetTagValue("messaging.destination.partition.id"));
+        Assert.Equal(0L, activity.GetTagValue("messaging.kafka.offset"));
+        Assert.Equal("test-consumer-group", activity.GetTagValue("messaging.consumer.group.name"));
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -230,14 +237,15 @@ public class TracingTests(KafkaFixture fixture)
             consumer.Close();
         }
 
-        Assert.Contains(activities, activity => activity.DisplayName == topic + " receive");
+        Assert.Contains(activities, activity => activity.DisplayName == "poll " + topic);
         var activity = Assert.Single(activities);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, activity.GetTagValue("messaging.destination.name"));
-        Assert.Equal(0, activity.GetTagValue("messaging.kafka.destination.partition"));
-        Assert.Equal(0L, activity.GetTagValue("messaging.kafka.message.offset"));
-        Assert.Equal("test-consumer-group", activity.GetTagValue("messaging.kafka.consumer.group"));
+        Assert.Equal("0", activity.GetTagValue("messaging.destination.partition.id"));
+        Assert.Equal(0L, activity.GetTagValue("messaging.kafka.offset"));
+        Assert.Equal("test-consumer-group", activity.GetTagValue("messaging.consumer.group.name"));
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -280,14 +288,15 @@ public class TracingTests(KafkaFixture fixture)
             consumer.Close();
         }
 
-        Assert.Contains(activities, activity => activity.DisplayName == topic + " receive");
+        Assert.Contains(activities, activity => activity.DisplayName == "poll " + topic);
         var activity = Assert.Single(activities);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, activity.GetTagValue("messaging.destination.name"));
-        Assert.Equal(0, activity.GetTagValue("messaging.kafka.destination.partition"));
-        Assert.Equal(0L, activity.GetTagValue("messaging.kafka.message.offset"));
-        Assert.Equal("test-consumer-group", activity.GetTagValue("messaging.kafka.consumer.group"));
+        Assert.Equal("0", activity.GetTagValue("messaging.destination.partition.id"));
+        Assert.Equal(0L, activity.GetTagValue("messaging.kafka.offset"));
+        Assert.Equal("test-consumer-group", activity.GetTagValue("messaging.consumer.group.name"));
     }
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -330,14 +339,16 @@ public class TracingTests(KafkaFixture fixture)
             consumer.Close();
         }
 
-        var processActivity = Assert.Single(activities, activity => activity.DisplayName == topic + " process");
+        var processActivity = Assert.Single(activities, activity => activity.DisplayName == "process " + topic);
 
+        Assert.Equal(ActivityKind.Consumer, processActivity.Kind);
         Assert.Equal("kafka", processActivity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
-        Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperation));
+        Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
+        Assert.Equal("process", processActivity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));
         Assert.Equal(topic, processActivity.GetTagValue("messaging.destination.name"));
-        Assert.Equal(0, processActivity.GetTagValue("messaging.kafka.destination.partition"));
-        Assert.Equal(0L, processActivity.GetTagValue("messaging.kafka.message.offset"));
-        Assert.Equal("test-consumer-group", processActivity.GetTagValue("messaging.kafka.consumer.group"));
+        Assert.Equal("0", processActivity.GetTagValue("messaging.destination.partition.id"));
+        Assert.Equal(0L, processActivity.GetTagValue("messaging.kafka.offset"));
+        Assert.Equal("test-consumer-group", processActivity.GetTagValue("messaging.consumer.group.name"));
 
         static ValueTask NoOpAsync(
             ConsumeResult<string, string> consumeResult,


### PR DESCRIPTION
- Fixes #2567
- Contributes to #4064

## Changes

Update to [v1.43.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/kafka.md) of the semantic conventions for messaging.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
