### PR TITLE
[Hangfire] Use ActivitySource and Meter factories

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireInstrumentation.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Reflection;
 using Hangfire;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Implementation;
@@ -29,7 +28,7 @@ internal sealed class HangfireInstrumentation
     /// <summary>
     /// The activity source.
     /// </summary>
-    internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Assembly.GetPackageVersion());
+    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<HangfireInstrumentation>(null); // These traces are not in the Semantic Conventions
 
     /// <summary>
     /// The default display name delegate.

--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/HangfireMetrics.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.Hangfire.Implementation;
 
@@ -84,5 +83,5 @@ internal static class HangfireMetrics
     /// <summary>
     /// Gets the meter instance for all Hangfire metrics.
     /// </summary>
-    private static Meter Meter => field ??= new(typeof(HangfireMetrics).Assembly.GetName().Name, typeof(HangfireMetrics).Assembly.GetPackageVersion());
+    private static Meter Meter => field ??= Metrics.MeterFactory.Create(typeof(HangfireMetrics), null); // These metrics are not in the Semantic Conventions
 }

--- a/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
@@ -28,8 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Contributes to #4064 and #4068.

## Changes

Use `MeterFactory` and `ActivitySourceFactory`. The Hangfire instrumentation doesn't follow any of the semantic conventions, so this just changes how the `ActivitySource` and `Meter` are created.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
