### PR TITLE
[Infra] Fix NuGet publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -364,7 +364,7 @@ jobs:
     permissions:
       attestations: read # Read GitHub attestations for the NuGet packages
       contents: read # Download the published artifacts
-      id-token: write # Use OIDC to authenticate with NuGet.org
+      id-token: write # Publish NuGet packages with trusted GitHub OIDC
 
     steps:
       - name: Setup .NET

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -364,6 +364,7 @@ jobs:
     permissions:
       attestations: read # Read GitHub attestations for the NuGet packages
       contents: read # Download the published artifacts
+      id-token: write # Use OIDC to authenticate with NuGet.org
 
     steps:
       - name: Setup .NET

--- a/src/OpenTelemetry.Instrumentation.Kusto/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Kusto/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 0.1.0-alpha.2
-
-Released 2026-Jul-03
-
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
 


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4647

## Changes

Add missing OIDC permission lost in refactor for #4601 to [fix publishing](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/28669131165/job/85028748475#step:5:10).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
