### PR TITLE
[GrpcNetClient] Remove redundant code

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -116,14 +116,6 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
             {
                 activity.SetTag(SemanticConventions.AttributeServerAddress, requestUri.Host);
                 activity.SetTag(SemanticConventions.AttributeServerPort, requestUri.Port);
-
-                var uriHostNameType = Uri.CheckHostName(requestUri.Host);
-
-                if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
-                {
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, requestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, requestUri.Port);
-                }
             }
 
             if (this.options.EnrichWithHttpRequestMessage is { } enrich)


### PR DESCRIPTION
## Changes

Remove duplicate code to set `network.peer.address` and `network.peer.port`.

The code ran after sampling and the `OnStop` copy is better placed as it would take into account any redirects that may have occurred.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
