### PR TITLE
[AspNet] Clear baggage when Activity is sampled out

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -116,6 +116,12 @@ internal static class ActivityHelper
             // created due to a sampling decision.
             InvokeRequestStoppedCallback(aspNetActivity, context, onRequestStoppedInstrumentationCallback, "OnInstrumentationStopped");
             context.Items[ContextKey] = null;
+
+            if (textMapPropagator is not TraceContextPropagator)
+            {
+                Baggage.Current = default;
+            }
+
             return;
         }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Avoid redundant `HttpContextWrapper` allocations in `TelemetryHttpModule`.
   ([#4903](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4903))
 
+* Fix baggage leaking when an incoming ASP.NET request does not create
+  an `Activity`.
+  ([#5001](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5001))
+
 ## 1.17.0
 
 Released 2026-Jul-17

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -320,6 +320,35 @@ public class ActivityHelperTest : IDisposable
     }
 
     [Fact]
+    public void Clears_Baggage_When_RootActivity_Is_Not_Created()
+    {
+        var previousBaggage = Baggage.Current;
+        try
+        {
+            Baggage.Current = default;
+
+            var propagator = new CompositeTextMapPropagator([new TraceContextPropagator(), new BaggagePropagator()]);
+            var requestHeaders = new Dictionary<string, string>
+            {
+                { BaggageHeaderName, BaggageInHeader },
+            };
+            var context = HttpContextHelper.GetFakeHttpContextBase(headers: requestHeaders);
+            using var rootActivity = ActivityHelper.StartAspNetActivity(propagator, context, null);
+
+            Assert.Null(rootActivity);
+            Assert.Equal(2, Baggage.Current.Count);
+
+            ActivityHelper.StopAspNetActivity(propagator, rootActivity, context, null);
+
+            Assert.Equal(0, Baggage.Current.Count);
+        }
+        finally
+        {
+            Baggage.Current = previousBaggage;
+        }
+    }
+
+    [Fact]
     public void Should_Not_Fire_Stop_Callback_Without_RootActivity()
     {
         var context = HttpContextHelper.GetFakeHttpContextBase();


### PR DESCRIPTION
## Changes

Fixes baggage leaking when an incoming ASP.NET request do not create an activity (metrics-only, sampling). Extracted baggage no longer remains in `Baggage.Current` after request completion. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
