### PR TITLE
[Kusto] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
@@ -22,7 +22,11 @@ internal sealed class KustoTraceRecordListener : KustoUtils.ITraceListener
     // complete callbacks for a single operation, and the client releases it once the operation finishes. Keying a
     // ConditionalWeakTable on it lets an operation that never reports completion be evicted automatically when the
     // client drops its reference. No manual bookkeeping nor unbounded growth.
+#if NET
+    private readonly ConditionalWeakTable<object, OperationContext> contexts = [];
+#else
     private readonly ConditionalWeakTable<object, OperationContext> contexts = new();
+#endif
 
     /// <summary>
     /// Gets or sets the trace options applied when emitting spans.

--- a/test/OpenTelemetry.Instrumentation.Kusto.Tests/KustoMeterProviderBuilderTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Kusto.Tests/KustoMeterProviderBuilderTests.cs
@@ -22,6 +22,6 @@ public class KustoMeterProviderBuilderTests
     {
         MeterProviderBuilder builder = null!;
 
-        Assert.Throws<ArgumentNullException>(() => builder.AddKustoInstrumentation());
+        Assert.Throws<ArgumentNullException>(builder.AddKustoInstrumentation);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Kusto.Tests/KustoTraceProviderBuilderTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Kusto.Tests/KustoTraceProviderBuilderTests.cs
@@ -22,7 +22,7 @@ public class KustoTraceProviderBuilderTests
     {
         TracerProviderBuilder builder = null!;
 
-        Assert.Throws<ArgumentNullException>(() => builder.AddKustoInstrumentation());
+        Assert.Throws<ArgumentNullException>(builder.AddKustoInstrumentation);
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

Fix code analysis warnings from the .NET 11 SDK.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
