### PR TITLE
[Infra] Fix MSB3277 warnings

### DIFF
--- a/build/Projects/OpenTelemetry.PersistentStorage.proj
+++ b/build/Projects/OpenTelemetry.PersistentStorage.proj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.Abstractions\OpenTelemetry.PersistentStorage.Abstractions.csproj" />
-    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.PersistentStorage.Abstractions.Tests\OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj" />
     <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.FileSystem\OpenTelemetry.PersistentStorage.FileSystem.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.PersistentStorage.Abstractions.Tests\OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj" />
     <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.PersistentStorage.FileSystem.Tests\OpenTelemetry.PersistentStorage.FileSystem.Tests.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.Abstractions\OpenTelemetry.PersistentStorage.Abstractions.csproj" />

--- a/build/Projects/OpenTelemetry.PersistentStorage.proj
+++ b/build/Projects/OpenTelemetry.PersistentStorage.proj
@@ -7,12 +7,14 @@
 
   <ItemGroup>
     <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.Abstractions\OpenTelemetry.PersistentStorage.Abstractions.csproj" />
+    <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.PersistentStorage.Abstractions.Tests\OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj" />
     <SolutionProjects Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.FileSystem\OpenTelemetry.PersistentStorage.FileSystem.csproj" />
     <SolutionProjects Include="$(RepoRoot)\test\OpenTelemetry.PersistentStorage.FileSystem.Tests\OpenTelemetry.PersistentStorage.FileSystem.Tests.csproj" />
 
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.Abstractions\OpenTelemetry.PersistentStorage.Abstractions.csproj" />
     <PackProjects Include="$(RepoRoot)\src\OpenTelemetry.PersistentStorage.FileSystem\OpenTelemetry.PersistentStorage.FileSystem.csproj" />
 
+    <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.PersistentStorage.Abstractions.Tests\OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj" />
     <TestProjects Include="$(RepoRoot)\test\OpenTelemetry.PersistentStorage.FileSystem.Tests\OpenTelemetry.PersistentStorage.FileSystem.Tests.csproj" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj
+++ b/test/OpenTelemetry.PersistentStorage.Abstractions.Tests/OpenTelemetry.PersistentStorage.Abstractions.Tests.csproj
@@ -14,4 +14,9 @@
     <Compile Include="$(RepoRoot)\test\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Memory" VersionOverride="4.6.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Changes

- Fix [MSB3277 warnings](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/30775244107/job/91569396403#step:7:603) caused by #4910.
- Add missing entries to `OpenTelemetry.PersistentStorage.proj` that caused the issue to not be detected in #4910 before merge.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
