### PR TITLE
Update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/core-version-update.yml
+++ b/.github/workflows/core-version-update.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -124,7 +124,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write
@@ -178,7 +178,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: read
         permission-pull-requests: write
@@ -225,7 +225,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write
@@ -279,7 +279,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-pull-requests: write
@@ -338,7 +338,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+        client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
         permission-contents: write
         permission-issues: write

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -428,7 +428,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/sync-sql-tests.yml
+++ b/.github/workflows/sync-sql-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOTNET_CONTRIB_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOTNET_CONTRIB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The `app-id` input for `actions/create-github-app-token` is deprecated in favor of `client-id`. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id` / `*_APP_ID` to `client-id` / `*_CLIENT_ID`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744