### PR TITLE
[Runtime] Remove reflection when accessing GC pause duration

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Use a direct call for GC pause duration metric, instead of reflection,
+  to improve trimming and NativeAOT compatibility.
+  ([#4904](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4904))
+
 ## 1.17.0
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -192,13 +192,11 @@ internal sealed class RuntimeMetrics : IDisposable
             unit: "bytes",
             description: "The heap fragmentation, as observed during the latest garbage collection. The value will be unavailable until at least one garbage collection has occurred.");
 
-#if NET
         meter.CreateObservableCounter(
             "process.runtime.dotnet.gc.duration",
             () => GC.GetTotalPauseDuration().Ticks * NanosecondsPerTick,
             unit: "ns",
             description: "The total amount of time paused in GC since the process start.");
-#endif
 
         meter.CreateObservableCounter(
             "process.runtime.dotnet.jit.il_compiled.size",

--- a/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
@@ -4,9 +4,6 @@
 using System.Diagnostics.Metrics;
 using System.Runtime.ExceptionServices;
 #if NET
-using System.Reflection;
-#endif
-#if NET
 using JitInfo = System.Runtime.JitInfo;
 #endif
 
@@ -195,16 +192,13 @@ internal sealed class RuntimeMetrics : IDisposable
             unit: "bytes",
             description: "The heap fragmentation, as observed during the latest garbage collection. The value will be unavailable until at least one garbage collection has occurred.");
 
-        var mi = typeof(GC).GetMethod("GetTotalPauseDuration", BindingFlags.Public | BindingFlags.Static);
-        var getTotalPauseDuration = mi?.CreateDelegate<Func<TimeSpan>>();
-        if (getTotalPauseDuration != null)
-        {
-            meter.CreateObservableCounter(
-                "process.runtime.dotnet.gc.duration",
-                () => getTotalPauseDuration().Ticks * NanosecondsPerTick,
-                unit: "ns",
-                description: "The total amount of time paused in GC since the process start.");
-        }
+#if NET
+        meter.CreateObservableCounter(
+            "process.runtime.dotnet.gc.duration",
+            () => GC.GetTotalPauseDuration().Ticks * NanosecondsPerTick,
+            unit: "ns",
+            description: "The total amount of time paused in GC since the process start.");
+#endif
 
         meter.CreateObservableCounter(
             "process.runtime.dotnet.jit.il_compiled.size",


### PR DESCRIPTION
## Changes

Use a direct call for accessing the GC pause duration metric to improve trimming and NativeAOT compatibility. Reflection was previously being used for .NET 6 compilation compatibility.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
