### PR TITLE
[Process] Update Semantic Conventions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -16,8 +16,8 @@
 
 * Updated semantic conventions to
   [v1.43.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/system/process-metrics.md)
-  and mark package as release candidate.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  and marked package as release candidate.
+  ([#4675](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4675))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -14,6 +14,11 @@
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
 
+* Updated semantic conventions to
+  [v1.43.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/system/process-metrics.md)
+  and mark package as release candidate.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-24

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -9,7 +9,7 @@ namespace OpenTelemetry.Instrumentation.Process;
 
 internal sealed class ProcessMetrics
 {
-    internal static readonly Version SemanticConventionsVersion = new(1, 42, 0);
+    internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
     internal static readonly Meter MeterInstance = Metrics.MeterFactory.Create<ProcessMetrics>(SemanticConventionsVersion);
 
     static ProcessMetrics()

--- a/src/OpenTelemetry.Instrumentation.Process/README.md
+++ b/src/OpenTelemetry.Instrumentation.Process/README.md
@@ -2,7 +2,7 @@
 
 | Status | |
 | ------ | --- |
-| Stability | [Beta](../../README.md#beta) |
+| Stability | [Release candidate](../../README.md#release-candidate) |
 | Code Owners | [@Yun-Ting](https://github.com/Yun-Ting) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Process)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process)
@@ -16,7 +16,7 @@ telemetry about process behavior.
 
 The process metric instruments being implemented are following OpenTelemetry
 [metrics semantic
-conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/system/process-metrics.md).
+conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/system/process-metrics.md).
 
 ## Steps to enable OpenTelemetry.Instrumentation.Process
 

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -8,6 +8,11 @@
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
 
+* Updated semantic conventions to
+  [v1.43.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/system/process-metrics.md)
+  and mark package as release candidate.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.15.1-beta.2
 
 Released 2026-May-06

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -9,9 +9,9 @@
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
 
 * Updated semantic conventions to
-  [v1.43.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/system/process-metrics.md)
-  and mark package as release candidate.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  [v1.43.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/resource/process.md)
+  and marked package as release candidate.
+  ([#4675](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4675))
 
 ## 1.15.1-beta.2
 

--- a/src/OpenTelemetry.Resources.Process/README.md
+++ b/src/OpenTelemetry.Resources.Process/README.md
@@ -2,7 +2,7 @@
 
 | Status | |
 | ------ | --- |
-| Stability | [Beta](../../README.md#beta) |
+| Stability | [Release candidate](../../README.md#release-candidate) |
 | Code Owners | [@Kielek](https://github.com/Kielek), [@lachmatt](https://github.com/lachmatt) |
 
 [![NuGet version badge](https://img.shields.io/nuget/v/OpenTelemetry.Resources.Process)](https://www.nuget.org/packages/OpenTelemetry.Resources.Process)

--- a/src/OpenTelemetry.Resources.Process/README.md
+++ b/src/OpenTelemetry.Resources.Process/README.md
@@ -10,7 +10,7 @@
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.Process)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.Process)
 
 > [!IMPORTANT]
-> Resources detected by this packages are defined by [experimental semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/v1.41.0/docs/resource/process.md#process).
+> Resources detected by this packages are defined by [experimental semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/resource/process.md#process).
 > These resources can be changed without prior notification.
 
 ## Getting Started


### PR DESCRIPTION
- Fixes #1515
- Contributes to #2186

## Changes

- Update semantic conventions version to [v1.43.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.43.0).
- Promote to release candidate. (see https://github.com/open-telemetry/semantic-conventions/pull/3758)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
