### PR TITLE
[Cassandra] Use MeterFactory

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Cassandra/CassandraMeter.cs
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CassandraMeter.cs
@@ -2,17 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Cassandra;
 
 internal static class CassandraMeter
 {
-    static CassandraMeter()
-    {
-        var assembly = typeof(CassandraMeter).Assembly;
-        Instance = new Meter(assembly.GetName().Name, assembly.GetPackageVersion());
-    }
-
-    public static Meter Instance { get; }
+    public static Meter Instance { get; } = Metrics.MeterFactory.Create(typeof(CassandraMeter), null); // These metrics are not in the Semantic Conventions
 }

--- a/src/OpenTelemetry.Instrumentation.Cassandra/OpenTelemetry.Instrumentation.Cassandra.csproj
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/OpenTelemetry.Instrumentation.Cassandra.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Contributes to #4064 and #4068.

## Changes

Use `MeterFactory`. The Cassandra instrumentation doesn't follow any of the semantic conventions, so this just moves how the `Meter` is created.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
