### PR TITLE
[Geneva] Fix ETW metadata to allow .NET EventSource subscriptions

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Updated ETW manifest and payload in `EtwDataTransport`
+  Added synthetic `byte[] field` to method signature and `int size` to payload so
+  that runtime-generated .Net ETW manifest matches actual payload
+  ([#4729](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4729)
+
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-* Updated ETW manifest and payload in `EtwDataTransport`
-  Added synthetic `byte[] field` to method signature and `int size` to payload so
-  that runtime-generated .Net ETW manifest matches actual payload
-  ([#4729](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4729)
-
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
+
+* Updated ETW manifest and payload in `EtwDataTransport`
+  with synthetic payload so that the runtime-generated .NET
+  ETW manifest matches the actual payload.
+  ([#4729](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4729)
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Transports/EtwDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Transports/EtwDataTransport.cs
@@ -20,7 +20,7 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
 
     public void Send(byte[] data, int size)
     {
-        this.eventSource.SendEvent((int)EtwEventSource.EtwEventId.TraceEvent, data, size);
+        this.eventSource.SendEvent(data, size);
     }
 
     public bool IsEnabled()
@@ -54,8 +54,19 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
 
 #pragma warning disable CA1822 // Mark members as static
 
+        /// <summary>
+        /// Dummy _data_ field is present so that when <see cref="SendEvent"/> is called, the event has at least one
+        /// parameter with <see cref="EtwEventId.TraceEvent"/> and single data object, it matches the runtime metadata
+        /// in ETW manifest.
+        /// </summary>
+        /// <param name="data">
+        /// Dummy placeholder for <see cref="EventSource"/> reflection-based ETW manifest generation.
+        /// Even though de-facto it's <c>byte[]</c> payload, <c>byte[]</c> when unwrapped to ETW manifest generation
+        /// is augmented with <c>size</c> metadata, and becomes two fields.
+        /// Geneva treats this only single parameter as messagepack raw blob and doesn't use manifest at all.
+        /// </param>
         [Event((int)EtwEventId.TraceEvent, Version = 1, Level = EventLevel.Informational)]
-        public void InformationalEvent()
+        public void InformationalEvent(byte[] data)
         {
         }
 
@@ -65,14 +76,16 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
 #if NET
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "WriteEventCore is safe when eventData object is a primitive type, which it is in this case.")]
 #endif
-        public unsafe void SendEvent(int eventId, byte[] data, int size)
+        public unsafe void SendEvent(byte[] data, int size)
         {
-            var dataDesc = stackalloc EventData[1];
+            EventData* dataDesc = stackalloc EventData[2];
             fixed (byte* ptr = data)
             {
-                dataDesc[0].DataPointer = (IntPtr)ptr;
-                dataDesc[0].Size = size;
-                this.WriteEventCore(eventId, 1, dataDesc);
+                dataDesc[0].DataPointer = (IntPtr)(&size);
+                dataDesc[0].Size = 4;
+                dataDesc[1].DataPointer = (IntPtr)ptr;
+                dataDesc[1].Size = size;
+                this.WriteEventCore((int)EtwEventId.TraceEvent, 2, dataDesc);
             }
         }
     }

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Transports/EtwDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Transports/EtwDataTransport.cs
@@ -61,17 +61,22 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
         /// </summary>
         /// <param name="data">
         /// Dummy placeholder for <see cref="EventSource"/> reflection-based ETW manifest generation.
-        /// Even though de-facto it's <c>byte[]</c> payload, <c>byte[]</c> when unwrapped to ETW manifest generation
-        /// is augmented with <c>size</c> metadata, and becomes two fields.
-        /// Geneva treats this only single parameter as messagepack raw blob and doesn't use manifest at all.
+        /// In the ETW manifest for .Net <c>byte[]</c> payload is always prepender with synthetic <c>length</c> field.
         /// </param>
         [Event((int)EtwEventId.TraceEvent, Version = 1, Level = EventLevel.Informational)]
         public void InformationalEvent(byte[] data)
         {
         }
-
 #pragma warning restore CA1822 // Mark members as static
 
+        /// <summary>
+        /// Writes given raw data to ETW buffer.
+        /// Two fields are written to conform .Net notation - length, and data.
+        /// Separate length fields isn't explicitly needed, since raw ETW payload always comes with buffer length data,
+        /// but convention for .Net ETW libraries require that field.
+        /// </summary>
+        /// <param name="data">Buffer with data to be sent.</param>
+        /// <param name="size">How many bytes of that buffer to send.</param>
         [NonEvent]
 #if NET
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "WriteEventCore is safe when eventData object is a primitive type, which it is in this case.")]

--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Transports/EtwDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Transports/EtwDataTransport.cs
@@ -61,7 +61,8 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
         /// </summary>
         /// <param name="data">
         /// Dummy placeholder for <see cref="EventSource"/> reflection-based ETW manifest generation.
-        /// In the ETW manifest for .Net <c>byte[]</c> payload is always prepender with synthetic <c>length</c> field.
+        /// In the ETW manifest for .NET, <c>byte[]</c> payload is always prepended with a synthetic <c>length</c>
+        /// field.
         /// </param>
         [Event((int)EtwEventId.TraceEvent, Version = 1, Level = EventLevel.Informational)]
         public void InformationalEvent(byte[] data)
@@ -71,9 +72,9 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
 
         /// <summary>
         /// Writes given raw data to ETW buffer.
-        /// Two fields are written to conform .Net notation - length, and data.
-        /// Separate length fields isn't explicitly needed, since raw ETW payload always comes with buffer length data,
-        /// but convention for .Net ETW libraries require that field.
+        /// Two fields are written to conform to .NET notation: length and data.
+        /// A separate length field isn't explicitly needed, since raw ETW payload already comes with buffer length
+        /// data, but the convention for .NET ETW libraries requires that field.
         /// </summary>
         /// <param name="data">Buffer with data to be sent.</param>
         /// <param name="size">How many bytes of that buffer to send.</param>
@@ -83,7 +84,7 @@ internal sealed class EtwDataTransport : IDataTransport, IDisposable
 #endif
         public unsafe void SendEvent(byte[] data, int size)
         {
-            EventData* dataDesc = stackalloc EventData[2];
+            var dataDesc = stackalloc EventData[2];
             fixed (byte* ptr = data)
             {
                 dataDesc[0].DataPointer = (IntPtr)(&size);

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
@@ -13,5 +13,5 @@ namespace OpenTelemetry.Exporter.Geneva.Tests;
 public sealed class EtwCollection
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
-    public const string Name = "Etw collection";
+    public const string Name = "ETW collection";
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
@@ -1,0 +1,17 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter.Geneva.Tests;
+
+/// <summary>
+/// Collection definition for ETW tests.
+///
+/// Since ETW is a system-global(not even process-global) resource, these tests shouldn't be run in parallel.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class EtwCollection
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+{
+    public const string Name = "Etw collection";
+}

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 namespace OpenTelemetry.Exporter.Geneva.Tests;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/EtwCollection.cs
@@ -5,8 +5,8 @@ namespace OpenTelemetry.Exporter.Geneva.Tests;
 
 /// <summary>
 /// Collection definition for ETW tests.
-///
-/// Since ETW is a system-global(not even process-global) resource, these tests shouldn't be run in parallel.
+/// <para/>
+/// Since ETW is a system-global (not even process-global) resource, these tests shouldn't be run in parallel.
 /// </summary>
 [CollectionDefinition(Name, DisableParallelization = true)]
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/Internal/Transports/EtwDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/Internal/Transports/EtwDataTransportTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Tracing;

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/Internal/Transports/EtwDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/Internal/Transports/EtwDataTransportTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Tracing;
-using System.Text;
 using OpenTelemetry.Exporter.Geneva.Transports;
 
 namespace OpenTelemetry.Exporter.Geneva.Tests.Internal.Transports;
@@ -22,9 +21,12 @@ public class EtwDataTransportTests
 
         Assert.Single(listener.Events);
         var theEvent = listener.Events[0];
+        Assert.NotNull(theEvent.Payload);
         Assert.Single(theEvent.Payload);
 
-        Assert.Equal(payload, (byte[])theEvent.Payload[0]);
+        var rawPayload = theEvent.Payload[0] as byte[];
+        Assert.NotNull(rawPayload);
+        Assert.Equal(payload, rawPayload);
     }
 
     /// <summary>

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/Internal/Transports/EtwDataTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/Internal/Transports/EtwDataTransportTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Tracing;
+using System.Text;
+using OpenTelemetry.Exporter.Geneva.Transports;
+
+namespace OpenTelemetry.Exporter.Geneva.Tests.Internal.Transports;
+
+[Collection(EtwCollection.Name)]
+public class EtwDataTransportTests
+{
+    [Fact]
+    public void TestEtwMessageRoundtrip()
+    {
+        var randomProviderName = "x" + Guid.NewGuid().ToString("N");
+        using var listener = new TestEventSourceListener(randomProviderName);
+        using var transport = new EtwDataTransport(randomProviderName);
+        byte[] payload = [1, 2, 3, 4];
+
+        transport.Send(payload, payload.Length);
+
+        Assert.Single(listener.Events);
+        var theEvent = listener.Events[0];
+        Assert.Single(theEvent.Payload);
+
+        Assert.Equal(payload, (byte[])theEvent.Payload[0]);
+    }
+
+    /// <summary>
+    /// Test event source listener.
+    /// </summary>
+    private sealed class TestEventSourceListener : EventListener
+    {
+        /// <summary>
+        /// Event source name to automatically attach to.
+        /// </summary>
+        private readonly string eventSourceName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestEventSourceListener"/> class.
+        /// </summary>
+        /// <param name="eventSourceName">The name of the event source to attach to.</param>
+        public TestEventSourceListener(string eventSourceName)
+        {
+            this.eventSourceName = eventSourceName;
+        }
+
+        /// <summary>
+        /// Gets events emitted by ETW.
+        /// </summary>
+        public List<EventWrittenEventArgs> Events { get; } = new();
+
+        /// <inheritdoc />
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            base.OnEventSourceCreated(eventSource);
+            if (string.Equals(eventSource.Name, this.eventSourceName, StringComparison.Ordinal))
+            {
+                this.EnableEvents(eventSource, EventLevel.LogAlways);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnEventWritten(EventWrittenEventArgs eventData) => this.Events.Add(eventData);
+    }
+}


### PR DESCRIPTION
It's impossible to subscribe to OpenTelemetry EventSource, since data published to the ETW doesn't match manifest/schema inferred from the EtwEventSource `Event`-annotated methods. Listeners receive errors and truncated data.

## Changes

Make manifest schema match the actual data written to the ETW. Changed the internal format to have two fields - buffer size, ad raw data, as .Net EventSource expects(mayb be a breaking change). Verified that Geneva MonitringAgent can ingest the data.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
