### PR TITLE
[ConfluentKafka] Update Semantic Conventions to v1.44.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated Semantic Conventions to [v1.44.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.44.0).
+  ([#PRA](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/PRA))
+
 ## 0.2.0-alpha.2
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated Semantic Conventions to [v1.44.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.44.0).
-  ([#PRA](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/PRA))
+  ([#4976](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4976))
 
 ## 0.2.0-alpha.2
 

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -14,8 +14,8 @@ namespace OpenTelemetry.Instrumentation.ConfluentKafka;
 /// Contains common constants and static members used by the Confluent Kafka instrumentation.
 /// </summary>
 /// <remarks>
-/// Follows the v1.43.0 messaging semantic conventions:
-/// https://github.com/open-telemetry/semantic-conventions/tree/v1.43.0/docs/messaging.
+/// Follows the v1.44.0 messaging semantic conventions:
+/// https://github.com/open-telemetry/semantic-conventions/tree/v1.44.0/docs/messaging.
 /// </remarks>
 internal static class ConfluentKafkaCommon
 {
@@ -31,7 +31,7 @@ internal static class ConfluentKafkaCommon
     internal const string ReceiveOperationType = "receive";
     internal const string ProcessOperationType = "process";
 
-    internal static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+    internal static readonly Version SemanticConventionsVersion = new(1, 44, 0);
 
     internal static readonly ActivitySource ActivitySource = ActivitySourceFactory.Create(typeof(ConfluentKafkaCommon), SemanticConventionsVersion);
     internal static readonly Meter Meter = MeterFactory.Create(typeof(ConfluentKafkaCommon), SemanticConventionsVersion);

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/README.md
@@ -80,7 +80,7 @@ and consumers, allowing you to collect and export telemetry data.
 ## Metrics
 
 The instrumentation is implemented based on the [messaging metrics semantic
-conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md).
+conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/messaging/messaging-metrics.md).
 The following metrics are produced:
 
 | Name | Instrument Type | Unit | Description | Attributes |

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -137,8 +137,8 @@ internal static class SemanticConventions
     public const string MetricMessagingClientSentMessages = "messaging.client.sent.messages"; // replaces: "messaging.publish.messages"
     public const string MetricMessagingClientConsumedMessages = "messaging.client.consumed.messages"; // replaces: "messaging.receive.messages"
 
-    // v1.42.0 Messaging (Kafka)
-    // https://github.com/open-telemetry/semantic-conventions/blob/v1.42.0/docs/messaging/kafka.md
+    // v1.44.0 Messaging (Kafka)
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/messaging/kafka.md
     public const string AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key";
     public const string AttributeMessagingKafkaMessageTombstone = "messaging.kafka.message.tombstone";
     public const string AttributeMessagingKafkaOffset = "messaging.kafka.offset"; // replaces: "messaging.kafka.message.offset"

--- a/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.ConfluentKafka.Tests/InstrumentedConsumerTests.cs
@@ -36,7 +36,7 @@ public class InstrumentedConsumerTests
 
         var activity = activities.Single(a => a.DisplayName == "poll consume-topic");
         Assert.Equal(ActivityKind.Client, activity.Kind);
-        Assert.Equal("https://opentelemetry.io/schemas/1.43.0", activity.Source.TelemetrySchemaUrl);
+        Assert.Equal("https://opentelemetry.io/schemas/1.44.0", activity.Source.TelemetrySchemaUrl);
         Assert.Equal("kafka", activity.GetTagValue(SemanticConventions.AttributeMessagingSystem));
         Assert.Equal("poll", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationName));
         Assert.Equal("receive", activity.GetTagValue(SemanticConventions.AttributeMessagingOperationType));


### PR DESCRIPTION
## Changes

Updates the Confluent Kafka instrumentation's semantic conventions
version reference from v1.43.0 (and the stale v1.42.0 Kafka-block
comment) to v1.44.0. This is a mechanical version bump only:

* `ConfluentKafkaCommon.cs`: `SemanticConventionsVersion` and the
  `<remarks>` doc comment/link.
* `SemanticConventions.cs`: the "Messaging (Kafka)" comment block and
  its doc link (comment-only change, no attribute changes).
* `README.md`: the metrics semconv doc link.
* `InstrumentedConsumerTests.cs`: the expected `TelemetrySchemaUrl`.
* `CHANGELOG.md`: new entry under Unreleased.

No new attributes are added in this PR. This was split out of #4739 to
keep that PR focused on the new `messaging.kafka.cluster.id` attribute
against the v1.43.0 baseline.

## Test plan

* `dotnet build` succeeds.
* `dotnet test` on `OpenTelemetry.Instrumentation.ConfluentKafka.Tests`
  passes (15/15).