### PR TITLE
[AWS] Fix missing cloud.region attribute

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
 
+* The `cloud.region` attribute is now emitted on AWS SDK client spans for all
+  `SemanticConventionVersion` values.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jun-18

--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * The `cloud.region` attribute is now emitted on AWS SDK client spans for all
   `SemanticConventionVersion` values.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4770](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4770))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fix `cloud.region` no longer being emitted by the resource detectors when using
+  the default `SemanticConventionVersion` (`V1_28_0`).
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix `cloud.region` no longer being emitted by the resource detectors when using
   the default `SemanticConventionVersion` (`V1_28_0`).
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4770](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4770))
 
 ## 1.16.0
 

--- a/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.Legacy.cs
@@ -27,6 +27,7 @@ internal partial class AWSSemanticConventions
         public override string AttributeCloudAvailabilityZone => "cloud.availability_zone";
         public override string AttributeCloudPlatform => "cloud.platform";
         public override string AttributeCloudProvider => "cloud.provider";
+        public override string AttributeCloudRegion => "cloud.region";
         public override string AttributeCloudResourceId => "cloud.resource_id";
         public override string CloudPlatformValuesAwsEc2 => "aws_ec2";
         public override string CloudPlatformValuesAwsEcs => "aws_ecs";

--- a/src/Shared/AWS/AWSSemanticConventions.v1.40.0.cs
+++ b/src/Shared/AWS/AWSSemanticConventions.v1.40.0.cs
@@ -18,9 +18,6 @@ internal partial class AWSSemanticConventions
     /// </summary>
     private class AWSSemanticConventions_V1_40_0 : AWSSemanticConventions_V1_29_0
     {
-        // CLOUD Attributes
-        public override string AttributeCloudRegion => "cloud.region";
-
         // AWS Attributes
         public override string AttributeAWSExtendedRequestId => "aws.extended_request_id";
         public override string AttributeAWSSNS => "aws.sns";

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
@@ -15,6 +15,22 @@ public class AWSEC2DetectorTests
         Timeout = TimeSpan.FromSeconds(3),
     };
 
+    public static TheoryData<SemanticConventionVersion> SemanticConventionVersions()
+    {
+        var data = new TheoryData<SemanticConventionVersion>();
+
+#if NET
+        foreach (var version in Enum.GetValues<SemanticConventionVersion>())
+#else
+        foreach (var version in Enum.GetValues(typeof(SemanticConventionVersion)).Cast<SemanticConventionVersion>())
+#endif
+        {
+            data.Add(version);
+        }
+
+        return data;
+    }
+
     public static async Task<bool> IsRunningOnEC2()
     {
         try
@@ -46,12 +62,13 @@ public class AWSEC2DetectorTests
         }
     }
 
-    [Fact]
-    public void TestExtractResourceAttributes()
+    [Theory]
+    [MemberData(nameof(SemanticConventionVersions))]
+    public void TestExtractResourceAttributes(SemanticConventionVersion semanticConventionVersion)
     {
         var awsEC2Detector = new AWSEC2Detector(
             new OpenTelemetry.AWS.AWSSemanticConventions(
-                SemanticConventionVersion.Latest));
+                semanticConventionVersion));
 
         var sampleEC2IdentityDocumentModel = new SampleAWSEC2IdentityDocumentModel();
         var hostName = "Test host name";

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
@@ -20,6 +20,18 @@ public class AWSECSDetectorTests
     private const string AWSECSMetadataURLKey = "ECS_CONTAINER_METADATA_URI";
     private const string AWSECSMetadataURLV4Key = "ECS_CONTAINER_METADATA_URI_V4";
 
+    public static TheoryData<SemanticConventionVersion> SemanticConventionVersions()
+    {
+        var data = new TheoryData<SemanticConventionVersion>();
+
+        foreach (var version in Enum.GetValues<SemanticConventionVersion>())
+        {
+            data.Add(version);
+        }
+
+        return data;
+    }
+
     [Fact]
     public void TestNotOnEcs()
     {
@@ -53,8 +65,9 @@ public class AWSECSDetectorTests
         }
     }
 
-    [Fact]
-    public async Task TestEcsMetadataV4Ec2()
+    [Theory]
+    [MemberData(nameof(SemanticConventionVersions))]
+    public async Task TestEcsMetadataV4Ec2(SemanticConventionVersion semanticConventionVersion)
     {
         var source = new CancellationTokenSource();
         var token = source.Token;
@@ -67,7 +80,7 @@ public class AWSECSDetectorTests
         {
             var ecsResourceDetector = new AWSECSDetector(
                 new OpenTelemetry.AWS.AWSSemanticConventions(
-                    SemanticConventionVersion.Latest));
+                    semanticConventionVersion));
 
             var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
 
@@ -97,8 +110,9 @@ public class AWSECSDetectorTests
         }
     }
 
-    [Fact]
-    public async Task TestEcsMetadataV4Fargate()
+    [Theory]
+    [MemberData(nameof(SemanticConventionVersions))]
+    public async Task TestEcsMetadataV4Fargate(SemanticConventionVersion semanticConventionVersion)
     {
         var source = new CancellationTokenSource();
         var token = source.Token;
@@ -111,7 +125,7 @@ public class AWSECSDetectorTests
         {
             var ecsResourceDetector = new AWSECSDetector(
                 new OpenTelemetry.AWS.AWSSemanticConventions(
-                    SemanticConventionVersion.Latest));
+                    semanticConventionVersion));
 
             var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
 


### PR DESCRIPTION
Fixes #4768

## Changes

Fix `cloud.region` attribute missing from AWS instrumentation and resource detectors when not using the latest version of the Semantic Conventions.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
