### PR TITLE
[Infra] Wait for NuGet packages to be published

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,6 +22,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: false
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+  DOTNET_NOLOGO: true
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  FORCE_COLOR: 3
+  TERM: xterm
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -423,6 +431,9 @@ jobs:
       - build-pack
       - publish-nuget
 
+    outputs:
+      pr-number: ${{ steps.post-notice.outputs.pr-number }}
+
     steps:
       - name: Generate GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -461,6 +472,7 @@ jobs:
             -releaseFiles "${env:GITHUB_WORKSPACE}/artifacts/*"
 
       - name: Post notice when packages are ready
+        id: post-notice
         shell: pwsh
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
@@ -469,9 +481,77 @@ jobs:
         run: |
           Import-Module .\build\scripts\post-release.psm1
 
-          TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
+          $prNumber = TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
             -gitRepository ${env:GITHUB_REPOSITORY} `
             -tag ${env:GITHUB_REF_NAME} `
             -tagSha ${env:GITHUB_SHA} `
             -packagesUrl ${env:PACKAGES_URL} `
             -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME}
+
+          "pr-number=${prNumber}" >> ${env:GITHUB_OUTPUT}
+
+  wait-nuget:
+    name: Wait for NuGet packages to be published
+    needs: [automation, build-pack, publish-nuget, post-build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    permissions:
+      contents: read # Download the published artifacts
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: ${{ needs.build-pack.outputs.dotnet-sdk-version }}
+
+      - name: Install WaitForNuGetPackage tool
+        shell: pwsh
+        env:
+            # renovate: datasource=nuget depName=MartinCostello.WaitForNuGetPackage
+            WAIT_FOR_NUGET_PACKAGE_VERSION: '1.3.1'
+        run: |
+          dotnet tool install --global MartinCostello.WaitForNuGetPackage --version ${env:WAIT_FOR_NUGET_PACKAGE_VERSION} --allow-roll-forward
+
+      - name: Download NuGet packages
+        id: download-packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-pack.outputs.artifact-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./packages
+
+      - name: Wait for NuGet packages to be published
+        id: wait-for-publish
+        shell: pwsh
+        env:
+          PACKAGES_DIRECTORY: ${{ steps.download-packages.outputs.download-path }}
+          PUBLISH_TIMEOUT: '00:45:00'
+        run: |
+          dotnet wait-for-package --directory ${env:PACKAGES_DIRECTORY} --timeout ${env:PUBLISH_TIMEOUT}
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::warning::Failed to wait for NuGet packages to be published and indexed."
+            exit 0
+          }
+
+          "published=true" >> ${env:GITHUB_OUTPUT}
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
+          permission-issues: write
+
+      - name: Post comment on release PR
+        if: steps.wait-for-publish.outputs.published == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          PR_NUMBER: ${{ needs.post-build.outputs.pr-number }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_URL: ${{ format('{0}/releases/tag/{1}', github.repositoryUrl, github.ref_name) }}
+        run: |
+          gh pr comment ${env:PR_NUMBER} --body "The packages for the [${env:RELEASE_TAG}](${env:RELEASE_URL}) release are now available from NuGet.org :package:" --repo ${env:GITHUB_REPOSITORY}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -509,7 +509,7 @@ jobs:
         shell: pwsh
         env:
           # renovate: datasource=nuget depName=MartinCostello.WaitForNuGetPackage
-          WAIT_FOR_NUGET_PACKAGE_VERSION: '1.3.1'
+          WAIT_FOR_NUGET_PACKAGE_VERSION: '1.3.2'
         run: |
           dotnet tool install --global MartinCostello.WaitForNuGetPackage --version ${env:WAIT_FOR_NUGET_PACKAGE_VERSION} --allow-roll-forward
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -508,8 +508,8 @@ jobs:
       - name: Install WaitForNuGetPackage tool
         shell: pwsh
         env:
-            # renovate: datasource=nuget depName=MartinCostello.WaitForNuGetPackage
-            WAIT_FOR_NUGET_PACKAGE_VERSION: '1.3.1'
+          # renovate: datasource=nuget depName=MartinCostello.WaitForNuGetPackage
+          WAIT_FOR_NUGET_PACKAGE_VERSION: '1.3.1'
         run: |
           dotnet tool install --global MartinCostello.WaitForNuGetPackage --version ${env:WAIT_FOR_NUGET_PACKAGE_VERSION} --allow-roll-forward
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -495,6 +495,7 @@ jobs:
     needs: [automation, build-pack, publish-nuget, post-build]
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    if: needs.post-build.outputs.pr-number != ''
 
     permissions:
       contents: read # Download the published artifacts

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -112,7 +112,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
   if ($prListResponse.Length -eq 0)
   {
     Write-Information 'No prepare release PR found for tag & commit skipping post notice'
-    return
+    return $null
   }
 
   foreach ($pr in $prListResponse)
@@ -147,7 +147,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
       continue
     }
 
-  $body =
+    $body =
 @"
 The [packages]($packagesUrl) for [$tag](https://github.com/$gitRepository/releases/tag/$tag) should be available on NuGet momentarily.
 
@@ -156,11 +156,12 @@ Have a nice day!
 
     $pullRequestNumber = $pr.number
 
-    gh pr comment $pullRequestNumber --body $body
-    return
+    gh pr comment $pullRequestNumber --body $body | Out-Null
+    return $pullRequestNumber
   }
 
   Write-Warning 'No prepare release PR found matched author and title with a valid comment'
+  return $null
 }
 
 Export-ModuleMember -Function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest

--- a/build/scripts/tests/post-release.Tests.ps1
+++ b/build/scripts/tests/post-release.Tests.ps1
@@ -114,12 +114,14 @@ Describe "TryPostPackagesReadyNoticeOnPrepareReleasePullRequest" {
             return $null
         }
 
-        TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
+        $result = TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
             -gitRepository "open-telemetry/opentelemetry-dotnet-contrib" `
             -tag "foo-1.9.0" `
             -tagSha "abc123" `
             -packagesUrl "https://example.com/packages" `
             -expectedPrAuthorUserName "otelbot" 6>$null
+
+        $result | Should-Be 42 -Because "the number of the pull request the notice was posted on should be returned"
 
         Should -Invoke -CommandName "gh" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
             $args -contains "comment" -and (($args -join " ") -match "available on NuGet")
@@ -132,12 +134,14 @@ Describe "TryPostPackagesReadyNoticeOnPrepareReleasePullRequest" {
             return $null
         }
 
-        TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
+        $result = TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
             -gitRepository "open-telemetry/opentelemetry-dotnet-contrib" `
             -tag "foo-1.9.0" `
             -tagSha "abc123" `
             -packagesUrl "https://example.com/packages" `
             -expectedPrAuthorUserName "otelbot" 6>$null
+
+        $result | Should-BeNull -Because "no pull request number should be returned when no pull request matches the commit"
 
         Should -Invoke -CommandName "gh" -ModuleName "post-release" -Times 0 -ParameterFilter {
             $args -contains "comment"
@@ -152,12 +156,14 @@ Describe "TryPostPackagesReadyNoticeOnPrepareReleasePullRequest" {
             return $null
         }
 
-        TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
+        $result = TryPostPackagesReadyNoticeOnPrepareReleasePullRequest `
             -gitRepository "open-telemetry/opentelemetry-dotnet-contrib" `
             -tag "foo-1.9.0" `
             -tagSha "abc123" `
             -packagesUrl "https://example.com/packages" `
             -expectedPrAuthorUserName "otelbot" 6>$null
+
+        $result | Should-BeNull -Because "no pull request number should be returned when the matching pull request has no pushed-tag comment"
 
         Should -Invoke -CommandName "gh" -ModuleName "post-release" -Times 0 -ParameterFilter {
             $args -contains "comment"


### PR DESCRIPTION
## Changes

Wait for NuGet packages to be published/indexed in NuGet.org and post a comment to the release PR once they are available for download using [this tool I built](https://github.com/martincostello/wait-for-nuget-package?tab=readme-ov-file).

The experience looks something [like this](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/actions/runs/27961760256/job/82744884162#step:6:25) and [this](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/actions/runs/27961760256#summary-82744884162).

Alternatively (or later in a follow-up) we could change the workflow to instead:

1. Publish the packages to NuGet.org
2. Wait for the packages to publish (or timeout due to publishing delays)
3. Open the post-release PR

That would avoid the _"PR fails, re-run when packages actually available"_ process we have today.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
