### PR TITLE
[SqlClient] Document CONTEXT_INFO lifetime and add tests

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -256,6 +256,9 @@ attributes for each of the query parameters associated with a database command.
 > [!NOTE]
 > Only `CommandType.Text` commands are supported for trace context propagation.
 > Only .NET runtimes are supported.
+>
+> Other command types do not get their own trace context. They observe whatever
+> was last set on the connection. See below.
 
 Database trace context propagation can be enabled by setting
 `OTEL_DOTNET_EXPERIMENTAL_SQLCLIENT_ENABLE_TRACE_CONTEXT_PROPAGATION`
@@ -264,6 +267,34 @@ This uses the [SET CONTEXT_INFO](https://learn.microsoft.com/en-us/sql/t-sql/sta
 command to set [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header)
 information for the current connection, which results in
 **an additional round-trip to the database**.
+
+`CONTEXT_INFO` is session state. It is scoped to the connection rather than to
+the command that set it, and the instrumentation only ever overwrites it, never
+clears it. This has a few consequences worth understanding before enabling the
+feature.
+
+* Commands other than `CommandType.Text` run with the `traceparent` of the most
+  recent text command on the same connection, if any, which may belong to an
+  unrelated trace. A stored procedure is therefore not merely missing its own
+  trace context, it can be attributed server-side to a different one.
+* With `MultipleActiveResultSets=true`, a command interleaved on the same
+  connection overwrites `CONTEXT_INFO` while an earlier reader is still
+  streaming, so the still-running query is re-attributed server-side to the
+  trace of the interleaved command.
+* Connection pooling does not carry the value across connections. A pooled
+  connection is reset before it is reused, and that reset clears
+  `CONTEXT_INFO`, so the first command on the reused connection does not
+  observe the previous one's `traceparent`. The reset is deferred until the
+  connection is next used, so an idle pooled connection still reports the
+  previous `traceparent` in `sys.dm_exec_sessions`.
+* The additional round-trip is paid for nearly every text command, not only for
+  the sampled ones. A command whose span is dropped by the sampler generally
+  still sets `CONTEXT_INFO`, with the sampled flag of the `traceparent`
+  cleared.
+* `Filter` does not suppress propagation. It is evaluated after `CONTEXT_INFO`
+  has been set, so a command excluded from telemetry still writes its
+  `traceparent` to the database, where it refers to a span that is never
+  exported.
 
 ## Activity Duration calculation
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -288,7 +288,8 @@ public sealed class SqlClientIntegrationTests :
 
         // The stopped activity is left as Activity.Current by the async command, which would
         // make the stored procedure a child of it. Clear it so the two commands belong to
-        // unrelated traces, which is the case the stale value actually mis-attributes.
+        // unrelated traces, which is the case where the stale value attributes the stored
+        // procedure to the wrong trace.
         Activity.Current = null;
 
         var sessionState = await ReadSessionStateAsync(sqlConnection);

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -12,12 +12,18 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 
+[Collection("SqlClient")]
 [Trait("CategoryName", "SqlIntegrationTests")]
 public sealed class SqlClientIntegrationTests :
     IClassFixture<SqlClientIntegrationTestsFixture>,
     IClassFixture<WeaverFixture>
 {
     private const string GetContextInfoQuery = "SELECT CONTEXT_INFO()";
+
+#if NET
+    private const string ReadSessionStateProcedureName = "dbo.otel_read_session_state";
+    private const string CreateReadSessionStateProcedureQuery = "CREATE OR ALTER PROCEDURE " + ReadSessionStateProcedureName + " AS SELECT TOP 1 c.connection_id, CONTEXT_INFO() FROM sys.dm_exec_connections AS c WHERE c.session_id = @@SPID";
+#endif
 
     private readonly ITestOutputHelper outputHelper;
     private readonly SqlClientIntegrationTestsFixture sqlServer;
@@ -176,6 +182,132 @@ public sealed class SqlClientIntegrationTests :
             this.outputHelper,
             [new("invalid_format", null)]); // See https://github.com/open-telemetry/weaver/issues/1443
     }
+
+    [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
+    public async Task ContextInfoIsClearedWhenPooledConnectionIsReused()
+    {
+        // Arrange
+        using var scope = EnvironmentVariableScope.Create(
+            SqlClientTraceInstrumentationOptions.ContextPropagationLevelEnvVar,
+            "true");
+
+        await this.CreateReadSessionStateProcedureAsync();
+
+        var activities = new List<Activity>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddInMemoryExporter(activities)
+            .AddSqlClientInstrumentation()
+            .Build();
+
+        // A distinct connection string is a distinct pool key, so this gives the test a pool
+        // that can hold exactly one physical connection. The reuse below is then guaranteed
+        // rather than dependent on the order the driver pops connections off its own pool.
+        var connectionStringBuilder = new SqlConnectionStringBuilder(this.GetConnectionString())
+        {
+            MaxPoolSize = 1,
+        };
+
+        Guid connectionId;
+
+        // Act
+        using (var sqlConnection = new SqlConnection(connectionStringBuilder.ConnectionString))
+        {
+            await sqlConnection.OpenAsync();
+
+            sqlConnection.ChangeDatabase("master");
+
+            using (var sqlCommand = new SqlCommand("select 1", sqlConnection))
+            {
+                await sqlCommand.ExecuteScalarAsync();
+            }
+
+            var textActivity = Assert.Single(activities);
+
+            var sessionState = await ReadSessionStateAsync(sqlConnection);
+
+            connectionId = sessionState.ConnectionId;
+
+            // The text command wrote its traceparent, so the assertion after the pooled
+            // reuse below is about the reset and not about propagation never having run.
+            Assert.Equal(textActivity.Id, sessionState.ContextInfo);
+        }
+
+        using (var sqlConnection = new SqlConnection(connectionStringBuilder.ConnectionString))
+        {
+            await sqlConnection.OpenAsync();
+
+            sqlConnection.ChangeDatabase("master");
+
+            var sessionState = await ReadSessionStateAsync(sqlConnection);
+
+            // Assert
+            Assert.Equal(connectionId, sessionState.ConnectionId);
+            Assert.Null(sessionState.ContextInfo);
+        }
+
+        Assert.Equal(3, activities.Count);
+
+        await WeaverTelemetryVerifier.VerifyAsync(
+            (activities, []),
+            SqlTelemetryHelper.SemanticConventionsVersion,
+            this.weaver,
+            this.outputHelper);
+    }
+
+    [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
+    public async Task StoredProcedureObservesContextInfoOfPrecedingTextCommand()
+    {
+        // Arrange
+        using var scope = EnvironmentVariableScope.Create(
+            SqlClientTraceInstrumentationOptions.ContextPropagationLevelEnvVar,
+            "true");
+
+        await this.CreateReadSessionStateProcedureAsync();
+
+        var activities = new List<Activity>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddInMemoryExporter(activities)
+            .AddSqlClientInstrumentation()
+            .Build();
+
+        using var sqlConnection = new SqlConnection(this.GetConnectionString());
+
+        await sqlConnection.OpenAsync();
+
+        sqlConnection.ChangeDatabase("master");
+
+        // Act
+        using (var sqlCommand = new SqlCommand("select 1", sqlConnection))
+        {
+            await sqlCommand.ExecuteScalarAsync();
+        }
+
+        var textActivity = Assert.Single(activities);
+
+        // The stopped activity is left as Activity.Current by the async command, which would
+        // make the stored procedure a child of it. Clear it so the two commands belong to
+        // unrelated traces, which is the case the stale value actually mis-attributes.
+        Activity.Current = null;
+
+        var sessionState = await ReadSessionStateAsync(sqlConnection);
+
+        // Assert
+        Assert.Equal(2, activities.Count);
+
+        var storedProcedureActivity = activities[1];
+
+        Assert.NotEqual(textActivity.TraceId, storedProcedureActivity.TraceId);
+        Assert.Equal(textActivity.Id, sessionState.ContextInfo);
+        Assert.NotEqual(storedProcedureActivity.Id, sessionState.ContextInfo);
+
+        await WeaverTelemetryVerifier.VerifyAsync(
+            (activities, []),
+            SqlTelemetryHelper.SemanticConventionsVersion,
+            this.weaver,
+            this.outputHelper);
+    }
 #endif
 
     [EnabledOnDockerPlatformFact(DockerPlatform.Linux)]
@@ -305,6 +437,51 @@ public sealed class SqlClientIntegrationTests :
                    && (string)kvp.Value == SqlTelemetryHelper.MicrosoftSqlServerDbSystemName);
     }
 
+#if NET
+    private static async Task<(Guid ConnectionId, string? ContextInfo)> ReadSessionStateAsync(SqlConnection sqlConnection)
+    {
+        // The read has to be a stored procedure: propagation only fires for CommandType.Text,
+        // so a text command would overwrite CONTEXT_INFO before it could be read back.
+        using var sqlCommand = new SqlCommand(ReadSessionStateProcedureName, sqlConnection)
+        {
+            CommandType = CommandType.StoredProcedure,
+        };
+
+        using var reader = await sqlCommand.ExecuteReaderAsync();
+
+        Assert.True(await reader.ReadAsync());
+
+        var connectionId = reader.GetGuid(0);
+        var contextInfo = reader.IsDBNull(1)
+            ? null
+            : Encoding.ASCII.GetString((byte[])reader[1]).TrimEnd('\0');
+
+        return (connectionId, contextInfo);
+    }
+#endif
+
     private string GetConnectionString()
         => this.sqlServer.TypedContainer.GetConnectionString();
+
+#if NET
+    private async Task CreateReadSessionStateProcedureAsync()
+    {
+        // Pooling is disabled so that the setup connection cannot be the one the pool
+        // hands back to the test, which asserts on a specific physical connection.
+        var connectionStringBuilder = new SqlConnectionStringBuilder(this.GetConnectionString())
+        {
+            Pooling = false,
+        };
+
+        using var sqlConnection = new SqlConnection(connectionStringBuilder.ConnectionString);
+
+        await sqlConnection.OpenAsync();
+
+        sqlConnection.ChangeDatabase("master");
+
+        using var sqlCommand = new SqlCommand(CreateReadSessionStateProcedureQuery, sqlConnection);
+
+        await sqlCommand.ExecuteNonQueryAsync();
+    }
+#endif
 }


### PR DESCRIPTION
Fixes #3137

## Changes

Adds 2 regression tests and extends `Trace Context Propagation` section within the README file.

Pooling is unaffected, meaning `sp_reset_connection` clears `CONTEXT_INFO` and previous command's `traceparent` is invisible.
There are a few cases where 'traceparent'  is used within a connection, all cases are documented.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
