### PR TITLE
[perf] Avoid boxing port values

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -196,7 +196,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
 
         if (!uri.IsDefaultPort)
         {
-            activity.SetTag(SemanticConventions.AttributeServerPort, uri.Port);
+            activity.SetTag(SemanticConventions.AttributeServerPort, GrpcTagHelper.GetBoxedPort(uri.Port));
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -116,14 +116,15 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
             if (requestUri != null)
             {
                 activity.SetTag(SemanticConventions.AttributeServerAddress, requestUri.Host);
-                activity.SetTag(SemanticConventions.AttributeServerPort, requestUri.Port);
+                var boxedPort = GrpcTagHelper.GetBoxedPort(requestUri.Port);
+                activity.SetTag(SemanticConventions.AttributeServerPort, boxedPort);
 
                 var uriHostNameType = Uri.CheckHostName(requestUri.Host);
 
                 if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                 {
                     activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, requestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, requestUri.Port);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, boxedPort);
                 }
             }
 
@@ -192,7 +193,7 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
                 if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                 {
                     activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, requestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, requestUri.Port);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, GrpcTagHelper.GetBoxedPort(requestUri.Port));
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -143,7 +143,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 if (request.RequestUri != null)
                 {
                     activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeServerPort, request.RequestUri.Port);
+                    activity.SetTag(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port));
                     activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, this.options.DisableUrlQueryRedaction));
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -55,7 +55,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 
                 if (!request.RequestUri.IsDefaultPort)
                 {
-                    tags.Add(new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, request.RequestUri.Port));
+                    tags.Add(new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port)));
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -77,7 +77,7 @@ internal static class HttpWebRequestActivitySource
             HttpTagHelper.RequestDataHelper.SetHttpMethodTag(activity, request.Method);
 
             activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
-            activity.SetTag(SemanticConventions.AttributeServerPort, request.RequestUri.Port);
+            activity.SetTag(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port));
 
             activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, TracingOptions.DisableUrlQueryRedaction));
 
@@ -422,12 +422,12 @@ internal static class HttpWebRequestActivitySource
 
             if (!request.RequestUri.IsDefaultPort)
             {
-                tags.Add(SemanticConventions.AttributeServerPort, request.RequestUri.Port);
+                tags.Add(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port));
             }
 
-            if (httpStatusCode.HasValue)
+            if (httpStatusCode is { } statusCode)
             {
-                tags.Add(SemanticConventions.AttributeHttpResponseStatusCode, (int)httpStatusCode.Value);
+                tags.Add(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(statusCode));
             }
 
             if (errorType != null)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/TelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/TelemetryHelper.cs
@@ -10,6 +10,12 @@ internal static class TelemetryHelper
 {
     public static readonly (object, string)[] BoxedStatusCodes = InitializeBoxedStatusCodes();
 
+    private static readonly object Port80 = 80;
+    private static readonly object Port443 = 443;
+    private static readonly object Port8080 = 8080;
+
+    private static object? lastBoxedPort;
+
     public static object GetBoxedStatusCode(HttpStatusCode statusCode)
     {
         var intStatusCode = (int)statusCode;
@@ -20,6 +26,33 @@ internal static class TelemetryHelper
     {
         var intStatusCode = (int)statusCode;
         return intStatusCode is >= 100 and < 600 ? BoxedStatusCodes[intStatusCode - 100].Item2 : statusCode.ToString();
+    }
+
+    public static object GetBoxedPort(int port)
+    {
+        var common = port switch
+        {
+            80 => Port80,
+            443 => Port443,
+            8080 => Port8080,
+            _ => null,
+        };
+
+        if (common is not null)
+        {
+            return common;
+        }
+
+        var last = lastBoxedPort;
+        if (last is not null && (int)last == port)
+        {
+            return last;
+        }
+
+        object boxed = port;
+        lastBoxedPort = boxed;
+
+        return boxed;
     }
 
     private static (object, string)[] InitializeBoxedStatusCodes()

--- a/src/Shared/GrpcTagHelper.cs
+++ b/src/Shared/GrpcTagHelper.cs
@@ -29,6 +29,39 @@ internal static class GrpcTagHelper
     public const string GrpcStatusCodeTagName = "grpc.status_code";
     public const string GrpcTargetTagName = "grpc.target";
 
+    private static readonly object Port80 = 80;
+    private static readonly object Port443 = 443;
+    private static readonly object Port8080 = 8080;
+
+    private static object? lastBoxedPort;
+
+    public static object GetBoxedPort(int port)
+    {
+        var common = port switch
+        {
+            80 => Port80,
+            443 => Port443,
+            8080 => Port8080,
+            _ => null,
+        };
+
+        if (common is not null)
+        {
+            return common;
+        }
+
+        var last = lastBoxedPort;
+        if (last is not null && (int)last == port)
+        {
+            return last;
+        }
+
+        object boxed = port;
+        lastBoxedPort = boxed;
+
+        return boxed;
+    }
+
     public static string? GetGrpcMethodFromActivity(Activity activity)
         => activity.GetTagValue(GrpcMethodTagName) as string;
 


### PR DESCRIPTION
## Changes

Use a cache of common pre-boxed HTTP(S) port numbers to avoid boxing every time an `server.port` or `network.peer.port` attribute is added to telemetry.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
