### PR TITLE
[Infra] Pin GitHub Action digests to Semver

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,7 @@
     "config:best-practices",
     "customManagers:dockerfileVersions",
     "customManagers:githubActionsVersions",
+    "helpers:pinGitHubActionDigestsToSemver",
     ":automergeRequireAllStatusChecks",
     ":disableRateLimiting",
     ":enableVulnerabilityAlerts",


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

This enables `helpers:pinGitHubActionDigestsToSemver` as mentioned in https://github.com/open-telemetry/sig-security/issues/116

Setting is explained at https://docs.renovatebot.com/presets-helpers/

This just brings consistency to the versions specified for github actions.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
