### PR TITLE
[Kusto] Avoid materializing query text

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
@@ -179,32 +179,38 @@ internal sealed class KustoTraceRecordListener : KustoUtils.ITraceListener
             {
                 var shouldSummarize = this.TraceOptions.RecordQuerySummary || this.MeterOptions.RecordQuerySummary;
                 var shouldSanitize = this.TraceOptions.RecordQueryText || this.MeterOptions.RecordQueryText;
-                var info = KustoProcessor.Process(shouldSummarize, shouldSanitize, result.QueryText.ToString());
 
-                if (!string.IsNullOrEmpty(info.Sanitized))
+                // Avoid materializing the (potentially large) query text into a string when
+                // neither summarization nor sanitization is enabled for traces or metrics.
+                if (shouldSummarize || shouldSanitize)
                 {
-                    if (this.TraceOptions.RecordQueryText)
+                    var info = KustoProcessor.Process(shouldSummarize, shouldSanitize, result.QueryText.ToString());
+
+                    if (!string.IsNullOrEmpty(info.Sanitized))
                     {
-                        activity?.AddTag(SemanticConventions.AttributeDbQueryText, info.Sanitized);
+                        if (this.TraceOptions.RecordQueryText)
+                        {
+                            activity?.AddTag(SemanticConventions.AttributeDbQueryText, info.Sanitized);
+                        }
+
+                        if (this.MeterOptions.RecordQueryText)
+                        {
+                            context.AddMeterTag(SemanticConventions.AttributeDbQueryText, info.Sanitized);
+                        }
                     }
 
-                    if (this.MeterOptions.RecordQueryText)
+                    if (info.Summarized is { Length: > 0 } summarized)
                     {
-                        context.AddMeterTag(SemanticConventions.AttributeDbQueryText, info.Sanitized);
-                    }
-                }
+                        if (this.TraceOptions.RecordQuerySummary)
+                        {
+                            activity?.AddTag(SemanticConventions.AttributeDbQuerySummary, summarized);
+                            activity?.DisplayName = summarized;
+                        }
 
-                if (info.Summarized is { Length: > 0 } summarized)
-                {
-                    if (this.TraceOptions.RecordQuerySummary)
-                    {
-                        activity?.AddTag(SemanticConventions.AttributeDbQuerySummary, summarized);
-                        activity?.DisplayName = summarized;
-                    }
-
-                    if (this.MeterOptions.RecordQuerySummary)
-                    {
-                        context.AddMeterTag(SemanticConventions.AttributeDbQuerySummary, summarized);
+                        if (this.MeterOptions.RecordQuerySummary)
+                        {
+                            context.AddMeterTag(SemanticConventions.AttributeDbQuerySummary, summarized);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Changes

Avoid materializing query text when neither summarization nor sanitization is enabled.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
