### PR TITLE
[SqlClient] Derive SQL connection tags once

### DIFF
--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/Implementation/EntityFrameworkDiagnosticListener.cs
@@ -111,7 +111,7 @@ internal sealed class EntityFrameworkDiagnosticListener : ListenerHandler
                             {
                                 this.AddTag(activity, ("peer.service", SemanticConventions.AttributeServerAddress), serverAddress);
 
-                                if (this.options.EmitNewAttributes && connectionDetails.Port is { } port)
+                                if (this.options.EmitNewAttributes && connectionDetails.BoxedPort is { } port)
                                 {
                                     activity.AddTag(SemanticConventions.AttributeServerPort, port);
                                 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlTelemetryHelper.cs
@@ -52,13 +52,9 @@ internal sealed class SqlTelemetryHelper
         {
             var connectionDetails = SqlConnectionDetails.ParseFromDataSource(dataSource);
 
-            if (!string.IsNullOrEmpty(databaseName))
+            if (databaseName is { Length: > 0 })
             {
-#pragma warning disable IDE0370 // Suppression is unnecessary
-                var dbNamespace = !string.IsNullOrEmpty(connectionDetails.InstanceName)
-                    ? $"{connectionDetails.InstanceName}.{databaseName}"
-                    : databaseName!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
+                var dbNamespace = connectionDetails.GetDbNamespace(databaseName);
                 tags.Add(SemanticConventions.AttributeDbNamespace, dbNamespace);
                 activityName = dbNamespace;
             }
@@ -67,27 +63,21 @@ internal sealed class SqlTelemetryHelper
             if (!string.IsNullOrEmpty(serverAddress))
             {
                 tags.Add(SemanticConventions.AttributeServerAddress, serverAddress);
-                if (connectionDetails.Port is { } port)
+                if (connectionDetails.BoxedPort is { } port)
                 {
                     tags.Add(SemanticConventions.AttributeServerPort, port);
                 }
 
                 if (activityName == MicrosoftSqlServerDbSystemName)
                 {
-#pragma warning disable IDE0370 // Suppression is unnecessary
-                    activityName = connectionDetails.Port is { } portNumber
-                        ? $"{serverAddress}:{portNumber}"
-                        : serverAddress!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
+                    activityName = connectionDetails.ServerAddressAndPort!;
                 }
             }
         }
-        else if (!string.IsNullOrEmpty(databaseName))
+        else if (databaseName is { Length: > 0 })
         {
             tags.Add(SemanticConventions.AttributeDbNamespace, databaseName);
-#pragma warning disable IDE0370 // Suppression is unnecessary
-            activityName = databaseName!;
-#pragma warning restore IDE0370 // Suppression is unnecessary
+            activityName = databaseName;
         }
 
         return tags;

--- a/src/Shared/SqlConnectionDetails.cs
+++ b/src/Shared/SqlConnectionDetails.cs
@@ -17,6 +17,8 @@ internal sealed partial class SqlConnectionDetails
 
     private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new(StringComparer.OrdinalIgnoreCase);
 
+    private DbNamespaceEntry? dbNamespace;
+
     private SqlConnectionDetails()
     {
     }
@@ -27,7 +29,11 @@ internal sealed partial class SqlConnectionDetails
 
     public string? InstanceName { get; private set; }
 
-    public int? Port { get; private set; }
+    public object? BoxedPort { get; private set; }
+
+    public string? ServerAddressAndPort { get; private set; }
+
+    public int? Port => (int?)this.BoxedPort;
 
     public static SqlConnectionDetails ParseFromDataSource(string dataSource)
     {
@@ -94,12 +100,17 @@ internal sealed partial class SqlConnectionDetails
                 }
             }
 
+            var serverAddress = serverHostName ?? serverIpAddress;
+
             connectionDetails = new SqlConnectionDetails
             {
+                BoxedPort = port,
+                InstanceName = instanceName,
                 ServerHostName = serverHostName,
                 ServerIpAddress = serverIpAddress,
-                InstanceName = instanceName,
-                Port = port,
+                ServerAddressAndPort = string.IsNullOrEmpty(serverAddress)
+                    ? null
+                    : port is { } portNumber ? $"{serverAddress}:{portNumber}" : serverAddress,
             };
         }
         catch (RegexMatchTimeoutException)
@@ -109,6 +120,39 @@ internal sealed partial class SqlConnectionDetails
 
         ConnectionDetailCache.TryAdd(dataSource, connectionDetails);
         return connectionDetails;
+    }
+
+    /// <summary>
+    /// Gets the <c>db.namespace</c> for a database reached through this data source.
+    /// </summary>
+    /// <param name="databaseName">The database name.</param>
+    /// <returns>
+    /// <paramref name="databaseName"/> qualified by the instance name, if there is one.
+    /// </returns>
+    /// <remarks>
+    /// Qualifying allocates, so the last result is kept. A data source is almost always used with
+    /// a single database, and holding one entry keeps what a data source can retain bounded.
+    /// </remarks>
+    public string GetDbNamespace(string databaseName)
+    {
+        if (string.IsNullOrEmpty(this.InstanceName))
+        {
+            return databaseName;
+        }
+
+        var lastDbNamespace = Volatile.Read(ref this.dbNamespace);
+
+        if (lastDbNamespace is not null &&
+            string.Equals(lastDbNamespace.DatabaseName, databaseName, StringComparison.Ordinal))
+        {
+            return lastDbNamespace.DbNamespace;
+        }
+
+        var value = $"{this.InstanceName}.{databaseName}";
+
+        Volatile.Write(ref this.dbNamespace, new DbNamespaceEntry(databaseName, value));
+
+        return value;
     }
 
 #if NET
@@ -158,4 +202,11 @@ internal sealed partial class SqlConnectionDetails
 
     private static Regex NamedPipeRegex() => NamedPipeRegexField;
 #endif
+
+    private sealed class DbNamespaceEntry(string databaseName, string dbNamespace)
+    {
+        public string DatabaseName { get; } = databaseName;
+
+        public string DbNamespace { get; } = dbNamespace;
+    }
 }

--- a/src/Shared/SqlConnectionDetails.cs
+++ b/src/Shared/SqlConnectionDetails.cs
@@ -33,8 +33,6 @@ internal sealed partial class SqlConnectionDetails
 
     public string? ServerAddressAndPort { get; private set; }
 
-    public int? Port => (int?)this.BoxedPort;
-
     public static SqlConnectionDetails ParseFromDataSource(string dataSource)
     {
         if (ConnectionDetailCache.TryGetValue(dataSource, out var connectionDetails))

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
@@ -40,7 +40,7 @@ public class SqlConnectionDetailsTests
         Assert.Equal(expectedServerHostName, sqlConnectionDetails.ServerHostName);
         Assert.Equal(expectedServerIpAddress, sqlConnectionDetails.ServerIpAddress);
         Assert.Equal(expectedInstanceName, sqlConnectionDetails.InstanceName);
-        Assert.Equal(expectedPort, sqlConnectionDetails.Port);
+        Assert.Equal(expectedPort, sqlConnectionDetails.BoxedPort);
     }
 
     [Theory]
@@ -62,7 +62,6 @@ public class SqlConnectionDetailsTests
     {
         var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("boxed-port.localhost, 1818");
 
-        Assert.Equal(1818, sqlConnectionDetails.Port);
         Assert.Equal(1818, sqlConnectionDetails.BoxedPort);
 
         // The port is boxed when the data source is parsed, not every time it is used.
@@ -74,7 +73,6 @@ public class SqlConnectionDetailsTests
     {
         var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("default-port.localhost,1433");
 
-        Assert.Null(sqlConnectionDetails.Port);
         Assert.Null(sqlConnectionDetails.BoxedPort);
     }
 

--- a/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/SqlConnectionDetailsTests.cs
@@ -42,4 +42,89 @@ public class SqlConnectionDetailsTests
         Assert.Equal(expectedInstanceName, sqlConnectionDetails.InstanceName);
         Assert.Equal(expectedPort, sqlConnectionDetails.Port);
     }
+
+    [Theory]
+    [InlineData("", null)]
+    [InlineData("localhost", "localhost")]
+    [InlineData("127.0.0.1,1433", "127.0.0.1")]
+    [InlineData("127.0.0.1, 1818", "127.0.0.1:1818")]
+    [InlineData("[::1],1818", "[::1]:1818")]
+    [InlineData("tcp://some.domain.local:5432", "some.domain.local:5432")]
+    public void ParseFromDataSourceDerivesTheServerAddressAndPort(string dataSource, string? expectedServerAddressAndPort)
+    {
+        var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource(dataSource);
+
+        Assert.Equal(expectedServerAddressAndPort, sqlConnectionDetails.ServerAddressAndPort);
+    }
+
+    [Fact]
+    public void ParseFromDataSourceBoxesThePortOnce()
+    {
+        var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("boxed-port.localhost, 1818");
+
+        Assert.Equal(1818, sqlConnectionDetails.Port);
+        Assert.Equal(1818, sqlConnectionDetails.BoxedPort);
+
+        // The port is boxed when the data source is parsed, not every time it is used.
+        Assert.Same(sqlConnectionDetails.BoxedPort, sqlConnectionDetails.BoxedPort);
+    }
+
+    [Fact]
+    public void ParseFromDataSourceDoesNotBoxADefaultPort()
+    {
+        var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("default-port.localhost,1433");
+
+        Assert.Null(sqlConnectionDetails.Port);
+        Assert.Null(sqlConnectionDetails.BoxedPort);
+    }
+
+    [Fact]
+    public void GetDbNamespaceReturnsTheDatabaseNameWhenThereIsNoInstanceName()
+    {
+        const string DatabaseName = "main";
+
+        var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("no-instance.localhost");
+
+        Assert.Null(sqlConnectionDetails.InstanceName);
+
+        // With no instance name to qualify it, the database name is already the namespace.
+        Assert.Same(DatabaseName, sqlConnectionDetails.GetDbNamespace(DatabaseName));
+    }
+
+    [Fact]
+    public void GetDbNamespaceQualifiesTheDatabaseNameWithTheInstanceName()
+    {
+        var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("with-instance.localhost\\instanceName");
+
+        Assert.Equal("instanceName", sqlConnectionDetails.InstanceName);
+        Assert.Equal("instanceName.main", sqlConnectionDetails.GetDbNamespace("main"));
+    }
+
+    [Fact]
+    public void GetDbNamespaceReusesTheNamespaceForTheSameDatabase()
+    {
+        var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("reused-instance.localhost\\instanceName");
+
+        var first = sqlConnectionDetails.GetDbNamespace("main");
+        var second = sqlConnectionDetails.GetDbNamespace("main");
+
+        Assert.Equal("instanceName.main", first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetDbNamespaceDerivesTheNamespaceAgainWhenTheDatabaseChanges()
+    {
+        var sqlConnectionDetails = SqlConnectionDetails.ParseFromDataSource("changed-instance.localhost\\instanceName");
+
+        var main = sqlConnectionDetails.GetDbNamespace("main");
+        var tempdb = sqlConnectionDetails.GetDbNamespace("tempdb");
+
+        Assert.Equal("instanceName.main", main);
+        Assert.Equal("instanceName.tempdb", tempdb);
+
+        // Only the most recent database is kept, so the first is derived again rather
+        // than the data source retaining a namespace for every database it is used with.
+        Assert.NotSame(main, sqlConnectionDetails.GetDbNamespace("main"));
+    }
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -17,17 +17,11 @@ public enum SqlClientLibrary
 }
 
 [Collection("SqlClient")]
-public class SqlClientTests : IDisposable
+public class SqlClientTests
 {
-    private const string TestConnectionString = "Data Source=(localdb)\\MSSQLLocalDB;Database=master;Encrypt=True;TrustServerCertificate=True";
+    private const string TestConnectionString = "Data Source=(localdb)\\MSSQLLocalDB;Database=main;Encrypt=True;TrustServerCertificate=True";
 
     public static IEnumerable<object[]> TestData => SqlClientTestCases.GetTestCases();
-
-    public void Dispose()
-    {
-        // TODO: Why is this here? Add comment explaining why.
-        GC.SuppressFinalize(this);
-    }
 
     [Fact]
     public void SqlClient_BadArgs()
@@ -39,16 +33,12 @@ public class SqlClientTests : IDisposable
     [Theory]
     [MemberData(nameof(TestData))]
     public void TestMicrosoftDataSqlClient(SqlClientTestCase testCase)
-    {
-        this.RunSqlClientTestCase(testCase, SqlClientLibrary.MicrosoftDataSqlClient);
-    }
+        => this.RunSqlClientTestCase(testCase, SqlClientLibrary.MicrosoftDataSqlClient);
 
     [Theory]
     [MemberData(nameof(TestData))]
     public void TestSystemDataSqlClient(SqlClientTestCase testCase)
-    {
-        this.RunSqlClientTestCase(testCase, SqlClientLibrary.SystemDataSqlClient);
-    }
+        => this.RunSqlClientTestCase(testCase, SqlClientLibrary.SystemDataSqlClient);
 
     [Theory]
     [InlineData("localhost", "localhost", null, null)]
@@ -64,6 +54,36 @@ public class SqlClientTests : IDisposable
         var tags = SqlTelemetryHelper.GetTagListFromConnectionInfo(dataSource, databaseName: null, out var _);
         Assert.Equal(expectedServerHostName ?? expectedServerIpAddress, tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeServerAddress).Value);
         Assert.Equal(expectedPort, tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeServerPort).Value);
+    }
+
+    [Theory]
+    [InlineData("localhost", "main")]
+    [InlineData("localhost\\instanceName", "instanceName.main")]
+    public void SqlClientAddsDatabaseNamespaceAttribute(string dataSource, string expectedDbNamespace)
+    {
+        var tags = SqlTelemetryHelper.GetTagListFromConnectionInfo(dataSource, databaseName: "main", out var activityName);
+
+        Assert.Equal(expectedDbNamespace, activityName);
+        Assert.Equal(expectedDbNamespace, tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeDbNamespace).Value);
+    }
+
+    [Fact]
+    public void SqlClientAddsDatabaseNamespaceAttributeWhenThereIsNoDataSource()
+    {
+        var tags = SqlTelemetryHelper.GetTagListFromConnectionInfo(dataSource: null, databaseName: "main", out var activityName);
+
+        Assert.Equal("main", activityName);
+        Assert.Equal("main", tags.FirstOrDefault(x => x.Key == SemanticConventions.AttributeDbNamespace).Value);
+        Assert.DoesNotContain(tags, x => x.Key == SemanticConventions.AttributeServerAddress);
+    }
+
+    [Fact]
+    public void SqlClientDoesNotAddDatabaseNamespaceAttributeWhenThereIsNoDataSourceOrDatabase()
+    {
+        var tags = SqlTelemetryHelper.GetTagListFromConnectionInfo(dataSource: null, databaseName: null, out var activityName);
+
+        Assert.Equal(SqlTelemetryHelper.MicrosoftSqlServerDbSystemName, activityName);
+        Assert.DoesNotContain(tags, x => x.Key == SemanticConventions.AttributeDbNamespace);
     }
 
     [Theory]
@@ -166,16 +186,16 @@ public class SqlClientTests : IDisposable
         Assert.Contains(
             samplingParameters.Tags,
             kvp => kvp.Key == SemanticConventions.AttributeDbSystemName
-                   && kvp.Value is string
-                   && (string)kvp.Value == SqlTelemetryHelper.MicrosoftSqlServerDbSystemName);
+                   && kvp.Value is string value
+                   && value == SqlTelemetryHelper.MicrosoftSqlServerDbSystemName);
 
         if (testCase.Expected.DbNamespace != null)
         {
             Assert.Contains(
                 samplingParameters.Tags,
                 kvp => kvp.Key == SemanticConventions.AttributeDbNamespace
-                       && kvp.Value is string
-                       && (string)kvp.Value == testCase.Expected.DbNamespace);
+                       && kvp.Value is string value
+                       && value == testCase.Expected.DbNamespace);
         }
 
         if (testCase.Expected.ServerAddress != null)
@@ -183,8 +203,8 @@ public class SqlClientTests : IDisposable
             Assert.Contains(
             samplingParameters.Tags,
             kvp => kvp.Key == SemanticConventions.AttributeServerAddress
-                   && kvp.Value is string
-                   && (string)kvp.Value == testCase.Expected.ServerAddress);
+                   && kvp.Value is string value
+                   && value == testCase.Expected.ServerAddress);
         }
 
         if (testCase.Expected.ServerPort.HasValue)
@@ -192,8 +212,8 @@ public class SqlClientTests : IDisposable
             Assert.Contains(
                 samplingParameters.Tags,
                 kvp => kvp.Key == SemanticConventions.AttributeServerPort
-                       && kvp.Value is int
-                       && (int)kvp.Value == testCase.Expected.ServerPort);
+                       && kvp.Value is int value
+                       && value == testCase.Expected.ServerPort);
         }
 
         if (!string.IsNullOrEmpty(testCase.Expected.DbQuerySummary))
@@ -201,8 +221,8 @@ public class SqlClientTests : IDisposable
             Assert.Contains(
                 samplingParameters.Tags,
                 kvp => kvp.Key == SemanticConventions.AttributeDbQuerySummary
-                       && kvp.Value is string
-                       && (string)kvp.Value == testCase.Expected.DbQuerySummary);
+                       && kvp.Value is string value
+                       && value == testCase.Expected.DbQuerySummary);
         }
 
         if (!string.IsNullOrEmpty(testCase.Expected.DbQueryText))
@@ -210,8 +230,8 @@ public class SqlClientTests : IDisposable
             Assert.Contains(
                 samplingParameters.Tags,
                 kvp => kvp.Key == SemanticConventions.AttributeDbQueryText
-                       && kvp.Value is string
-                       && (string)kvp.Value == testCase.Expected.DbQueryText);
+                       && kvp.Value is string value
+                       && value == testCase.Expected.DbQueryText);
         }
 
         if (!string.IsNullOrEmpty(testCase.Expected.DbOperationName))
@@ -219,8 +239,8 @@ public class SqlClientTests : IDisposable
             Assert.Contains(
                 samplingParameters.Tags,
                 kvp => kvp.Key == SemanticConventions.AttributeDbOperationName
-                       && kvp.Value is string
-                       && (string)kvp.Value == testCase.Expected.DbOperationName);
+                       && kvp.Value is string value
+                       && value == testCase.Expected.DbOperationName);
         }
 
         if (!string.IsNullOrEmpty(testCase.Expected.DbCollectionName))
@@ -228,8 +248,8 @@ public class SqlClientTests : IDisposable
             Assert.Contains(
                 samplingParameters.Tags,
                 kvp => kvp.Key == SemanticConventions.AttributeDbCollectionName
-                       && kvp.Value is string
-                       && (string)kvp.Value == testCase.Expected.DbCollectionName);
+                       && kvp.Value is string value
+                       && value == testCase.Expected.DbCollectionName);
         }
 
         if (!string.IsNullOrEmpty(testCase.Expected.DbStoredProcedureName))
@@ -237,8 +257,8 @@ public class SqlClientTests : IDisposable
             Assert.Contains(
                 samplingParameters.Tags,
                 kvp => kvp.Key == SemanticConventions.AttributeDbStoredProcedureName
-                       && kvp.Value is string
-                       && (string)kvp.Value == testCase.Expected.DbStoredProcedureName);
+                       && kvp.Value is string value
+                       && value == testCase.Expected.DbStoredProcedureName);
         }
     }
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -221,9 +221,9 @@ public class SqlEventSourceTests
             Assert.Equal(connectionDetails.ServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
         }
 
-        if (connectionDetails.Port.HasValue)
+        if (connectionDetails.BoxedPort != null)
         {
-            Assert.Equal(connectionDetails.Port, activity.GetTagValue(SemanticConventions.AttributeServerPort));
+            Assert.Equal(connectionDetails.BoxedPort, activity.GetTagValue(SemanticConventions.AttributeServerPort));
         }
 
         Assert.Equal(SqlTelemetryHelper.MicrosoftSqlServerDbSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystemName));
@@ -265,15 +265,11 @@ public class SqlEventSourceTests
     {
         [Event(SqlEventSourceListener.BeginExecuteEventId)]
         public void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText)
-        {
-            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
-        }
+            => this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
 
         [Event(SqlEventSourceListener.EndExecuteEventId)]
         public void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber)
-        {
-            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
-        }
+            => this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
     }
 
     [EventSource(Name = SqlEventSourceListener.MdsEventSourceName + "-FakeFriendly")]
@@ -281,15 +277,11 @@ public class SqlEventSourceTests
     {
         [Event(SqlEventSourceListener.BeginExecuteEventId)]
         public void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText)
-        {
-            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
-        }
+            => this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
 
         [Event(SqlEventSourceListener.EndExecuteEventId)]
         public void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber)
-        {
-            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
-        }
+            => this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
     }
 
     [EventSource(Name = SqlEventSourceListener.AdoNetEventSourceName + "-FakeEvil")]
@@ -297,15 +289,11 @@ public class SqlEventSourceTests
     {
         [Event(SqlEventSourceListener.BeginExecuteEventId)]
         public void WriteBeginExecuteEvent(string arg1)
-        {
-            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
-        }
+            => this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
 
         [Event(SqlEventSourceListener.EndExecuteEventId)]
         public void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4)
-        {
-            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
-        }
+            => this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
 
         [Event(3)]
         public void WriteUnknownEventWithNullPayload()
@@ -321,15 +309,11 @@ public class SqlEventSourceTests
     {
         [Event(SqlEventSourceListener.BeginExecuteEventId)]
         public void WriteBeginExecuteEvent(string arg1)
-        {
-            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
-        }
+            => this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
 
         [Event(SqlEventSourceListener.EndExecuteEventId)]
         public void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4)
-        {
-            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
-        }
+            => this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
 
         [Event(3)]
         public void WriteUnknownEventWithNullPayload()


### PR DESCRIPTION
## Changes

Avoid allocations from boxing and parsing SQL connection information, particularly in the case of an application that only ever connects to the same SQL Server instance, by only doing the work once per data source.

Throwaway benchmarks by Claude Code show the results below. TL;DR - allocations for the parsing are now zero per command after the initial parse with reduced a reduce mean for connections with either a non-default port or an instance name.

<details>

<summary>Expand to view</summary>

| Method  | Connections | Data source shape        |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD | Allocated | Alloc Ratio |
|---------|------------:|--------------------------|---------:|---------:|---------:|---------:|------:|--------:|----------:|------------:|
| main    |           1 | HostAndDatabase          | 29.12 ns | 0.549 ns | 0.487 ns | 29.12 ns |  1.00 |    0.02 |         - |          NA |
| this PR |           1 | HostAndDatabase          | 28.35 ns | 0.413 ns | 0.386 ns | 28.30 ns |  0.97 |    0.02 |         - |          NA |
|         |             |                          |          |          |          |          |       |         |           |             |
| main    |           1 | NamedInstanceAndDatabase | 38.26 ns | 0.760 ns | 1.776 ns | 38.05 ns |  1.00 |    0.06 |      64 B |        1.00 |
| this PR |           1 | NamedInstanceAndDatabase | 26.67 ns | 0.456 ns | 0.640 ns | 26.58 ns |  0.70 |    0.04 |         - |        0.00 |
|         |             |                          |          |          |          |          |       |         |           |             |
| main    |           1 | HostPortNoDatabase       | 49.13 ns | 1.005 ns | 1.706 ns | 48.95 ns |  1.00 |    0.05 |      96 B |        1.00 |
| this PR |           1 | HostPortNoDatabase       | 27.00 ns | 1.138 ns | 3.265 ns | 25.78 ns |  0.55 |    0.07 |         - |        0.00 |
|         |             |                          |          |          |          |          |       |         |           |             |
| main    |          64 | HostAndDatabase          | 31.61 ns | 0.649 ns | 0.821 ns | 31.80 ns |  1.00 |    0.04 |         - |          NA |
| this PR |          64 | HostAndDatabase          | 30.94 ns | 0.553 ns | 0.893 ns | 30.90 ns |  0.98 |    0.04 |         - |          NA |
|         |             |                          |          |          |          |          |       |         |           |             |
| main    |          64 | NamedInstanceAndDatabase | 38.74 ns | 0.800 ns | 1.269 ns | 38.39 ns |  1.00 |    0.05 |      64 B |        1.00 |
| this PR |          64 | NamedInstanceAndDatabase | 28.05 ns | 0.585 ns | 0.858 ns | 27.82 ns |  0.72 |    0.03 |         - |        0.00 |
|         |             |                          |          |          |          |          |       |         |           |             |
| main    |          64 | HostPortNoDatabase       | 53.20 ns | 1.060 ns | 1.134 ns | 53.20 ns |  1.00 |    0.03 |      96 B |        1.00 |
| this PR |          64 | HostPortNoDatabase       | 25.09 ns | 0.506 ns | 0.562 ns | 25.14 ns |  0.47 |    0.01 |         - |        0.00 |

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
