### PR TITLE
[HttpClient] Pass correct timestamp for async .NET Framework calls

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -6,6 +6,11 @@
   enabled and a filtered request is redirected on .NET Framework.
   ([#4917](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4917))
 
+* Preserve the original request start timestamp when recording
+  `http.client.request.duration` for asynchronous .NET Framework
+  `HttpWebRequest` calls.
+  ([#5000](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5000))
+
 ## 1.17.0
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -267,7 +267,7 @@ internal static class HttpWebRequestActivitySource
         }
 
         // Hook into the result callback if it hasn't already fired.
-        var callback = new AsyncCallbackWrapper(writeAsyncContextCallback.Request, writeAsyncContextCallback.Activity, reflection.AsyncCallbackAccessor(readAsyncContext), Stopwatch.GetTimestamp());
+        var callback = new AsyncCallbackWrapper(writeAsyncContextCallback.Request, writeAsyncContextCallback.Activity, reflection.AsyncCallbackAccessor(readAsyncContext), writeAsyncContextCallback.StartTimestamp);
         reflection.AsyncCallbackModifier(readAsyncContext, callback.AsyncCallback);
     }
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using OpenTelemetry.Instrumentation.Http.Implementation;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 
@@ -354,6 +355,46 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         Assert.Equal("Stop", stopEvent.Key);
 
         VerifyActivityStopTags(200, activity);
+    }
+
+    [Fact]
+    public async Task TestAsyncWebRequestDurationIncludesTimeBetweenRequestAndResponse()
+    {
+        var metrics = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddHttpClientInstrumentation()
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+        var webRequest = (HttpWebRequest)WebRequest.Create(new Uri(this.BuildRequestUrl()));
+        webRequest.Method = "POST";
+
+        using (var stream = await webRequest.GetRequestStreamAsync())
+        using (var writer = new StreamWriter(stream))
+        {
+            await writer.WriteAsync("hello world");
+        }
+
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+        using (var webResponse = (HttpWebResponse)await webRequest.GetResponseAsync())
+        using (var reader = new StreamReader(webResponse.GetResponseStream()))
+        {
+            await reader.ReadToEndAsync();
+        }
+
+        meterProvider.ForceFlush();
+
+        var metric = Assert.Single(metrics, metric => metric.Name == "http.client.request.duration");
+        var metricPoints = new List<MetricPoint>();
+        foreach (var point in metric.GetMetricPoints())
+        {
+            metricPoints.Add(point);
+        }
+
+        var metricPoint = Assert.Single(metricPoints);
+
+        Assert.True(metricPoint.GetHistogramSum() >= 0.05, $"Expected duration to include the delay, but was {metricPoint.GetHistogramSum()} seconds.");
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

Async .NET Framework calls with only metrics  enabled could record `http.client.request.duration` using a fresh timestamp while processing the response, rather than the original request timestamp, underreporting the actual duration.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
