### PR TITLE
[Infra] Digitally sign DLLs with cosign

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -123,7 +123,15 @@ jobs:
           foreach ($projectFile in $projectFiles) {
               $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectFile)
 
-              Get-ChildItem -Path artifacts/bin/$projectName/release*/$projectName.dll -File | ForEach-Object {
+              $dllSearchPath = "artifacts/bin/$projectName/release*/$projectName.dll"
+
+              # Components that were not built (e.g. in tag/component
+              # builds) will not have any output, so skip them.
+              if (-not (Test-Path -Path $dllSearchPath)) {
+                  continue
+              }
+
+              Get-ChildItem -Path $dllSearchPath -File | ForEach-Object {
                   $fileFullPath = $_.FullName
                   Write-Output "Signing $fileFullPath"
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -181,7 +181,7 @@ jobs:
   validate:
     name: Validate NuGet packages
     needs: [build-pack]
-    runs-on: ubuntu-24.04
+    runs-on: windows-2025
 
     permissions:
       attestations: read # Verify GitHub attestations for the build outputs

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -123,7 +123,7 @@ jobs:
           foreach ($projectFile in $projectFiles) {
               $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectFile)
 
-              Get-ChildItem -Path artifacts/bin/$projectName/release_*/$projectName.dll -File | ForEach-Object {
+              Get-ChildItem -Path artifacts/bin/$projectName/release*/$projectName.dll -File | ForEach-Object {
                   $fileFullPath = $_.FullName
                   Write-Output "Signing $fileFullPath"
 
@@ -135,7 +135,7 @@ jobs:
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: |
-            ./artifacts/bin/*/release_*/OpenTelemetry*.dll
+            ./artifacts/bin/*/release*/OpenTelemetry*.dll
             !./artifacts/bin/*/**/OpenTelemetry.dll
             !./artifacts/bin/*/**/OpenTelemetry.Api.dll
             !./artifacts/bin/*/**/OpenTelemetry.Api.ProviderBuilderExtensions.dll

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -32,7 +32,12 @@ jobs:
 
   build-pack:
     name: Build and pack
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.event.repository.fork == false)
     runs-on: windows-2025
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      COSIGN_YES: "yes"
 
     outputs:
       artifact-url: ${{ steps.upload-artifacts.outputs.artifact-url }}
@@ -107,6 +112,25 @@ jobs:
       - name: dotnet test ${{ steps.resolve-project.outputs.title }}
         run: dotnet test ${env:PROJECT_PATH} --configuration Release --no-restore --no-build
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign DLLs with Cosign Keyless
+        shell: pwsh
+        run: |
+          $projectFiles = Get-ChildItem -Path src/*/*.csproj -File
+
+          foreach ($projectFile in $projectFiles) {
+              $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectFile)
+
+              Get-ChildItem -Path artifacts/bin/$projectName/release_*/$projectName.dll -File | ForEach-Object {
+                  $fileFullPath = $_.FullName
+                  Write-Output "Signing $fileFullPath"
+
+                  cosign.exe sign-blob --yes --bundle "$fileFullPath.sigstore.json" $fileFullPath
+              }
+          }
+
       - name: Create GitHub attestations for DLLs
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -169,6 +193,9 @@ jobs:
         with:
           dotnet-version: ${{ needs.build-pack.outputs.dotnet-sdk-version }}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Install NuGet package validation tools
         env:
           # renovate: datasource=nuget depName=dotnet-validate
@@ -217,6 +244,42 @@ jobs:
           if ($invalidPackages -gt 0) {
             Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
             exit 1
+          }
+
+      - name: Verify package DLL Cosign Keyless signatures
+        shell: pwsh
+        env:
+          CERTIFICATE_IDENTITY: "${{ github.server_url }}/${{ github.repository }}/.github/workflows/publish-packages.yml@${{ github.ref }}"
+          CERTIFICATE_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
+          COSIGN_YES: "yes"
+        run: |
+          $nupkgFiles = Get-ChildItem -Path "./artifacts/*.nupkg" -File
+
+          # Copy the NuGet packages to a temporary directory and extract them
+          $tempDir = New-Item -ItemType Directory -Path (Join-Path -Path ${env:RUNNER_TEMP} -ChildPath ([System.Guid]::NewGuid().ToString()))
+          foreach ($nupkgFile in $nupkgFiles) {
+              $nupkgFilePath = $nupkgFile.FullName
+              $packageName = [System.IO.Path]::GetFileNameWithoutExtension($nupkgFilePath)
+              Write-Output "Extracting $nupkgFilePath"
+              Expand-Archive -Path $nupkgFilePath -DestinationPath (Join-Path $tempDir.FullName $packageName)
+          }
+
+          # Iterate over all DLL files in the extracted packages and verify their signatures
+          $dllFiles = Get-ChildItem -Path $tempDir.FullName -Recurse -Filter *.dll -File
+          foreach ($dllFile in $dllFiles) {
+              $dllFilePath = $dllFile.FullName
+              Write-Output "Verifying $dllFilePath"
+              cosign.exe verify-blob `
+                --bundle "$dllFilePath.sigstore.json" `
+                --certificate-identity ${env:CERTIFICATE_IDENTITY} `
+                --certificate-oidc-issuer ${env:CERTIFICATE_OIDC_ISSUER} `
+                --use-signed-timestamps `
+                $dllFilePath
+              if ($LASTEXITCODE -ne 0) {
+                  Write-Output "::error::Signature verification failed for $dllFilePath."
+                  exit 1
+              }
+              Write-Output "Signature verification succeeded for $dllFilePath"
           }
 
       - name: Verify artifact attestations

--- a/README.md
+++ b/README.md
@@ -143,6 +143,40 @@ Nightly builds from this repo are published to [MyGet](https://www.myget.org),
 and can be installed using the
 `https://www.myget.org/F/opentelemetry/api/v3/index.json` source.
 
+## Digital signing
+
+Starting with the `1.17.*` releases the DLLs included in the packages pushed to
+NuGet are digitally signed using [Sigstore](https://www.sigstore.dev/). Within
+each NuGet package the digital signature artifacts are placed alongside the
+shipped DLL(s) in the `/lib` folder. When a project targets multiple frameworks
+each target outputs a dedicated DLL and signing artifacts into a sub folder
+based on the [TFM](https://learn.microsoft.com/dotnet/standard/frameworks).
+
+The digital signature files share the same name prefix as the DLL to ensure
+easy identification and association.
+
+To verify the integrity of a DLL inside a NuGet package use the
+[cosign](https://github.com/sigstore/cosign) tool from Sigstore.
+
+Signatures use the bundle format known from cosign 3.0+.
+
+```bash
+$TAG="Instrumentation.AspNetCore-1.17.0"
+$PACKAGE="OpenTelemetry.Instrumentation.AspNetCore"
+cosign verify-blob \
+    --bundle "${PACKAGE}.dll.sigstore.json" \
+    --certificate-identity "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/.github/workflows/publish-packages.yml@refs/tags/${TAG}" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    --use-signed-timestamps \
+    "${PACKAGE}.dll"
+```
+
+> [!NOTE]
+> A successful verification outputs `Verify OK`.
+
+For more verification options please refer to the [cosign
+documentation](https://github.com/sigstore/cosign/blob/main/doc/cosign_verify-blob.md).
+
 ## Attestation
 
 Starting with the `1.14.*` releases the DLLs included in the packages pushed to

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ and can be installed using the
 
 ## Digital signing
 
-Starting with the `1.17.*` releases the DLLs included in the packages pushed to
+For releases published since July 3rd 2026 the DLLs included in the packages pushed to
 NuGet are digitally signed using [Sigstore](https://www.sigstore.dev/). Within
 each NuGet package the digital signature artifacts are placed alongside the
 shipped DLL(s) in the `/lib` folder. When a project targets multiple frameworks

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ cosign verify-blob \
 ```
 
 > [!NOTE]
-> A successful verification outputs `Verify OK`.
+> A successful verification outputs `Verified OK`.
 
 For more verification options please refer to the [cosign
 documentation](https://github.com/sigstore/cosign/blob/main/doc/cosign_verify-blob.md).

--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ and can be installed using the
 
 ## Digital signing
 
-For releases published since July 3rd 2026 the DLLs included in the packages pushed to
-NuGet are digitally signed using [Sigstore](https://www.sigstore.dev/). Within
-each NuGet package the digital signature artifacts are placed alongside the
-shipped DLL(s) in the `/lib` folder. When a project targets multiple frameworks
-each target outputs a dedicated DLL and signing artifacts into a sub folder
-based on the [TFM](https://learn.microsoft.com/dotnet/standard/frameworks).
+For releases published since July 3rd 2026 the DLLs included in the packages
+pushed to NuGet are digitally signed using [Sigstore](https://www.sigstore.dev/).
+Within each NuGet package the digital signature artifacts are placed alongside
+the shipped DLL(s) in the `/lib` folder. When a project targets multiple
+frameworks each target outputs a dedicated DLL and signing artifacts into a
+sub folder based on the [TFM](https://learn.microsoft.com/dotnet/standard/frameworks).
 
 The digital signature files share the same name prefix as the DLL to ensure
 easy identification and association.

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ To verify the integrity of a DLL inside a NuGet package use the
 Signatures use the bundle format known from cosign 3.0+.
 
 ```bash
-$TAG="Instrumentation.AspNetCore-1.17.0"
-$PACKAGE="OpenTelemetry.Instrumentation.AspNetCore"
+TAG="Instrumentation.AspNetCore-1.17.0"
+PACKAGE="OpenTelemetry.Instrumentation.AspNetCore"
 cosign verify-blob \
     --bundle "${PACKAGE}.dll.sigstore.json" \
     --certificate-identity "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/.github/workflows/publish-packages.yml@refs/tags/${TAG}" \

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -140,4 +140,18 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)/BannedSymbols.txt" />
   </ItemGroup>
 
+  <!-- This target adds any signatures found to NuGet packages -->
+  <Target Name="IncludeSigningSignaturesInPackages" BeforeTargets="_GetTargetFrameworksOutput">
+    <ItemGroup>
+      <SigstoreBundle Include="$(ArtifactsPath)\bin\$(MSBuildProjectName)\$(Configuration.ToLower())_*\$(MSBuildProjectName).dll.sigstore.json" />
+      <!-- RecursiveDir is equal to e.g. `release_net8.0` so we need to strip it out -->
+      <SigstoreBundleWithTfm Include="@(SigstoreBundle)">
+        <TargetFramework>$([System.String]::Copy('%(RecursiveDir)').Replace(`$(Configuration.ToLower())_`, ''))</TargetFramework>
+      </SigstoreBundleWithTfm>
+      <Content Include="@(SigstoreBundleWithTfm)" Pack="True" PackagePath="lib\%(SigstoreBundleWithTfm.TargetFramework)%(Filename)%(Extension)" />
+    </ItemGroup>
+    <Message Importance="high" Text="**IncludeSignaturesInPackagesDebug** SignatureFiles: @(SignatureFilesWithTfm)" />
+    <Message Importance="high" Text="**IncludeCertificatesInPackagesDebug** CertificateFiles: @(CertificateFilesWithTfm)" />
+  </Target>
+
 </Project>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -143,10 +143,17 @@
   <!-- This target adds any signatures found to NuGet packages -->
   <Target Name="IncludeSigningSignaturesInPackages" BeforeTargets="_GetTargetFrameworksOutput">
     <ItemGroup>
+      <!-- Multi-TFM layout: ...\release_net8.0\Foo.dll.sigstore.json -->
       <SigstoreBundle Include="$(ArtifactsPath)\bin\$(MSBuildProjectName)\$(Configuration.ToLower())_*\$(MSBuildProjectName).dll.sigstore.json" />
-      <!-- RecursiveDir is equal to e.g. `release_net8.0` so we need to strip it out -->
+      <!-- Single-TFM layout: ...\release\Foo.dll.sigstore.json -->
+      <SigstoreBundle Include="$(ArtifactsPath)\bin\$(MSBuildProjectName)\$(Configuration.ToLower())\$(MSBuildProjectName).dll.sigstore.json" />
+
+      <!-- RecursiveDir is equal to e.g. `release_net8.0` or `release` so we need to strip it out -->
       <SigstoreBundleWithTfm Include="@(SigstoreBundle)">
-        <TargetFramework>$([System.String]::Copy('%(RecursiveDir)').Replace(`$(Configuration.ToLower())_`, ''))</TargetFramework>
+        <_RecursiveDir>$([System.String]::Copy('%(RecursiveDir)').TrimEnd('\','/'))</_RecursiveDir>
+        <!-- If directory is config_tfm, extract tfm; otherwise fall back to project TFM -->
+        <TargetFramework Condition="$([System.String]::Copy('%(_RecursiveDir)').StartsWith('$(Configuration.ToLower())_'))">$([System.String]::Copy('%(_RecursiveDir)').Substring($([System.String]::Copy('$(Configuration.ToLower())_').Length)))</TargetFramework>
+        <TargetFramework Condition="'%(SigstoreBundleWithTfm.TargetFramework)' == ''">$(TargetFramework)</TargetFramework>
       </SigstoreBundleWithTfm>
       <Content Include="@(SigstoreBundleWithTfm)" Pack="True" PackagePath="lib\%(SigstoreBundleWithTfm.TargetFramework)%(Filename)%(Extension)" />
     </ItemGroup>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -143,22 +143,24 @@
   <!-- This target adds any signatures found to NuGet packages -->
   <Target Name="IncludeSigningSignaturesInPackages" BeforeTargets="_GetTargetFrameworksOutput">
     <ItemGroup>
-      <!-- Multi-TFM layout: ...\release_net8.0\Foo.dll.sigstore.json -->
+      <!-- Multi-TFM layout: ...\release_net8.0\Foo.dll.sigstore.json (the * wildcard populates RecursiveDir with the config_tfm directory) -->
       <SigstoreBundle Include="$(ArtifactsPath)\bin\$(MSBuildProjectName)\$(Configuration.ToLower())_*\$(MSBuildProjectName).dll.sigstore.json" />
-      <!-- Single-TFM layout: ...\release\Foo.dll.sigstore.json -->
-      <SigstoreBundle Include="$(ArtifactsPath)\bin\$(MSBuildProjectName)\$(Configuration.ToLower())\$(MSBuildProjectName).dll.sigstore.json" />
 
-      <!-- RecursiveDir is equal to e.g. `release_net8.0` or `release` so we need to strip it out -->
-      <SigstoreBundleWithTfm Include="@(SigstoreBundle)">
-        <_RecursiveDir>$([System.String]::Copy('%(RecursiveDir)').TrimEnd('\','/'))</_RecursiveDir>
-        <!-- If directory is config_tfm, extract tfm; otherwise fall back to project TFM -->
-        <TargetFramework Condition="$([System.String]::Copy('%(_RecursiveDir)').StartsWith('$(Configuration.ToLower())_'))">$([System.String]::Copy('%(_RecursiveDir)').Substring($([System.String]::Copy('$(Configuration.ToLower())_').Length)))</TargetFramework>
-        <TargetFramework Condition="'%(SigstoreBundleWithTfm.TargetFramework)' == ''">$(TargetFramework)</TargetFramework>
-      </SigstoreBundleWithTfm>
-      <Content Include="@(SigstoreBundleWithTfm)" Pack="True" PackagePath="lib\%(SigstoreBundleWithTfm.TargetFramework)%(Filename)%(Extension)" />
+      <!-- Single-TFM layout: ...\release\Foo.dll.sigstore.json. This is a literal (non-wildcard) path, so it is guarded with Exists() to avoid adding a phantom item that does not exist for multi-TFM projects. -->
+      <SigstoreBundle
+          Include="$(ArtifactsPath)\bin\$(MSBuildProjectName)\$(Configuration.ToLower())\$(MSBuildProjectName).dll.sigstore.json"
+          Condition="Exists('$(ArtifactsPath)\bin\$(MSBuildProjectName)\$(Configuration.ToLower())\$(MSBuildProjectName).dll.sigstore.json')" />
+
+      <!-- RecursiveDir is e.g. `release_net8.0\` for multi-TFM (strip the slashes and the `release_` prefix to get the TFM) or empty for single-TFM (fall back to the project TFM). -->
+      <SigstoreBundle Update="@(SigstoreBundle)">
+        <TargetFramework>$([System.String]::Copy('%(RecursiveDir)').Replace('\', '').Replace('/', '').Replace('$(Configuration.ToLower())_', ''))</TargetFramework>
+      </SigstoreBundle>
+      <SigstoreBundle Update="@(SigstoreBundle)" Condition="'%(SigstoreBundle.TargetFramework)' == ''">
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+      </SigstoreBundle>
+      <Content Include="@(SigstoreBundle)" Pack="True" PackagePath="lib\%(SigstoreBundle.TargetFramework)\%(Filename)%(Extension)" />
     </ItemGroup>
-    <Message Importance="high" Text="**IncludeSignaturesInPackagesDebug** SignatureFiles: @(SignatureFilesWithTfm)" />
-    <Message Importance="high" Text="**IncludeCertificatesInPackagesDebug** CertificateFiles: @(CertificateFilesWithTfm)" />
+    <Message Importance="high" Text="**IncludeSignaturesInPackagesDebug** SigstoreBundles: @(SigstoreBundle->'%(Identity) => lib\%(TargetFramework)\%(Filename)%(Extension)')" />
   </Target>
 
 </Project>

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -15,6 +15,9 @@
   temporary arrays/strings.
   ([#4498](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4498))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.2
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.0.0-alpha.8
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-18

--- a/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.2
 
 Released 2026-Apr-23

--- a/src/OpenTelemetry.Extensions.Enrichment.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.Http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.2
 
 Released 2026-Apr-23

--- a/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.0-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-18

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-18

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.0.0-beta.6
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -9,6 +9,9 @@
   and producers created outside a DI container.
   ([#4545](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4545))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 0.1.0-alpha.7
 
 Released 2026-May-29

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-alpha.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.0.0-beta.12
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Kusto/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Kusto/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 0.1.0-alpha.1
 
 Released 2026-Jul-02

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -11,6 +11,9 @@
   * Added the `process.windows.handle.count` metric (Windows only).
   * Added the `process.unix.file_descriptor.count` metric (Linux only).
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.Remoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Remoting/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 0.1.0-alpha.1
 
 Released 2026-Jun-01

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-16

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 0.5.0-alpha.1
 
 Released 2026-Jul-01

--- a/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.Abstractions/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.1.0
 
 Released 2026-May-05

--- a/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.PersistentStorage.FileSystem/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.1.0
 
 Released 2026-May-05

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.0.0-alpha.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.2
 
 Released 2026-May-06

--- a/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 1.15.1-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Assemblies are now digitally signed using cosign.
+  ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
 ## 0.1.0-alpha.10
 
 Released 2026-Jun-24


### PR DESCRIPTION
Fixes #4603

## Changes

Copy the approach for the .NET SDK and sign the assemblies in the NuGet packages with a cosign keyless blob.

Tested [here](https://github.com/martincostello/opentelemetry-dotnet-contrib/actions/runs/28602487743).

I haven't added this to the CHANGELOGs, but I can if wanted.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
