### PR TITLE
[Repo] Add first-time contributor workflow

### DIFF
--- a/.github/workflows/first-time-pr.yml
+++ b/.github/workflows/first-time-pr.yml
@@ -1,0 +1,13 @@
+name: First time contributor
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] Only code from the main branch is executed
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  welcome:
+    permissions:
+      pull-requests: write # To post the welcome comment
+    uses: open-telemetry/shared-workflows/.github/workflows/first-time-pr.yml@2192ef0cade1b727dafcc3ebba58713281059653 # v0.1.0


### PR DESCRIPTION
## Changes

Add workflow to leave a comment on PRs opened by first time contributors using the [shared workflow](https://github.com/open-telemetry/shared-workflows/tree/main/first-time-pr).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
