### PR TITLE
[Exporter.InfluxDB] Apply backpressure via ExportResult.Failure instead of unbounded buffering

### DIFF
--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* The metrics exporter now reports `ExportResult.Failure` when asynchronous
+  writes to InfluxDB are failing and stops enqueuing points into the unbounded
+  `WriteApi` buffer while the backend is unreachable. This prevents unbounded
+  memory growth (potential OOM) when InfluxDB is down or falling behind. Since
+  the reader uses cumulative temporality, no data is lost: the SDK retains the
+  accumulated values and the `PeriodicExportingMetricReader` retries on the next
+  export cycle.
+  ([#4474](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4474))
+
 * Updated OpenTelemetry core component version(s) to `1.16.0`.
   ([#4487](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4487))
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
@@ -13,6 +13,15 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
     private readonly InfluxDBClient influxDbClient;
     private readonly WriteApi writeApi;
 
+    // WriteApi writes are fire-and-forget into an unbounded Rx buffer and never
+    // surface failures to the caller (backpressure is not implemented in the C#
+    // client). We track the outcome of those asynchronous writes here so that
+    // Export can stop feeding the buffer and report Failure while InfluxDB is
+    // unreachable. Because the reader uses cumulative temporality, returning
+    // Failure loses no data: the SDK keeps the accumulated values and re-exports
+    // them once writes succeed again.
+    private volatile bool writeApiHealthy = true;
+
     public InfluxDBMetricsExporter(IMetricsWriter writer, InfluxDBClient influxDbClient, WriteApi writeApi)
     {
         this.writer = writer;
@@ -23,8 +32,16 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
         {
             switch (args)
             {
+                case WriteSuccessEvent:
+                    this.writeApiHealthy = true;
+                    break;
                 case WriteErrorEvent writeErrorEvent:
+                    this.writeApiHealthy = false;
                     InfluxDBEventSource.Log.FailedToExport(writeErrorEvent.Exception.Message);
+                    break;
+                case WriteRetriableErrorEvent writeRetriableErrorEvent:
+                    this.writeApiHealthy = false;
+                    InfluxDBEventSource.Log.FailedToExport(writeRetriableErrorEvent.Exception.Message);
                     break;
                 default:
                     break;
@@ -34,6 +51,16 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
 
     public override ExportResult Export(in Batch<Metric> batch)
     {
+        // If previous asynchronous writes failed, avoid enqueuing more points
+        // into the unbounded WriteApi buffer (which would grow until OOM) and
+        // let the PeriodicExportingMetricReader apply backpressure by retrying
+        // on the next export cycle. Cumulative temporality guarantees no data is
+        // lost in the meantime.
+        if (!this.writeApiHealthy)
+        {
+            return ExportResult.Failure;
+        }
+
         try
         {
             foreach (var metric in batch)

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
@@ -15,12 +15,18 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
 
     // WriteApi writes are fire-and-forget into an unbounded Rx buffer and never
     // surface failures to the caller (backpressure is not implemented in the C#
-    // client). We track the outcome of those asynchronous writes here so that
-    // Export can stop feeding the buffer and report Failure while InfluxDB is
+    // client). We track the outcome of those asynchronous writes so that Export
+    // can report Failure and stop feeding the buffer while InfluxDB is
     // unreachable. Because the reader uses cumulative temporality, returning
     // Failure loses no data: the SDK keeps the accumulated values and re-exports
     // them once writes succeed again.
     private volatile bool writeApiHealthy = true;
+
+    // Set while a batch has been handed to WriteApi but its outcome has not been
+    // observed yet. While writes are failing we only allow a single such batch to
+    // be in flight at a time: it acts as a probe that lets us detect recovery
+    // (a WriteSuccessEvent) without piling further points onto the buffer.
+    private volatile bool writeInFlight;
 
     public InfluxDBMetricsExporter(IMetricsWriter writer, InfluxDBClient influxDbClient, WriteApi writeApi)
     {
@@ -34,12 +40,15 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
             {
                 case WriteSuccessEvent:
                     this.writeApiHealthy = true;
+                    this.writeInFlight = false;
                     break;
                 case WriteErrorEvent writeErrorEvent:
                     this.writeApiHealthy = false;
+                    this.writeInFlight = false;
                     InfluxDBEventSource.Log.FailedToExport(writeErrorEvent.Exception.Message);
                     break;
                 case WriteRetriableErrorEvent writeRetriableErrorEvent:
+                    // The client will retry this batch, so it is still in flight.
                     this.writeApiHealthy = false;
                     InfluxDBEventSource.Log.FailedToExport(writeRetriableErrorEvent.Exception.Message);
                     break;
@@ -51,12 +60,13 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
 
     public override ExportResult Export(in Batch<Metric> batch)
     {
-        // If previous asynchronous writes failed, avoid enqueuing more points
-        // into the unbounded WriteApi buffer (which would grow until OOM) and
-        // let the PeriodicExportingMetricReader apply backpressure by retrying
-        // on the next export cycle. Cumulative temporality guarantees no data is
-        // lost in the meantime.
-        if (!this.writeApiHealthy)
+        // While writes are failing, avoid enqueuing more points into the unbounded
+        // WriteApi buffer (which would otherwise grow until the process is
+        // OOM-killed). We still let a single probe batch stay in flight so that a
+        // subsequent WriteSuccessEvent can signal recovery. Cumulative temporality
+        // guarantees no data is lost: the SDK keeps the accumulated values and the
+        // PeriodicExportingMetricReader retries on the next export cycle.
+        if (!this.writeApiHealthy && this.writeInFlight)
         {
             return ExportResult.Failure;
         }
@@ -68,7 +78,12 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
                 this.writer.Write(metric, this.ParentProvider?.GetResource(), this.writeApi);
             }
 
-            return ExportResult.Success;
+            this.writeInFlight = true;
+
+            // Report the last observed health: on the first failing cycle this is
+            // still Success, but as soon as the asynchronous failure is observed
+            // every subsequent cycle reports Failure until writes recover.
+            return this.writeApiHealthy ? ExportResult.Success : ExportResult.Failure;
         }
         catch (Exception exception)
         {

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
@@ -1,7 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Net;
 using System.Reflection;
 using OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 using OpenTelemetry.Metrics;
@@ -514,6 +516,93 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(measurement, dataPoint.Measurement);
         AssertUtils.HasField(valueKey, 42L, dataPoint.Fields);
         AssertUtils.HasTag("MeterTag", "MeterValue", 0, dataPoint.Tags);
+    }
+
+    [Fact]
+    public void ExportReportsFailureWhenInfluxDBIsUnavailable()
+    {
+        // Arrange - the backend rejects every write, simulating an unavailable InfluxDB.
+        using var influxServer = new InfluxDBFakeServer { ResponseStatusCode = HttpStatusCode.BadRequest };
+        var influxServerEndpoint = influxServer.Endpoint;
+
+        using var meter = new Meter("MyMeter", "0.0.1");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
+            .AddInfluxDBMetricsExporter(options =>
+            {
+                options.WithDefaultTestConfiguration();
+                options.Endpoint = influxServerEndpoint;
+            })
+            .Build();
+
+        var counter = meter.CreateCounter<int>("test-counter");
+        counter.Add(100);
+
+        // Act & Assert - the first flush enqueues the batch and still succeeds; once the
+        // asynchronous write failure is observed, subsequent flushes must report failure
+        // so the SDK applies backpressure instead of buffering unboundedly.
+        Assert.True(
+            WaitForForceFlushResult(provider, expected: false, TimeSpan.FromSeconds(10)),
+            "Export was expected to report Failure while InfluxDB is unavailable.");
+    }
+
+    [Fact]
+    public void ExportRecoversWhenInfluxDBBecomesAvailableAgain()
+    {
+        // Arrange - start with an unavailable backend.
+        using var influxServer = new InfluxDBFakeServer { ResponseStatusCode = HttpStatusCode.BadRequest };
+        var influxServerEndpoint = influxServer.Endpoint;
+
+        using var meter = new Meter("MyMeter", "0.0.1");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
+            .AddInfluxDBMetricsExporter(options =>
+            {
+                options.WithDefaultTestConfiguration();
+                options.Endpoint = influxServerEndpoint;
+            })
+            .Build();
+
+        var counter = meter.CreateCounter<int>("test-counter");
+        counter.Add(100);
+
+        Assert.True(
+            WaitForForceFlushResult(provider, expected: false, TimeSpan.FromSeconds(10)),
+            "Export was expected to report Failure while InfluxDB is unavailable.");
+
+        // Act - the backend recovers.
+        influxServer.ResponseStatusCode = HttpStatusCode.OK;
+
+        // Assert - Export reports Success again and data flows through once more.
+        Assert.True(
+            WaitForForceFlushResult(provider, expected: true, TimeSpan.FromSeconds(10)),
+            "Export was expected to recover and report Success once InfluxDB is available again.");
+
+        var dataPoint = influxServer.ReadPoint();
+        Assert.Equal("test-counter", dataPoint.Measurement);
+        AssertUtils.HasField("counter", 100L, dataPoint.Fields);
+    }
+
+    private static bool WaitForForceFlushResult(MeterProvider provider, bool expected, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        do
+        {
+            // ForceFlush returns whether the underlying Export succeeded.
+            if (provider.ForceFlush(5000) == expected)
+            {
+                return true;
+            }
+
+            Thread.Sleep(50);
+        }
+        while (stopwatch.Elapsed < timeout);
+
+        return false;
     }
 
     private static void AssertTags(PointData dataPoint)

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
@@ -22,13 +22,18 @@ internal class InfluxDBFakeServer : IDisposable
             {
                 var buffer = new byte[context.Request.ContentLength64];
                 _ = context.Request.InputStream.Read(buffer, 0, buffer.Length);
-                var text = Encoding.UTF8.GetString(buffer);
-                foreach (var line in text.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries))
+
+                var statusCode = this.ResponseStatusCode;
+                if (statusCode == HttpStatusCode.OK)
                 {
-                    this.lines.Add(line);
+                    var text = Encoding.UTF8.GetString(buffer);
+                    foreach (var line in text.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        this.lines.Add(line);
+                    }
                 }
 
-                context.Response.StatusCode = (int)HttpStatusCode.OK;
+                context.Response.StatusCode = (int)statusCode;
                 context.Response.Close();
             },
             out var baseAddress);
@@ -36,6 +41,13 @@ internal class InfluxDBFakeServer : IDisposable
     }
 
     public Uri Endpoint { get; }
+
+    /// <summary>
+    /// Gets or sets the HTTP status code returned for write requests. Setting a
+    /// non-success code (for example <see cref="HttpStatusCode.BadRequest"/>)
+    /// simulates an unavailable/erroring InfluxDB backend.
+    /// </summary>
+    public HttpStatusCode ResponseStatusCode { get; set; } = HttpStatusCode.OK;
 
     public void Dispose()
         => this.httpServer.Dispose();


### PR DESCRIPTION
## Fixes

Addresses the unbounded memory growth described in #4474 (closed as inactive).

## Changes

The InfluxDB metrics exporter writes points fire-and-forget into `WriteApi`. Its internal Rx buffer is [documented as unbounded and without backpressure in the C# client](https://github.com/influxdata/influxdb-client-csharp/blob/master/Client/WriteApi.cs), and write failures are only surfaced asynchronously via the event stream. As a result, when InfluxDB is down or cannot keep up:

- the buffer grows until the process is OOM-killed, and
- `Export()` always returns `ExportResult.Success`, so the SDK never throttles.

This PR implements the lightweight approach suggested during the review of #4474, instead of adding a custom bounded queue / background worker / new public API:

- Track the outcome of the asynchronous writes via the existing `WriteApi.EventHandler` (`WriteSuccessEvent` → healthy, `WriteErrorEvent` / `WriteRetriableErrorEvent` → unhealthy).
- While writes are failing, `Export()` stops enqueuing new points into the unbounded buffer and returns `ExportResult.Failure`.

Because the reader uses `MetricReaderTemporalityPreference.Cumulative`, returning `Failure` loses no data: the SDK keeps the accumulated values and the `PeriodicExportingMetricReader` retries on the next export cycle. This turns the reader into the natural backpressure/retry mechanism. Memory is then bounded by cardinality (and `MaxMetricPointsPerMetricStream`), not by the duration of the outage — so even a permanently unreachable InfluxDB no longer causes unbounded growth.

Trade-off: during an outage the per-interval resolution is dropped, but cumulative totals remain correct once writes resume (counters recover their full total, gauges/histograms keep their latest cumulative state).

## Merge requirement checklist

- [x] CHANGELOG.md updated for non-trivial changes
- [x] Changes in public API reviewed (if applicable) — no public API changes
