### PR TITLE
[Http] Improve redaction performance

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -20,6 +20,8 @@ internal static class HttpTagHelper
     /// <returns>Span uri value.</returns>
     public static string GetUriTagValueFromRequestUri(Uri uri, bool disableQueryRedaction)
     {
+        string? query = null;
+
         if (string.IsNullOrEmpty(uri.UserInfo))
         {
             if (disableQueryRedaction)
@@ -36,11 +38,13 @@ internal static class HttpTagHelper
 
             if (scheme == Uri.UriSchemeHttps || scheme == Uri.UriSchemeHttp)
             {
+                query = uri.Query;
+
                 var indexOfEquals =
 #if NET
-                    uri.Query.IndexOf('=', StringComparison.Ordinal);
+                    query.IndexOf('=', StringComparison.Ordinal);
 #else
-                    uri.Query.IndexOf('=');
+                    query.IndexOf('=');
 #endif
 
                 if (indexOfEquals < 0)
@@ -50,7 +54,12 @@ internal static class HttpTagHelper
             }
         }
 
-        var query = disableQueryRedaction ? uri.Query : RedactionHelper.GetRedactedQueryString(uri.Query);
+        query ??= uri.Query;
+
+        if (!disableQueryRedaction)
+        {
+            query = RedactionHelper.GetRedactedQueryString(query);
+        }
 
         return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.AbsolutePath, query, uri.Fragment);
     }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -20,9 +20,34 @@ internal static class HttpTagHelper
     /// <returns>Span uri value.</returns>
     public static string GetUriTagValueFromRequestUri(Uri uri, bool disableQueryRedaction)
     {
-        if (string.IsNullOrEmpty(uri.UserInfo) && disableQueryRedaction)
+        if (string.IsNullOrEmpty(uri.UserInfo))
         {
-            return uri.OriginalString;
+            if (disableQueryRedaction)
+            {
+                return uri.OriginalString;
+            }
+
+            // Redaction only rewrites the query when it contains a '=', so avoid
+            // recreating a string that is equivalent to the original string otherwise.
+            // Non HTTP(S) schemes with no authority behave slightly differently
+            // for AbsoluteUri so they ignore this optimization to ensure they
+            // return the right value to the caller.
+            var scheme = uri.Scheme;
+
+            if (scheme == Uri.UriSchemeHttps || scheme == Uri.UriSchemeHttp)
+            {
+                var indexOfEquals =
+#if NET
+                    uri.Query.IndexOf('=', StringComparison.Ordinal);
+#else
+                    uri.Query.IndexOf('=');
+#endif
+
+                if (indexOfEquals < 0)
+                {
+                    return uri.AbsoluteUri;
+                }
+            }
         }
 
         var query = disableQueryRedaction ? uri.Query : RedactionHelper.GetRedactedQueryString(uri.Query);

--- a/src/Shared/UriHelper.cs
+++ b/src/Shared/UriHelper.cs
@@ -9,6 +9,12 @@ internal static class UriHelper
 
     public static Uri ScrubUserInfo(Uri uri)
     {
+        // Nothing to scrub, so avoid allocating a UriBuilder to parse it
+        if (string.IsNullOrEmpty(uri.UserInfo))
+        {
+            return uri;
+        }
+
         var uriBuilder = new UriBuilder(uri);
         if (!string.IsNullOrEmpty(uriBuilder.UserName))
         {


### PR DESCRIPTION
## Changes

Avoid reparsing URLs when there is nothing to redact.

A throwaway benchmark written by Claude Code gives the following improvements:

| Url                    | Before    | After   | Ratio | Alloc         |
|----------------------- |----------:|--------:|------:|--------------:|
| no query               |  50.21 ns | 5.96 ns |  0.12 | 136 B -> 0 B  |
| no query, long path    |  52.89 ns | 6.05 ns |  0.11 | 152 B -> 0 B  |
| query without '='      |  53.76 ns | 6.30 ns |  0.12 | 152 B -> 0 B  |
| query with '=' (redact)|  99.96 ns | 99.19 ns|  0.99 | 248 B -> 248 B|

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
