### PR TITLE
[Process] Reduce allocations of Process objects

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
+++ b/src/OpenTelemetry.Instrumentation.Process/OpenTelemetry.Instrumentation.Process.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -7,44 +7,39 @@ using Diagnostics = System.Diagnostics;
 
 namespace OpenTelemetry.Instrumentation.Process;
 
-internal sealed class ProcessMetrics : IDisposable
+internal sealed class ProcessMetrics
 {
     internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
     internal static readonly Meter MeterInstance = Metrics.MeterFactory.Create<ProcessMetrics>(SemanticConventionsVersion);
 
     private static readonly long SnapshotTtlTicks = Diagnostics.Stopwatch.Frequency / 100; // 10ms
 
-    private readonly Diagnostics.Process currentProcess;
-    private readonly DateTime processStartTimeUtc;
-    private readonly Lock snapshotLock;
+    private static readonly Diagnostics.Process CurrentProcess = Diagnostics.Process.GetCurrentProcess();
+    private static readonly DateTime ProcessStartTimeUtc = CurrentProcess.StartTime.ToUniversalTime();
+    private static readonly Lock SnapshotLock = new();
 
-    private bool disposed;
-    private long snapshotTimestamp;
+    private static long snapshotTimestamp;
 
-    public ProcessMetrics()
+    static ProcessMetrics()
     {
-        this.snapshotLock = new();
-        this.currentProcess = Diagnostics.Process.GetCurrentProcess();
-        this.processStartTimeUtc = this.currentProcess.StartTime.ToUniversalTime();
-
         MeterInstance.CreateObservableUpDownCounter(
             "process.memory.usage",
-            () => this.Measure((p) => p.WorkingSet64),
+            static () => Measure(static (p) => p.WorkingSet64),
             unit: "By",
             description: "The amount of physical memory in use.");
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.memory.virtual",
-            () => this.Measure((p) => p.VirtualMemorySize64),
+            static () => Measure(static (p) => p.VirtualMemorySize64),
             unit: "By",
             description: "The amount of committed virtual memory.");
 
         MeterInstance.CreateObservableCounter<double>(
             "process.cpu.time",
-            () =>
+            static () =>
             {
-                (var userSeconds, var privilegedSeconds) = this.Measure(
-                    (p) => (p.UserProcessorTime.TotalSeconds, p.PrivilegedProcessorTime.TotalSeconds));
+                (var userSeconds, var privilegedSeconds) = Measure(
+                    static (p) => (p.UserProcessorTime.TotalSeconds, p.PrivilegedProcessorTime.TotalSeconds));
 
                 return
                 [
@@ -57,13 +52,13 @@ internal sealed class ProcessMetrics : IDisposable
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.thread.count",
-            () => this.Measure((p) => p.Threads.Count),
+            static () => Measure(static (p) => p.Threads.Count),
             unit: "{thread}",
             description: "Process threads count.");
 
         MeterInstance.CreateObservableGauge(
             "process.uptime",
-            () => (DateTime.UtcNow - this.processStartTimeUtc).TotalSeconds,
+            static () => (DateTime.UtcNow - ProcessStartTimeUtc).TotalSeconds,
             unit: "s",
             description: "The time the process has been running.");
 
@@ -71,7 +66,7 @@ internal sealed class ProcessMetrics : IDisposable
         {
             MeterInstance.CreateObservableUpDownCounter(
                 "process.windows.handle.count",
-                () => this.Measure((p) => p.HandleCount),
+                static () => Measure(static (p) => p.HandleCount),
                 unit: "{handle}",
                 description: "Number of handles held by the process.");
         }
@@ -79,52 +74,31 @@ internal sealed class ProcessMetrics : IDisposable
         {
             MeterInstance.CreateObservableUpDownCounter(
                 "process.unix.file_descriptor.count",
-                () => this.Measure((p) => p.HandleCount),
+                static () => Measure(static (p) => p.HandleCount),
                 unit: "{file_descriptor}",
                 description: "Number of unix file descriptors in use by the process.");
         }
     }
 
-    public void Dispose()
+    private static T Measure<T>(Func<Diagnostics.Process, T> func)
     {
-        lock (this.snapshotLock)
+        lock (SnapshotLock)
         {
-            if (!this.disposed)
-            {
-                this.currentProcess?.Dispose();
-                this.disposed = true;
-            }
+            RefreshSnapshotIfStale();
+            return func(CurrentProcess);
         }
     }
 
-    private T Measure<T>(Func<Diagnostics.Process, T> func)
+    private static void RefreshSnapshotIfStale()
     {
-        lock (this.snapshotLock)
-        {
-            this.RefreshSnapshotIfStale();
-            return func(this.currentProcess);
-        }
-    }
-
-    private void RefreshSnapshotIfStale()
-    {
-#if NET8_0_OR_GREATER
-        ObjectDisposedException.ThrowIf(this.disposed, this);
-#else
-        if (this.disposed)
-        {
-            throw new ObjectDisposedException(nameof(ProcessMetrics));
-        }
-#endif
-
         var now = Diagnostics.Stopwatch.GetTimestamp();
 
-        if (now - this.snapshotTimestamp <= SnapshotTtlTicks)
+        if (now - snapshotTimestamp <= SnapshotTtlTicks)
         {
             return;
         }
 
-        this.snapshotTimestamp = now;
-        this.currentProcess.Refresh();
+        snapshotTimestamp = now;
+        CurrentProcess.Refresh();
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -7,64 +7,62 @@ using Diagnostics = System.Diagnostics;
 
 namespace OpenTelemetry.Instrumentation.Process;
 
-internal sealed class ProcessMetrics
+internal sealed class ProcessMetrics : IDisposable
 {
     internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
     internal static readonly Meter MeterInstance = Metrics.MeterFactory.Create<ProcessMetrics>(SemanticConventionsVersion);
 
-    static ProcessMetrics()
+    private static readonly long SnapshotTtlTicks = Diagnostics.Stopwatch.Frequency / 100; // 10ms
+
+    private readonly Diagnostics.Process currentProcess;
+    private readonly DateTime processStartTimeUtc;
+    private readonly Lock snapshotLock;
+
+    private long snapshotTimestamp;
+
+    public ProcessMetrics()
     {
+        this.snapshotLock = new();
+        this.currentProcess = Diagnostics.Process.GetCurrentProcess();
+        this.processStartTimeUtc = this.currentProcess.StartTime.ToUniversalTime();
+
         MeterInstance.CreateObservableUpDownCounter(
             "process.memory.usage",
-            () =>
-            {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return process.WorkingSet64;
-            },
+            () => this.Measure((p) => p.WorkingSet64),
             unit: "By",
             description: "The amount of physical memory in use.");
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.memory.virtual",
-            () =>
-            {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return process.VirtualMemorySize64;
-            },
+            () => this.Measure((p) => p.VirtualMemorySize64),
             unit: "By",
             description: "The amount of committed virtual memory.");
 
-        MeterInstance.CreateObservableCounter(
+        MeterInstance.CreateObservableCounter<double>(
             "process.cpu.time",
             () =>
             {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return new[]
-                {
-                    new Measurement<double>(process.UserProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("cpu.mode", "user")),
-                    new Measurement<double>(process.PrivilegedProcessorTime.TotalSeconds, new KeyValuePair<string, object?>("cpu.mode", "system")),
-                };
+                (var userSeconds, var privilegedSeconds) = this.Measure(
+                    (p) => (p.UserProcessorTime.TotalSeconds, p.PrivilegedProcessorTime.TotalSeconds));
+
+                return
+                [
+                    new Measurement<double>(userSeconds, new KeyValuePair<string, object?>("cpu.mode", "user")),
+                    new Measurement<double>(privilegedSeconds, new KeyValuePair<string, object?>("cpu.mode", "system")),
+                ];
             },
             unit: "s",
             description: "Total CPU seconds broken down by different CPU modes.");
 
         MeterInstance.CreateObservableUpDownCounter(
             "process.thread.count",
-            () =>
-            {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return process.Threads.Count;
-            },
+            () => this.Measure((p) => p.Threads.Count),
             unit: "{thread}",
             description: "Process threads count.");
 
         MeterInstance.CreateObservableGauge(
             "process.uptime",
-            () =>
-            {
-                using var process = Diagnostics.Process.GetCurrentProcess();
-                return (DateTime.UtcNow - process.StartTime.ToUniversalTime()).TotalSeconds;
-            },
+            () => (DateTime.UtcNow - this.processStartTimeUtc).TotalSeconds,
             unit: "s",
             description: "The time the process has been running.");
 
@@ -72,11 +70,7 @@ internal sealed class ProcessMetrics
         {
             MeterInstance.CreateObservableUpDownCounter(
                 "process.windows.handle.count",
-                () =>
-                {
-                    using var process = Diagnostics.Process.GetCurrentProcess();
-                    return process.HandleCount;
-                },
+                () => this.Measure((p) => p.HandleCount),
                 unit: "{handle}",
                 description: "Number of handles held by the process.");
         }
@@ -84,13 +78,33 @@ internal sealed class ProcessMetrics
         {
             MeterInstance.CreateObservableUpDownCounter(
                 "process.unix.file_descriptor.count",
-                () =>
-                {
-                    using var process = Diagnostics.Process.GetCurrentProcess();
-                    return process.HandleCount;
-                },
+                () => this.Measure((p) => p.HandleCount),
                 unit: "{file_descriptor}",
                 description: "Number of unix file descriptors in use by the process.");
         }
+    }
+
+    public void Dispose() => this.currentProcess.Dispose();
+
+    private T Measure<T>(Func<Diagnostics.Process, T> func)
+    {
+        lock (this.snapshotLock)
+        {
+            this.RefreshSnapshotIfStale();
+            return func(this.currentProcess);
+        }
+    }
+
+    private void RefreshSnapshotIfStale()
+    {
+        var now = Diagnostics.Stopwatch.GetTimestamp();
+
+        if (now - this.snapshotTimestamp <= SnapshotTtlTicks)
+        {
+            return;
+        }
+
+        this.snapshotTimestamp = now;
+        this.currentProcess.Refresh();
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.Process/ProcessMetrics.cs
@@ -18,6 +18,7 @@ internal sealed class ProcessMetrics : IDisposable
     private readonly DateTime processStartTimeUtc;
     private readonly Lock snapshotLock;
 
+    private bool disposed;
     private long snapshotTimestamp;
 
     public ProcessMetrics()
@@ -84,7 +85,17 @@ internal sealed class ProcessMetrics : IDisposable
         }
     }
 
-    public void Dispose() => this.currentProcess.Dispose();
+    public void Dispose()
+    {
+        lock (this.snapshotLock)
+        {
+            if (!this.disposed)
+            {
+                this.currentProcess?.Dispose();
+                this.disposed = true;
+            }
+        }
+    }
 
     private T Measure<T>(Func<Diagnostics.Process, T> func)
     {
@@ -97,6 +108,15 @@ internal sealed class ProcessMetrics : IDisposable
 
     private void RefreshSnapshotIfStale()
     {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+#else
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(ProcessMetrics));
+        }
+#endif
+
         var now = Diagnostics.Stopwatch.GetTimestamp();
 
         if (now - this.snapshotTimestamp <= SnapshotTtlTicks)

--- a/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Process.Tests/ProcessMetricsTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Metrics;
 using System.Runtime.InteropServices;
 using OpenTelemetry.Metrics;
 
@@ -227,6 +228,68 @@ public class ProcessMetricsTests
 
         Assert.NotEmpty(exportedItemsA);
         Assert.Empty(exportedItemsB);
+    }
+
+    [Fact]
+    public void ProcessMetricsAreCapturedAfterAnotherMeterProviderIsDisposed()
+    {
+        var exportedItemsA = new List<Metric>();
+        var exportedItemsB = new List<Metric>();
+
+        var meterProviderA = Sdk.CreateMeterProviderBuilder()
+            .AddProcessInstrumentation()
+            .AddInMemoryExporter(exportedItemsA)
+            .Build();
+
+        using var meterProviderB = Sdk.CreateMeterProviderBuilder()
+            .AddProcessInstrumentation()
+            .AddInMemoryExporter(exportedItemsB)
+            .Build();
+
+        meterProviderA.Dispose();
+
+        meterProviderB.ForceFlush(MaxTimeToAllowForFlush);
+
+        Assert.Equal(ExpectedMetricCount, exportedItemsB.Count);
+
+        var physicalMemoryMetric = exportedItemsB.FirstOrDefault(i => i.Name == "process.memory.usage");
+        Assert.NotNull(physicalMemoryMetric);
+        Assert.True(GetValue(physicalMemoryMetric) > 0, "No memory usage reported.");
+    }
+
+    [Fact]
+    public void ProcessInstrumentsAreOnlyCreatedOnce()
+    {
+        using var meterProviderA = Sdk.CreateMeterProviderBuilder()
+            .AddProcessInstrumentation()
+            .Build();
+
+        using (var meterProviderB = Sdk.CreateMeterProviderBuilder()
+            .AddProcessInstrumentation()
+            .Build())
+        {
+            // Enabling process instrumentation more than once must not create a second
+            // set of instruments, otherwise the callbacks and the instances they capture
+            // are leaked for the lifetime of the process.
+        }
+
+        var instrumentNames = new List<string>();
+
+        using var listener = new MeterListener()
+        {
+            InstrumentPublished = (instrument, _) =>
+            {
+                if (instrument.Meter.Name == "OpenTelemetry.Instrumentation.Process")
+                {
+                    instrumentNames.Add(instrument.Name);
+                }
+            },
+        };
+
+        listener.Start();
+
+        Assert.Equal(ExpectedMetricCount, instrumentNames.Count);
+        Assert.Equal(instrumentNames.Count, instrumentNames.Distinct().Count());
     }
 
     private static double GetValue(Metric metric)


### PR DESCRIPTION
## Changes

- Reduce allocations by reusing the same `Process` object and synchronising access to it with periodic refreshing across each instrument.
- Compute the process' start time once.

Overall throughput under a benchmark is ~4x and allocations are ~0.25x.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
