### PR TITLE
[Sampler.AWS] Add Regex match timeout

### DIFF
--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Applied a timeout to the wildcard rule matching regular expressions.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4858](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4858))
 
 ## 0.1.0-alpha.12
 

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Applied a timeout to the wildcard rule matching regular expressions.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 0.1.0-alpha.12
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Sampler.AWS/Matcher.cs
+++ b/src/OpenTelemetry.Sampler.AWS/Matcher.cs
@@ -17,6 +17,8 @@ internal static class Matcher
         { "aws_lambda", "AWS::Lambda::Function" },
     };
 
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
     public static bool WildcardMatch(string? text, string? globPattern)
     {
         if (globPattern == "*")
@@ -34,13 +36,20 @@ internal static class Matcher
             return text.Length == 0;
         }
 
-        // it is faster to check if we need a regex comparison than
-        // doing always regex comparison, even where we may not need it.
+        // It is faster to check if we need a regex comparison than
+        // always doing a regex comparison, even where we may not need it.
         foreach (var c in globPattern)
         {
             if (c is '*' or '?')
             {
-                return Regex.IsMatch(text, ToRegexPattern(globPattern));
+                try
+                {
+                    return Regex.IsMatch(text, ToRegexPattern(globPattern), RegexOptions.None, RegexTimeout);
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    return false;
+                }
             }
         }
 

--- a/test/OpenTelemetry.Sampler.AWS.Tests/TestMatcher.cs
+++ b/test/OpenTelemetry.Sampler.AWS.Tests/TestMatcher.cs
@@ -86,4 +86,21 @@ public class TestMatcher
         Assert.False(Matcher.AttributeMatch([], ruleAttributes));
         Assert.False(Matcher.AttributeMatch(null, ruleAttributes));
     }
+
+    [Fact]
+    public void WildcardMatchWithCatastrophicPatternIsBoundedByTimeout()
+    {
+        var globPattern = "*a*a*a*a*a*a*a*a*b";
+        var maliciousInput = new string('a', 100_000);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var result = Matcher.WildcardMatch(maliciousInput, globPattern);
+        stopwatch.Stop();
+
+        Assert.False(result);
+
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"WildcardMatch was not bounded by the regex timeout; took {stopwatch.Elapsed}.");
+    }
 }


### PR DESCRIPTION
## Changes

Add a timeout to Regular Expression used with wildcard sampling rule matching.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
