### PR TITLE
[Owin] Skip work if tracing is not enabled

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*  Skip unnecessary OWIN processing when tracing is not enabled.
+* Skip unnecessary OWIN processing when tracing is not enabled.
   ([#4919](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4919))
 
 ## 1.17.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+*  Skip unnecessary OWIN processing when tracing is not enabled.
+  ([#4919](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4919))
+
 ## 1.17.0-beta.1
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
@@ -60,6 +60,11 @@ internal sealed class DiagnosticsMiddleware : OwinMiddleware
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void BeginRequest(IOwinContext owinContext)
     {
+        if (!OwinInstrumentationActivitySource.ActivitySource.HasListeners())
+        {
+            return;
+        }
+
         var options = OwinInstrumentationActivitySource.Options;
 
         if (options?.Filter is { } filter)

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
@@ -289,6 +289,39 @@ public class DiagnosticsMiddlewareTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task NoListeners_FilterNotInvoked_MetricsRecorded()
+    {
+        var filterInvocationCount = 0;
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddOwinInstrumentation(options => options.Filter = _ =>
+            {
+                filterInvocationCount++;
+                return true;
+            })
+            .Build())
+        {
+        }
+
+        List<Metric> exportedMetrics = [];
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddInMemoryExporter(exportedMetrics)
+            .AddOwinInstrumentation()
+            .Build();
+
+        using var client = new HttpClient();
+        this.requestCompleteHandle.Reset();
+        using var response = await client.GetAsync(new Uri($"{this.serviceBaseUri}api/test"));
+
+        Assert.True(this.requestCompleteHandle.WaitOne(3000));
+        Assert.Equal(0, filterInvocationCount);
+
+        meterProvider.Dispose();
+        var metric = Assert.Single(exportedMetrics);
+        Assert.Equal("http.server.request.duration", metric.Name);
+        Assert.Equal(1, Assert.Single(this.GetMetricPoints(metric)).GetHistogramCount());
+    }
+
     [Theory]
     [InlineData("path?a=b&c=d", "path?a=Redacted&c=Redacted", false, false)]
     [InlineData("path?a=b&c=d", "path?a=b&c=d", true, false)]


### PR DESCRIPTION
## Changes

Skip the initial OWIN trace-processing steps when tracing is not enabled, avoiding filter evaluation and propagation extraction.  

There should be no functional difference as the results were already being discarded, only that returning early has a minor perf boost.

OWIN metrics continue to be recorded independently.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
