### PR TITLE
[StackExchange.Redis] ignore Enrich callback exceptions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -6,6 +6,10 @@
   zero-interval spin loops.
   ([#4860](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4860))
 
+* Fixed exceptions thrown from a user-supplied `Enrich`
+  callback preventing the `Activity` from being stopped.
+  ([#4900](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4900))
+
 ## 1.17.0-beta.1
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -228,7 +228,14 @@ internal static class RedisProfilerEntryToActivityConverter
                 activity.AddEvent(new ActivityEvent("ResponseReceived", response));
             }
 
-            options.Enrich?.Invoke(activity, new(parentActivity, command));
+            try
+            {
+                options.Enrich?.Invoke(activity, new(parentActivity, command));
+            }
+            catch
+            {
+                // exceptions in Enrich callback should not prevent the activity from being stopped.
+            }
         }
 
         activity.Stop();

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -135,6 +135,22 @@ public class RedisProfilerEntryToActivityConverterTests : IDisposable
         Assert.Equal(dnsEndPoint.Port, result.GetTagValue(SemanticConventions.AttributeServerPort));
     }
 
+    [Fact]
+    public void ProfilerCommandToActivity_EnrichThrows_StillStopsActivity()
+    {
+        var activity = new Activity("redis-profiler");
+        var profiledCommand = new TestProfiledCommand(DateTime.UtcNow);
+        var options = new StackExchangeRedisInstrumentationOptions
+        {
+            Enrich = (_, _) => throw new InvalidOperationException("boom"),
+        };
+
+        var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand, options);
+
+        Assert.NotNull(result);
+        Assert.NotEqual(default, result.Duration);
+    }
+
 #if !NETFRAMEWORK
     [Fact]
     public void ProfilerCommandToActivity_UsesOtherEndPointAsEndPoint()


### PR DESCRIPTION
## Changes

Ignore Enrich callback exceptions just like the existing Filter callback handling. Exceptions from the Enrich callback prevented the activity being constructed from being stopped appropriately.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
