### PR TITLE
[Geneva] Do not cache long logger names

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -14,7 +14,7 @@
   strings and HTTP url spans directly into the output buffer instead of via
   temporary arrays/strings.
   ([#4498](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4498),
-  [#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  [#4684](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4684))
 
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -13,7 +13,8 @@
   valid names) and freeze the cache on .NET 8+, serialize metric base-128
   strings and HTTP url spans directly into the output buffer instead of via
   temporary arrays/strings.
-  ([#4498](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4498))
+  ([#4498](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4498),
+  [#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
 
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/TldLogCommon.cs
@@ -15,7 +15,8 @@ namespace OpenTelemetry.Exporter.Geneva.Tld;
 internal abstract class TldLogCommon : IDisposable
 {
     protected const int MaxSanitizedEventNameLength = 50;
-    protected const int MaxCachedSanitizedCategoryNames = 10000;
+    protected const int MaxCachedSanitizedCategoryNames = 10_000;
+    protected const int MaxCachedCategoryNameLength = 512;
 
     protected static readonly ThreadLocal<List<KeyValuePair<string, object?>>> EnvProperties = new();
     protected static readonly ThreadLocal<KeyValuePair<string, object>[]> PartCFields = new(); // This is used to temporarily store the PartC fields from tags
@@ -310,6 +311,12 @@ internal abstract class TldLogCommon : IDisposable
     private string GetSanitizedCategoryNameRare(string categoryName)
     {
         var sanitized = SanitizeCategoryName(categoryName);
+
+        // Never cache pathologically long category names
+        if (categoryName.Length > MaxCachedCategoryNameLength)
+        {
+            return sanitized;
+        }
 
         // Lock-free copy-on-write update. The cache is a pure memoization of a
         // deterministic, side-effect-free function, so a lost race is harmless:

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/TldLogCommonSanitizationTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/TldLogCommonSanitizationTests.cs
@@ -85,6 +85,37 @@ public class TldLogCommonSanitizationTests
         Assert.Same(first, second);
     }
 
+    [Fact]
+    public void GetSanitizedCategoryName_AtMaxCachedLength_IsCached()
+    {
+        using var probe = CreateProbe();
+
+        var categoryName = "a" + new string('b', CategorySanitizerProbe.MaxCachedCategoryNameLengthValue - 1);
+        var expected = "A" + new string('b', 49);
+
+        var first = probe.Sanitize(categoryName);
+        var second = probe.Sanitize(categoryName);
+
+        Assert.Equal(expected, first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetSanitizedCategoryName_ExceedsMaxCachedLength_IsNotCachedButStillSanitized()
+    {
+        using var probe = CreateProbe();
+
+        var categoryName = "a" + new string('b', CategorySanitizerProbe.MaxCachedCategoryNameLengthValue);
+        var expected = "A" + new string('b', 49);
+
+        var first = probe.Sanitize(categoryName);
+        var second = probe.Sanitize(categoryName);
+
+        Assert.Equal(expected, first);
+        Assert.Equal(expected, second);
+        Assert.NotSame(first, second);
+    }
+
     private static CategorySanitizerProbe CreateProbe()
     {
         return new CategorySanitizerProbe(new GenevaExporterOptions
@@ -106,6 +137,8 @@ public class TldLogCommonSanitizationTests
             : base(options)
         {
         }
+
+        public static int MaxCachedCategoryNameLengthValue => MaxCachedCategoryNameLength;
 
         public string Sanitize(string categoryName)
             => this.GetSanitizedCategoryName(categoryName);


### PR DESCRIPTION
## Changes

Apply an upper limit to the length of cached sanitized logger names added in #4498.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
