### PR TITLE
[Sampler.AWS] Fix concurrency issue

### DIFF
--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fixed a race condition where a concurrent rule poll could discard the sampling
   targets applied by a target poll (and vice versa), causing the sampler to
   briefly revert to stale sampling decisions.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#4638](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4638))
 
 ## 0.1.0-alpha.10
 

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fixed a race condition where a concurrent rule poll could discard the sampling
+  targets applied by a target poll (and vice versa), causing the sampler to
+  briefly revert to stale sampling decisions.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 ## 0.1.0-alpha.10
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
+++ b/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
@@ -60,13 +60,20 @@ internal class RulesCache : IDisposable
         this.rwLock.EnterWriteLock();
         try
         {
+            Dictionary<string, SamplingRuleApplier> existingAppliers = new(this.RuleAppliers.Count);
+
+            foreach (var applier in this.RuleAppliers)
+            {
+                existingAppliers[applier.RuleName] = applier;
+            }
+
             List<SamplingRuleApplier> newRuleAppliers = [];
             foreach (var rule in newRules)
             {
                 // If the ruleApplier already exists in the current list of appliers, then we reuse it.
-                var ruleApplier = this.RuleAppliers
-                    .FirstOrDefault(currentApplier => currentApplier.RuleName == rule.RuleName) ??
-                    new SamplingRuleApplier(this.ClientId, this.Clock, rule, new Statistics());
+                var ruleApplier = existingAppliers.TryGetValue(rule.RuleName, out var currentApplier)
+                    ? currentApplier
+                    : new SamplingRuleApplier(this.ClientId, this.Clock, rule, new Statistics());
 
                 // update the rule in the applier in case rule attributes have changed
                 ruleApplier.Rule = rule;
@@ -124,13 +131,15 @@ internal class RulesCache : IDisposable
         this.rwLock.EnterWriteLock();
         try
         {
+            var now = this.Clock.Now();
+
             List<SamplingRuleApplier> newRuleAppliers = [];
             foreach (var ruleApplier in this.RuleAppliers)
             {
                 targets.TryGetValue(ruleApplier.RuleName, out var target);
                 if (target != null)
                 {
-                    newRuleAppliers.Add(ruleApplier.WithTarget(target, this.Clock.Now()));
+                    newRuleAppliers.Add(ruleApplier.WithTarget(target, now));
                 }
                 else
                 {

--- a/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
+++ b/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
@@ -54,23 +54,26 @@ internal class RulesCache : IDisposable
         // sort the new rules
         newRules.Sort((x, y) => x.CompareTo(y));
 
-        List<SamplingRuleApplier> newRuleAppliers = [];
-        foreach (var rule in newRules)
-        {
-            // If the ruleApplier already exists in the current list of appliers, then we reuse it.
-            var ruleApplier = this.RuleAppliers
-                .FirstOrDefault(currentApplier => currentApplier.RuleName == rule.RuleName) ??
-                new SamplingRuleApplier(this.ClientId, this.Clock, rule, new Statistics());
-
-            // update the rule in the applier in case rule attributes have changed
-            ruleApplier.Rule = rule;
-
-            newRuleAppliers.Add(ruleApplier);
-        }
-
+        // Build and swap the appliers under the write lock so that a concurrent
+        // UpdateTargets (target poller) cannot have its result discarded by the
+        // stale snapshot of RuleAppliers this method reuses appliers from.
         this.rwLock.EnterWriteLock();
         try
         {
+            List<SamplingRuleApplier> newRuleAppliers = [];
+            foreach (var rule in newRules)
+            {
+                // If the ruleApplier already exists in the current list of appliers, then we reuse it.
+                var ruleApplier = this.RuleAppliers
+                    .FirstOrDefault(currentApplier => currentApplier.RuleName == rule.RuleName) ??
+                    new SamplingRuleApplier(this.ClientId, this.Clock, rule, new Statistics());
+
+                // update the rule in the applier in case rule attributes have changed
+                ruleApplier.Rule = rule;
+
+                newRuleAppliers.Add(ruleApplier);
+            }
+
             this.RuleAppliers = newRuleAppliers;
             this.UpdatedAt = this.Clock.Now();
         }
@@ -115,24 +118,27 @@ internal class RulesCache : IDisposable
 
     public void UpdateTargets(Dictionary<string, SamplingTargetDocument> targets)
     {
-        List<SamplingRuleApplier> newRuleAppliers = [];
-        foreach (var ruleApplier in this.RuleAppliers)
-        {
-            targets.TryGetValue(ruleApplier.RuleName, out var target);
-            if (target != null)
-            {
-                newRuleAppliers.Add(ruleApplier.WithTarget(target, this.Clock.Now()));
-            }
-            else
-            {
-                // did not get target for this rule. Will be updated in future target poll.
-                newRuleAppliers.Add(ruleApplier);
-            }
-        }
-
+        // Build and swap the appliers under the write lock so that a concurrent
+        // UpdateRules (rule poller) cannot discard the targets applied here by
+        // swapping in a list rebuilt from a stale snapshot of RuleAppliers.
         this.rwLock.EnterWriteLock();
         try
         {
+            List<SamplingRuleApplier> newRuleAppliers = [];
+            foreach (var ruleApplier in this.RuleAppliers)
+            {
+                targets.TryGetValue(ruleApplier.RuleName, out var target);
+                if (target != null)
+                {
+                    newRuleAppliers.Add(ruleApplier.WithTarget(target, this.Clock.Now()));
+                }
+                else
+                {
+                    // did not get target for this rule. Will be updated in future target poll.
+                    newRuleAppliers.Add(ruleApplier);
+                }
+            }
+
             this.RuleAppliers = newRuleAppliers;
         }
         finally

--- a/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
+++ b/src/OpenTelemetry.Sampler.AWS/RulesCache.cs
@@ -158,16 +158,18 @@ internal class RulesCache : IDisposable
 
     public DateTimeOffset NextTargetFetchTime()
     {
-        var defaultPollingTime = this.Clock.Now().AddSeconds(AWSXRayRemoteSampler.DefaultTargetInterval.TotalSeconds);
+        var now = this.Clock.Now();
+        var defaultPollingTime = now.AddSeconds(AWSXRayRemoteSampler.DefaultTargetInterval.TotalSeconds);
+        var appliers = this.RuleAppliers;
 
-        if (this.RuleAppliers.Count == 0)
+        if (appliers.Count == 0)
         {
             return defaultPollingTime;
         }
 
-        var minPollingTime = this.RuleAppliers.Min(r => r.NextSnapshotTime);
+        var minPollingTime = appliers.Min(r => r.NextSnapshotTime);
 
-        return minPollingTime < this.Clock.Now() ? defaultPollingTime : minPollingTime;
+        return minPollingTime < now ? defaultPollingTime : minPollingTime;
     }
 
     public void Dispose()

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestRulesCache.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestRulesCache.cs
@@ -213,6 +213,84 @@ public class TestRulesCache
         Assert.Equal(clock.Now().AddSeconds(5), rulesCache.NextTargetFetchTime());
     }
 
+    [Fact]
+    public async Task TestConcurrentUpdateRulesAndUpdateTargetsDoesNotLoseUpdates()
+    {
+        var clock = new TestClock();
+        var rule = this.CreateRule("rule1", 0, 0.0, 1); // reservoir 0 and fixed rate 0 => drops until a target is applied
+        var rulesCache = new RulesCache(clock, "clientId", ResourceBuilder.CreateEmpty().Build(), new AlwaysOffSampler())
+        {
+            RuleAppliers = new List<SamplingRuleApplier>
+            {
+                { new("clientId", clock, rule, new Statistics()) },
+            },
+        };
+
+        // Applying this target gives the rule a 100% fixed rate. UpdateRules
+        // preserves it when it reuses the applier by name, so once a target poll
+        // has applied it the decision must never revert to Drop.
+        var targets = new Dictionary<string, SamplingTargetDocument>
+        {
+            {
+                "rule1",
+                new SamplingTargetDocument
+                {
+                    FixedRate = 1.0,
+                    RuleName = "rule1",
+                }
+            },
+        };
+
+        const int Iterations = 5000;
+        var pollersRunning = true;
+        var sawSample = false;
+        var lostUpdate = false;
+
+        // The rule poller and target poller run concurrently. Without the fix a
+        // stale rule poll can swap in a snapshot rebuilt before the target was
+        // applied, discarding it (a lost update).
+        var updateRules = Task.Run(() =>
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                rulesCache.UpdateRules([rule]);
+            }
+        });
+        var updateTargets = Task.Run(() =>
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                rulesCache.UpdateTargets(targets);
+            }
+        });
+
+        // Continuously sample while the pollers run. Once the target has taken
+        // effect (a sample is seen), a subsequent Drop means an update was lost.
+        var sampler = Task.Run(() =>
+        {
+            while (Volatile.Read(ref pollersRunning))
+            {
+                if (rulesCache.ShouldSample(default).Decision == SamplingDecision.RecordAndSample)
+                {
+                    Volatile.Write(ref sawSample, true);
+                }
+                else if (Volatile.Read(ref sawSample))
+                {
+                    Volatile.Write(ref lostUpdate, true);
+                }
+            }
+        });
+
+        await Task.WhenAll(updateRules, updateTargets);
+        Volatile.Write(ref pollersRunning, false);
+        await sampler;
+
+        Assert.False(lostUpdate, "A concurrent rule poll discarded the sampling target applied by a target poll.");
+        Assert.Single(rulesCache.RuleAppliers);
+        Assert.Equal("rule1", rulesCache.RuleAppliers[0].RuleName);
+        Assert.Equal(SamplingDecision.RecordAndSample, rulesCache.ShouldSample(default).Decision);
+    }
+
     private SamplingRule CreateDefaultRule(int reservoirSize, double fixedRate)
     {
         return this.CreateRule("Default", reservoirSize, fixedRate, 10000);


### PR DESCRIPTION
## Changes

Moved the newRuleAppliers construction inside the write lock in both UpdateRules and UpdateTargets, so the whole read-build-swap is atomic and the two pollers are serialized.

Found through [this flaky test](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/28590914476/job/84773977649?pr=4637#step:9:26).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
