### PR TITLE
[Exporter.InfluxDB] Apply backpressure via ExportResult.Failure

### DIFF
--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Write metrics synchronously and report `ExportResult.Failure` when a write to
+  InfluxDB fails, so the SDK applies backpressure instead of growing an unbounded
+  in-memory buffer while InfluxDB is unavailable. The `FlushInterval` option is
+  deprecated as it no longer applies.
+  ([#4861](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4861))
+
 ## 1.0.0-alpha.10
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Exporter.InfluxDB/IMetricsWriter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/IMetricsWriter.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using InfluxDB.Client;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 
@@ -9,5 +8,5 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal interface IMetricsWriter
 {
-    void Write(Metric metric, Resource? resource, WriteApi writeApi);
+    void Write(Metric metric, Resource? resource, List<string> lineProtocol);
 }

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBExporterExtensions.cs
@@ -42,12 +42,8 @@ public static class InfluxDBExporterExtensions
             }
 
             var influxDbClient = new InfluxDBClient(influxDbClientOptions);
-            var writeApi = influxDbClient.GetWriteApi(new WriteOptions
-            {
-                FlushInterval = options.FlushInterval,
-            });
             var metricsWriter = CreateMetricsWriter(options.MetricsSchema);
-            var exporter = new InfluxDBMetricsExporter(metricsWriter, influxDbClient, writeApi);
+            var exporter = new InfluxDBMetricsExporter(metricsWriter, influxDbClient);
             return new PeriodicExportingMetricReader(exporter, options.MetricExportIntervalMilliseconds)
             {
                 TemporalityPreference = MetricReaderTemporalityPreference.Cumulative,

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using InfluxDB.Client;
-using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter.InfluxDB;
@@ -11,36 +10,31 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
 {
     private readonly IMetricsWriter writer;
     private readonly InfluxDBClient influxDbClient;
-    private readonly WriteApi writeApi;
+    private readonly WriteApiAsync writeApiAsync;
 
-    public InfluxDBMetricsExporter(IMetricsWriter writer, InfluxDBClient influxDbClient, WriteApi writeApi)
+    public InfluxDBMetricsExporter(IMetricsWriter writer, InfluxDBClient influxDbClient)
     {
         this.writer = writer;
         this.influxDbClient = influxDbClient;
-        this.writeApi = writeApi;
-
-        this.writeApi.EventHandler += (_, args) =>
-        {
-            switch (args)
-            {
-                case WriteErrorEvent writeErrorEvent:
-                    InfluxDBEventSource.Log.FailedToExport(writeErrorEvent.Exception.Message);
-                    break;
-                default:
-                    break;
-            }
-        };
+        this.writeApiAsync = influxDbClient.GetWriteApiAsync();
     }
 
     public override ExportResult Export(in Batch<Metric> batch)
     {
         try
         {
+            List<string> lineProtocol = [];
             foreach (var metric in batch)
             {
-                this.writer.Write(metric, this.ParentProvider?.GetResource(), this.writeApi);
+                this.writer.Write(metric, this.ParentProvider?.GetResource(), lineProtocol);
             }
 
+            if (lineProtocol.Count == 0)
+            {
+                return ExportResult.Success;
+            }
+
+            this.writeApiAsync.WriteRecordsAsync(lineProtocol).GetAwaiter().GetResult();
             return ExportResult.Success;
         }
         catch (Exception exception)
@@ -54,7 +48,6 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
     {
         if (disposing)
         {
-            this.writeApi.Dispose();
             this.influxDbClient.Dispose();
         }
 

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporter.cs
@@ -29,12 +29,11 @@ internal sealed class InfluxDBMetricsExporter : BaseExporter<Metric>
                 this.writer.Write(metric, this.ParentProvider?.GetResource(), lineProtocol);
             }
 
-            if (lineProtocol.Count == 0)
+            if (lineProtocol.Count > 0)
             {
-                return ExportResult.Success;
+                this.writeApiAsync.WriteRecordsAsync(lineProtocol).GetAwaiter().GetResult();
             }
 
-            this.writeApiAsync.WriteRecordsAsync(lineProtocol).GetAwaiter().GetResult();
             return ExportResult.Success;
         }
         catch (Exception exception)

--- a/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/InfluxDBMetricsExporterOptions.cs
@@ -40,6 +40,7 @@ public class InfluxDBMetricsExporterOptions
     /// <summary>
     /// Gets or sets the time to wait at most (milliseconds) with the write.
     /// </summary>
+    [Obsolete("FlushInterval no longer has any effect. Metrics are now written synchronously and this option will be removed in a future release.")]
     public int FlushInterval { get; set; } = 1000;
 
     /// <summary>

--- a/src/OpenTelemetry.Exporter.InfluxDB/README.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/README.md
@@ -87,11 +87,6 @@ The authentication token for InfluxDB.
 The chosen metrics schema to write. Default value is
 `MetricsSchema.TelegrafPrometheusV1`.
 
-### FlushInterval
-
-The time to wait at most (in milliseconds) with the write. Default value
-is 1000.
-
 ## InfluxDB 1.8 API Compatibility
 
 InfluxDB 1.8.0 introduced forward compatibility APIs for InfluxDB 2.0,

--- a/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV1.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV1.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
-using InfluxDB.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
@@ -12,7 +11,7 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
 {
-    public void Write(Metric metric, Resource? resource, WriteApi writeApi)
+    public void Write(Metric metric, Resource? resource, List<string> lineProtocol)
     {
         var measurement = metric.Name;
 
@@ -29,7 +28,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -46,7 +45,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -63,7 +62,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -80,7 +79,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -97,7 +96,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -114,7 +113,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -146,7 +145,7 @@ internal sealed class TelegrafPrometheusWriterV1 : IMetricsWriter
                         pointData = pointData.Field(boundFieldKey, histogramBucket.BucketCount);
                     }
 
-                    writeApi.WritePoint(pointData);
+                    lineProtocol.Add(pointData.ToLineProtocol());
                 }
 
                 break;

--- a/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV2.cs
+++ b/src/OpenTelemetry.Exporter.InfluxDB/TelegrafPrometheusWriterV2.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
-using InfluxDB.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using OpenTelemetry.Metrics;
@@ -12,7 +11,7 @@ namespace OpenTelemetry.Exporter.InfluxDB;
 
 internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
 {
-    public void Write(Metric metric, Resource? resource, WriteApi writeApi)
+    public void Write(Metric metric, Resource? resource, List<string> lineProtocol)
     {
         var measurement = "prometheus";
         var metricName = metric.Name;
@@ -30,7 +29,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -47,7 +46,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -64,7 +63,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -81,7 +80,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(metricPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -98,7 +97,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -115,7 +114,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Tags(metric.MeterTags)
                             .Tags(resource?.Attributes)
                             .Timestamp(dataPoint.EndTime.UtcDateTime, WritePrecision.Ns);
-                        writeApi.WritePoint(pointData);
+                        lineProtocol.Add(pointData.ToLineProtocol());
                     }
 
                     break;
@@ -142,7 +141,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                             .Field($"{metricName}_max", max);
                     }
 
-                    writeApi.WritePoint(headPoint);
+                    lineProtocol.Add(headPoint.ToLineProtocol());
 
                     long cumulativeCount = 0;
 
@@ -156,7 +155,7 @@ internal sealed class TelegrafPrometheusWriterV2 : IMetricsWriter
                         var bucketPoint = basePoint
                             .Tag("le", boundFieldKey)
                             .Field($"{metricName}_bucket", cumulativeCount);
-                        writeApi.WritePoint(bucketPoint);
+                        lineProtocol.Add(bucketPoint.ToLineProtocol());
                     }
                 }
 

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/InfluxDBMetricsExporterTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
+using System.Net;
 using System.Reflection;
 using OpenTelemetry.Exporter.InfluxDB.Tests.Utils;
 using OpenTelemetry.Metrics;
@@ -514,6 +515,75 @@ public class InfluxDBMetricsExporterTests
         Assert.Equal(measurement, dataPoint.Measurement);
         AssertUtils.HasField(valueKey, 42L, dataPoint.Fields);
         AssertUtils.HasTag("MeterTag", "MeterValue", 0, dataPoint.Tags);
+    }
+
+    [Fact]
+    public void ExportReturnsFailureWhenInfluxDBIsUnavailable()
+    {
+        // Arrange - the backend rejects every write, simulating an unavailable InfluxDB.
+        using var influxServer = new InfluxDBFakeServer { ResponseStatusCode = HttpStatusCode.BadRequest };
+        var influxServerEndpoint = influxServer.Endpoint;
+
+        using var meter = new Meter("MyMeter", "0.0.1");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
+            .AddInfluxDBMetricsExporter(options =>
+            {
+                options.WithDefaultTestConfiguration();
+                options.Endpoint = influxServerEndpoint;
+            })
+            .Build();
+
+        var counter = meter.CreateCounter<int>("test-counter");
+        counter.Add(100);
+
+        // Act & Assert - the write fails synchronously, so ForceFlush must report the
+        // failure back to the SDK, which applies backpressure instead of buffering.
+        Assert.False(
+            provider.ForceFlush(),
+            "Export was expected to report Failure while InfluxDB is unavailable.");
+    }
+
+    [Fact]
+    public void ExportRecoversWhenInfluxDBBecomesAvailableAgain()
+    {
+        // Arrange - start with an unavailable backend.
+        using var influxServer = new InfluxDBFakeServer { ResponseStatusCode = HttpStatusCode.BadRequest };
+        var influxServerEndpoint = influxServer.Endpoint;
+
+        using var meter = new Meter("MyMeter", "0.0.1");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .ConfigureDefaultTestResource()
+            .AddInfluxDBMetricsExporter(options =>
+            {
+                options.WithDefaultTestConfiguration();
+                options.Endpoint = influxServerEndpoint;
+            })
+            .Build();
+
+        var counter = meter.CreateCounter<int>("test-counter");
+        counter.Add(100);
+
+        Assert.False(
+            provider.ForceFlush(),
+            "Export was expected to report Failure while InfluxDB is unavailable.");
+
+        // Act - the backend recovers.
+        influxServer.ResponseStatusCode = HttpStatusCode.OK;
+
+        // Assert - Export reports Success again and, because the reader uses cumulative
+        // temporality, the accumulated value is re-exported with no data loss.
+        Assert.True(
+            provider.ForceFlush(),
+            "Export was expected to recover and report Success once InfluxDB is available again.");
+
+        var dataPoint = influxServer.ReadPoint();
+        Assert.Equal("test-counter", dataPoint.Measurement);
+        AssertUtils.HasField("counter", 100L, dataPoint.Fields);
     }
 
     private static void AssertTags(PointData dataPoint)

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBFakeServer.cs
@@ -14,21 +14,31 @@ internal class InfluxDBFakeServer : IDisposable
     private readonly IDisposable httpServer;
     private readonly BlockingCollection<string> lines;
 
+    // Read on the listener thread, written from test threads; keep it volatile so a
+    // recovery (flipping the status code back to OK) is observed by the handler.
+    private volatile int responseStatusCode = (int)HttpStatusCode.OK;
+
     public InfluxDBFakeServer()
     {
         this.lines = [];
         this.httpServer = TestHttpServer.RunServer(
             context =>
             {
-                var buffer = new byte[context.Request.ContentLength64];
-                _ = context.Request.InputStream.Read(buffer, 0, buffer.Length);
-                var text = Encoding.UTF8.GetString(buffer);
-                foreach (var line in text.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries))
+                // Read the whole body: Stream.Read may return fewer bytes than requested,
+                // so a single Read can truncate larger write payloads.
+                using var reader = new StreamReader(context.Request.InputStream, Encoding.UTF8);
+                var text = reader.ReadToEnd();
+
+                var statusCode = (HttpStatusCode)this.responseStatusCode;
+                if (statusCode == HttpStatusCode.OK)
                 {
-                    this.lines.Add(line);
+                    foreach (var line in text.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        this.lines.Add(line);
+                    }
                 }
 
-                context.Response.StatusCode = (int)HttpStatusCode.OK;
+                context.Response.StatusCode = (int)statusCode;
                 context.Response.Close();
             },
             out var baseAddress);
@@ -36,6 +46,18 @@ internal class InfluxDBFakeServer : IDisposable
     }
 
     public Uri Endpoint { get; }
+
+    /// <summary>
+    /// Gets or sets the HTTP status code returned for write requests. Setting a
+    /// non-success code (for example <see cref="HttpStatusCode.BadRequest"/>)
+    /// simulates an unavailable/erroring InfluxDB backend; write payloads received
+    /// while a non-OK code is configured are discarded.
+    /// </summary>
+    public HttpStatusCode ResponseStatusCode
+    {
+        get => (HttpStatusCode)this.responseStatusCode;
+        set => this.responseStatusCode = (int)value;
+    }
 
     public void Dispose()
         => this.httpServer.Dispose();

--- a/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBMetricsExporterOptionsTestExtensions.cs
+++ b/test/OpenTelemetry.Exporter.InfluxDB.Tests/Utils/InfluxDBMetricsExporterOptionsTestExtensions.cs
@@ -10,8 +10,5 @@ internal static class InfluxDBMetricsExporterOptionsTestExtensions
         options.Bucket = "MyBucket";
         options.Org = "MyOrg";
         options.Token = "MyToken";
-
-        // For tests, we want to flush the metrics ASAP
-        options.FlushInterval = 1;
     }
 }


### PR DESCRIPTION
Fixes #4473

## Changes

Metrics were written fire-and-forget into WriteApi's internal Rx buffer, which is unbounded and never surfaces write failures to the caller, so Export always returned Success. When InfluxDB was unavailable the buffer grew until the process was OOM-killed (#4474).

Write metrics synchronously via IWriteApiAsync and return ExportResult.Failure when a write fails. The SDK then applies backpressure and PeriodicExportingMetricReader retries on the next export cycle. Because the reader uses cumulative temporality, no data is lost: the accumulated values are re-exported once writes succeed again, so memory is bounded by cardinality rather than by outage duration. The now-unused FlushInterval option is removed.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
