### PR TITLE
[Infra] Fail if cosign signing fails

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -144,6 +144,10 @@ jobs:
                   Write-Output "Signing $fileFullPath"
 
                   cosign.exe sign-blob --yes --bundle "$fileFullPath.sigstore.json" $fileFullPath
+                  if ($LASTEXITCODE -ne 0) {
+                      Write-Output "::error::cosign failed to sign $fileFullPath (exit code $LASTEXITCODE)."
+                      exit 1
+                  }
               }
           }
 


### PR DESCRIPTION
## Changes

Fix cosign failures being ignored.

Found when [this failed](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/29416773590/job/87367221845#step:10:38) but the job still succeeded.

The error was caught [in a different job](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/29416773590/job/87372834741#step:7:87).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
