### PR TITLE
[Resources.Host] Remove CA1416 suppression

### DIFF
--- a/src/OpenTelemetry.Resources.Host/HostDetector.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetector.cs
@@ -231,11 +231,15 @@ internal sealed class HostDetector : IResourceDetector
     }
 #endif
 
-#pragma warning disable CA1416
-    // stylecop wants this protected by System.OperatingSystem.IsWindows
-    // this type only exists in .NET 5+
     private static string? GetMachineIdWindows()
     {
+#if NET
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+#endif
+
         try
         {
             using var subKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography", false);
@@ -248,7 +252,6 @@ internal sealed class HostDetector : IResourceDetector
 
         return null;
     }
-#pragma warning restore CA1416
 
     private string? GetMachineId() =>
 #if NETFRAMEWORK


### PR DESCRIPTION
## Changes

Remove CA1416 suppression by adding a call to `OperatingSystem.IsWindows()` when running under modern .NET.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
