### PR TITLE
[Geneva] Fix exception argument

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/UncheckedASCIIEncoding.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Internal/Tld/UncheckedASCIIEncoding.cs
@@ -131,7 +131,7 @@ internal sealed class UncheckedASCIIEncoding : Encoding
         }
         else if (chars.Length - charIndex < charCount)
         {
-            throw new ArgumentOutOfRangeException(chars);
+            throw new ArgumentOutOfRangeException(nameof(chars));
         }
         else if (byteIndex < 0 || byteIndex > bytes.Length)
         {


### PR DESCRIPTION
## Changes

Fix the value of `chars` being used as the parameter name instead of the literal `"chars"`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
