### PR TITLE
[Infra] Remove workaround

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,4 @@
     <ArtifactsPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'artifacts'))</ArtifactsPath>
     <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
-  <!-- TODO remove when https://github.com/dotnet/efcore/issues/38463 is fixed by: https://github.com/dotnet/efcore/pull/38402 -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Changes

Remove workaround for now-fixed issue in .NET 10.0.11.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
