### PR TITLE
[SqlClient] SqlProcessor fixes

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* Fixed query sanitization so that a `)` inside a value or a comment in an
+  `IN (...)` clause no longer causes the values which follow it to be left
+  unsanitized.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
+* Fixed query sanitization so that literals are still redacted after the
+  `db.query.summary` length limit is reached.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.17.0-beta.1
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -5,11 +5,11 @@
 * Fixed query sanitization so that a `)` inside a value or a comment in an
   `IN (...)` clause no longer causes the values which follow it to be left
   unsanitized.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4929))
 
 * Fixed query sanitization so that literals are still redacted after the
   `db.query.summary` length limit is reached.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4929))
 
 ## 1.17.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* Fixed query sanitization so that a `)` inside a value or a comment in an
+  `IN (...)` clause no longer causes the values which follow it to be left
+  unsanitized.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
+* Fixed query sanitization so that literals are still redacted after the
+  `db.query.summary` length limit is reached.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.17.0
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -5,11 +5,11 @@
 * Fixed query sanitization so that a `)` inside a value or a comment in an
   `IN (...)` clause no longer causes the values which follow it to be left
   unsanitized.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4929))
 
 * Fixed query sanitization so that literals are still redacted after the
   `db.query.summary` length limit is reached.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#4929](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4929))
 
 ## 1.17.0
 

--- a/src/Shared/SqlProcessor.cs
+++ b/src/Shared/SqlProcessor.cs
@@ -37,10 +37,15 @@ internal static class SqlProcessor
     private static readonly char[] LineBreakChars = [CarriageReturnChar, NewLineChar];
 #endif
 
+    // The characters which can start a construct that a ')' may legitimately appear inside
+    // (a string literal or a comment), plus ')' itself. Used to find the end of an IN clause.
+    private static readonly char[] InClauseScanChars = [CloseParenChar, SingleQuoteChar, DashChar, ForwardSlashChar];
+
 #if NET
     private static readonly SearchValues<char> AsciiLetterSearchValues = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
     private static readonly SearchValues<char> LineBreakSearchValues = SearchValues.Create("\n\r");
     private static readonly SearchValues<char> WhitespaceSearchValues = SearchValues.Create(WhitespaceChars);
+    private static readonly SearchValues<char> InClauseScanSearchValues = SearchValues.Create(InClauseScanChars);
 #endif
 
     // This is not an exhaustive list but covers the majority of common reserved SQL keywords that may follow a FROM clause.
@@ -291,14 +296,10 @@ internal static class SqlProcessor
                 continue;
             }
 
-            if (state.SummaryPosition >= MaxSummaryLength)
-            {
-                ParseNextTokenFast(sqlSpan, buffer, ref state);
-            }
-            else
-            {
-                ParseNextToken(sqlSpan, buffer, ref state);
-            }
+            // Reaching the summary length limit must not change how the statement itself is
+            // parsed. Tokenization continues unchanged and only the accumulation of the summary
+            // stops, which ParseNextToken handles via SummaryIsComplete.
+            ParseNextToken(sqlSpan, buffer, ref state);
         }
 
         var summary = state.SummaryBuffer.Slice(0, state.SummaryPosition);
@@ -389,30 +390,6 @@ internal static class SqlProcessor
 
         state.RentedSummaryBuffer = newBuffer;
         state.SummaryBuffer = newBuffer.AsSpan();
-    }
-
-    private static void ParseNextTokenFast(
-        ReadOnlySpan<char> sql,
-        Span<char> buffer,
-        ref ParseState state)
-    {
-        var start = state.ParsePosition;
-        var remaining = sql.Length - start;
-
-#if NET
-        var indexOfNextWhitespace = sql.Slice(start).IndexOfAny(WhitespaceSearchValues);
-#else
-        var indexOfNextWhitespace = sql.Slice(start).IndexOfAny(WhitespaceChars);
-#endif
-
-        var length = indexOfNextWhitespace >= 0 ? indexOfNextWhitespace : remaining;
-
-        sql.Slice(start, length).CopyTo(buffer.Slice(state.SanitizedPosition));
-        state.SanitizedPosition += length;
-        state.ParsePosition += length;
-
-        // Note, for efficiency, we do not attempt to update the previous token start/end positions
-        // We no longer use these when in fast path mode.
     }
 
     private static void ParseNextToken(
@@ -518,7 +495,7 @@ internal static class SqlProcessor
                     state.SanitizedPosition += keywordLength;
 
                     // Potentially copy the keyword to the summary buffer.
-                    if (SqlKeywordInfo.CaptureInSummary(in state, potentialKeywordInfo))
+                    if (!state.SummaryIsComplete && SqlKeywordInfo.CaptureInSummary(in state, potentialKeywordInfo))
                     {
                         if (state.SummaryPosition == 0)
                         {
@@ -607,7 +584,7 @@ internal static class SqlProcessor
                 }
 
                 // Optionally copy to summary buffer.
-                if (state.CaptureNextNonKeywordTokenAsIdentifier)
+                if (state.CaptureNextNonKeywordTokenAsIdentifier && !state.SummaryIsComplete)
                 {
                     AppendSummaryToken(sql.Slice(start, length), ref state);
 
@@ -632,19 +609,22 @@ internal static class SqlProcessor
             {
                 state.InEscapedIdentifier = false;
 
-                // Remove the space we added after the identifier in the summary buffer before we write the closing bracket.
-                state.SummaryPosition--;
-
-                AppendSummaryChar(CloseSquareBracketChar, ref state);
-
-                var nextPos = state.ParsePosition + 1;
-                if (nextPos >= sql.Length || sql[nextPos] != DotChar)
+                if (!state.SummaryIsComplete)
                 {
-                    AppendSummaryChar(SpaceChar, ref state);
-                }
-                else
-                {
-                    AppendSummaryChar(DotChar, ref state); // write the dot to summary
+                    // Remove the space we added after the identifier in the summary buffer before we write the closing bracket.
+                    state.SummaryPosition--;
+
+                    AppendSummaryChar(CloseSquareBracketChar, ref state);
+
+                    var nextPos = state.ParsePosition + 1;
+                    if (nextPos >= sql.Length || sql[nextPos] != DotChar)
+                    {
+                        AppendSummaryChar(SpaceChar, ref state);
+                    }
+                    else
+                    {
+                        AppendSummaryChar(DotChar, ref state); // write the dot to summary
+                    }
                 }
             }
 
@@ -658,7 +638,11 @@ internal static class SqlProcessor
                 && HasTerminatingEscapedIdentifier(sql, state.ParsePosition, ref state))
             {
                 state.InEscapedIdentifier = true;
-                AppendSummaryChar(OpenSquareBracketChar, ref state);
+
+                if (!state.SummaryIsComplete)
+                {
+                    AppendSummaryChar(OpenSquareBracketChar, ref state);
+                }
             }
 
             buffer[state.SanitizedPosition++] = currentChar;
@@ -975,16 +959,150 @@ internal static class SqlProcessor
                 return false;
             }
 
-            var closeParenIndex = sql.Slice(parsePosition).IndexOf(CloseParenChar);
-            if (closeParenIndex >= 0)
+            // The closing parenthesis has to be located with a literal- and comment-aware
+            // scan. A plain IndexOf(')') can match a ')' inside a value (for example
+            // "IN ('a)b', 'secret')"), which would leave the parser positioned in the middle of
+            // that literal. Every subsequent quote would then be mismatched and the remaining
+            // values would be copied into the sanitized SQL verbatim instead of being replaced.
+            if (TryFindEndOfInClause(sql, parsePosition, out var closeParenIndex))
             {
-                state.ParsePosition = parsePosition + closeParenIndex;
+                state.ParsePosition = closeParenIndex;
                 buffer[state.SanitizedPosition++] = SanitizationPlaceholder;
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Finds the index of the parenthesis which closes an <c>IN (</c> clause, ignoring any
+    /// parenthesis which appears inside a string literal or a comment.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if a closing parenthesis was found, in which case
+    /// <paramref name="closeParenIndex"/> is its index in <paramref name="sql"/>.
+    /// <see langword="false"/> if the clause is not terminated, in which case the caller
+    /// falls back to sanitizing each value individually.
+    /// </returns>
+    private static bool TryFindEndOfInClause(ReadOnlySpan<char> sql, int start, out int closeParenIndex)
+    {
+        var length = sql.Length;
+        var i = start;
+
+        while (i < length)
+        {
+#if NET
+            var offset = sql.Slice(i).IndexOfAny(InClauseScanSearchValues);
+#else
+            var offset = sql.Slice(i).IndexOfAny(InClauseScanChars);
+#endif
+
+            if (offset < 0)
+            {
+                break;
+            }
+
+            i += offset;
+
+            switch (sql[i])
+            {
+                case CloseParenChar:
+                    closeParenIndex = i;
+                    return true;
+
+                case SingleQuoteChar:
+                    i = SkipStringLiteral(sql, i);
+                    break;
+
+                case DashChar:
+                    i = i + 1 < length && sql[i + 1] == DashChar
+                        ? SkipSingleLineComment(sql, i)
+                        : i + 1;
+                    break;
+
+                // ForwardSlashChar
+                default:
+                    i = i + 1 < length && sql[i + 1] == AsteriskChar
+                        ? SkipMultiLineComment(sql, i)
+                        : i + 1;
+                    break;
+            }
+        }
+
+        closeParenIndex = -1;
+        return false;
+
+        // Returns the index after the closing quote, or the end of the input if the
+        // literal is not terminated.
+        static int SkipStringLiteral(ReadOnlySpan<char> sql, int quotePosition)
+        {
+            var length = sql.Length;
+            var i = quotePosition + 1;
+
+            while (i < length)
+            {
+                var quoteIndex = sql.Slice(i).IndexOf(SingleQuoteChar);
+                if (quoteIndex < 0)
+                {
+                    break;
+                }
+
+                i += quoteIndex;
+
+                // A doubled quote ('') is an escaped quote within the literal.
+                if (i + 1 < length && sql[i + 1] == SingleQuoteChar)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                return i + 1;
+            }
+
+            return length;
+        }
+
+        // Returns the index of the line break which ends the comment, or the end of the
+        // input if there is none.
+        static int SkipSingleLineComment(ReadOnlySpan<char> sql, int dashPosition)
+        {
+#if NET
+            var lineBreakIndex = sql.Slice(dashPosition + 2).IndexOfAny(LineBreakSearchValues);
+#else
+            var lineBreakIndex = sql.Slice(dashPosition + 2).IndexOfAny(LineBreakChars);
+#endif
+
+            return lineBreakIndex < 0 ? sql.Length : dashPosition + 2 + lineBreakIndex;
+        }
+
+        // Returns the index after the closing "*/", or the end of the input if the comment
+        // is not terminated.
+        static int SkipMultiLineComment(ReadOnlySpan<char> sql, int slashPosition)
+        {
+            var length = sql.Length;
+            var i = slashPosition + 2;
+
+            while (i < length)
+            {
+                var asteriskIndex = sql.Slice(i).IndexOf(AsteriskChar);
+                if (asteriskIndex < 0)
+                {
+                    break;
+                }
+
+                i += asteriskIndex;
+
+                if (i + 1 < length && sql[i + 1] == ForwardSlashChar)
+                {
+                    return i + 2;
+                }
+
+                i++;
+            }
+
+            return length;
+        }
     }
 
     private ref struct ParseState
@@ -1040,6 +1158,12 @@ internal static class SqlProcessor
         /// As soon as we match a reserved keyword, we exit the FROM clause state.
         /// </summary>
         public bool InFromClause; // 1 byte
+
+        /// <summary>
+        /// Gets a value indicating whether the summary has reached its maximum length, after which
+        /// nothing further is appended to it.
+        /// </summary>
+        public readonly bool SummaryIsComplete => this.SummaryPosition >= MaxSummaryLength;
     }
 
     private sealed class SqlKeywordInfo

--- a/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.FuzzTests/SqlProcessorTests.cs
@@ -70,6 +70,61 @@ public static class SqlProcessorTests
     }
 
     [Property(MaxTest = MaxValue)]
+    public static void GetSanitizedSql_In_Clause_Literals_Are_Sanitized(NonEmptyString input)
+    {
+        // Arrange
+        const string Secret = "s3cr3t-v4lu3";
+
+        if (input.Get.Contains(Secret, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Whatever the first value contains, no later value may survive sanitization.
+        var sql = $"SELECT * FROM table WHERE name IN ('{input.Get.Replace("'", "''")}', '{Secret}')";
+
+        // Act
+        var actual = SqlProcessor.GetSanitizedSql(sql);
+
+        // Assert
+        Assert.DoesNotContain(Secret, actual.SanitizedSql);
+    }
+
+    [Property(MaxTest = MaxValue)]
+    public static void GetSanitizedSql_Literals_Are_Sanitized_Beyond_Summary_Length_Limit(
+        PositiveInt tableCount,
+        NonNegativeInt variant)
+    {
+        // Arrange
+        const string Secret = "s3cr3t-v4lu3";
+
+        // Pad the FROM clause so that the summary reaches its maximum length, after which the
+        // remainder of the statement must still be sanitized.
+        var count = (tableCount.Get % 40) + 1;
+        var tables = string.Join(",", Enumerable.Range(0, count).Select((p) => $"CustomerOrderDetails{p}"));
+
+        // The literal is deliberately not preceded by whitespace in most variants, because that
+        // is the case a whitespace-delimited scan copies verbatim.
+        var clause = (variant.Get % 5) switch
+        {
+            0 => $"WHERE Name='{Secret}'",
+            1 => $"WHERE Name=N'{Secret}'",
+            2 => $"WHERE Name IN ('{Secret}')",
+            3 => $"WHERE Name LIKE'%{Secret}%'",
+            _ => $"WHERE Name = '{Secret}'",
+        };
+
+        var sql = $"SELECT * FROM {tables} {clause}";
+
+        // Act
+        var actual = SqlProcessor.GetSanitizedSql(sql);
+
+        // Assert
+        Assert.DoesNotContain(Secret, actual.SanitizedSql);
+        Assert.True(actual.DbQuerySummary.Length <= 255);
+    }
+
+    [Property(MaxTest = MaxValue)]
     public static void GetSanitizedSql_Hex_Literals_Are_Sanitized(NonNegativeInt number)
     {
         // Arrange

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlProcessorTests.cs
@@ -5,6 +5,12 @@ namespace OpenTelemetry.Instrumentation.Tests;
 
 public class SqlProcessorTests
 {
+    /// <summary>
+    /// A table name long enough that the query summary reaches its maximum length of 255
+    /// characters once it has been captured.
+    /// </summary>
+    private static readonly string LongCapturedIdentifier = new('T', 260);
+
     private readonly ITestOutputHelper output;
 
     public SqlProcessorTests(ITestOutputHelper output)
@@ -57,6 +63,141 @@ public class SqlProcessorTests
         Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
         Assert.DoesNotContain("123", sqlStatementInfo.SanitizedSql);
         Assert.DoesNotContain("DEADBEEF", sqlStatementInfo.SanitizedSql);
+    }
+
+    [Theory]
+    [InlineData("SELECT * FROM Users WHERE Name IN ('a)b', 'secret-name')")]
+    [InlineData("SELECT * FROM Users WHERE Name IN ('a)b', 'secret-name', 'another)one')")]
+    [InlineData("SELECT * FROM Users WHERE Name IN ('O''Brien)', 'secret-name')")]
+    [InlineData("SELECT * FROM Users WHERE Name IN ('))', 'secret-name')")]
+    [InlineData("SELECT * FROM Users WHERE Name IN (1 /* don't */, 'a)b', 'secret-name')")]
+    [InlineData("SELECT * FROM Users WHERE Name IN (1 /* ) */, 'secret-name')")]
+    [InlineData("SELECT * FROM Users WHERE Name IN (1, -- don't )\n'secret-name')")]
+    public void GetSanitizedSql_InClauseLiteralOrCommentContainingCloseParen_SanitizesAllLiterals(string sql)
+    {
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        this.output.WriteLine($"Sanitized: {sqlStatementInfo.SanitizedSql}");
+
+        Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
+        Assert.Equal("SELECT * FROM Users WHERE Name IN (?)", sqlStatementInfo.SanitizedSql);
+        Assert.Equal("SELECT Users", sqlStatementInfo.DbQuerySummary);
+    }
+
+    [Fact]
+    public void GetSanitizedSql_InClauseLiteralContainingCloseParen_DoesNotLeakPersonalData()
+    {
+        var sql = "SELECT Id FROM Users WHERE Email IN ('x)', 'user@example.com')";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        Assert.DoesNotContain("user@example.com", sqlStatementInfo.SanitizedSql);
+        Assert.Equal("SELECT Id FROM Users WHERE Email IN (?)", sqlStatementInfo.SanitizedSql);
+    }
+
+    [Fact]
+    public void GetSanitizedSql_UnterminatedInClauseLiteralContainingCloseParen_SanitizesAllLiterals()
+    {
+        // Without a closing parenthesis outside of the literals there is no clause to collapse,
+        // so each value is sanitized individually instead.
+        var sql = "SELECT * FROM Users WHERE Name IN ('a)b', 'secret-name'";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
+        Assert.Equal("SELECT * FROM Users WHERE Name IN (?, ?", sqlStatementInfo.SanitizedSql);
+    }
+
+    [Fact]
+    public void GetSanitizedSql_UnterminatedInClauseStringLiteral_SanitizesLiteral()
+    {
+        var sql = "SELECT * FROM Users WHERE Name IN ('secret-name";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
+        Assert.Equal("SELECT * FROM Users WHERE Name IN (?", sqlStatementInfo.SanitizedSql);
+    }
+
+    [Theory]
+    [InlineData("WHERE Password='secret-name'")]
+    [InlineData("WHERE Password=N'secret-name'")]
+    [InlineData("WHERE Password = 'secret-name'")]
+    [InlineData("WHERE Email IN ('secret-name','other')")]
+    [InlineData("WHERE Email LIKE'%secret-name%'")]
+    [InlineData("INSERT INTO Credentials (User, Password) VALUES ('admin','secret-name')")]
+    public void GetSanitizedSql_StringLiteralAfterSummaryLengthLimitReached_SanitizesLiteral(string clause)
+    {
+        var sql = $"SELECT * FROM {LongCapturedIdentifier} {clause}";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        this.output.WriteLine($"Sanitized: {sqlStatementInfo.SanitizedSql}");
+
+        Assert.DoesNotContain("secret-name", sqlStatementInfo.SanitizedSql);
+    }
+
+    [Theory]
+    [InlineData("WHERE SocialSecurityNumber=123456789", "123456789")]
+    [InlineData("WHERE SocialSecurityNumber = 123456789", "123456789")]
+    [InlineData("WHERE ApiToken=0xDEADBEEF", "DEADBEEF")]
+    [InlineData("WHERE ApiToken = 0xDEADBEEF", "DEADBEEF")]
+    public void GetSanitizedSql_NumericOrHexLiteralAfterSummaryLengthLimitReached_SanitizesLiteral(string clause, string literal)
+    {
+        var sql = $"SELECT * FROM {LongCapturedIdentifier} {clause}";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        this.output.WriteLine($"Sanitized: {sqlStatementInfo.SanitizedSql}");
+
+        Assert.DoesNotContain(literal, sqlStatementInfo.SanitizedSql);
+    }
+
+    [Fact]
+    public void GetSanitizedSql_ManyJoinsExceedingSummaryLengthLimit_SanitizesLiteral()
+    {
+        var joins = string.Join(
+            " ",
+            Enumerable.Range(0, 12).Select(i =>
+                $"INNER JOIN CustomerOrderDetails{i} AS d{i} ON d{i}.OrderId = o.OrderId"));
+
+        var sql = $"SELECT o.OrderId, c.Email FROM Orders AS o {joins} WHERE c.Email='user@example.com'";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        this.output.WriteLine($"Sanitized: {sqlStatementInfo.SanitizedSql}");
+
+        Assert.DoesNotContain("user@example.com", sqlStatementInfo.SanitizedSql);
+        Assert.True(sqlStatementInfo.DbQuerySummary.Length <= 255);
+    }
+
+    [Fact]
+    public void GetSanitizedSql_ManyTablesExceedingSummaryLengthLimit_SanitizesLiteral()
+    {
+        var tables = string.Join(",", Enumerable.Range(0, 12).Select(i => $"CustomerOrderDetails{i}"));
+
+        var sql = $"SELECT * FROM {tables} WHERE Email='user@example.com'";
+
+        var sqlStatementInfo = SqlProcessor.GetSanitizedSql(sql);
+
+        this.output.WriteLine($"Sanitized: {sqlStatementInfo.SanitizedSql}");
+
+        Assert.DoesNotContain("user@example.com", sqlStatementInfo.SanitizedSql);
+        Assert.True(sqlStatementInfo.DbQuerySummary.Length <= 255);
+    }
+
+    [Fact]
+    public void GetSanitizedSql_SummaryLengthLimitReached_DoesNotChangeSanitizedSql()
+    {
+        const string Clause = "WHERE Password='secret-name' AND Id=123 AND Token=0xDEADBEEF";
+
+        var shortSummary = SqlProcessor.GetSanitizedSql($"SELECT * FROM Orders {Clause}");
+        var fullSummary = SqlProcessor.GetSanitizedSql($"SELECT * FROM {LongCapturedIdentifier} {Clause}");
+
+        var expected = "WHERE Password=? AND Id=? AND Token=?";
+
+        Assert.EndsWith(expected, shortSummary.SanitizedSql, StringComparison.Ordinal);
+        Assert.EndsWith(expected, fullSummary.SanitizedSql, StringComparison.Ordinal);
     }
 
     [SkippableTheory]


### PR DESCRIPTION
## Changes

- Handle `IN` clauses correctly when values might contain escaped identifiers, such as `)`.
- Ensure queries longer than `db.query.summary` are still redacted correctly.

Found by a Copilot/Claude scan of the repository code.

I asked Claude to investigate whether these changes have any performance impact. It's findings are summarised below.

<details>

<summary>Expand to read Claude 🐙 summary</summary>

## Performance impact of the SQL sanitization fixes

Benchmarks for the two `src/Shared/SqlProcessor.cs` sanitization fixes. Three variants were
compiled into a single process under separate namespaces so they run in one BDN session:

| Variant | Contents |
|---|---|
| `1_head` | neither fix (baseline) |
| `2_pending` | literal/comment-aware `IN (...)` close-paren scan only |
| `3_fixed` | the above **plus** removing the summary-length fast path |

### Methodology note

`GetSanitizedSql` memoises results by statement text (1000-entry cache), so the existing
`SqlProcessorBenchmarks` mostly measures a `ConcurrentDictionary` hit rather than the parser.
An additive uncached entry point (`=> SanitizeSql(sql)`) was used to measure parsing, and the
cached public API was measured separately. The existing benchmark `[Params]` corpus also
contains no statement whose summary reaches `MaxSummaryLength` (255), so the fast path was
previously unbenchmarked.

### Parser throughput (uncached)

| Query shape | `1_head` | `2_pending` | `3_fixed` | ratio | alloc ratio |
|---|---:|---:|---:|---:|---:|
| short_select | 236 ns | 211 ns | 215 ns | 0.92 | 1.00 |
| short_subquery | 542 ns | 480 ns | 492 ns | 0.92 | 1.00 |
| short_insert | 554 ns | 512 ns | 461 ns | 0.83 | 1.00 |
| short_update | 249 ns | 255 ns | 222 ns | 0.90 | 1.00 |
| short_comments | 182 ns | 183 ns | 179 ns | 0.98 | 1.00 |
| short_2tables | 388 ns | 373 ns | 381 ns | 0.98 | 1.00 |
| in_clause_200 | 279 ns | 255 ns | 257 ns | 0.92 | 1.00 |
| limit_joins12 | 3.04 µs | 2.99 µs | 3.26 µs | **1.07** | 4.51 |
| limit_tables12 | 814 ns | 800 ns | 913 ns | **1.13** | 2.17 |
| limit_longident | 548 ns | 538 ns | 707 ns | **1.30** | 17.2 |
| limit_verylong | 5.08 µs | 5.33 µs | 18.3 µs | **3.60** | 23.7 |

The first seven rows are the existing benchmark corpus: **no regression** (all ratios ≤ 1.00;
sub-1.0 values are run-to-run noise). The `IN`-clause fix is free everywhere, including a
200-value `IN` list. Cost appears only on the `limit_*` rows, i.e. statements whose summary
exceeds 255 characters — exactly where the fast path used to engage.

### Isolating CPU cost from allocation

| Control case | `1_head` | `3_fixed` | ratio | alloc ratio |
|---|---:|---:|---:|---:|
| long statement, summary stays **short** | 6.95 µs | 7.16 µs | **1.03** | 1.00 |
| past the limit, **no literals** to redact | 9.59 µs | 21.6 µs | **2.25** | **1.00** |

* The first control shows the change costs nothing for full parsing itself — a comparably long
  statement that never trips the limit is unchanged.
* The second isolates pure CPU at identical allocation: **2.25×**. That is the real cost of
  tokenizing past the limit instead of bulk-copying to the next whitespace.
* Comparing the two controls explains the allocation column, which is **not** waste. Previously
  the fast path left the text unchanged, so `SanitizeSql` took its
  `sanitizedSqlSpan.SequenceEqual(sqlSpan) ? sql : …` branch and returned the *original string
  instance* — allocating nothing, because it had leaked. Once literals are actually redacted the
  string genuinely differs and must be materialised. `limit_longident` is the clearest case:
  40 B → 688 B is the ~300-character redacted statement that previously wasn't produced at all.

### Cached path (steady state, what an application pays per execution)

| Query | `1_head` | `3_fixed` | ratio | allocated |
|---|---:|---:|---:|---:|
| joins12 | 231 ns | 244 ns | 1.06 | 0 B both |
| verylong | 1.74 µs | 1.81 µs | 1.05 | 0 B both |

Within noise, zero allocation either way. Parse cost is paid once per distinct statement text.

### Summary

* No regression for typical statements, or for long statements generally.
* Measurable cost is confined to statements whose summary exceeds `MaxSummaryLength`:
  **1.07–1.30×** for realistic shapes (12 joins, 12 comma-listed tables, long identifier) and
  **3.60×** for a deliberately pathological 5.6 KB statement.
* Amortised to **~5%** by the existing cache.
* Increased allocation reflects correct redaction now happening, not new overhead.

### Environment

```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8875/25H2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 11.0.100-preview.6.26359.118
  [Host] : .NET 10.0.10 (10.0.1026.32716), X64 RyuJIT x86-64-v3
Job=ShortRun  Toolchain=InProcessEmitToolchain  IterationCount=3  LaunchCount=1  WarmupCount=3
```

ShortRun with 3 iterations gives wide error bars; differences under roughly ±10% should be
read as noise. The multi-fold figures were stable across repeated runs.

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
