### PR TITLE
[Infra] Fix code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/UncheckedASCIIEncoding.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/UncheckedASCIIEncoding.cs
@@ -31,25 +31,13 @@ internal sealed class UncheckedASCIIEncoding : Encoding
 
     #region Required implementation of Encoding abstract methods
 
-    public override int GetMaxByteCount(int charCount)
-    {
-        return charCount;
-    }
+    public override int GetMaxByteCount(int charCount) => charCount;
 
-    public override int GetMaxCharCount(int byteCount)
-    {
-        return byteCount;
-    }
+    public override int GetMaxCharCount(int byteCount) => byteCount;
 
-    public override int GetByteCount(char[] chars, int charIndex, int charCount)
-    {
-        return charCount;
-    }
+    public override int GetByteCount(char[] chars, int charIndex, int charCount) => charCount;
 
-    public override int GetCharCount(byte[] bytes, int byteIndex, int byteCount)
-    {
-        return byteCount;
-    }
+    public override int GetCharCount(byte[] bytes, int byteIndex, int byteCount) => byteCount;
 
     public override unsafe int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
     {
@@ -127,15 +115,9 @@ internal sealed class UncheckedASCIIEncoding : Encoding
         return chars.Length;
     }
 
-    public override unsafe int GetByteCount(char* charPtr, int charCount)
-    {
-        return charCount;
-    }
+    public override unsafe int GetByteCount(char* charPtr, int charCount) => charCount;
 
-    public override unsafe int GetCharCount(byte* bytePtr, int byteCount)
-    {
-        return byteCount;
-    }
+    public override unsafe int GetCharCount(byte* bytePtr, int byteCount) => byteCount;
 
     public override unsafe int GetBytes(string chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
     {

--- a/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
+++ b/src/OpenTelemetry.Instrumentation.ConfluentKafka/ConfluentKafkaCommon.cs
@@ -64,7 +64,12 @@ internal static class ConfluentKafkaCommon
             return await FetchClusterIdAsync(handle).ConfigureAwait(false);
         }
 
+#if NET
+        var key = bootstrapServers;
+#else
         var key = bootstrapServers!;
+#endif
+
         var task = ClusterIdCache.GetOrAdd(key, _ => FetchClusterIdAsync(handle));
         var result = await task.ConfigureAwait(false);
 

--- a/test/OpenTelemetry.Extensions.FuzzTests/ConsistentProbabilityFuzzTests.cs
+++ b/test/OpenTelemetry.Extensions.FuzzTests/ConsistentProbabilityFuzzTests.cs
@@ -39,7 +39,7 @@ public static class ConsistentProbabilityFuzzTests
     [Property(MaxTest = MaxValue)]
     public static void EncodeThresholdInteger_And_DecodeThreshold_RoundTrip(ulong rawThreshold)
     {
-        var threshold = (long)(rawThreshold % (ulong)ConsistentProbability.MaxAdjustedCount); // [0, 2^56).
+        var threshold = (long)(rawThreshold % ConsistentProbability.MaxAdjustedCount); // [0, 2^56).
 
         var encoded = ConsistentProbability.EncodeThresholdInteger(threshold);
 
@@ -92,7 +92,7 @@ public static class ConsistentProbabilityFuzzTests
 
         // 0 = explicit rv, 1 = random TraceId flag, 2 = presumed TraceId randomness.
         var mode = modeSelector % 3;
-        var explicitRandomness = (long)(rawRandomness % (ulong)ConsistentProbability.MaxAdjustedCount);
+        var explicitRandomness = (long)(rawRandomness % ConsistentProbability.MaxAdjustedCount);
 
         var traceId = ActivityTraceId.CreateRandom();
         _ = ConsistentProbability.TryParseHex56(traceId.ToHexString().AsSpan(18), out var traceIdRandomness);
@@ -184,7 +184,7 @@ public static class ConsistentProbabilityFuzzTests
         var higher = Math.Max(ToProbability(rawProbabilityA), ToProbability(rawProbabilityB));
 
         // A fixed, shared randomness value makes the decisions comparable across probabilities.
-        var randomness = (long)(rawRandomness % (ulong)ConsistentProbability.MaxAdjustedCount);
+        var randomness = (long)(rawRandomness % ConsistentProbability.MaxAdjustedCount);
         var traceState = "ot=rv:" + Hex14(randomness);
         var parent = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None, traceState);
         var parameters = new SamplingParameters(parent, ActivityTraceId.CreateRandom(), "operation", ActivityKind.Internal, tags: null, links: null);

--- a/test/OpenTelemetry.Extensions.Tests/Trace/ConsistentProbabilitySamplerTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/ConsistentProbabilitySamplerTests.cs
@@ -416,7 +416,9 @@ public class ConsistentProbabilitySamplerTests
         Assert.Equal(SamplingDecision.Drop, Sample(0.1));
 
         SamplingDecision Sample(double probability)
-            => new ConsistentProbabilitySampler(probability).ShouldSample(in parameters).Decision;
+        {
+            return new ConsistentProbabilitySampler(probability).ShouldSample(in parameters).Decision;
+        }
     }
 
     [Fact]
@@ -566,10 +568,14 @@ public class ConsistentProbabilitySamplerTests
         Assert.Equal(ExpectedDecision(0.25), RemoteDecision(0.25));
 
         SamplingDecision ExpectedDecision(double probability)
-            => IsSampled(probability, randomness) ? SamplingDecision.RecordAndSample : SamplingDecision.Drop;
+        {
+            return IsSampled(probability, randomness) ? SamplingDecision.RecordAndSample : SamplingDecision.Drop;
+        }
 
         SamplingDecision RemoteDecision(double probability)
-            => new ConsistentProbabilitySampler(probability).ShouldSample(remoteParameters).Decision;
+        {
+            return new ConsistentProbabilitySampler(probability).ShouldSample(remoteParameters).Decision;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings in .NET 11 from #3867.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
