### PR TITLE
[EventCounters] Use MeterFactory

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/EventCountersMetrics.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.EventCounters;
 
@@ -31,8 +30,7 @@ internal sealed class EventCountersMetrics : EventListener
         // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1024.
         _ = EventCountersInstrumentationEventSource.Log;
 
-        var assembly = typeof(EventCountersMetrics).Assembly;
-        MeterInstance = new Meter(assembly.GetName().Name, assembly.GetPackageVersion());
+        MeterInstance = Metrics.MeterFactory.Create<EventCountersMetrics>(null); // These metrics are not in the Semantic Conventions
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Contributes to #4064 and #4068.

## Changes

Use `MeterFactory`. The EventCounters instrumentation doesn't follow any of the semantic conventions, so this just moves how the `Meter` is created.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
