### PR TITLE
[Shared] Improve RedactionHelper performance

### DIFF
--- a/src/Shared/RedactionHelper.cs
+++ b/src/Shared/RedactionHelper.cs
@@ -1,7 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Text;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Internal;
 
@@ -11,14 +13,24 @@ internal sealed class RedactionHelper
 
     public static string? GetRedactedQueryString(string query)
     {
+        var index =
+#if NET
+            query.IndexOf('=', StringComparison.Ordinal);
+#else
+            query.IndexOf('=');
+#endif
+
+        if (index == -1)
+        {
+            return query;
+        }
+
         var length = query.Length;
-        var index = 0;
 
         // Preallocate some size to avoid re-sizing multiple times.
         // Since the size will increase, allocating twice as much.
-        // TODO: Check to see if we can borrow from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
-        // to improve perf.
-        StringBuilder queryBuilder = new(2 * length);
+        using ValueStringBuilder queryBuilder = new(2 * length);
+        queryBuilder.Append(query.AsSpan(0, index));
         while (index < query.Length)
         {
             // Check if the character is = for redacting value.
@@ -53,5 +65,113 @@ internal sealed class RedactionHelper
         }
 
         return queryBuilder.ToString();
+    }
+
+    // Simplified version of System.Text.ValueStringBuilder from .NET runtime
+    // https://github.com/dotnet/runtime/blob/7db43828cc273aa164f2247744a43f70555f780f/src/libraries/Common/src/System/Text/ValueStringBuilder.cs,
+    // keeping only the members this type actually uses, to avoid the heap
+    // allocation and copying overhead of System.Text.StringBuilder.
+    private ref struct ValueStringBuilder
+    {
+        private char[]? arrayToReturnToPool;
+        private Span<char> chars;
+        private int pos;
+
+        public ValueStringBuilder(int initialCapacity)
+        {
+            this.arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            this.chars = this.arrayToReturnToPool;
+            this.pos = 0;
+        }
+
+        public override string ToString()
+        {
+            var s = this.chars.Slice(0, this.pos).ToString();
+            this.Dispose();
+            return s;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            var currentPos = this.pos;
+            var currentChars = this.chars;
+            if ((uint)currentPos < (uint)currentChars.Length)
+            {
+                currentChars[currentPos] = c;
+                this.pos = currentPos + 1;
+            }
+            else
+            {
+                this.GrowAndAppend(c);
+            }
+        }
+
+#if !NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            this.Append(s.AsSpan());
+        }
+#endif
+
+        public void Append(scoped ReadOnlySpan<char> value)
+        {
+            var currentPos = this.pos;
+            if (currentPos > this.chars.Length - value.Length)
+            {
+                this.Grow(value.Length);
+            }
+
+            value.CopyTo(this.chars.Slice(this.pos));
+            this.pos += value.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            var toReturn = this.arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            this.Grow(1);
+            this.Append(c);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPos)
+        {
+            Debug.Assert(additionalCapacityBeyondPos > 0, "additionalCapacityBeyondPos must be positive.");
+            Debug.Assert(this.pos > this.chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+            const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+            var newCapacity = (int)Math.Max(
+                (uint)(this.pos + additionalCapacityBeyondPos),
+                Math.Min((uint)this.chars.Length * 2, ArrayMaxLength));
+
+            var poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
+
+            this.chars.Slice(0, this.pos).CopyTo(poolArray);
+
+            var toReturn = this.arrayToReturnToPool;
+            this.chars = this.arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Changes

Benefits the AspNet, AspNetCore, Http and Owin instrumentation.

- Avoid allocations if there's nothing to redact.
- Improve performance when redaction required.
- Resolve TODO by using `ValueStringBuilder` to reduce allocations.

## Benchmarks

```text
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8655/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
```

| Method                | Mean      | Error     | StdDev     | Median     | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|---------------------- |----------:|----------:|-----------:|-----------:|------:|--------:|-------:|----------:|------------:|
| Old_NoRedactionNeeded | 90.166 ns | 7.1802 ns | 21.1709 ns | 100.867 ns |  1.07 |    0.39 | 0.0267 |     336 B |        1.00 |
| New_NoRedactionNeeded |  2.034 ns | 0.0855 ns |  0.0839 ns |   2.007 ns |  0.02 |    0.01 |      - |         - |        0.00 |
| Old_WithRedaction     | 79.225 ns | 1.5864 ns |  1.7632 ns |  79.410 ns |  0.94 |    0.26 | 0.0356 |     448 B |        1.33 |
| New_WithRedaction     | 74.156 ns | 1.4069 ns |  1.2472 ns |  73.877 ns |  0.88 |    0.24 | 0.0107 |     136 B |        0.40 |
| Old_EmptyQuery        |  8.980 ns | 0.3799 ns |  1.0960 ns |   8.844 ns |  0.11 |    0.03 | 0.0083 |     104 B |        0.31 |
| New_EmptyQuery        |  1.440 ns | 0.0941 ns |  0.0880 ns |   1.418 ns |  0.02 |    0.00 |      - |         - |        0.00 |

<details>

<summary>Benchmark Code</summary>

```csharp
using BenchmarkDotNet.Attributes;
using OpenTelemetry.Internal;

namespace OpenTelemetry.Instrumentation.Benchmarks;

[MemoryDiagnoser]
public class RedactionHelperBenchmarks
{
    private const string QueryWithoutRedaction = "?justAFlag&anotherFlag&noEqualsSignHere";
    private const string QueryWithRedaction = "?userId=12345&sessionToken=abcdef0123456789&region=us-east-1";
    private const string EmptyQuery = "";

    [Benchmark(Baseline = true)]
    public string? Old_NoRedactionNeeded() => LegacyGetRedactedQueryString(QueryWithoutRedaction);

    [Benchmark]
    public string? New_NoRedactionNeeded() => RedactionHelper.GetRedactedQueryString(QueryWithoutRedaction);

    [Benchmark]
    public string? Old_WithRedaction() => LegacyGetRedactedQueryString(QueryWithRedaction);

    [Benchmark]
    public string? New_WithRedaction() => RedactionHelper.GetRedactedQueryString(QueryWithRedaction);

    [Benchmark]
    public string? Old_EmptyQuery() => LegacyGetRedactedQueryString(EmptyQuery);

    [Benchmark]
    public string? New_EmptyQuery() => RedactionHelper.GetRedactedQueryString(EmptyQuery);

    // Legacy implementation kept only for benchmark comparison (this is the exact
    // pre-fix algorithm, with no fast path for "nothing to redact") — do not use elsewhere.
    private static string? LegacyGetRedactedQueryString(string query)
    {
        var length = query.Length;
        var index = 0;
        System.Text.StringBuilder queryBuilder = new(2 * length);
        while (index < query.Length)
        {
            if (query[index] == '=')
            {
                queryBuilder.Append('=');
                index++;
                queryBuilder.Append("Redacted");
                while (index < length && query[index] != '&')
                {
                    index++;
                }

                if (index < length && query[index] == '&')
                {
                    queryBuilder.Append(query[index]);
                }
            }
            else
            {
                queryBuilder.Append(query[index]);
            }

            index++;
        }

        return queryBuilder.ToString();
    }
}
```

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
