### PR TITLE
[ConfluentKafka] Reduce allocations

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedConsumer.cs
@@ -354,11 +354,11 @@ internal class InstrumentedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
             : [];
 
         // Provide the attributes that can influence sampling decisions at span creation time
-        var initialTags = new ActivityTagsCollection
+        var initialTags = new TagList
         {
-            [SemanticConventions.AttributeMessagingOperationName] = ConfluentKafkaCommon.PollOperationName,
-            [SemanticConventions.AttributeMessagingOperationType] = ConfluentKafkaCommon.ReceiveOperationType,
-            [SemanticConventions.AttributeMessagingSystem] = ConfluentKafkaCommon.KafkaMessagingSystem,
+            { SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.PollOperationName },
+            { SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.ReceiveOperationType },
+            { SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem },
         };
 
         if (this.GroupId is { Length: > 0 } groupId)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/InstrumentedProducer.cs
@@ -322,12 +322,12 @@ internal sealed class InstrumentedProducer<TKey, TValue> : IProducer<TKey, TValu
         var spanName = string.Concat(ConfluentKafkaCommon.SendOperationName, " ", topic);
 
         // Provide the attributes that can influence sampling decisions at span creation time
-        var initialTags = new ActivityTagsCollection
+        var initialTags = new TagList
         {
-            [SemanticConventions.AttributeMessagingDestinationName] = topic,
-            [SemanticConventions.AttributeMessagingOperationName] = ConfluentKafkaCommon.SendOperationName,
-            [SemanticConventions.AttributeMessagingOperationType] = ConfluentKafkaCommon.SendOperationType,
-            [SemanticConventions.AttributeMessagingSystem] = ConfluentKafkaCommon.KafkaMessagingSystem,
+            { SemanticConventions.AttributeMessagingDestinationName, topic },
+            { SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.SendOperationName },
+            { SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.SendOperationType },
+            { SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem },
         };
 
         if (partition is { } partitionValue)

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/OpenTelemetryConsumeResultExtensions.cs
@@ -142,11 +142,11 @@ public static class OpenTelemetryConsumeResultExtensions
             : [];
 
         // Provide the attributes that can influence sampling decisions at span creation time
-        var initialTags = new ActivityTagsCollection
+        var initialTags = new TagList
         {
-            [SemanticConventions.AttributeMessagingOperationName] = ConfluentKafkaCommon.ProcessOperationName,
-            [SemanticConventions.AttributeMessagingOperationType] = ConfluentKafkaCommon.ProcessOperationType,
-            [SemanticConventions.AttributeMessagingSystem] = ConfluentKafkaCommon.KafkaMessagingSystem,
+            { SemanticConventions.AttributeMessagingOperationName, ConfluentKafkaCommon.ProcessOperationName },
+            { SemanticConventions.AttributeMessagingOperationType, ConfluentKafkaCommon.ProcessOperationType },
+            { SemanticConventions.AttributeMessagingSystem, ConfluentKafkaCommon.KafkaMessagingSystem },
         };
 
         if (groupId is { Length: > 0 })


### PR DESCRIPTION
## Changes

Reduce allocations for tags by using `TagList` instead of `ActivityTagsCollection`.

A throwaway benchmark gives a modest improvement in throughput and allocations:

| Method | Topic       | Mean     | Ratio | Allocated | Alloc Ratio |
|------- |------------ |---------:|------:|----------:|------------:|
| Before | orders      | 459.8 ns |  1.01 |    1.1 KB |        1.00 |
| After  | orders      | 326.6 ns |  0.71 |   1.04 KB |        0.94 |
| Before | long topic  | 399.5 ns |  1.00 |   1.15 KB |        1.00 |
| After  | long topic  | 345.1 ns |  0.86 |   1.04 KB |        0.90 |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
