### PR TITLE
[Extensions] Add cap to tracestate members

### DIFF
--- a/src/OpenTelemetry.Extensions/Internal/OtelTraceState.cs
+++ b/src/OpenTelemetry.Extensions/Internal/OtelTraceState.cs
@@ -93,8 +93,7 @@ internal struct OtelTraceState
             if (separator <= 0)
             {
                 // Malformed member: preserve it verbatim rather than discarding data.
-                state.otherMembers ??= [];
-                state.otherMembers.Add(member.ToString());
+                state.AddOtherMember(member);
                 continue;
             }
 
@@ -108,8 +107,7 @@ internal struct OtelTraceState
             }
             else
             {
-                state.otherMembers ??= [];
-                state.otherMembers.Add(member.ToString());
+                state.AddOtherMember(member);
             }
         }
 
@@ -478,5 +476,20 @@ internal struct OtelTraceState
             // Only oversized sub-keys were present, so remove the empty "ot=" prefix.
             builder.Length = prefixIndex;
         }
+    }
+
+    /// <summary>
+    /// Records a non-<c>ot</c> or malformed <c>tracestate</c> member for verbatim round-tripping,
+    /// bounding the number retained to <see cref="TraceStateMemberLimit"/>.
+    /// </summary>
+    private void AddOtherMember(ReadOnlySpan<char> member)
+    {
+        if (this.otherMembers is { Count: >= TraceStateMemberLimit })
+        {
+            return;
+        }
+
+        this.otherMembers ??= [];
+        this.otherMembers.Add(member.ToString());
     }
 }

--- a/test/OpenTelemetry.Extensions.Tests/Trace/OtelTraceStateTests.cs
+++ b/test/OpenTelemetry.Extensions.Tests/Trace/OtelTraceStateTests.cs
@@ -166,6 +166,43 @@ public class OtelTraceStateTests
     }
 
     [Fact]
+    public void ParseAndSerialize_WithManyMembers_KeepsAtMostMemberLimit()
+    {
+        var incomingMembers = Enumerable.Range(0, OtelTraceState.TraceStateMemberLimit * 100)
+                                        .Select(static index => $"vendor{index}=value")
+                                        .ToArray();
+
+        var outgoingMembers = OtelTraceState.Parse(string.Join(",", incomingMembers)).Serialize().Split(',');
+
+        Assert.Equal(OtelTraceState.TraceStateMemberLimit, outgoingMembers.Length);
+        Assert.Equal(incomingMembers.Take(OtelTraceState.TraceStateMemberLimit), outgoingMembers);
+    }
+
+    [Fact]
+    public void ParseAndSerialize_WithManyMalformedMembers_KeepsAtMostMemberLimit()
+    {
+        var incomingMembers = Enumerable.Range(0, OtelTraceState.TraceStateMemberLimit * 100)
+                                        .Select(static index => $"malformed{index}")
+                                        .ToArray();
+
+        var outgoingMembers = OtelTraceState.Parse(string.Join(",", incomingMembers)).Serialize().Split(',');
+
+        Assert.Equal(OtelTraceState.TraceStateMemberLimit, outgoingMembers.Length);
+        Assert.Equal(incomingMembers.Take(OtelTraceState.TraceStateMemberLimit), outgoingMembers);
+    }
+
+    [Fact]
+    public void ParseAndSerialize_AtMemberLimit_RoundTripsAllMembers()
+    {
+        var members = Enumerable.Range(0, OtelTraceState.TraceStateMemberLimit)
+                                .Select(static index => $"vendor{index}=value")
+                                .ToArray();
+        var traceState = string.Join(",", members);
+
+        Assert.Equal(traceState, OtelTraceState.Parse(traceState).Serialize());
+    }
+
+    [Fact]
     public void Parse_DiscardsOtEntryThatExceedsTheSizeLimit()
     {
         var large = new string('a', OtelTraceState.TraceStateSizeLimit);


### PR DESCRIPTION
## Changes

Add an upper-bound to the number of other members processed by `OtelTraceState` to match the serializer.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
