### PR TITLE
[SqlClient] Improve tag addition efficiency

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -362,14 +362,7 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
 
         if (activity != null && activity.IsAllDataRequested)
         {
-            foreach (var name in SqlTelemetryHelper.SharedTagNames)
-            {
-                var value = activity.GetTagItem(name);
-                if (value != null)
-                {
-                    tags.Add(name, value);
-                }
-            }
+            SqlTelemetryHelper.AddSharedTags(activity, ref tags);
         }
         else if (payload != null)
         {

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -240,14 +240,7 @@ internal sealed class SqlEventSourceListener : EventListener
 
         if (activity != null && activity.IsAllDataRequested)
         {
-            foreach (var name in SqlTelemetryHelper.SharedTagNames)
-            {
-                var value = activity.GetTagItem(name);
-                if (value != null)
-                {
-                    tags.Add(name, value);
-                }
-            }
+            SqlTelemetryHelper.AddSharedTags(activity, ref tags);
         }
         else
         {

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -141,7 +141,7 @@ internal sealed class SqlTelemetryHelper
 
     private static Dictionary<string, int> CreateSharedTagNameIndexes()
     {
-        Debug.Assert(SharedTagNames.Length <= 32, "There are too many shared tag names to track with a 32-bit mask.");
+        Debug.Assert(SharedTagNames.Length < 32, "There are too many shared tag names to track with a 32-bit mask.");
 
         var indexes = new Dictionary<string, int>(SharedTagNames.Length, StringComparer.Ordinal);
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -44,22 +44,41 @@ internal sealed class SqlTelemetryHelper
     ];
 
 #if NET
-    private static readonly FrozenSet<string> SharedTagNameSet = SharedTagNames.ToFrozenSet(StringComparer.Ordinal);
+    private static readonly FrozenDictionary<string, int> SharedTagNameIndexes = CreateSharedTagNameIndexes().ToFrozenDictionary(StringComparer.Ordinal);
 #else
-    private static readonly HashSet<string> SharedTagNameSet = new(SharedTagNames, StringComparer.Ordinal);
+    private static readonly Dictionary<string, int> SharedTagNameIndexes = CreateSharedTagNameIndexes();
 #endif
+
+    private static readonly int AllSharedTagsFoundMask = (1 << SharedTagNames.Length) - 1;
 
     public static void AddSharedTags(Activity activity, ref TagList tags)
     {
         var enumerator = activity.EnumerateTagObjects();
+        var found = 0;
 
         while (enumerator.MoveNext())
         {
             ref readonly var tag = ref enumerator.Current;
 
-            if (tag.Value != null && SharedTagNameSet.Contains(tag.Key))
+            if (tag.Value == null || !SharedTagNameIndexes.TryGetValue(tag.Key, out var index))
             {
-                tags.Add(tag.Key, tag.Value);
+                continue;
+            }
+
+            var mask = 1 << index;
+
+            if ((found & mask) != 0)
+            {
+                // A value for this tag name has already been added.
+                continue;
+            }
+
+            tags.Add(tag.Key, tag.Value);
+            found |= mask;
+
+            if (found == AllSharedTagsFoundMask)
+            {
+                break;
             }
         }
     }
@@ -119,4 +138,18 @@ internal sealed class SqlTelemetryHelper
 
     internal static double CalculateDurationFromTimestamp(long begin)
         => Stopwatch.GetElapsedTime(begin).TotalSeconds;
+
+    private static Dictionary<string, int> CreateSharedTagNameIndexes()
+    {
+        Debug.Assert(SharedTagNames.Length <= 32, "There are too many shared tag names to track with a 32-bit mask.");
+
+        var indexes = new Dictionary<string, int>(SharedTagNames.Length, StringComparer.Ordinal);
+
+        for (var i = 0; i < SharedTagNames.Length; i++)
+        {
+            indexes[SharedTagNames[i]] = i;
+        }
+
+        return indexes;
+    }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
+using System.Collections.Frozen;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Trace;
@@ -39,6 +42,27 @@ internal sealed class SqlTelemetryHelper
         SemanticConventions.AttributeServerPort,
         SemanticConventions.AttributeServerAddress,
     ];
+
+#if NET
+    private static readonly FrozenSet<string> SharedTagNameSet = SharedTagNames.ToFrozenSet(StringComparer.Ordinal);
+#else
+    private static readonly HashSet<string> SharedTagNameSet = new(SharedTagNames, StringComparer.Ordinal);
+#endif
+
+    public static void AddSharedTags(Activity activity, ref TagList tags)
+    {
+        var enumerator = activity.EnumerateTagObjects();
+
+        while (enumerator.MoveNext())
+        {
+            ref readonly var tag = ref enumerator.Current;
+
+            if (tag.Value != null && SharedTagNameSet.Contains(tag.Key))
+            {
+                tags.Add(tag.Key, tag.Value);
+            }
+        }
+    }
 
     public static TagList GetTagListFromConnectionInfo(string? dataSource, string? databaseName, out string activityName)
     {

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -60,7 +60,9 @@ internal sealed class SqlTelemetryHelper
         {
             ref readonly var tag = ref enumerator.Current;
 
-            if (tag.Value == null || !SharedTagNameIndexes.TryGetValue(tag.Key, out var index))
+            if (tag.Key is null ||
+                tag.Value is null ||
+                !SharedTagNameIndexes.TryGetValue(tag.Key, out var index))
             {
                 continue;
             }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -66,6 +66,58 @@ public class SqlClientTests : IDisposable
         Assert.Equal(expectedPort, tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeServerPort).Value);
     }
 
+    [Fact]
+    public void AddSharedTagsAddsEachSharedTagAtMostOnce()
+    {
+        var activity = new Activity("test");
+
+        activity.AddTag(SemanticConventions.AttributeDbSystemName, SqlTelemetryHelper.MicrosoftSqlServerDbSystemName);
+        activity.AddTag(SemanticConventions.AttributeDbNamespace, "main");
+        activity.AddTag(SemanticConventions.AttributeDbQueryText, "SELECT * FROM Orders");
+        activity.AddTag(SemanticConventions.AttributeServerAddress, "localhost");
+        activity.AddTag(SemanticConventions.AttributeServerPort, 1433);
+        activity.AddTag(SemanticConventions.AttributeErrorType, null);
+
+        // Duplicate keys, as can happen if enrichment uses Activity.AddTag()
+        // for a tag which the instrumentation has already added itself.
+        activity.AddTag(SemanticConventions.AttributeDbNamespace, "other-database");
+        activity.AddTag(SemanticConventions.AttributeServerAddress, "other-host");
+
+        TagList tags = default;
+
+        SqlTelemetryHelper.AddSharedTags(activity, ref tags);
+
+        Assert.Equal(
+            [
+                new(SemanticConventions.AttributeDbSystemName, SqlTelemetryHelper.MicrosoftSqlServerDbSystemName),
+                new(SemanticConventions.AttributeDbNamespace, "main"),
+                new(SemanticConventions.AttributeServerAddress, "localhost"),
+                new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, 1433),
+            ],
+            tags);
+    }
+
+    [Fact]
+    public void AddSharedTagsAddsAllSharedTags()
+    {
+        var activity = new Activity("test");
+
+        foreach (var name in SqlTelemetryHelper.SharedTagNames)
+        {
+            activity.AddTag(name, name);
+        }
+
+        activity.AddTag(SemanticConventions.AttributeDbQueryText, "SELECT * FROM Orders");
+
+        TagList tags = default;
+
+        SqlTelemetryHelper.AddSharedTags(activity, ref tags);
+
+        Assert.Equal(
+            SqlTelemetryHelper.SharedTagNames.Select(name => new KeyValuePair<string, object?>(name, name)),
+            tags);
+    }
+
     [Theory]
     [InlineData(true, false)]
     [InlineData(false, false)]


### PR DESCRIPTION
## Changes

Turn an `O(m * n)` scan for tags into `O(n)`.

Identified by a scan of the code by Claude Code.

A throwaway benchmark gives the following numbers for the change. TL;DR: ~30-40% improvement.

<details>

<summary>Click to expand</summary>

| Method | TagCount | Duplicates | Mean | Ratio | Allocated |
|---|---|---|---:|---:|---:|
| Before (main) | 5 | 0 | 44.26 ns | 1.00 | – |
| AfterOriginal | 5 | 0 | 23.67 ns | 0.53 | – |
| **AfterDeduped (branch)** | 5 | 0 | 25.09 ns | **0.57** | – |
| Before (main) | 9 | 0 | 57.35 ns | 1.00 | – |
| AfterOriginal | 9 | 0 | 34.14 ns | 0.60 | – |
| **AfterDeduped (branch)** | 9 | 0 | 36.77 ns | **0.64** | – |
| Before (main) | 10 | 0 | 61.15 ns | 1.00 | – |
| AfterOriginal | 10 | 0 | 39.30 ns | 0.64 | – |
| **AfterDeduped (branch)** | 10 | 0 | 43.85 ns | **0.72** | – |
| Before (main) | 5 | 2 | 50.96 ns | 1.00 | – |
| AfterOriginal | 5 | 2 | 31.91 ns | 0.63 | – |
| **AfterDeduped (branch)** | 5 | 2 | 27.94 ns | **0.55** | – |
| Before (main) | 9 | 2 | 60.58 ns | 1.00 | – |
| AfterOriginal | 9 | 2 | 57.72 ns | 0.95 | **280 B** |
| **AfterDeduped (branch)** | 9 | 2 | 40.11 ns | **0.66** | – |
| Before (main) | 10 | 2 | 68.65 ns | 1.00 | – |
| AfterOriginal | 10 | 2 | 65.18 ns | 0.95 | **280 B** |
| **AfterDeduped (branch)** | 10 | 2 | 45.56 ns | **0.66** | – |

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
