### PR TITLE
[Resources] Add schema URL to resources

### DIFF
--- a/opentelemetry-dotnet-contrib.slnx
+++ b/opentelemetry-dotnet-contrib.slnx
@@ -206,6 +206,7 @@
     <File Path="src/Shared/RequestDataHelper.cs" />
     <File Path="src/Shared/ResourceSemanticConventions.cs" />
     <File Path="src/Shared/RpcSemanticConventionHelper.cs" />
+    <File Path="src/Shared/SchemaUrls.cs" />
     <File Path="src/Shared/SemanticConventions.cs" />
     <File Path="src/Shared/ServerCertificateValidationHandler.cs" />
     <File Path="src/Shared/ServerCertificateValidationProvider.cs" />

--- a/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWS/OpenTelemetry.Instrumentation.AWS.csproj
@@ -37,6 +37,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AWS\*.cs" Link="Includes\AWS\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
@@ -7,6 +7,7 @@ using OpenTelemetry.AWS;
 using OpenTelemetry.Instrumentation.AWSLambda.Implementation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda;
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Assemblies are now digitally signed using cosign.
   ([#4637](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4637))
 
+* Add schema URL to resource detector.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0
 
 Released 2026-Jun-18

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
@@ -32,6 +32,9 @@ internal sealed class AWSLambdaResourceDetector : IResourceDetector
                 .AddAttributeFaasMaxMemory(AWSLambdaUtils.GetFunctionMemorySize())
                 .Build();
 
-        return new Resource(resourceAttributes);
+        var version = this.semanticConventionBuilder.Version;
+        var schemaUrl = Internal.SchemaUrls.Get(version);
+
+        return new Resource(resourceAttributes, schemaUrl);
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaResourceDetector.cs
@@ -6,14 +6,9 @@ using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Implementation;
 
-internal sealed class AWSLambdaResourceDetector : IResourceDetector
+internal sealed class AWSLambdaResourceDetector(AWSSemanticConventions semanticConventionBuilder) : IResourceDetector
 {
-    private readonly AWSSemanticConventions semanticConventionBuilder;
-
-    public AWSLambdaResourceDetector(AWSSemanticConventions semanticConventionBuilder)
-    {
-        this.semanticConventionBuilder = semanticConventionBuilder;
-    }
+    private readonly AWSSemanticConventions semanticConventionBuilder = semanticConventionBuilder;
 
     /// <summary>
     /// Detect the resource attributes for AWS Lambda.

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -37,6 +37,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AWS\*.cs" Link="Includes\AWS\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
@@ -31,6 +31,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SpanHelper.cs" Link="Includes\SpanHelper.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -31,6 +31,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SpanHelper.cs" Link="Includes\SpanHelper.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Cassandra/OpenTelemetry.Instrumentation.Cassandra.csproj
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/OpenTelemetry.Instrumentation.Cassandra.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.Metrics;
 using System.Globalization;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.ConfluentKafka;
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetry.Instrumentation.ConfluentKafka.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.EntityFrameworkCore.Implementation;
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/OpenTelemetry.Instrumentation.EntityFrameworkCore.csproj
@@ -35,6 +35,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlConnectionDetails.cs" Link="Includes\SqlConnectionDetails.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlParameterProcessor.cs" Link="Includes\SqlParameterProcessor.cs" />

--- a/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/OpenTelemetry.Instrumentation.EventCounters.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\GrpcStatusCanonicalCode.cs" Link="Includes\GrpcStatusCanonicalCode.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation;
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
@@ -33,6 +33,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/OpenTelemetry.Instrumentation.Hangfire.csproj
@@ -32,6 +32,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.Http.Implementation;
 

--- a/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
+++ b/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
@@ -31,6 +31,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SpanHelper.cs" Link="Includes\SpanHelper.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoActivitySource.cs
+++ b/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoActivitySource.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Kusto.Implementation;
 
@@ -11,5 +10,5 @@ namespace OpenTelemetry.Instrumentation.Kusto.Implementation;
 /// </summary>
 internal static class KustoActivitySource
 {
-    public static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create(typeof(KustoActivitySource), KustoSemanticConventions.SemanticConventionsVersion);
+    public static readonly ActivitySource ActivitySource = Trace.ActivitySourceFactory.Create(typeof(KustoActivitySource), KustoSemanticConventions.SemanticConventionsVersion);
 }

--- a/src/OpenTelemetry.Instrumentation.Kusto/OpenTelemetry.Instrumentation.Kusto.csproj
+++ b/src/OpenTelemetry.Instrumentation.Kusto/OpenTelemetry.Instrumentation.Kusto.csproj
@@ -41,6 +41,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
+++ b/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs"/>
     <Compile Include="$(RepoRoot)\src\Shared\SpanHelper.cs" Link="Includes\SpanHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />

--- a/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
+++ b/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
@@ -26,6 +26,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.Quartz/Implementation/QuartzDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Quartz/Implementation/QuartzDiagnosticListener.cs
@@ -3,13 +3,12 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Quartz.Implementation;
 
 internal sealed class QuartzDiagnosticListener : ListenerHandler
 {
-    internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create<QuartzDiagnosticListener>(null);  // These traces are not in the Semantic Conventions
+    internal static readonly ActivitySource ActivitySource = Trace.ActivitySourceFactory.Create<QuartzDiagnosticListener>(null);  // These traces are not in the Semantic Conventions
     internal readonly PropertyFetcher<object> JobDetailsPropertyFetcher = new("JobDetail");
 
     private readonly QuartzInstrumentationOptions options;

--- a/src/OpenTelemetry.Instrumentation.Quartz/OpenTelemetry.Instrumentation.Quartz.csproj
+++ b/src/OpenTelemetry.Instrumentation.Quartz/OpenTelemetry.Instrumentation.Quartz.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.Remoting/OpenTelemetry.Instrumentation.Remoting.csproj
+++ b/src/OpenTelemetry.Instrumentation.Remoting/OpenTelemetry.Instrumentation.Remoting.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
+++ b/src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Trace;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -33,6 +33,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlConnectionDetails.cs" Link="Includes\SqlConnectionDetails.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlParameterProcessor.cs" Link="Includes\SqlParameterProcessor.cs" />

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
 
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -8,6 +8,7 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
 using StackExchange.Redis.Profiling;
+using ActivitySourceFactory = OpenTelemetry.Trace.ActivitySourceFactory;
 
 namespace OpenTelemetry.Instrumentation.StackExchangeRedis;
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
+++ b/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
@@ -41,6 +41,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RpcSemanticConventionHelper.cs" Link="Includes\RpcSemanticConventionHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
@@ -42,7 +42,9 @@ internal sealed class AWSEBSDetector : IResourceDetector
 
             var metadata = GetEBSMetadata(filePath);
 
-            return new Resource(this.ExtractResourceAttributes(metadata));
+            return new Resource(
+                this.ExtractResourceAttributes(metadata),
+                Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
@@ -44,7 +44,7 @@ internal sealed class AWSEBSDetector : IResourceDetector
 
             return new Resource(
                 this.ExtractResourceAttributes(metadata),
-                Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
+                Internal.SchemaUrls.Get(this.semanticConventionBuilder.Version));
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEBSDetector.cs
@@ -34,18 +34,10 @@ internal sealed class AWSEBSDetector : IResourceDetector
     {
         try
         {
-            string? filePath;
 #if NET
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                filePath = AWSEBSMetadataWindowsFilePath;
-            }
-            else
-            {
-                filePath = AWSEBSMetadataLinuxFilePath;
-            }
+            var filePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? AWSEBSMetadataWindowsFilePath : AWSEBSMetadataLinuxFilePath;
 #else
-            filePath = AWSEBSMetadataWindowsFilePath;
+            var filePath = AWSEBSMetadataWindowsFilePath;
 #endif
 
             var metadata = GetEBSMetadata(filePath);
@@ -60,14 +52,12 @@ internal sealed class AWSEBSDetector : IResourceDetector
         return Resource.Empty;
     }
 
-    internal static AWSEBSMetadataModel? GetEBSMetadata(string filePath)
-    {
+    internal static AWSEBSMetadataModel? GetEBSMetadata(string filePath) =>
 #if NETFRAMEWORK
-        return ResourceDetectorUtils.DeserializeFromFile<AWSEBSMetadataModel>(filePath);
+        ResourceDetectorUtils.DeserializeFromFile<AWSEBSMetadataModel>(filePath);
 #else
-        return ResourceDetectorUtils.DeserializeFromFile(filePath, SourceGenerationContext.Default.AWSEBSMetadataModel);
+        ResourceDetectorUtils.DeserializeFromFile(filePath, SourceGenerationContext.Default.AWSEBSMetadataModel);
 #endif
-    }
 
     internal List<KeyValuePair<string, object>> ExtractResourceAttributes(AWSEBSMetadataModel? metadata)
     {

--- a/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
@@ -35,8 +35,9 @@ internal sealed class AWSEC2Detector : IResourceDetector
     {
         try
         {
-            // Prevents EC2 related http call from being instrumented.
+            // Prevents EC2 related HTTP calls from being instrumented.
             using var scope = SuppressInstrumentationScope.Begin();
+
             var token = GetAWSEC2Token();
             var identity = GetAWSEC2Identity(token);
             var hostName = GetAWSEC2HostName(token);

--- a/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
@@ -44,7 +44,7 @@ internal sealed class AWSEC2Detector : IResourceDetector
 
             return new Resource(
                 this.ExtractResourceAttributes(identity, hostName),
-                Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
+                Internal.SchemaUrls.Get(this.semanticConventionBuilder.Version));
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEC2Detector.cs
@@ -41,7 +41,9 @@ internal sealed class AWSEC2Detector : IResourceDetector
             var identity = GetAWSEC2Identity(token);
             var hostName = GetAWSEC2HostName(token);
 
-            return new Resource(this.ExtractResourceAttributes(identity, hostName));
+            return new Resource(
+                this.ExtractResourceAttributes(identity, hostName),
+                Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
@@ -62,7 +62,9 @@ internal sealed partial class AWSECSDetector : IResourceDetector
             AWSResourcesEventSource.Log.ResourceAttributesExtractException(nameof(AWSECSDetector), ex);
         }
 
-        return new Resource(resourceAttributes.Build());
+        return new Resource(
+            resourceAttributes.Build(),
+            Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
     }
 
     internal static string? GetECSContainerId(string path)

--- a/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSECSDetector.cs
@@ -64,7 +64,7 @@ internal sealed partial class AWSECSDetector : IResourceDetector
 
         return new Resource(
             resourceAttributes.Build(),
-            Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
+            Internal.SchemaUrls.Get(this.semanticConventionBuilder.Version));
     }
 
     internal static string? GetECSContainerId(string path)

--- a/src/OpenTelemetry.Resources.AWS/AWSEKSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEKSDetector.cs
@@ -41,7 +41,7 @@ internal sealed class AWSEKSDetector : IResourceDetector
                 this.ExtractResourceAttributes(
                     GetEKSClusterName(credentials, httpClientHandler),
                     GetEKSContainerId(AWSEKSMetadataFilePath)),
-                Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
+                Internal.SchemaUrls.Get(this.semanticConventionBuilder.Version));
     }
 
     internal static string? GetEKSCredentials(string path)

--- a/src/OpenTelemetry.Resources.AWS/AWSEKSDetector.cs
+++ b/src/OpenTelemetry.Resources.AWS/AWSEKSDetector.cs
@@ -37,9 +37,11 @@ internal sealed class AWSEKSDetector : IResourceDetector
 
         return credentials == null || !IsEKSProcess(credentials, httpClientHandler)
             ? Resource.Empty
-            : new Resource(this.ExtractResourceAttributes(
-                GetEKSClusterName(credentials, httpClientHandler),
-                GetEKSContainerId(AWSEKSMetadataFilePath)));
+            : new Resource(
+                this.ExtractResourceAttributes(
+                    GetEKSClusterName(credentials, httpClientHandler),
+                    GetEKSContainerId(AWSEKSMetadataFilePath)),
+                Internal.SchemaUrls.Get(ResourceDetectorUtils.SemanticConventionsVersion));
     }
 
     internal static string? GetEKSCredentials(string path)

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detectors.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.AWS/OpenTelemetry.Resources.AWS.csproj
+++ b/src/OpenTelemetry.Resources.AWS/OpenTelemetry.Resources.AWS.csproj
@@ -34,6 +34,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpClientHelpers.cs" Link="Includes\HttpClientHelpers.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\IServerCertificateValidationEventSource.cs" Link="Includes\IServerCertificateValidationEventSource.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ServerCertificateValidationHandler.cs" Link="Includes\ServerCertificateValidationHandler.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ServerCertificateValidationProvider.cs" Link="Includes\ServerCertificateValidationProvider.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Resources.AWS/ResourceDetectorUtils.cs
+++ b/src/OpenTelemetry.Resources.AWS/ResourceDetectorUtils.cs
@@ -17,6 +17,8 @@ namespace OpenTelemetry.Resources.AWS;
 /// </summary>
 internal static class ResourceDetectorUtils
 {
+    internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
 #if NETFRAMEWORK
     private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
 #endif

--- a/src/OpenTelemetry.Resources.AWS/ResourceDetectorUtils.cs
+++ b/src/OpenTelemetry.Resources.AWS/ResourceDetectorUtils.cs
@@ -17,8 +17,6 @@ namespace OpenTelemetry.Resources.AWS;
 /// </summary>
 internal static class ResourceDetectorUtils
 {
-    internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
-
 #if NETFRAMEWORK
     private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
 #endif

--- a/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
@@ -56,7 +56,9 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
             return Resource.Empty;
         }
 
-        return new Resource(attributeList);
+        return new Resource(
+            attributeList,
+            Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
     }
 
     private static string? GetAzureResourceURI(string websiteSiteName)

--- a/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
@@ -55,9 +55,9 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
                     Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // TODO: log exception.
+            AzureResourcesEventSource.Log.FailedToDetectAppServiceResources(ex);
         }
 
         return Resource.Empty;

--- a/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
@@ -12,11 +12,11 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
 {
     internal static readonly IReadOnlyDictionary<string, string> AppServiceResourceAttributes = new Dictionary<string, string>
     {
-        { ResourceSemanticConventions.AttributeCloudRegion, ResourceAttributeConstants.AppServiceRegionNameEnvVar },
-        { ResourceSemanticConventions.AttributeDeploymentEnvironmentName, ResourceAttributeConstants.AppServiceSlotNameEnvVar },
-        { ResourceSemanticConventions.AttributeHostId, ResourceAttributeConstants.AppServiceHostNameEnvVar },
-        { ResourceSemanticConventions.AttributeServiceInstance, ResourceAttributeConstants.AppServiceInstanceIdEnvVar },
-        { ResourceAttributeConstants.AzureAppServiceStamp, ResourceAttributeConstants.AppServiceStampNameEnvVar },
+        [ResourceSemanticConventions.AttributeCloudRegion] = ResourceAttributeConstants.AppServiceRegionNameEnvVar,
+        [ResourceSemanticConventions.AttributeDeploymentEnvironmentName] = ResourceAttributeConstants.AppServiceSlotNameEnvVar,
+        [ResourceSemanticConventions.AttributeHostId] = ResourceAttributeConstants.AppServiceHostNameEnvVar,
+        [ResourceSemanticConventions.AttributeServiceInstance] = ResourceAttributeConstants.AppServiceInstanceIdEnvVar,
+        [ResourceAttributeConstants.AzureAppServiceStamp] = ResourceAttributeConstants.AppServiceStampNameEnvVar,
     };
 
     /// <inheritdoc/>
@@ -67,11 +67,11 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
         var websiteOwnerName = Environment.GetEnvironmentVariable(ResourceAttributeConstants.AppServiceOwnerNameEnvVar) ?? string.Empty;
 
 #if NET
-        var idx = websiteOwnerName.IndexOf('+', StringComparison.Ordinal);
+        var index = websiteOwnerName.IndexOf('+', StringComparison.Ordinal);
 #else
-        var idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
+        var index = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
 #endif
-        var subscriptionId = idx > 0 ? websiteOwnerName.Substring(0, idx) : websiteOwnerName;
+        var subscriptionId = index > 0 ? websiteOwnerName.Substring(0, index) : websiteOwnerName;
 
         return string.IsNullOrEmpty(websiteResourceGroup) || string.IsNullOrEmpty(subscriptionId)
             ? null

--- a/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
@@ -22,22 +22,23 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
     /// <inheritdoc/>
     public Resource Detect()
     {
-        List<KeyValuePair<string, object>> attributeList = [];
-
         try
         {
             var websiteSiteName = Environment.GetEnvironmentVariable(ResourceAttributeConstants.AppServiceSiteNameEnvVar);
 
             if (websiteSiteName != null)
             {
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, websiteSiteName));
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeCloudProvider, ResourceAttributeConstants.AzureCloudProviderValue));
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeCloudPlatform, ResourceAttributeConstants.AzureAppServicePlatformValue));
+                var attributeList = new List<KeyValuePair<string, object>>
+                {
+                    new(ResourceSemanticConventions.AttributeServiceName, websiteSiteName),
+                    new(ResourceSemanticConventions.AttributeCloudProvider, ResourceAttributeConstants.AzureCloudProviderValue),
+                    new(ResourceSemanticConventions.AttributeCloudPlatform, ResourceAttributeConstants.AzureAppServicePlatformValue),
+                };
 
                 var azureResourceUri = GetAzureResourceURI(websiteSiteName);
                 if (azureResourceUri != null)
                 {
-                    attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeCloudResourceId, azureResourceUri));
+                    attributeList.Add(new(ResourceSemanticConventions.AttributeCloudResourceId, azureResourceUri));
                 }
 
                 foreach (var kvp in AppServiceResourceAttributes)
@@ -45,20 +46,21 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
                     var attributeValue = Environment.GetEnvironmentVariable(kvp.Value);
                     if (attributeValue != null)
                     {
-                        attributeList.Add(new KeyValuePair<string, object>(kvp.Key, attributeValue));
+                        attributeList.Add(new(kvp.Key, attributeValue));
                     }
                 }
+
+                return new Resource(
+                    attributeList,
+                    Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
             }
         }
         catch
         {
             // TODO: log exception.
-            return Resource.Empty;
         }
 
-        return new Resource(
-            attributeList,
-            Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
+        return Resource.Empty;
     }
 
     private static string? GetAzureResourceURI(string websiteSiteName)

--- a/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
@@ -25,34 +25,33 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
     /// <inheritdoc/>
     public Resource Detect()
     {
-        List<KeyValuePair<string, object>> attributeList = [];
         try
         {
             var containerAppName = Environment.GetEnvironmentVariable(ResourceAttributeConstants.AzureContainerAppsNameEnvVar);
             var containerAppJobName = Environment.GetEnvironmentVariable(ResourceAttributeConstants.AzureContainerAppJobNameEnvVar);
 
+            var attributeList = new List<KeyValuePair<string, object>>();
+
             if (containerAppName != null)
             {
                 AddBaseAttributes(attributeList, containerAppName);
-
                 AddResourceAttributes(attributeList, AzureContainerAppResourceAttributes);
             }
             else if (containerAppJobName != null)
             {
                 AddBaseAttributes(attributeList, containerAppJobName);
-
                 AddResourceAttributes(attributeList, AzureContainerAppJobResourceAttributes);
             }
+
+            return new Resource(
+                attributeList,
+                Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
         }
         catch
         {
             // TODO: log exception.
             return Resource.Empty;
         }
-
-        return new Resource(
-            attributeList,
-            Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
     }
 
     private static void AddResourceAttributes(List<KeyValuePair<string, object>> attributeList, IReadOnlyDictionary<string, string> resourceAttributes)
@@ -62,15 +61,15 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
             var attributeValue = Environment.GetEnvironmentVariable(kvp.Value);
             if (attributeValue != null)
             {
-                attributeList.Add(new KeyValuePair<string, object>(kvp.Key, attributeValue));
+                attributeList.Add(new(kvp.Key, attributeValue));
             }
         }
     }
 
     private static void AddBaseAttributes(List<KeyValuePair<string, object>> attributeList, string serviceName)
     {
-        attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, serviceName));
-        attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeCloudProvider, ResourceAttributeConstants.AzureCloudProviderValue));
-        attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeCloudPlatform, ResourceAttributeConstants.AzureContainerAppsPlatformValue));
+        attributeList.Add(new(ResourceSemanticConventions.AttributeServiceName, serviceName));
+        attributeList.Add(new(ResourceSemanticConventions.AttributeCloudProvider, ResourceAttributeConstants.AzureCloudProviderValue));
+        attributeList.Add(new(ResourceSemanticConventions.AttributeCloudPlatform, ResourceAttributeConstants.AzureContainerAppsPlatformValue));
     }
 }

--- a/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
@@ -50,7 +50,9 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
             return Resource.Empty;
         }
 
-        return new Resource(attributeList);
+        return new Resource(
+            attributeList,
+            Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
     }
 
     private static void AddResourceAttributes(List<KeyValuePair<string, object>> attributeList, IReadOnlyDictionary<string, string> resourceAttributes)

--- a/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
@@ -47,9 +47,9 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
                 attributeList,
                 Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
         }
-        catch
+        catch (Exception ex)
         {
-            // TODO: log exception.
+            AzureResourcesEventSource.Log.FailedToDetectAzureContainerAppResources(ex);
             return Resource.Empty;
         }
     }

--- a/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
@@ -12,14 +12,14 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
 {
     internal static readonly IReadOnlyDictionary<string, string> AzureContainerAppResourceAttributes = new Dictionary<string, string>
     {
-        { ResourceSemanticConventions.AttributeServiceInstance, ResourceAttributeConstants.AzureContainerAppsReplicaNameEnvVar },
-        { ResourceSemanticConventions.AttributeServiceVersion, ResourceAttributeConstants.AzureContainerAppsRevisionEnvVar },
+        [ResourceSemanticConventions.AttributeServiceInstance] = ResourceAttributeConstants.AzureContainerAppsReplicaNameEnvVar,
+        [ResourceSemanticConventions.AttributeServiceVersion] = ResourceAttributeConstants.AzureContainerAppsRevisionEnvVar,
     };
 
     internal static readonly IReadOnlyDictionary<string, string> AzureContainerAppJobResourceAttributes = new Dictionary<string, string>
     {
-        { ResourceSemanticConventions.AttributeServiceInstance, ResourceAttributeConstants.AzureContainerAppsReplicaNameEnvVar },
-        { ResourceSemanticConventions.AttributeServiceVersion, ResourceAttributeConstants.AzureContainerAppJobExecutionNameEnvVar },
+        [ResourceSemanticConventions.AttributeServiceInstance] = ResourceAttributeConstants.AzureContainerAppsReplicaNameEnvVar,
+        [ResourceSemanticConventions.AttributeServiceVersion] = ResourceAttributeConstants.AzureContainerAppJobExecutionNameEnvVar,
     };
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
@@ -43,9 +43,11 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
                 AddResourceAttributes(attributeList, AzureContainerAppJobResourceAttributes);
             }
 
-            return new Resource(
-                attributeList,
-                Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
+            return attributeList.Count == 0
+                ? Resource.Empty
+                : new Resource(
+                    attributeList,
+                    Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Resources.Azure/AzureResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureResourceBuilderExtensions.cs
@@ -11,6 +11,8 @@ namespace OpenTelemetry.Resources;
 /// </summary>
 public static class AzureResourceBuilderExtensions
 {
+    internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
     /// <summary>
     /// Enables Azure App Service resource detector.
     /// </summary>

--- a/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Tracing;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Resources.Azure;
+
+[EventSource(Name = "OpenTelemetry-Resources-Azure")]
+internal sealed class AzureResourcesEventSource : EventSource
+{
+    public static AzureResourcesEventSource Log = new();
+
+    private const int EventIdFailedToDetectAppServiceResources = 1;
+    private const int EventIdFailedToDetectAzureContainerAppResources = 2;
+    private const int EventIdFailedToDetectAzureVMResources = 3;
+
+    [NonEvent]
+    public void FailedToDetectAppServiceResources(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.FailedToDetectAppServiceResources(ex.ToInvariantString());
+        }
+    }
+
+    [NonEvent]
+    public void FailedToDetectAzureContainerAppResources(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.FailedToDetectAzureContainerAppResources(ex.ToInvariantString());
+        }
+    }
+
+    [NonEvent]
+    public void FailedToDetectAzureVMResources(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.FailedToDetectAzureVMResources(ex.ToInvariantString());
+        }
+    }
+
+    [Event(EventIdFailedToDetectAppServiceResources, Message = "Failed to detect Azure App Service resources. Exception: {0}", Level = EventLevel.Warning)]
+    public void FailedToDetectAppServiceResources(string exception)
+        => this.WriteEvent(EventIdFailedToDetectAppServiceResources, exception);
+
+    [Event(EventIdFailedToDetectAzureContainerAppResources, Message = "Failed to detect Azure Container App resources. Exception: {0}", Level = EventLevel.Warning)]
+    public void FailedToDetectAzureContainerAppResources(string exception)
+        => this.WriteEvent(EventIdFailedToDetectAzureContainerAppResources, exception);
+
+    [Event(EventIdFailedToDetectAzureVMResources, Message = "Failed to detect Azure VM resources. Exception: {0}", Level = EventLevel.Warning)]
+    public void FailedToDetectAzureVMResources(string exception)
+        => this.WriteEvent(EventIdFailedToDetectAzureVMResources, exception);
+}

--- a/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
@@ -57,9 +57,9 @@ internal sealed class AzureVMResourceDetector : IResourceDetector
                 attributeList,
                 Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
         }
-        catch
+        catch (Exception ex)
         {
-            // TODO: log exception.
+            AzureResourcesEventSource.Log.FailedToDetectAzureVMResources(ex);
             vmResource = Resource.Empty;
         }
 

--- a/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
@@ -53,6 +53,12 @@ internal sealed class AzureVMResourceDetector : IResourceDetector
                 attributeList.Add(new(field, vmMetaDataResponse.GetValueForField(field)));
             }
 
+            if (attributeList.Count == 0)
+            {
+                vmResource = Resource.Empty;
+                return vmResource;
+            }
+
             vmResource = new Resource(
                 attributeList,
                 Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
@@ -65,4 +71,6 @@ internal sealed class AzureVMResourceDetector : IResourceDetector
 
         return vmResource;
     }
+
+    internal static void ClearCachedResource() => vmResource = null;
 }

--- a/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
@@ -37,21 +37,20 @@ internal sealed class AzureVMResourceDetector : IResourceDetector
                 return vmResource;
             }
 
-            // Prevents the http operations from being instrumented.
+            // Prevents the HTTP operations from being instrumented.
             using var scope = SuppressInstrumentationScope.Begin();
 
             var vmMetaDataResponse = AzureVmMetaDataRequestor.GetAzureVmMetaDataResponse();
             if (vmMetaDataResponse == null)
             {
                 vmResource = Resource.Empty;
-
                 return vmResource;
             }
 
             var attributeList = new List<KeyValuePair<string, object>>(ExpectedAzureAmsFields.Count);
             foreach (var field in ExpectedAzureAmsFields)
             {
-                attributeList.Add(new KeyValuePair<string, object>(field, vmMetaDataResponse.GetValueForField(field)));
+                attributeList.Add(new(field, vmMetaDataResponse.GetValueForField(field)));
             }
 
             vmResource = new Resource(

--- a/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
@@ -54,7 +54,9 @@ internal sealed class AzureVMResourceDetector : IResourceDetector
                 attributeList.Add(new KeyValuePair<string, object>(field, vmMetaDataResponse.GetValueForField(field)));
             }
 
-            vmResource = new Resource(attributeList);
+            vmResource = new Resource(
+                attributeList,
+                Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
         }
         catch
         {

--- a/src/OpenTelemetry.Resources.Azure/AzureVmMetadataResponse.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureVmMetadataResponse.cs
@@ -60,7 +60,10 @@ internal sealed class AzureVmMetadataResponse
                 amsValue = this.VmSize;
                 break;
             case ResourceSemanticConventions.AttributeOsType:
-                amsValue = this.OsType;
+#pragma warning disable CA1308 // Normalize strings to uppercase
+                // The os.type value must be lowercase per the semantic conventions.
+                amsValue = this.OsType?.ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
                 break;
             case ResourceSemanticConventions.AttributeOsVersion:
                 amsValue = this.Version;

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Fix `os.type` not being normalized to lowercase for Azure VMs.
   ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
 
+* Add event source to log exceptions during resource detection.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detectors.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add schema URL to resource detectors.
   ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
 
+* Fix `os.type` not being normalized to lowercase for Azure VMs.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.Azure/OpenTelemetry.Resources.Azure.csproj
+++ b/src/OpenTelemetry.Resources.Azure/OpenTelemetry.Resources.Azure.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpClientHelpers.cs" Link="Includes\HttpClientHelpers.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs"/>

--- a/src/OpenTelemetry.Resources.Azure/OpenTelemetry.Resources.Azure.csproj
+++ b/src/OpenTelemetry.Resources.Azure/OpenTelemetry.Resources.Azure.csproj
@@ -29,6 +29,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpClientHelpers.cs" Link="Includes\HttpClientHelpers.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs"/>
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detector.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
+++ b/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
@@ -15,6 +15,8 @@ internal sealed partial class ContainerDetector : IResourceDetector
     private const string FilepathV2 = "/proc/self/mountinfo";
     private const string Hostname = "hostname";
 
+    private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
     /// <summary>
     /// CGroup Parse Versions.
     /// </summary>
@@ -56,9 +58,9 @@ internal sealed partial class ContainerDetector : IResourceDetector
     {
         var containerId = this.ExtractContainerId(path, cgroupVersion);
 
-#pragma warning disable IDE0370 // Suppression is unnecessary
-        return string.IsNullOrEmpty(containerId) ? Resource.Empty : new Resource([new(ContainerSemanticConventions.AttributeContainerId, containerId!)]);
-#pragma warning restore IDE0370 // Suppression is unnecessary
+        return containerId is { Length: > 0 } ?
+            new Resource([new(ContainerSemanticConventions.AttributeContainerId, containerId)], Internal.SchemaUrls.Get(SemanticConventionsVersion)) :
+            Resource.Empty;
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Resources.Container/OpenTelemetry.Resources.Container.csproj
+++ b/src/OpenTelemetry.Resources.Container/OpenTelemetry.Resources.Container.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detector.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.0.0-alpha.2
 
 Released 2026-Jul-09

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add schema URL to resource detector.
   ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
 
+* Fix `cloud.zone` being emitted instead of `cloud.availability_zone`.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.0.0-alpha.2
 
 Released 2026-Jul-09

--- a/src/OpenTelemetry.Resources.Gcp/GcpResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Gcp/GcpResourceDetector.cs
@@ -11,6 +11,8 @@ namespace OpenTelemetry.Resources.Gcp;
 /// </summary>
 internal sealed class GcpResourceDetector : IResourceDetector
 {
+    private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
     /// <inheritdoc/>
     public Resource Detect()
     {
@@ -31,7 +33,7 @@ internal sealed class GcpResourceDetector : IResourceDetector
             _ => ExtractGceResourceAttributes(platform),
         };
 
-        return new Resource(attributeList);
+        return new Resource(attributeList, Internal.SchemaUrls.Get(SemanticConventionsVersion));
     }
 
     internal static List<KeyValuePair<string, object>> ExtractGkeResourceAttributes(Platform platform)

--- a/src/OpenTelemetry.Resources.Gcp/GcpResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Gcp/GcpResourceDetector.cs
@@ -43,7 +43,7 @@ internal sealed class GcpResourceDetector : IResourceDetector
             new(ResourceSemanticConventions.AttributeCloudProvider, ResourceAttributeConstants.GcpCloudProviderValue),
             new(ResourceSemanticConventions.AttributeCloudAccount, platform.ProjectId),
             new(ResourceSemanticConventions.AttributeCloudPlatform, ResourceAttributeConstants.GcpGkePlatformValue),
-            new(ResourceSemanticConventions.AttributeCloudZone, platform.GkeDetails.Zone),
+            new(ResourceSemanticConventions.AttributeCloudAvailabilityZone, platform.GkeDetails.Zone),
             new(ResourceSemanticConventions.AttributeHostId, platform.GkeDetails.InstanceId),
             new(ResourceSemanticConventions.AttributeK8sCluster, platform.GkeDetails.ClusterName),
             new(ResourceSemanticConventions.AttributeK8sNamespace, platform.GkeDetails.NamespaceId),

--- a/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
+++ b/src/OpenTelemetry.Resources.Gcp/OpenTelemetry.Resources.Gcp.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detector.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-beta.2
 
 Released 2026-Jul-15

--- a/src/OpenTelemetry.Resources.Host/HostDetector.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetector.cs
@@ -19,6 +19,11 @@ internal sealed class HostDetector : IResourceDetector
 #if !NETFRAMEWORK
     private const string ETCMACHINEID = "/etc/machine-id";
     private const string ETCVARDBUSMACHINEID = "/var/lib/dbus/machine-id";
+#endif
+
+    private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
+#if !NETFRAMEWORK
     private readonly Func<OSPlatform, bool> isOsPlatform;
     private readonly Func<IEnumerable<string>> getFilePaths;
     private readonly Func<string?> getMacOsMachineId;
@@ -131,7 +136,7 @@ internal sealed class HostDetector : IResourceDetector
 #error Architecture is available in .NET Framework 4.7.1+, enable it when we move to that as minimum supported version
 #endif
 
-            return new Resource(attributes);
+            return new Resource(attributes, SchemaUrls.Get(SemanticConventionsVersion));
         }
         catch (InvalidOperationException ex)
         {

--- a/src/OpenTelemetry.Resources.Host/OpenTelemetry.Resources.Host.csproj
+++ b/src/OpenTelemetry.Resources.Host/OpenTelemetry.Resources.Host.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.OperatingSystem/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detector.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.OperatingSystem/OpenTelemetry.Resources.OperatingSystem.csproj
+++ b/src/OpenTelemetry.Resources.OperatingSystem/OpenTelemetry.Resources.OperatingSystem.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Resources.OperatingSystem/OperatingSystemDetector.cs
+++ b/src/OpenTelemetry.Resources.OperatingSystem/OperatingSystemDetector.cs
@@ -32,6 +32,8 @@ internal sealed class OperatingSystemDetector : IResourceDetector
     ];
 #endif
 
+    private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
     private readonly string? osType;
     private readonly string? registryKey;
 #if NET
@@ -111,7 +113,7 @@ internal sealed class OperatingSystemDetector : IResourceDetector
                 break;
         }
 
-        return new Resource(attributes);
+        return new Resource(attributes, Internal.SchemaUrls.Get(SemanticConventionsVersion));
     }
 
     private static void AddAttributeIfNotNullOrEmpty(List<KeyValuePair<string, object>> attributes, string key, object? value)

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add schema URL to resource detector.
   ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
 
+* Fix `process.creation.time` not being emitted as UTC.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-rc.1
 
 Released 2026-Jul-09

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detector.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-rc.1
 
 Released 2026-Jul-09

--- a/src/OpenTelemetry.Resources.Process/OpenTelemetry.Resources.Process.csproj
+++ b/src/OpenTelemetry.Resources.Process/OpenTelemetry.Resources.Process.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Resources.Process/ProcessDetector.cs
+++ b/src/OpenTelemetry.Resources.Process/ProcessDetector.cs
@@ -31,7 +31,8 @@ internal sealed class ProcessDetector : IResourceDetector
 
         if (creationTime is { } startTime)
         {
-            attributes.Add(new(ProcessSemanticConventions.AttributeProcessCreationTime, startTime.ToString("O", CultureInfo.InvariantCulture)));
+            // The semantic conventions require an ISO 8601 timestamp; normalize to UTC so the value is unambiguous.
+            attributes.Add(new(ProcessSemanticConventions.AttributeProcessCreationTime, startTime.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture)));
         }
 
         return new Resource(attributes, Internal.SchemaUrls.Get(SemanticConventionsVersion));

--- a/src/OpenTelemetry.Resources.Process/ProcessDetector.cs
+++ b/src/OpenTelemetry.Resources.Process/ProcessDetector.cs
@@ -11,6 +11,8 @@ namespace OpenTelemetry.Resources.Process;
 /// </summary>
 internal sealed class ProcessDetector : IResourceDetector
 {
+    private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
     /// <summary>
     ///     Detects the resource attributes for process.
     /// </summary>
@@ -32,7 +34,7 @@ internal sealed class ProcessDetector : IResourceDetector
             attributes.Add(new(ProcessSemanticConventions.AttributeProcessCreationTime, startTime.ToString("O", CultureInfo.InvariantCulture)));
         }
 
-        return new Resource(attributes);
+        return new Resource(attributes, Internal.SchemaUrls.Get(SemanticConventionsVersion));
 
         static void GetProcessAttributes(
             out int processId,

--- a/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Updated OpenTelemetry core component version(s) to `1.17.0`.
   ([#4773](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4773))
 
+* Add schema URL to resource detector.
+  ([#4775](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4775))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jul-10

--- a/src/OpenTelemetry.Resources.ProcessRuntime/OpenTelemetry.Resources.ProcessRuntime.csproj
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/OpenTelemetry.Resources.ProcessRuntime.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Resources.ProcessRuntime/ProcessRuntimeDetector.cs
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/ProcessRuntimeDetector.cs
@@ -78,28 +78,25 @@ internal sealed class ProcessRuntimeDetector : IResourceDetector
     }
 
     // Checking the version using >= enables forward compatibility.
-    private static string? CheckFor45PlusVersion(int releaseKey)
+    private static string? CheckFor45PlusVersion(int releaseKey) => releaseKey switch
     {
-        return releaseKey switch
-        {
-            >= 533320 => "4.8.1",
-            >= 528040 => "4.8",
-            >= 461808 => "4.7.2",
-            >= 461308 => "4.7.1",
-            >= 460798 => "4.7",
-            >= 394802 => "4.6.2",
+        >= 533320 => "4.8.1",
+        >= 528040 => "4.8",
+        >= 461808 => "4.7.2",
+        >= 461308 => "4.7.1",
+        >= 460798 => "4.7",
+        >= 394802 => "4.6.2",
 
-            // Following versions are deprecated
-            // >= 394254 => "4.6.1",
-            // >= 393295 => "4.6",
-            // >= 379893 => "4.5.2",
-            // >= 378675 => "4.5.1",
-            // >= 378389 => "4.5",
+        // Following versions are deprecated
+        // >= 394254 => "4.6.1",
+        // >= 393295 => "4.6",
+        // >= 379893 => "4.5.2",
+        // >= 378675 => "4.5.1",
+        // >= 378389 => "4.5",
 
-            // This code should never execute. A non-null release key should mean
-            // that 4.5 or later is installed.
-            _ => null,
-        };
-    }
+        // This code should never execute. A non-null release key should mean
+        // that 4.5 or later is installed.
+        _ => null,
+    };
 #endif
 }

--- a/src/OpenTelemetry.Resources.ProcessRuntime/ProcessRuntimeDetector.cs
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/ProcessRuntimeDetector.cs
@@ -13,6 +13,8 @@ namespace OpenTelemetry.Resources.ProcessRuntime;
 /// </summary>
 internal sealed class ProcessRuntimeDetector : IResourceDetector
 {
+    private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+
     /// <summary>
     /// Detects the resource attributes from .NET runtime.
     /// </summary>
@@ -51,11 +53,12 @@ internal sealed class ProcessRuntimeDetector : IResourceDetector
         }
 
         return new Resource(
-        [
-            new(ProcessRuntimeSemanticConventions.AttributeProcessRuntimeDescription, frameworkDescription),
-            new(ProcessRuntimeSemanticConventions.AttributeProcessRuntimeName, netRuntimeName!),
-            new(ProcessRuntimeSemanticConventions.AttributeProcessRuntimeVersion, netRuntimeVersion!),
-        ]);
+            [
+                new(ProcessRuntimeSemanticConventions.AttributeProcessRuntimeDescription, frameworkDescription),
+                new(ProcessRuntimeSemanticConventions.AttributeProcessRuntimeName, netRuntimeName!),
+                new(ProcessRuntimeSemanticConventions.AttributeProcessRuntimeVersion, netRuntimeVersion!),
+            ],
+            Internal.SchemaUrls.Get(SemanticConventionsVersion));
     }
 
 #if NETFRAMEWORK || NETSTANDARD

--- a/src/Shared/ActivitySourceFactory.cs
+++ b/src/Shared/ActivitySourceFactory.cs
@@ -52,7 +52,7 @@ internal static class ActivitySourceFactory
 
         if (semanticConventionsVersion is not null)
         {
-            options.TelemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
+            options.TelemetrySchemaUrl = SchemaUrls.Get(semanticConventionsVersion);
         }
 
         return new(options);

--- a/src/Shared/MeterFactory.cs
+++ b/src/Shared/MeterFactory.cs
@@ -52,7 +52,7 @@ internal static class MeterFactory
 
         if (semanticConventionsVersion is not null)
         {
-            options.TelemetrySchemaUrl = $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
+            options.TelemetrySchemaUrl = SchemaUrls.Get(semanticConventionsVersion);
         }
 
         return new(options);

--- a/src/Shared/ResourceSemanticConventions.cs
+++ b/src/Shared/ResourceSemanticConventions.cs
@@ -49,7 +49,6 @@ internal static class ResourceSemanticConventions
     public const string AttributeCloudProvider = "cloud.provider";
     public const string AttributeCloudRegion = "cloud.region";
     public const string AttributeCloudResourceId = "cloud.resource_id";
-    public const string AttributeCloudZone = "cloud.zone";
     public const string AttributeComponent = "component";
 
     public const string AttributeOsType = "os.type";

--- a/src/Shared/SchemaUrls.cs
+++ b/src/Shared/SchemaUrls.cs
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Internal;
+
+internal static class SchemaUrls
+{
+    public static string Get(Version semanticConventionsVersion)
+        => $"https://opentelemetry.io/schemas/{semanticConventionsVersion.ToString(3)}";
+}

--- a/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/OpenTelemetry.Contrib.Shared.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlConnectionDetails.cs" Link="Includes\SqlConnectionDetails.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SqlParameterProcessor.cs" Link="Includes\SqlParameterProcessor.cs" />

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -350,6 +350,7 @@ public class AWSLambdaWrapperTests : IDisposable
     private void AssertResourceAttributes(Resource? resource)
     {
         Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
         Assert.Equal("aws", resourceAttributes[ExpectedSemanticConventions.AttributeCloudProvider]);

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
@@ -36,11 +36,15 @@ public class AWSEC2DetectorTests
                 SemanticConventionVersion.Latest));
 
         var resource = awsEC2Detector.Detect();
+
+        Assert.NotNull(resource);
+
         var attributes = resource.Attributes;
 
         if (!await IsRunningOnEC2())
         {
-            Assert.Empty(attributes); // Will be null as it's not in EC2 environment
+            Assert.Empty(attributes); // Will be empty as it's not in EC2 environment
+            Assert.Null(resource.SchemaUrl);
         }
         else
         {

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSEC2DetectorTests.cs
@@ -35,14 +35,17 @@ public class AWSEC2DetectorTests
             new OpenTelemetry.AWS.AWSSemanticConventions(
                 SemanticConventionVersion.Latest));
 
-        var attributes = awsEC2Detector.Detect().Attributes;
+        var resource = awsEC2Detector.Detect();
+        var attributes = resource.Attributes;
+
         if (!await IsRunningOnEC2())
         {
-            Assert.Empty(attributes); // will be null as it's not in ec2 environment
+            Assert.Empty(attributes); // Will be null as it's not in EC2 environment
         }
         else
         {
             Assert.NotEmpty(attributes);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
         }
     }
 

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
@@ -46,7 +46,12 @@ public class AWSECSDetectorTests
                 new OpenTelemetry.AWS.AWSSemanticConventions(
                     SemanticConventionVersion.Latest));
 
-            var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
+            var resource = ecsResourceDetector.Detect();
+
+            Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+            var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudProvider], "aws");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudPlatform], "aws_ecs");
@@ -69,7 +74,12 @@ public class AWSECSDetectorTests
                 new OpenTelemetry.AWS.AWSSemanticConventions(
                     SemanticConventionVersion.Latest));
 
-            var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
+            var resource = ecsResourceDetector.Detect();
+
+            Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+            var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudProvider], "aws");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudPlatform], "aws_ecs");
@@ -113,7 +123,12 @@ public class AWSECSDetectorTests
                 new OpenTelemetry.AWS.AWSSemanticConventions(
                     SemanticConventionVersion.Latest));
 
-            var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
+            var resource = ecsResourceDetector.Detect();
+
+            Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+            var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudProvider], "aws");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudPlatform], "aws_ecs");
@@ -154,7 +169,12 @@ public class AWSECSDetectorTests
                 new OpenTelemetry.AWS.AWSSemanticConventions(
                     SemanticConventionVersion.Latest));
 
-            var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
+            var resource = ecsResourceDetector.Detect();
+
+            Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+            var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudProvider], "aws");
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudPlatform], "aws_ecs");
@@ -185,7 +205,12 @@ public class AWSECSDetectorTests
                 new OpenTelemetry.AWS.AWSSemanticConventions(
                     SemanticConventionVersion.Latest));
 
-            var resourceAttributes = ecsResourceDetector.Detect().Attributes.ToDictionary(x => x.Key, x => x.Value);
+            var resource = ecsResourceDetector.Detect();
+
+            Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+            var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
             Assert.Equal(2, resourceAttributes.Count);
             Assert.Equal(resourceAttributes[ExpectedSemanticConventions.AttributeCloudProvider], "aws");

--- a/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.AWS.Tests/AWSECSDetectorTests.cs
@@ -27,10 +27,11 @@ public class AWSECSDetectorTests
             new OpenTelemetry.AWS.AWSSemanticConventions(
                 SemanticConventionVersion.Latest));
 
-        var resourceAttributes = ecsResourceDetector.Detect();
+        var resource = ecsResourceDetector.Detect();
 
-        Assert.NotNull(resourceAttributes);
-        Assert.Empty(resourceAttributes.Attributes);
+        Assert.NotNull(resource);
+        Assert.Null(resource.SchemaUrl);
+        Assert.Empty(resource.Attributes);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -45,6 +45,8 @@ public class AzureResourceDetectorTests
     [Fact]
     public async Task AzureVMResourceDetectorDoesNotThrow()
     {
+        AzureVMResourceDetector.ClearCachedResource();
+
         var resource = ResourceBuilder.CreateEmpty()
             .AddAzureVMDetector()
             .Build();
@@ -61,8 +63,6 @@ public class AzureResourceDetectorTests
             Assert.Null(resource.SchemaUrl);
             Assert.Empty(resource.Attributes);
         }
-
-        AzureVMResourceDetector.ClearCachedResource();
     }
 
     [Fact]
@@ -132,6 +132,8 @@ public class AzureResourceDetectorTests
                 VmScaleSetName = ResourceAttributeConstants.AzureVmScaleSetName,
             };
         };
+
+        AzureVMResourceDetector.ClearCachedResource();
 
         var resource = ResourceBuilder.CreateEmpty().AddAzureVMDetector().Build();
 

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -83,6 +83,16 @@ public class AzureResourceDetectorTests
         }
     }
 
+    [Theory]
+    [InlineData("Linux", "linux")]
+    [InlineData("Windows", "windows")]
+    public void AzureVmResourceDetectorNormalizesOsTypeToLowercase(string osType, string expected)
+    {
+        var response = new AzureVmMetadataResponse() { OsType = osType };
+
+        Assert.Equal(expected, response.GetValueForField(ResourceSemanticConventions.AttributeOsType));
+    }
+
     [Fact]
     public void AzureContainerAppsResourceDetectorReturnsResourceWithAttributes()
     {

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -11,15 +11,19 @@ namespace OpenTelemetry.Resources.Azure.Tests;
 
 public class AzureResourceDetectorTests
 {
-    private const string AzureVmMetadataEndpointUri = "http://169.254.169.254/metadata/instance/compute";
+    // See https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service
+    private const string AzureVmMetadataEndpointUri = "http://169.254.169.254/metadata/instance?api-version=2025-04-07";
     private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(3) };
 
     public static async Task<bool> IsRunningOnAzureVMAsync()
     {
         try
         {
-            var instanceId = await HttpClient.GetStringAsync(new Uri(AzureVmMetadataEndpointUri));
-            return !string.IsNullOrEmpty(instanceId);
+            using var request = new HttpRequestMessage(HttpMethod.Get, AzureVmMetadataEndpointUri);
+            request.Headers.Add("Metadata", "true");
+
+            using var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            return response.IsSuccessStatusCode;
         }
         catch
         {

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -8,6 +8,41 @@ namespace OpenTelemetry.Resources.Azure.Tests;
 public class AzureResourceDetectorTests
 {
     [Fact]
+    public void AppServiceResourceDetectorHandlesFailure()
+    {
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddAzureAppServiceDetector()
+            .Build();
+
+        Assert.NotNull(resource);
+        Assert.Null(resource.SchemaUrl);
+    }
+
+    [Fact]
+    public void AzureVMResourceDetectorHandlesFailure()
+    {
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddAzureVMDetector()
+            .Build();
+
+        Assert.NotNull(resource);
+        Assert.Null(resource.SchemaUrl);
+
+        AzureVMResourceDetector.ClearCachedResource();
+    }
+
+    [Fact]
+    public void AzureContainerAppsResourceDetectorHandlesFailure()
+    {
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddAzureContainerAppsDetector()
+            .Build();
+
+        Assert.NotNull(resource);
+        Assert.Null(resource.SchemaUrl);
+    }
+
+    [Fact]
     public void AppServiceResourceDetectorReturnsResourceWithAttributes()
     {
         var environment = new Dictionary<string, string?>();

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -30,7 +30,9 @@ public class AzureResourceDetectorTests
         using (EnvironmentVariableScope.Create(environment))
         {
             var resource = ResourceBuilder.CreateEmpty().AddAzureAppServiceDetector().Build();
+
             Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
             var expectedResourceUri = "/subscriptions/testtestSubscriptionId/resourceGroups/testResourceGroup/providers/Microsoft.Web/sites/sitename";
             Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeCloudResourceId, expectedResourceUri), resource.Attributes);
@@ -63,7 +65,9 @@ public class AzureResourceDetectorTests
         };
 
         var resource = ResourceBuilder.CreateEmpty().AddAzureVMDetector().Build();
+
         Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
         foreach (var field in AzureVMResourceDetector.ExpectedAzureAmsFields)
         {
@@ -94,7 +98,9 @@ public class AzureResourceDetectorTests
         using (EnvironmentVariableScope.Create(environment))
         {
             var resource = ResourceBuilder.CreateEmpty().AddAzureContainerAppsDetector().Build();
+
             Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
             Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, "containerAppName"), resource.Attributes);
 
@@ -120,7 +126,9 @@ public class AzureResourceDetectorTests
         using (EnvironmentVariableScope.Create(environment))
         {
             var resource = ResourceBuilder.CreateEmpty().AddAzureContainerAppsDetector().Build();
+
             Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
             Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, "containerAppJobName"), resource.Attributes);
 
@@ -148,6 +156,7 @@ public class AzureResourceDetectorTests
                 .Build();
 
             Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
             // Detector is applied after AddAttributes, so detector value wins.
             Assert.Contains(
@@ -176,6 +185,7 @@ public class AzureResourceDetectorTests
                 .Build();
 
             Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
             // AddAttributes is applied after the detector, so the custom value wins.
             Assert.Contains(

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -1,12 +1,32 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Resources.Azure.Tests;
 
 public class AzureResourceDetectorTests
 {
+    private const string AzureVmMetadataEndpointUri = "http://169.254.169.254/metadata/instance/compute";
+    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(3) };
+
+    public static async Task<bool> IsRunningOnAzureVMAsync()
+    {
+        try
+        {
+            var instanceId = await HttpClient.GetStringAsync(new Uri(AzureVmMetadataEndpointUri));
+            return !string.IsNullOrEmpty(instanceId);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     [Fact]
     public void AppServiceResourceDetectorHandlesFailure()
     {
@@ -19,8 +39,14 @@ public class AzureResourceDetectorTests
     }
 
     [Fact]
-    public void AzureVMResourceDetectorHandlesFailure()
+    public async Task AzureVMResourceDetectorHandlesFailure()
     {
+        if (await IsRunningOnAzureVMAsync())
+        {
+            // Skip if running in an actual Azure VM environment
+            return;
+        }
+
         var resource = ResourceBuilder.CreateEmpty()
             .AddAzureVMDetector()
             .Build();

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -39,20 +39,24 @@ public class AzureResourceDetectorTests
     }
 
     [Fact]
-    public async Task AzureVMResourceDetectorHandlesFailure()
+    public async Task AzureVMResourceDetectorDoesNotThrow()
     {
-        if (await IsRunningOnAzureVMAsync())
-        {
-            // Skip if running in an actual Azure VM environment
-            return;
-        }
-
         var resource = ResourceBuilder.CreateEmpty()
             .AddAzureVMDetector()
             .Build();
 
         Assert.NotNull(resource);
-        Assert.Null(resource.SchemaUrl);
+
+        if (await IsRunningOnAzureVMAsync())
+        {
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+            Assert.NotEmpty(resource.Attributes);
+        }
+        else
+        {
+            Assert.Null(resource.SchemaUrl);
+            Assert.Empty(resource.Attributes);
+        }
 
         AzureVMResourceDetector.ClearCachedResource();
     }

--- a/test/OpenTelemetry.Resources.Azure.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/EventSourceTests.cs
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Tests;
+
+namespace OpenTelemetry.Resources.Azure.Tests;
+
+public class EventSourceTests
+{
+    [Fact]
+    public void EventSourceTests_AzureResourcesEventSource() =>
+        EventSourceTestHelper.ValidateEventSourceIds<AzureResourcesEventSource>();
+}

--- a/test/OpenTelemetry.Resources.Azure.Tests/OpenTelemetry.Resources.Azure.Tests.csproj
+++ b/test/OpenTelemetry.Resources.Azure.Tests/OpenTelemetry.Resources.Azure.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>$(SupportedNetTargets)</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);$(NetFrameworkMinimumSupportedVersion)</TargetFrameworks>
   </PropertyGroup>
@@ -12,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\EnvironmentVariableScope.cs" Link="Includes\EnvironmentVariableScope.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
@@ -145,6 +145,17 @@ public class ContainerDetectorTests
         Assert.Equal(containerDetector.BuildResource(Path.GetTempPath(), ContainerDetector.ParseMode.V2), Resource.Empty);
     }
 
+    [Fact]
+    public void ContainerDetectorHandlesFailure()
+    {
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddContainerDetector()
+            .Build();
+
+        Assert.NotNull(resource);
+        Assert.Null(resource.SchemaUrl);
+    }
+
     private static string GetContainerId(Resource resource)
     {
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);

--- a/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
@@ -97,9 +97,13 @@ public class ContainerDetectorTests
         {
             using var tempFile = new TempFile();
             tempFile.Write(testCase.Line);
-            Assert.Equal(
-                testCase.ExpectedContainerId,
-                GetContainerId(containerDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion)));
+
+            var resource = containerDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion);
+
+            Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+            Assert.Equal(testCase.ExpectedContainerId, GetContainerId(resource));
         }
     }
 

--- a/test/OpenTelemetry.Resources.Gcp.Tests/GcpResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Gcp.Tests/GcpResourceDetectorTests.cs
@@ -30,7 +30,7 @@ public class GcpResourceDetectorTests
         Assert.Equal(ResourceAttributeConstants.GcpCloudProviderValue, attrs[ResourceSemanticConventions.AttributeCloudProvider]);
         Assert.Equal("projectId", attrs[ResourceSemanticConventions.AttributeCloudAccount]);
         Assert.Equal(ResourceAttributeConstants.GcpGkePlatformValue, attrs[ResourceSemanticConventions.AttributeCloudPlatform]);
-        Assert.Equal("us-central1-a", attrs[ResourceSemanticConventions.AttributeCloudZone]);
+        Assert.Equal("us-central1-a", attrs[ResourceSemanticConventions.AttributeCloudAvailabilityZone]);
         Assert.Equal("instanceId", attrs[ResourceSemanticConventions.AttributeHostId]);
         Assert.Equal("clusterName", attrs[ResourceSemanticConventions.AttributeK8sCluster]);
         Assert.Equal("namespaceId", attrs[ResourceSemanticConventions.AttributeK8sNamespace]);

--- a/test/OpenTelemetry.Resources.Gcp.Tests/GcpResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Gcp.Tests/GcpResourceDetectorTests.cs
@@ -9,6 +9,17 @@ namespace OpenTelemetry.Resources.Gcp.Tests;
 public class GcpResourceDetectorTests
 {
     [Fact]
+    public void GcpResourceDetectorHandlesFailure()
+    {
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddGcpDetector()
+            .Build();
+
+        Assert.NotNull(resource);
+        Assert.Null(resource.SchemaUrl);
+    }
+
+    [Fact]
     public void TestExtractGkeResourceAttributes()
     {
         var details = new GkePlatformDetails(

--- a/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
@@ -50,6 +50,9 @@ public class HostDetectorTests
     {
         var resource = ResourceBuilder.CreateEmpty().AddHostDetector().Build();
 
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 
 #if NET
@@ -113,6 +116,10 @@ public class HostDetectorTests
                 () => throw new Exception("should not be called"),
                 () => throw new Exception("should not be called"));
             var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
+
+            Assert.NotNull(resource);
+            Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
             var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
             if (string.IsNullOrEmpty(expected))
             {
@@ -135,6 +142,10 @@ public class HostDetectorTests
             () => MacOSMachineIdOutput,
             () => throw new Exception("should not be called"));
         var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
+
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
         Assert.Equal("1AB2345C-03E4-57D4-A375-1234D48DE123", resourceAttributes[HostSemanticConventions.AttributeHostId]);
@@ -158,6 +169,10 @@ public class HostDetectorTests
 #endif
 
         var resource = ResourceBuilder.CreateEmpty().AddDetector(detector).Build();
+
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
         Assert.NotEmpty(resourceAttributes[HostSemanticConventions.AttributeHostId]);
         Assert.Equal("windows-machine-id", resourceAttributes[HostSemanticConventions.AttributeHostId]);
@@ -186,7 +201,11 @@ public class HostDetectorTests
             windowsMethodCalled = true;
             return string.Empty;
         });
-        detector.Detect();
+
+        var resource = detector.Detect();
+
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {

--- a/test/OpenTelemetry.Resources.OperatingSystem.Tests/OperatingSystemDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.OperatingSystem.Tests/OperatingSystemDetectorTests.cs
@@ -11,6 +11,10 @@ public class OperatingSystemDetectorTests
     public void TestOperatingSystemAttributes()
     {
         var resource = ResourceBuilder.CreateEmpty().AddOperatingSystemDetector().Build();
+
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 
         string expectedPlatform;
@@ -67,7 +71,13 @@ public class OperatingSystemDetectorTests
             null,
             null,
             [path]);
-        var attributes = osDetector.Detect().Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
+
+        var resource = osDetector.Detect();
+
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+        var attributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 
         Assert.Equal("Mac OS X", attributes[OperatingSystemSemanticConventions.AttributeOperatingSystemName]);
         Assert.Equal("10.6.8", attributes[OperatingSystemSemanticConventions.AttributeOperatingSystemVersion]);
@@ -85,7 +95,13 @@ public class OperatingSystemDetectorTests
             kernelPath,
             [path],
             null);
-        var attributes = osDetector.Detect().Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
+
+        var resource = osDetector.Detect();
+
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
+        var attributes = resource.Attributes.ToDictionary(x => x.Key, x => (string)x.Value);
 
         Assert.Equal("Ubuntu", attributes[OperatingSystemSemanticConventions.AttributeOperatingSystemName]);
         Assert.Equal("22.04", attributes[OperatingSystemSemanticConventions.AttributeOperatingSystemVersion]);

--- a/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
@@ -10,6 +10,9 @@ public class ProcessDetectorTests
     {
         var resource = ResourceBuilder.CreateEmpty().AddProcessDetector().Build();
 
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
         Assert.IsType<string>(resourceAttributes[ProcessSemanticConventions.AttributeProcessCreationTime]);

--- a/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Process.Tests/ProcessDetectorTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Globalization;
+
 namespace OpenTelemetry.Resources.Process.Tests;
 
 public class ProcessDetectorTests
@@ -15,8 +17,14 @@ public class ProcessDetectorTests
 
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
-        Assert.IsType<string>(resourceAttributes[ProcessSemanticConventions.AttributeProcessCreationTime]);
         Assert.IsType<string>(resourceAttributes[ProcessSemanticConventions.AttributeProcessOwner]);
         Assert.IsType<long>(resourceAttributes[ProcessSemanticConventions.AttributeProcessPid]);
+
+        var creationTime = Assert.IsType<string>(resourceAttributes[ProcessSemanticConventions.AttributeProcessCreationTime]);
+
+        // The creation time must be an ISO 8601 timestamp normalized to UTC.
+        Assert.EndsWith("Z", creationTime, StringComparison.Ordinal);
+        Assert.True(DateTime.TryParse(creationTime, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed), $"Failed to parse creation time '{creationTime}'.");
+        Assert.Equal(DateTimeKind.Utc, parsed.Kind);
     }
 }

--- a/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.ProcessRuntime.Tests/ProcessRuntimeDetectorTests.cs
@@ -10,6 +10,9 @@ public class ProcessRuntimeDetectorTests
     {
         var resource = ResourceBuilder.CreateEmpty().AddProcessRuntimeDetector().Build();
 
+        Assert.NotNull(resource);
+        Assert.StartsWith("https://opentelemetry.io/schemas/", resource.SchemaUrl);
+
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
 
         Assert.Equal(3, resourceAttributes.Count);


### PR DESCRIPTION
Fixes #4651

## Changes

- Add schema URLs to all resource detectors.
- Normalize `os.type` to lowercase in the Azure VM resource detector.
- Fix `cloud.zone` being emitted instead of `cloud.availability_zone` in the GCP resource detector.
- Fix `process.creation.time` not being emitted as UTC by the process resource detector.
- Add event source to Azure resource detector for logging exceptions.
- Cherry-pick change from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3867 to avoid type name conflicts in .NET 11 which adds its own `ActivitySourceFactory` type.
- Improve test coverage.
- Tidy-up some code in files touched.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
