### PR TITLE
[Geneva] Fix exemplar corruption

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed a metric TLV serialization issue where an exemplar whose filtered tags
   serialized to more than 255 bytes caused the payload to be corrupted.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4856](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4856))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed a metric TLV serialization issue where an exemplar whose filtered tags
+  serialized to more than 255 bytes caused the payload to be corrupted.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.17.0
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
@@ -480,7 +480,6 @@ internal sealed class TlvMetricExporter : IDisposable
         byte numberOfLabels = 0;
 
         // Ensure any exemplars fit within the single-byte length/count.
-        // If the exemplar's filtered tags exceed 255 bytes, drop it.
         const int MaxExemplarLength = byte.MaxValue;
 
         foreach (var tag in exemplar.FilteredTags)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/TlvMetricExporter.cs
@@ -479,10 +479,25 @@ internal sealed class TlvMetricExporter : IDisposable
 
         byte numberOfLabels = 0;
 
+        // Ensure any exemplars fit within the single-byte length/count.
+        // If the exemplar's filtered tags exceed 255 bytes, drop it.
+        const int MaxExemplarLength = byte.MaxValue;
+
         foreach (var tag in exemplar.FilteredTags)
         {
+            var bufferIndexBeforeLabel = bufferIndex;
+
             MetricSerializer.SerializeBase128String(buffer, ref bufferIndex, tag.Key);
             MetricSerializer.SerializeBase128String(buffer, ref bufferIndex, Convert.ToString(tag.Value, CultureInfo.InvariantCulture));
+
+            if ((bufferIndex - bufferIndexForLength + 1) > MaxExemplarLength || numberOfLabels == byte.MaxValue)
+            {
+                // Adding this label would overflow the single-byte length/count.
+                // Roll back and drop it (and any remaining labels) for this exemplar.
+                bufferIndex = bufferIndexBeforeLabel;
+                break;
+            }
+
             numberOfLabels++;
         }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -599,44 +599,71 @@ public class GenevaMetricExporterTests
         var metricPoint = metricPointsEnumerator.Current;
         Assert.True(metricPoint.TryGetExemplars(out var exemplars));
 
-        var exporterOptions = new GenevaMetricExporterOptions
+        var path = string.Empty;
+        Socket server = null;
+        try
         {
-            ConnectionString = "Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace",
-        };
+            var exporterOptions = new GenevaMetricExporterOptions();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                exporterOptions.ConnectionString = "Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace";
+            }
+            else
+            {
+                // On non-Windows the TLV exporter requires a Unix domain socket endpoint.
+                path = GenerateTempFilePath();
+                exporterOptions.ConnectionString = $"Endpoint=unix:{path};Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace";
+                var endpoint = new UnixDomainSocketEndPoint(path);
+                server = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                server.Bind(endpoint);
+                server.Listen(1);
+            }
 
-        using var exporter = new TlvMetricExporter(
-            new ConnectionStringBuilder(exporterOptions.ConnectionString),
-            null);
+            using var exporter = new TlvMetricExporter(
+                new ConnectionStringBuilder(exporterOptions.ConnectionString),
+                null);
 
-        var metricData = new MetricData { UInt64Value = Convert.ToUInt64(metricPoint.GetSumLong()) };
-        exporter.SerializeMetricWithTLV(
-            MetricEventType.ULongMetric,
-            metric.Name,
-            metricPoint.EndTime.ToFileTime(),
-            metricPoint.Tags,
-            metricData,
-            metric.MetricType,
-            exemplars,
-            out _,
-            out _);
+            var metricData = new MetricData { UInt64Value = Convert.ToUInt64(metricPoint.GetSumLong()) };
+            exporter.SerializeMetricWithTLV(
+                MetricEventType.ULongMetric,
+                metric.Name,
+                metricPoint.EndTime.ToFileTime(),
+                metricPoint.Tags,
+                metricData,
+                metric.MetricType,
+                exemplars,
+                out _,
+                out _);
 
-        var buffer = typeof(TlvMetricExporter)
-            .GetField("buffer", BindingFlags.NonPublic | BindingFlags.Instance)
-            .GetValue(exporter) as byte[];
+            var buffer = typeof(TlvMetricExporter)
+                .GetField("buffer", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(exporter) as byte[];
 
-        var data = new MetricsContract(new KaitaiStream(buffer));
-        var fields = ((UserdataV2)data.Body).Fields;
-        var exemplarsPayload = fields.First(field => field.Type == PayloadTypes.Exemplars).Value as Exemplars;
-        var body = exemplarsPayload.ExemplarList[0].Body;
+            var data = new MetricsContract(new KaitaiStream(buffer));
+            var fields = ((UserdataV2)data.Body).Fields;
+            var exemplarsPayload = fields.First(field => field.Type == PayloadTypes.Exemplars).Value as Exemplars;
+            var body = exemplarsPayload.ExemplarList[0].Body;
 
-        if (expectLabelKept)
-        {
-            Assert.Equal(1, body.NumberOfLabels);
-            Assert.Equal(filteredTagValue, body.Labels[0].Value.Value);
+            if (expectLabelKept)
+            {
+                Assert.Equal(1, body.NumberOfLabels);
+                Assert.Equal(filteredTagValue, body.Labels[0].Value.Value);
+            }
+            else
+            {
+                Assert.Equal(0, body.NumberOfLabels);
+            }
         }
-        else
+        finally
         {
-            Assert.Equal(0, body.NumberOfLabels);
+            server?.Dispose();
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
         }
     }
 

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterTests.cs
@@ -568,6 +568,78 @@ public class GenevaMetricExporterTests
         }
     }
 
+    [Theory]
+    [InlineData(10, true)]
+    [InlineData(300, false)]
+    public void ExemplarExceedingByteLengthDropsLabelsInsteadOfCorrupting(int filteredTagValueLength, bool expectLabelKept)
+    {
+        using var meter = new Meter("ExemplarOverflow", "0.0.1");
+        var counter = meter.CreateCounter<long>("longCounter");
+        var exportedItems = new List<Metric>();
+        using var inMemoryReader = new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems))
+        {
+            TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+        };
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter("ExemplarOverflow")
+            .SetExemplarFilter(ExemplarFilterType.AlwaysOn)
+            .AddView("*", new MetricStreamConfiguration { TagKeys = ["tag1"] })
+            .AddReader(inMemoryReader)
+            .Build();
+
+        var filteredTagValue = new string('x', filteredTagValueLength);
+        counter.Add(1, new("tag1", "keep"), new("bigFilteredTag", filteredTagValue));
+
+        inMemoryReader.Collect();
+
+        var metric = Assert.Single(exportedItems);
+        var metricPointsEnumerator = metric.GetMetricPoints().GetEnumerator();
+        Assert.True(metricPointsEnumerator.MoveNext());
+        var metricPoint = metricPointsEnumerator.Current;
+        Assert.True(metricPoint.TryGetExemplars(out var exemplars));
+
+        var exporterOptions = new GenevaMetricExporterOptions
+        {
+            ConnectionString = "Account=OTelMonitoringAccount;Namespace=OTelMetricNamespace",
+        };
+
+        using var exporter = new TlvMetricExporter(
+            new ConnectionStringBuilder(exporterOptions.ConnectionString),
+            null);
+
+        var metricData = new MetricData { UInt64Value = Convert.ToUInt64(metricPoint.GetSumLong()) };
+        exporter.SerializeMetricWithTLV(
+            MetricEventType.ULongMetric,
+            metric.Name,
+            metricPoint.EndTime.ToFileTime(),
+            metricPoint.Tags,
+            metricData,
+            metric.MetricType,
+            exemplars,
+            out _,
+            out _);
+
+        var buffer = typeof(TlvMetricExporter)
+            .GetField("buffer", BindingFlags.NonPublic | BindingFlags.Instance)
+            .GetValue(exporter) as byte[];
+
+        var data = new MetricsContract(new KaitaiStream(buffer));
+        var fields = ((UserdataV2)data.Body).Fields;
+        var exemplarsPayload = fields.First(field => field.Type == PayloadTypes.Exemplars).Value as Exemplars;
+        var body = exemplarsPayload.ExemplarList[0].Body;
+
+        if (expectLabelKept)
+        {
+            Assert.Equal(1, body.NumberOfLabels);
+            Assert.Equal(filteredTagValue, body.Labels[0].Value.Value);
+        }
+        else
+        {
+            Assert.Equal(0, body.NumberOfLabels);
+        }
+    }
+
     [Fact]
     public void SuccessfulSerializationWithTLVWithViews()
     {


### PR DESCRIPTION
## Changes

Fixed metric TLV serialization where an exemplar whose filtered tags serialized to more than 255 bytes caused the payload to be corrupted.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
