### PR TITLE
[SqlClient] Add metrics-only fast path for netfx

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -136,6 +136,14 @@ internal sealed class SqlEventSourceListener : EventListener
             return;
         }
 
+        // Metrics-only fast path: if the ActivitySource has no listeners then StartActivity
+        // will always return null and no trace will be produced, so skip redundant work.
+        if (!SqlTelemetryHelper.ActivitySource.HasListeners())
+        {
+            this.beginTimestamp.Value = Stopwatch.GetTimestamp();
+            return;
+        }
+
         var dataSource = (string)eventData.Payload[1];
         var databaseName = (string)eventData.Payload[2];
         var startTags = SqlTelemetryHelper.GetTagListFromConnectionInfo(dataSource, databaseName, out var activityName);


### PR DESCRIPTION
## Changes

Add a fast-path for .NET Framework to avoid redundant work when only metrics is enabled.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
