### PR TITLE
[Infra] Avoid multiple Environment.Version calls

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationTracerProviderBuilderExtensions.cs
@@ -130,9 +130,10 @@ public static class AspNetCoreInstrumentationTracerProviderBuilderExtensions
         }
 
         var options = serviceProvider?.GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>().Get(optionsName);
+        var version = Environment.Version;
 
         // SignalR activities first added in .NET 9.0
-        if (Environment.Version.Major >= 9)
+        if (version.Major >= 9)
         {
             if (options is null || options.EnableAspNetCoreSignalRSupport)
             {
@@ -142,7 +143,7 @@ public static class AspNetCoreInstrumentationTracerProviderBuilderExtensions
         }
 
         // Blazor activities first added in .NET 10.0
-        if (Environment.Version.Major >= 10)
+        if (version.Major >= 10)
         {
             if (options is null || options.EnableRazorComponentsSupport)
             {

--- a/src/OpenTelemetry.Resources.ProcessRuntime/ProcessRuntimeDetector.cs
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/ProcessRuntimeDetector.cs
@@ -23,16 +23,17 @@ internal sealed class ProcessRuntimeDetector : IResourceDetector
         string? netRuntimeVersion = null;
         string? netRuntimeName = null;
         var frameworkSet = false;
+        var version = Environment.Version;
 
 #if NETSTANDARD || NETFRAMEWORK
-        if (Environment.Version.Major == 4)
+        if (version.Major == 4)
         {
             var netFrameworkVersion = GetNetFrameworkVersionFromRegistry();
             netRuntimeName = ".NET Framework";
             if (netFrameworkVersion == null)
             {
                 var lastSpace = frameworkDescription.LastIndexOf(' ');
-                netRuntimeVersion = lastSpace > 0 ? frameworkDescription.Substring(lastSpace + 1) : Environment.Version.ToString();
+                netRuntimeVersion = lastSpace > 0 ? frameworkDescription.Substring(lastSpace + 1) : version.ToString();
             }
             else
             {
@@ -45,7 +46,7 @@ internal sealed class ProcessRuntimeDetector : IResourceDetector
 
         if (!frameworkSet)
         {
-            netRuntimeVersion = Environment.Version.ToString();
+            netRuntimeVersion = version.ToString();
             netRuntimeName = ".NET";
         }
 


### PR DESCRIPTION
## Changes

`Environment.Version` allocates a `Version` on each access ([.NET 8](https://github.com/dotnet/runtime/blob/53af66a48215f0b7833dce499343eccae1dc9dff/src/libraries/System.Private.CoreLib/src/System/Environment.cs#L204-L220), [.NET 9+](https://github.com/dotnet/runtime/blob/1baa904ac12c971494469fc724fb3b9f7126716d/src/libraries/System.Private.CoreLib/gen/ProductVersionInfoGenerator.cs#L37-L46)), so cache its value into a local when used more than once in the same member.

The [other usages](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-dotnet-contrib+%22Environment.Version%22+path%3A%2F%5Esrc%5C%2F%2F&type=code) do not seem worth the saving for one-time savings in static constructors,

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
