### PR TITLE
[Hangfire] Fix NullReferenceException for unresolvable jobs

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-* Fixed NRE in the metrics filter when a job's definition cannot be resolved.
-  ([#4731](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4731))
-
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
+
+* Fixed `NullReferenceException` in the metrics filter when a job's definition
+  cannot be resolved.
+  ([#4731](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4731))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed NRE in the metrics filter when a job's definition cannot be resolved.
+  ([#4731](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4731))
+
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
 

--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/JobNameFormatter.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/JobNameFormatter.cs
@@ -9,8 +9,15 @@ namespace OpenTelemetry.Instrumentation.Hangfire.Implementation;
 
 internal static class JobNameFormatter
 {
-    internal static string FormatJobName(this Job job)
+    private const string UnknownJobName = "UNKNOWN";
+
+    internal static string FormatJobName(this Job? job)
     {
+        if (job is null)
+        {
+            return UnknownJobName;
+        }
+
         var sb = new StringBuilder()
             .Append(job.Type.ToGenericTypeString())
             .Append('.')

--- a/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/JobNameFormatter.cs
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/Implementation/JobNameFormatter.cs
@@ -9,13 +9,11 @@ namespace OpenTelemetry.Instrumentation.Hangfire.Implementation;
 
 internal static class JobNameFormatter
 {
-    private const string UnknownJobName = "UNKNOWN";
-
     internal static string FormatJobName(this Job? job)
     {
         if (job is null)
         {
-            return UnknownJobName;
+            return "UNKNOWN";
         }
 
         var sb = new StringBuilder()

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/JobNameFormatterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/JobNameFormatterTests.cs
@@ -21,13 +21,13 @@ public class JobNameFormatterTests
     }
 
     [Fact]
-    public void FormatJobName_Does_Not_Throw_NullReferenceException_When_Job_Is_Unresolvable()
+    public void FormatJobName_Returns_Unknown_When_Job_Is_Unresolvable()
     {
         // null! mimics Hangfire's runtime state for a job whose definition failed to deserialize.
         var backgroundJob = new BackgroundJob("job-id", job: null!, DateTime.UtcNow);
 
-        var exception = Record.Exception(() => backgroundJob.FormatJobName());
+        var name = backgroundJob.FormatJobName();
 
-        Assert.False(exception is NullReferenceException, $"Expected no NullReferenceException, but got: {exception}");
+        Assert.Equal("UNKNOWN", name);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Hangfire.Tests/JobNameFormatterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Hangfire.Tests/JobNameFormatterTests.cs
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Hangfire;
+using Hangfire.Common;
+using OpenTelemetry.Instrumentation.Hangfire.Implementation;
+
+namespace OpenTelemetry.Instrumentation.Hangfire.Tests;
+
+public class JobNameFormatterTests
+{
+    [Fact]
+    public void FormatJobName_Returns_TypeAndMethod_When_Job_Is_Resolved()
+    {
+        var job = Job.FromExpression<TestJob>(x => x.Execute());
+        var backgroundJob = new BackgroundJob("job-id", job, DateTime.UtcNow);
+
+        var name = backgroundJob.FormatJobName();
+
+        Assert.Equal("TestJob.Execute", name);
+    }
+
+    [Fact]
+    public void FormatJobName_Does_Not_Throw_NullReferenceException_When_Job_Is_Unresolvable()
+    {
+        // null! mimics Hangfire's runtime state for a job whose definition failed to deserialize.
+        var backgroundJob = new BackgroundJob("job-id", job: null!, DateTime.UtcNow);
+
+        var exception = Record.Exception(() => backgroundJob.FormatJobName());
+
+        Assert.False(exception is NullReferenceException, $"Expected no NullReferenceException, but got: {exception}");
+    }
+}


### PR DESCRIPTION
## Changes

The metrics instrumentation registers `HangfireMetricsStateFilter`, a global `IApplyStateFilter`. It formats a job name on every state transition, and `JobNameFormatter` dereferences `BackgroundJob.Job` with no null check.

When a job's invocation data cannot be deserialized (missing assembly, renamed type/method), `Job` is null. The filter throws `NullReferenceException`.

Affects all versions incl. `1.16.0-beta.1`.

> [!NOTE]
> This typically happens in platforms where the Hangfire scheduler (enqueues jobs) and the worker (executes jobs) are separate applications.
> The job's type/method can exist in the scheduler but be missing in the worker, so the worker can't deserialize the job and Job is null.

Observed in production (stack trimmed):

    "10 state change attempt(s) failed... moving job to the FailedState"
    System.NullReferenceException
       at ...JobNameFormatter.FormatJobName(Job job)
       at ...JobNameFormatter.FormatJobName(BackgroundJob backgroundJob)
       at ...HangfireTagBuilder.GetDefinitionName(BackgroundJob backgroundJob)

Preceded by `System.IO.FileNotFoundException: Could not resolve assembly '...'` at `InvocationData.DeserializeJob()`.

Fix: null-guard `JobNameFormatter` and return a sentinel when the job definition cannot be resolved.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable) — n/a, no public API change