### PR TITLE
[StackExchange.Redis] Fix empty `Baggage.Current` on command activities

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -14,6 +14,15 @@
   instrumentation is disposed.
   ([#4905](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4905))
 
+* Fixed `Baggage.Current` being empty in samplers, processors and the `Filter`
+  and `Enrich` callbacks for Redis command activities.
+  ([#4927](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4927))
+
+* Fixed the Redis command drain thread inheriting the execution context of the
+  thread that created the instrumentation, which leaked that context's baggage
+  onto every Redis command activity.
+  ([#4927](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4927))
+
 ## 1.17.0-beta.1
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -243,11 +243,34 @@ internal static class RedisProfilerEntryToActivityConverter
         return activity;
     }
 
-    public static void DrainSession(Activity? parentActivity, IEnumerable<IProfiledCommand> sessionCommands, StackExchangeRedisInstrumentationOptions options)
+    public static void DrainSession(
+        Activity? parentActivity,
+        IEnumerable<IProfiledCommand> sessionCommands,
+        Baggage baggage,
+        StackExchangeRedisInstrumentationOptions options)
     {
-        foreach (var command in sessionCommands)
+        // Whoever issued the commands isn't the one draining them, so their baggage has
+        // to be put back by hand. Skipped when empty, or every Activity below pays for it.
+        var previousBaggage = Baggage.Current;
+        var applyBaggage = baggage.Count != 0;
+        if (applyBaggage)
         {
-            ProfilerCommandToActivity(parentActivity, command, options);
+            Baggage.Current = baggage;
+        }
+
+        try
+        {
+            foreach (var command in sessionCommands)
+            {
+                ProfilerCommandToActivity(parentActivity, command, options);
+            }
+        }
+        finally
+        {
+            if (applyBaggage)
+            {
+                Baggage.Current = previousBaggage;
+            }
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs
@@ -45,8 +45,9 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
         new(SemanticConventions.AttributeDbSystemName, "redis"),
     ];
 
-    internal readonly ConcurrentDictionary<(ActivityTraceId TraceId, ActivitySpanId SpanId), (Activity Activity, ProfilingSession Session)> Cache
-        = new();
+    internal readonly ConcurrentDictionary<
+        (ActivityTraceId TraceId, ActivitySpanId SpanId),
+        (Activity Activity, ProfilingSession Session, Baggage Baggage)> Cache = new();
 
     private readonly StackExchangeRedisInstrumentationOptions options;
     private readonly EventWaitHandle stopHandle = new(false, EventResetMode.ManualReset);
@@ -74,7 +75,26 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
             Name = string.IsNullOrWhiteSpace(name) ? "OpenTelemetry.Redis" : $"OpenTelemetry.Redis{{{name}}}",
             IsBackground = true,
         };
-        this.drainThread.Start();
+
+        // Thread.Start() would hand the drain thread this execution context, and with it
+        // this thread's BaggageHolder, which draining would then write straight through.
+        var restoreFlow = !ExecutionContext.IsFlowSuppressed();
+        if (restoreFlow)
+        {
+            ExecutionContext.SuppressFlow();
+        }
+
+        try
+        {
+            this.drainThread.Start();
+        }
+        finally
+        {
+            if (restoreFlow)
+            {
+                ExecutionContext.RestoreFlow();
+            }
+        }
 
         connection.RegisterProfiler(this.GetProfilerSessionsFactory());
     }
@@ -102,7 +122,9 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
         var cacheKey = (parent.TraceId, parent.SpanId);
         if (!this.Cache.TryGetValue(cacheKey, out var session))
         {
-            session = (parent, new ProfilingSession());
+            // This runs on the thread that issued the command, the only point at which
+            // the caller's Baggage is still reachable. Draining happens elsewhere.
+            session = (parent, new ProfilingSession(), Baggage.Current);
             this.Cache.TryAdd(cacheKey, session);
         }
 
@@ -127,7 +149,9 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
 
     internal void Flush()
     {
-        RedisProfilerEntryToActivityConverter.DrainSession(null, this.defaultSession.FinishProfiling(), this.options);
+        // Commands with no parent Activity share defaultSession, so there is no single
+        // caller to attribute baggage to.
+        RedisProfilerEntryToActivityConverter.DrainSession(null, this.defaultSession.FinishProfiling(), default, this.options);
 
         foreach (var entry in this.Cache)
         {
@@ -137,7 +161,7 @@ internal sealed class StackExchangeRedisConnectionInstrumentation : IDisposable
             if (this.options.EnableEarlyCommandDrain || parentCompleted)
             {
                 var session = entry.Value.Session;
-                RedisProfilerEntryToActivityConverter.DrainSession(parent, session.FinishProfiling(), this.options);
+                RedisProfilerEntryToActivityConverter.DrainSession(parent, session.FinishProfiling(), entry.Value.Baggage, this.options);
             }
 
             if (parentCompleted)

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Benchmarks/RedisProfilerDrainSessionBenchmarks.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Benchmarks/RedisProfilerDrainSessionBenchmarks.cs
@@ -15,12 +15,16 @@ public class RedisProfilerDrainSessionBenchmarks
     private Activity? parentActivity;
     private StackExchangeRedisInstrumentationOptions? options;
     private IProfiledCommand[]? sessionCommands;
+    private Baggage baggage;
 
     [Params(false, true)]
     public bool EnrichActivityWithTimingEvents { get; set; }
 
     [Params(1, 10, 100)]
     public int CommandCount { get; set; }
+
+    [Params(0, 3)]
+    public int BaggageItemCount { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -53,6 +57,11 @@ public class RedisProfilerDrainSessionBenchmarks
         {
             this.sessionCommands[i] = BenchmarkProfiledCommand.Create(commandCreated.AddTicks(i), i);
         }
+
+        for (var i = 0; i < this.BaggageItemCount; i++)
+        {
+            this.baggage = this.baggage.SetBaggage($"key{i}", $"value{i}");
+        }
     }
 
     [GlobalCleanup]
@@ -60,5 +69,5 @@ public class RedisProfilerDrainSessionBenchmarks
 
     [Benchmark]
     public void DrainSession() =>
-        RedisProfilerEntryToActivityConverter.DrainSession(this.parentActivity, this.sessionCommands!, this.options!);
+        RedisProfilerEntryToActivityConverter.DrainSession(this.parentActivity, this.sessionCommands!, this.baggage, this.options!);
 }

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Net;
+using System.Runtime.ExceptionServices;
 using OpenTelemetry.Instrumentation.StackExchangeRedis.Tests;
 
 #if !NETFRAMEWORK
@@ -168,4 +169,93 @@ public class RedisProfilerEntryToActivityConverterTests : IDisposable
         Assert.Equal(unixEndPoint.ToString(), result.GetTagValue(SemanticConventions.AttributeNetworkPeerAddress));
     }
 #endif
+
+    [Fact]
+    public void DrainSession_UsesCapturedBaggage()
+    {
+        var recorded = new List<Baggage>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(StackExchangeRedisConnectionInstrumentation.ActivitySource.Name)
+            .AddProcessor(new BaggageRecordingProcessor(recorded))
+            .Build();
+
+        var activity = new Activity("redis-profiler");
+        var commands = new[] { new TestProfiledCommand(DateTime.UtcNow) };
+        var captured = default(Baggage).SetBaggage("user.id", "u-42");
+
+        DrainOnIsolatedThread(() =>
+        {
+            Baggage.SetBaggage("user.id", "stale-from-construction");
+
+            RedisProfilerEntryToActivityConverter.DrainSession(activity, commands, captured, new StackExchangeRedisInstrumentationOptions());
+        });
+
+        Assert.Equal("u-42", Assert.Single(recorded).GetBaggage("user.id"));
+    }
+
+    [Fact]
+    public void DrainSession_RestoresPreviousBaggage()
+    {
+        var activity = new Activity("redis-profiler");
+        var commands = new[] { new TestProfiledCommand(DateTime.UtcNow) };
+        var captured = default(Baggage).SetBaggage("user.id", "u-42");
+
+        DrainOnIsolatedThread(() =>
+        {
+            Baggage.SetBaggage("owner", "draining-thread");
+
+            RedisProfilerEntryToActivityConverter.DrainSession(activity, commands, captured, new StackExchangeRedisInstrumentationOptions());
+
+            Assert.Equal("draining-thread", Baggage.Current.GetBaggage("owner"));
+            Assert.Null(Baggage.Current.GetBaggage("user.id"));
+        });
+    }
+
+    // Runs on a thread that does not inherit this execution context, the way the real
+    // drain thread is started. Baggage set inside is not visible to the test thread.
+    private static void DrainOnIsolatedThread(Action action)
+    {
+        ExceptionDispatchInfo? failure = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                failure = ExceptionDispatchInfo.Capture(ex);
+            }
+        })
+        {
+            IsBackground = true,
+        };
+
+        var restoreFlow = !ExecutionContext.IsFlowSuppressed();
+        if (restoreFlow)
+        {
+            ExecutionContext.SuppressFlow();
+        }
+
+        try
+        {
+            thread.Start();
+        }
+        finally
+        {
+            if (restoreFlow)
+            {
+                ExecutionContext.RestoreFlow();
+            }
+        }
+
+        thread.Join();
+        failure?.Throw();
+    }
+
+    private sealed class BaggageRecordingProcessor(List<Baggage> recorded) : BaseProcessor<Activity>
+    {
+        public override void OnEnd(Activity data) => recorded.Add(Baggage.Current);
+    }
 }


### PR DESCRIPTION
Fixes #2681  

## Changes

Redis activities are created on a drain thread, so `Baggage.Current` is not visible when the activity is created.
The session factory now reads it when creating a profiling session.  Baggage is captured once per session.

The drain thread no longer inherits the execution context of the thread that constructed the instrumentation, since that leaked that context's baggage onto every activity (both threads shared one `BaggageHolder`) .`CHANGELOG.md` entry is present for it.

### Performance
`DrainSession` skips the set and restore when the captured baggage is empty. Both columns are `BaggageItemCount = 0`, so the path an app with no baggage takes.

Timing events | Commands | With check | Without check | Δ
-- | -- | -- | -- | --
False | 1 | 792 B | 880 B | +88 B
False | 10 | 7,112 B | 7,992 B | +880 B
False | 100 | 70,832 B | 79,632 B | +8,800 B (+12.4%)
True | 1 | 992 B | 1,080 B | +88 B
True | 10 | 9,112 B | 9,992 B | +880 B
True | 100 | 90,832 B | 99,632 B | +8,800 B (+9.7%)


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
