### PR TITLE
[Infra] Upgrade to Pester v6

### DIFF
--- a/build/scripts/tests/RunTests.ps1
+++ b/build/scripts/tests/RunTests.ps1
@@ -22,7 +22,7 @@ Runs the tests using the default pinned version of Pester.
 [CmdletBinding()]
 param(
     # renovate: datasource=nuget depName=Pester
-    [string]$PesterVersion = "5.7.1",
+    [string]$PesterVersion = "6.0.0",
     [int]$MinimumCoveragePercent = 80
 )
 

--- a/build/scripts/tests/build.Tests.ps1
+++ b/build/scripts/tests/build.Tests.ps1
@@ -31,9 +31,9 @@ Describe "ResolveProject" {
             -project ([ref]$project) `
             -component ([ref]$component)
 
-        $title | Should -Be "OpenTelemetry.Contrib.proj"
-        $project | Should -Be "./build/Projects/OpenTelemetry.Contrib.proj"
-        $component | Should -BeNullOrEmpty -Because "a named project is not a component build"
+        $title | Should-Be "OpenTelemetry.Contrib.proj"
+        $project | Should-Be "./build/Projects/OpenTelemetry.Contrib.proj"
+        $component | Should-BeNull -Because "a named project is not a component build"
     }
 
     It "resolves a Component[...] value to the shared component build project" {
@@ -47,9 +47,9 @@ Describe "ResolveProject" {
             -project ([ref]$project) `
             -component ([ref]$component)
 
-        $component | Should -Be "OpenTelemetry.Instrumentation.Foo"
-        $title | Should -Be "Component.proj for OpenTelemetry.Instrumentation.Foo"
-        $project | Should -Be "./build/Projects/Component.proj"
+        $component | Should-Be "OpenTelemetry.Instrumentation.Foo"
+        $title | Should-Be "Component.proj for OpenTelemetry.Instrumentation.Foo"
+        $project | Should-Be "./build/Projects/Component.proj"
     }
 }
 
@@ -62,8 +62,8 @@ Describe "ResolveProjectForTag" {
 
         ResolveProjectForTag -tag "" -title ([ref]$title) -project ([ref]$project) -component ([ref]$component)
 
-        $title | Should -Be "opentelemetry-dotnet-contrib.proj"
-        $project | Should -Be "opentelemetry-dotnet-contrib.proj"
+        $title | Should-Be "opentelemetry-dotnet-contrib.proj"
+        $project | Should-Be "opentelemetry-dotnet-contrib.proj"
     }
 
     It "resolves a tag to a matching build project file" {
@@ -86,8 +86,8 @@ Describe "ResolveProjectForTag" {
             Pop-Location
         }
 
-        $title | Should -Be "Foo.proj"
-        $project | Should -Be "./build/Projects/Foo.proj"
+        $title | Should-Be "Foo.proj"
+        $project | Should-Be "./build/Projects/Foo.proj"
     }
 
     It "falls back to the shared component build for a matching csproj" {
@@ -114,9 +114,9 @@ Describe "ResolveProjectForTag" {
             Pop-Location
         }
 
-        $component | Should -Be "OpenTelemetry.Instrumentation.Foo"
-        $title | Should -Be "Component.proj for OpenTelemetry.Instrumentation.Foo"
-        $projectPath | Should -Be "./build/Projects/Component.proj"
+        $component | Should-Be "OpenTelemetry.Instrumentation.Foo"
+        $title | Should-Be "Component.proj for OpenTelemetry.Instrumentation.Foo"
+        $projectPath | Should-Be "./build/Projects/Component.proj"
     }
 
     It "throws when the tag cannot be parsed" {
@@ -125,7 +125,7 @@ Describe "ResolveProjectForTag" {
         $component = $null
 
         { ResolveProjectForTag -tag "notag" -title ([ref]$title) -project ([ref]$project) -component ([ref]$component) } |
-            Should -Throw "*Could not parse prefix or version from tag*"
+            Should-Throw -ExceptionMessage "*Could not parse prefix or version from tag*"
     }
 
     It "throws when no project matches the tag prefix" {
@@ -145,7 +145,7 @@ Describe "ResolveProjectForTag" {
         Push-Location -Path $work -ErrorAction Stop
         try {
             { ResolveProjectForTag -tag "missing-1.0.0" -title ([ref]$title) -project ([ref]$projectPath) -component ([ref]$component) } |
-                Should -Throw "*No project file found matching tag prefix*"
+                Should-Throw -ExceptionMessage "*No project file found matching tag prefix*"
         }
         finally {
             Pop-Location
@@ -190,11 +190,11 @@ components:
         # If the [void] cast on $componentOwners.Value.Add(...) is ever removed
         # the boolean results of Add() leak into the output stream and the
         # function returns more than the single expected $true value.
-        @($result).Count | Should -Be 1 -Because "the boolean from HashSet.Add must not leak into the output"
-        $result | Should -BeTrue
+        @($result).Count | Should-Be 1 -Because "the boolean from HashSet.Add must not leak into the output"
+        $result | Should-BeTrue
 
-        $componentOwners.Contains("owner1") | Should -BeTrue
-        $componentOwners.Contains("owner2") | Should -BeTrue
+        $componentOwners.Contains("owner1") | Should-BeTrue
+        $componentOwners.Contains("owner2") | Should-BeTrue
     }
 
     It "comments and returns false when the component project file is missing" {
@@ -216,7 +216,7 @@ components:
             Pop-Location
         }
 
-        $result | Should -BeFalse
+        $result | Should-BeFalse
         Should -Invoke -CommandName "gh" -ModuleName "build" -Exactly -Times 1 -ParameterFilter {
             $args -contains "issue" -and $args -contains "comment"
         } -Because "the requester should be told the component project could not be found"
@@ -246,6 +246,6 @@ components:
             Pop-Location
         }
 
-        $result | Should -BeFalse
+        $result | Should-BeFalse
     }
 }

--- a/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
+++ b/build/scripts/tests/check-for-new-sdk-releases.Tests.ps1
@@ -288,8 +288,8 @@ Describe "check-for-new-sdk-releases.ps1" {
             $args -contains "workflow" -and $args -contains "run"
         } -Because "no version is out of date and the missing release kinds should be skipped"
 
-        ($warnings -join "`n") | Should -Match "Could not find a prerelease release" -Because "a warning should be emitted when a matching release is missing"
-        ($warnings -join "`n") | Should -Match "Could not find an? unstable release" -Because "a warning should be emitted when a matching release is missing"
+        ($warnings -join "`n") | Should-MatchString "Could not find a prerelease release" -Because "a warning should be emitted when a matching release is missing"
+        ($warnings -join "`n") | Should-MatchString "Could not find an? unstable release" -Because "a warning should be emitted when a matching release is missing"
     }
 
     It "throws when an expected version property is missing from Directory.Packages.props" {
@@ -302,6 +302,6 @@ Describe "check-for-new-sdk-releases.ps1" {
         Mock -CommandName "gh" -MockWith { $global:LASTEXITCODE = 0 }
 
         { & $scriptPath -repoRoot $work -contribRepository "open-telemetry/opentelemetry-dotnet-contrib" 6>$null } |
-            Should -Throw "*OpenTelemetryCoreLatestPrereleaseVersion*"
+            Should-Throw -ExceptionMessage "*OpenTelemetryCoreLatestPrereleaseVersion*"
     }
 }

--- a/build/scripts/tests/finalize-publicapi.Tests.ps1
+++ b/build/scripts/tests/finalize-publicapi.Tests.ps1
@@ -37,9 +37,9 @@ Describe "finalize-publicapi.ps1" {
         }
 
         $shipped = @(Get-Content -Path $shippedPath | Where-Object { $_ -ne "" })
-        $shipped | Should -Be @("A", "B", "C") -Because "shipped should be the sorted, de-duplicated union of both files"
+        $shipped | Should-BeCollection @("A", "B", "C") -Because "shipped should be the sorted, de-duplicated union of both files"
 
-        (Get-Content -Path $unshippedPath -Raw) | Should -BeNullOrEmpty -Because "the unshipped file should be emptied once merged"
+        (Get-Content -Path $unshippedPath -Raw) | Should-BeNull -Because "the unshipped file should be emptied once merged"
     }
 
     It "does not touch projects that do not match the tag prefix" {
@@ -65,6 +65,6 @@ Describe "finalize-publicapi.ps1" {
             Pop-Location
         }
 
-        (Get-Content -Path $unshippedPath -Raw).Trim() | Should -Be "ShouldRemain" -Because "projects that do not match the tag prefix should be left untouched"
+        (Get-Content -Path $unshippedPath -Raw).Trim() | Should-Be "ShouldRemain" -Because "projects that do not match the tag prefix should be left untouched"
     }
 }

--- a/build/scripts/tests/post-release.Tests.ps1
+++ b/build/scripts/tests/post-release.Tests.ps1
@@ -100,7 +100,7 @@ Released 2024-01-01
 
     It "throws when the tag cannot be parsed" {
         { CreateRelease -gitRepository "open-telemetry/opentelemetry-dotnet-contrib" -tag "noprefix" 6>$null } |
-            Should -Throw "*Could not parse prefix or version from tag*" -Because "a tag without a prefix cannot be parsed"
+            Should-Throw -ExceptionMessage "*Could not parse prefix or version from tag*" -Because "a tag without a prefix cannot be parsed"
     }
 }
 
@@ -192,7 +192,7 @@ Describe "CreatePackageValidationBaselineVersionUpdatePullRequest" {
         }
 
         (Get-Content -Path (Join-Path -Path $project -ChildPath "OpenTelemetry.Instrumentation.Foo.csproj") -Raw) |
-            Should -Match "<PackageValidationBaselineVersion>1\.2\.3</PackageValidationBaselineVersion>" -Because "the baseline version should be bumped to the released version"
+            Should-MatchString "<PackageValidationBaselineVersion>1\.2\.3</PackageValidationBaselineVersion>" -Because "the baseline version should be bumped to the released version"
 
         Should -Invoke -CommandName "gh" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
             $args -contains "pr" -and
@@ -264,7 +264,7 @@ Released 2024-01-01
         }
 
         (Get-Content -Path (Join-Path -Path $work -ChildPath "Directory.Packages.props") -Raw) |
-            Should -Match "<OpenTelemetryCoreLatestVersion>1\.2\.3</OpenTelemetryCoreLatestVersion>" -Because "the core version should be bumped in Directory.Packages.props"
+            Should-MatchString "<OpenTelemetryCoreLatestVersion>1\.2\.3</OpenTelemetryCoreLatestVersion>" -Because "the core version should be bumped in Directory.Packages.props"
 
         Should -Invoke -CommandName "gh" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
             $args -contains "pr" -and $args -contains "create" -and $args -contains "--label" -and $args -contains "release"
@@ -275,7 +275,7 @@ Released 2024-01-01
         } -Because "the update branch should contain the full core tag"
 
         (Get-Content -Path (Join-Path -Path $project -ChildPath "CHANGELOG.md") -Raw) |
-            Should -Match "Updated OpenTelemetry core component version\(s\) to ``1\.2\.3``" -Because "the CHANGELOG of an affected project should be updated"
+            Should-MatchString "Updated OpenTelemetry core component version\(s\) to ``1\.2\.3``" -Because "the CHANGELOG of an affected project should be updated"
     }
 
     It "updates the core unstable version for a coreunstable tag" {
@@ -308,7 +308,7 @@ Released 2024-01-01
         }
 
         (Get-Content -Path (Join-Path -Path $work -ChildPath "Directory.Packages.props") -Raw) |
-            Should -Match "<OpenTelemetryCoreUnstableLatestVersion>1\.1\.0-beta\.1</OpenTelemetryCoreUnstableLatestVersion>" -Because "the core unstable version should be bumped"
+            Should-MatchString "<OpenTelemetryCoreUnstableLatestVersion>1\.1\.0-beta\.1</OpenTelemetryCoreUnstableLatestVersion>" -Because "the core unstable version should be bumped"
 
         Should -Invoke -CommandName "gh" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
             $args -contains "pr" -and $args -contains "create" -and $args -contains "--label" -and $args -contains "release"
@@ -365,12 +365,12 @@ Describe "GetCoreDependenciesForProjects" {
             }
         }
 
-        @($result).Count | Should -Be 1 -Because "'dotnet restore' output must be piped to Out-Null so it does not leak into the return value"
-        $result | Should -BeOfType [hashtable] -Because "the function should return only the dependency map"
+        @($result).Count | Should-Be 1 -Because "'dotnet restore' output must be piped to Out-Null so it does not leak into the return value"
+        $result | Should-HaveType ([hashtable]) -Because "the function should return only the dependency map"
 
         $dependencies = $result.Values | Select-Object -First 1
-        $dependencies["OpenTelemetry"] | Should -Be "1.9.0" -Because "the version should be parsed from project.assets.json"
-        $dependencies.ContainsKey("Newtonsoft.Json") | Should -BeFalse -Because "only OpenTelemetry core packages should be tracked"
+        $dependencies["OpenTelemetry"] | Should-Be "1.9.0" -Because "the version should be parsed from project.assets.json"
+        $dependencies.ContainsKey("Newtonsoft.Json") | Should-BeFalse -Because "only OpenTelemetry core packages should be tracked"
     }
 }
 
@@ -406,6 +406,6 @@ Describe "UpdateCommonPropsVersion" {
         }
 
         (Get-Content -Path (Join-Path -Path $work -ChildPath "Directory.Packages.props") -Raw) |
-            Should -Match "<OpenTelemetryInstrumentationFooLatestStableVersion>1\.0\.0</OpenTelemetryInstrumentationFooLatestStableVersion>" -Because "the version should be updated in Directory.Packages.props"
+            Should-MatchString "<OpenTelemetryInstrumentationFooLatestStableVersion>1\.0\.0</OpenTelemetryInstrumentationFooLatestStableVersion>" -Because "the version should be updated in Directory.Packages.props"
     }
 }

--- a/build/scripts/tests/prepare-release.Tests.ps1
+++ b/build/scripts/tests/prepare-release.Tests.ps1
@@ -59,7 +59,7 @@ Describe "CreatePullRequestToUpdateChangelogsAndPublicApis" {
                 -component "OpenTelemetry.Instrumentation.Foo" `
                 -version $Version `
                 -requestedByUserName "someone"
-        } | Should -Throw "*did not match expected format*" -Because "'$Version' is not a valid release version"
+        } | Should-Throw -ExceptionMessage "*did not match expected format*" -Because "'$Version' is not a valid release version"
     }
 
     It "throws when the project file has no MinVerTagPrefix" {
@@ -75,7 +75,7 @@ Describe "CreatePullRequestToUpdateChangelogsAndPublicApis" {
                     -component "OpenTelemetry.Instrumentation.Foo" `
                     -version "1.2.3" `
                     -requestedByUserName "someone" 6>$null
-            } | Should -Throw "*Could not parse MinVerTagPrefix*"
+            } | Should-Throw -ExceptionMessage "*Could not parse MinVerTagPrefix*"
         }
         finally {
             Pop-Location
@@ -164,7 +164,7 @@ Describe "CreatePullRequestToUpdateChangelogsAndPublicApis" {
                     -component "OpenTelemetry.Instrumentation.Foo" `
                     -version "1.2.3" `
                     -requestedByUserName "someone" 6>$null
-            } | Should -Throw "*git switch failure*" -Because "a failure to create the branch should stop the release"
+            } | Should-Throw -ExceptionMessage "*git switch failure*" -Because "a failure to create the branch should stop the release"
         }
         finally {
             Pop-Location
@@ -184,7 +184,7 @@ Describe "CreatePullRequestToUpdateChangelogsAndPublicApis" {
                     -component "OpenTelemetry.Instrumentation.Foo" `
                     -version "1.2.3" `
                     -requestedByUserName "someone" 6>$null
-            } | Should -Throw "*git commit failure*"
+            } | Should-Throw -ExceptionMessage "*git commit failure*"
         }
         finally {
             Pop-Location
@@ -225,7 +225,7 @@ Describe "LockPullRequestAndPostNoticeToCreateReleaseTag" {
                 -gitRepository "open-telemetry/opentelemetry-dotnet-contrib" `
                 -pullRequestNumber "789" `
                 -expectedPrAuthorUserName "otelbot"
-        } | Should -Throw "*PR author was unexpected*" -Because "only pull requests opened by the expected bot should be processed"
+        } | Should-Throw -ExceptionMessage "*PR author was unexpected*" -Because "only pull requests opened by the expected bot should be processed"
     }
 }
 
@@ -307,8 +307,8 @@ Released 0000-00-00
         }
 
         $changelog = Get-Content -Path (Join-Path -Path $project -ChildPath "CHANGELOG.md") -Raw
-        $changelog | Should -BeLike "*Released $expectedReleaseDate*" -Because "the placeholder release date should be replaced with today's date"
-        $changelog | Should -Not -Match "0000-00-00" -Because "the placeholder date should no longer be present"
+        $changelog | Should-BeLikeString "*Released $expectedReleaseDate*" -Because "the placeholder release date should be replaced with today's date"
+        $changelog | Should-NotMatchString "0000-00-00" -Because "the placeholder date should no longer be present"
 
         Should -Invoke -CommandName "gh" -ModuleName "prepare-release" -Exactly -Times 1 -ParameterFilter {
             $args -contains "comment" -and (($args -join " ") -match "I updated the CHANGELOG release dates")

--- a/build/scripts/tests/report-unreleased-changes.Tests.ps1
+++ b/build/scripts/tests/report-unreleased-changes.Tests.ps1
@@ -45,10 +45,10 @@ Released 2024-01-01
 
         $output = (& $scriptPath -repoRoot $work) -join "`n"
 
-        $output | Should -Match "# Unreleased Changes" -Because "the report should have a top-level heading"
-        $output | Should -Match ':package: Instrumentation\.Foo' -Because "the package should be listed in the summary table by its short name"
-        $output | Should -Match '## OpenTelemetry\.Instrumentation\.Foo' -Because "the package should have its own changes section"
-        $output | Should -Match '\* Added the thing\.' -Because "the unreleased changes should be included"
+        $output | Should-MatchString "# Unreleased Changes" -Because "the report should have a top-level heading"
+        $output | Should-MatchString ':package: Instrumentation\.Foo' -Because "the package should be listed in the summary table by its short name"
+        $output | Should-MatchString '## OpenTelemetry\.Instrumentation\.Foo' -Because "the package should have its own changes section"
+        $output | Should-MatchString '\* Added the thing\.' -Because "the unreleased changes should be included"
     }
 
     It "suggests next versions for packages in a range of states" {
@@ -92,11 +92,11 @@ Released 2024-01-01
 
         $output = (& $scriptPath -repoRoot $work) -join "`n"
 
-        $output | Should -Match "# Unreleased Changes"
-        $output | Should -Match '`1\.13\.0`' -Because "a package tracking the core version should follow the recorded core bump"
-        $output | Should -Match '`1\.12\.0-alpha\.1`' -Because "an unreleased package should be suggested as an initial alpha based on the core version"
-        $output | Should -Match '`1\.12\.0-beta\.2`' -Because "a package last released as a prerelease should advance the prerelease number"
-        $output | Should -Match "_All changes - this package has not yet been released._" -Because "a never-released package should be flagged as such"
+        $output | Should-MatchString "# Unreleased Changes"
+        $output | Should-MatchString '`1\.13\.0`' -Because "a package tracking the core version should follow the recorded core bump"
+        $output | Should-MatchString '`1\.12\.0-alpha\.1`' -Because "an unreleased package should be suggested as an initial alpha based on the core version"
+        $output | Should-MatchString '`1\.12\.0-beta\.2`' -Because "a package last released as a prerelease should advance the prerelease number"
+        $output | Should-MatchString "_All changes - this package has not yet been released._" -Because "a never-released package should be flagged as such"
     }
 
     It "reports that there are no unreleased changes when none are present" {
@@ -113,8 +113,8 @@ Released 2024-01-01
 
         $output = (& $scriptPath -repoRoot $work) -join "`n"
 
-        $output | Should -Match "No packages have any unreleased changes" -Because "an empty unreleased section should be treated as no changes"
-        $output | Should -Not -Match "# Unreleased Changes" -Because "the full report should not be produced when there is nothing to report"
+        $output | Should-MatchString "No packages have any unreleased changes" -Because "an empty unreleased section should be treated as no changes"
+        $output | Should-NotMatchString "# Unreleased Changes" -Because "the full report should not be produced when there is nothing to report"
     }
 
     It "ignores changelogs that have no unreleased section" {
@@ -129,7 +129,7 @@ Released 2024-01-01
 
         $output = (& $scriptPath -repoRoot $work) -join "`n"
 
-        $output | Should -Match "No packages have any unreleased changes" -Because "a changelog without an Unreleased heading contributes nothing"
+        $output | Should-MatchString "No packages have any unreleased changes" -Because "a changelog without an Unreleased heading contributes nothing"
     }
 
     It "omits packages whose unreleased section is empty" {
@@ -157,8 +157,8 @@ Released 2024-01-01
 
         $output = (& $scriptPath -repoRoot $work) -join "`n"
 
-        $output | Should -Match ':package: Instrumentation\.Foo' -Because "the package with changes should be listed"
-        $output | Should -Not -Match 'Instrumentation\.Empty' -Because "the package without changes should be omitted"
+        $output | Should-MatchString ':package: Instrumentation\.Foo' -Because "the package with changes should be listed"
+        $output | Should-NotMatchString 'Instrumentation\.Empty' -Because "the package without changes should be omitted"
     }
 
     It "does not modify the working tree" {
@@ -179,6 +179,6 @@ Released 2024-01-01
 
         & $scriptPath -repoRoot $work | Out-Null
 
-        Get-Content -Path $changelogPath -Raw | Should -Be $before -Because "the report script must only read, never modify, the changelog files"
+        Get-Content -Path $changelogPath -Raw | Should-Be $before -Because "the report script must only read, never modify, the changelog files"
     }
 }

--- a/build/scripts/tests/scripts.Tests.ps1
+++ b/build/scripts/tests/scripts.Tests.ps1
@@ -24,7 +24,7 @@ Describe "PowerShell scripts" {
         It "can be imported without error" {
             $module = Import-Module -Name $Path -Force -PassThru -ErrorAction Stop
             try {
-                $module | Should -Not -BeNullOrEmpty -Because "importing the module should succeed"
+                $module | Should-NotBeNull -Because "importing the module should succeed"
             }
             finally {
                 Remove-Module -Name $module.Name -Force -ErrorAction SilentlyContinue
@@ -34,7 +34,7 @@ Describe "PowerShell scripts" {
         It "exports at least one function" {
             $module = Import-Module -Name $Path -Force -PassThru
             try {
-                $module.ExportedFunctions.Count | Should -BeGreaterThan 0
+                $module.ExportedFunctions.Count | Should-BeGreaterThan 0
             }
             finally {
                 Remove-Module -Name $module.Name -Force -ErrorAction SilentlyContinue
@@ -47,7 +47,7 @@ Describe "PowerShell scripts" {
         It "has valid PowerShell syntax" {
             $errors = $null
             $null = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$errors)
-            $errors | Should -BeNullOrEmpty
+            $errors.Count | Should-Be 0
         }
     }
 }

--- a/build/scripts/tests/update-changelogs.Tests.ps1
+++ b/build/scripts/tests/update-changelogs.Tests.ps1
@@ -44,11 +44,11 @@ Describe "update-changelogs.ps1" {
         }
 
         $matchingChangelog = Get-Content -Path (Join-Path -Path $matchingProject -ChildPath "CHANGELOG.md") -Raw
-        $matchingChangelog | Should -Match "## 1\.2\.3" -Because "the version heading should be added for a matching project"
-        $matchingChangelog | Should -BeLike "*Released $expectedReleaseDate*" -Because "a release date should be added for a matching project"
-        $matchingChangelog | Should -Match "\* Some change" -Because "existing changelog entries should be preserved"
+        $matchingChangelog | Should-MatchString "## 1\.2\.3" -Because "the version heading should be added for a matching project"
+        $matchingChangelog | Should-BeLikeString "*Released $expectedReleaseDate*" -Because "a release date should be added for a matching project"
+        $matchingChangelog | Should-MatchString "\* Some change" -Because "existing changelog entries should be preserved"
 
         $otherChangelog = Get-Content -Path (Join-Path -Path $otherProject -ChildPath "CHANGELOG.md") -Raw
-        $otherChangelog | Should -Not -Match "## 1\.2\.3" -Because "projects with a different tag prefix should not be updated"
+        $otherChangelog | Should-NotMatchString "## 1\.2\.3" -Because "projects with a different tag prefix should not be updated"
     }
 }


### PR DESCRIPTION
## Changes

Upgrade script tests to Pester v6 and use new syntax where appropriate.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
