### PR TITLE
[Dynamic Control] Phase 3a: Add PolicyKey, SourceRegistrationId, and PolicySourceMetadata

### DIFF
--- a/src/OpenTelemetry.DynamicControl/CHANGELOG.md
+++ b/src/OpenTelemetry.DynamicControl/CHANGELOG.md
@@ -6,4 +6,9 @@
   model and validation.
   ([#4950](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4950))
 
+* Added internal `PolicyKey`, `SourceRegistrationId`, `PolicySourceKind`,
+  and `PolicySourceMetadata` identity types for keying policies and
+  configured sources.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+
 For more details, please refer to the [README](README.md).

--- a/src/OpenTelemetry.DynamicControl/CHANGELOG.md
+++ b/src/OpenTelemetry.DynamicControl/CHANGELOG.md
@@ -9,6 +9,6 @@
 * Added internal `PolicyKey`, `SourceRegistrationId`, `PolicySourceKind`,
   and `PolicySourceMetadata` identity types for keying policies and
   configured sources.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/XXXX))
+  ([#5011](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5011))
 
 For more details, please refer to the [README](README.md).

--- a/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
@@ -1,0 +1,116 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.DynamicControl.Internal.Policies;
+
+/// <summary>
+/// Identifies the slot that a telemetry policy occupies, across all configured sources.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cross-source policy identity is the composite of the policy type and the
+/// provider-assigned policy identifier, rather than the identifier alone.
+/// </para>
+/// </remarks>
+internal readonly struct PolicyKey : IEquatable<PolicyKey>
+{
+    private readonly string? policyType;
+    private readonly string? policyId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PolicyKey"/> struct.
+    /// </summary>
+    /// <param name="policyType">The policy type discriminator. Must not be null or whitespace.</param>
+    /// <param name="policyId">The provider-assigned policy identifier. Must not be null or whitespace.</param>
+    /// <exception cref="ArgumentException">Thrown when either component is null, empty, or whitespace.</exception>
+    public PolicyKey(string policyType, string policyId)
+    {
+        Guard.ThrowIfNullOrWhitespace(policyType, nameof(policyType));
+        Guard.ThrowIfNullOrWhitespace(policyId, nameof(policyId));
+
+        this.policyType = policyType;
+        this.policyId = policyId;
+    }
+
+    /// <summary>
+    /// Gets the policy type discriminator (e.g. <c>trace-sampling</c>).
+    /// </summary>
+    /// <remarks>
+    /// The constructor rejects a blank type. <see langword="default"/> instances bypass
+    /// every constructor, so they report an empty value rather than <see langword="null"/>.
+    /// </remarks>
+    public string PolicyType => this.policyType ?? string.Empty;
+
+    /// <summary>
+    /// Gets the opaque, provider-assigned policy identifier.
+    /// </summary>
+    /// <remarks>
+    /// The constructor rejects a blank identifier. <see langword="default"/> instances
+    /// bypass every constructor, so they report an empty value rather than
+    /// <see langword="null"/>.
+    /// </remarks>
+    public string PolicyId => this.policyId ?? string.Empty;
+
+    /// <summary>
+    /// Determines whether two <see cref="PolicyKey"/> instances identify the same policy.
+    /// </summary>
+    /// <param name="left">The first key to compare.</param>
+    /// <param name="right">The second key to compare.</param>
+    /// <returns><see langword="true"/> if the keys are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(PolicyKey left, PolicyKey right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two <see cref="PolicyKey"/> instances identify different policies.
+    /// </summary>
+    /// <param name="left">The first key to compare.</param>
+    /// <param name="right">The second key to compare.</param>
+    /// <returns><see langword="true"/> if the keys are not equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(PolicyKey left, PolicyKey right) => !left.Equals(right);
+
+    /// <summary>
+    /// Creates the key identifying the slot that <paramref name="policy"/> occupies.
+    /// </summary>
+    /// <param name="policy">The policy to derive a key from.</param>
+    /// <returns>The key composed of the policy's type and identifier.</returns>
+    /// <remarks>
+    /// The returned key depends only on identity, never on policy content, so an updated
+    /// value for the same policy resolves to the same slot.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="policy"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the policy reports a blank type or identifier. Validated policy models
+    /// cannot, so this indicates a faulty <see cref="ITelemetryPolicy"/> implementation.
+    /// </exception>
+    public static PolicyKey FromPolicy(ITelemetryPolicy policy)
+    {
+        Guard.ThrowIfNull(policy);
+
+        return new PolicyKey(policy.PolicyType, policy.Id);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(PolicyKey other)
+        => string.Equals(this.policyType ?? string.Empty, other.policyType ?? string.Empty, StringComparison.Ordinal)
+            && string.Equals(this.policyId ?? string.Empty, other.policyId ?? string.Empty, StringComparison.Ordinal);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is PolicyKey other && this.Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = (17 * 31) + StringComparer.Ordinal.GetHashCode(this.PolicyType);
+            return (hash * 31) + StringComparer.Ordinal.GetHashCode(this.PolicyId);
+        }
+    }
+
+    /// <summary>
+    /// Returns a diagnostic representation of the key.
+    /// </summary>
+    /// <returns>The policy type and identifier, separated by a forward slash.</returns>
+    public override string ToString() => this.PolicyType + "/" + this.PolicyId;
+}

--- a/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
@@ -101,11 +101,17 @@ internal readonly struct PolicyKey : IEquatable<PolicyKey>
     /// <inheritdoc/>
     public override int GetHashCode()
     {
+#if NET || NETSTANDARD2_1_OR_GREATER
+        return HashCode.Combine(
+            StringComparer.Ordinal.GetHashCode(this.PolicyType),
+            StringComparer.Ordinal.GetHashCode(this.PolicyId));
+#else
         unchecked
         {
             var hash = (17 * 31) + StringComparer.Ordinal.GetHashCode(this.PolicyType);
             return (hash * 31) + StringComparer.Ordinal.GetHashCode(this.PolicyId);
         }
+#endif
     }
 
     /// <summary>

--- a/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
@@ -16,6 +16,12 @@ namespace OpenTelemetry.DynamicControl.Internal.Policies;
 /// </remarks>
 internal readonly struct PolicyKey : IEquatable<PolicyKey>
 {
+    /// <summary>
+    /// A read-only instance of the <see cref="PolicyKey"/> structure whose values
+    /// are all <see langword="default"/>.
+    /// </summary>
+    public static readonly PolicyKey None;
+
     private readonly string? policyType;
     private readonly string? policyId;
 
@@ -37,20 +43,11 @@ internal readonly struct PolicyKey : IEquatable<PolicyKey>
     /// <summary>
     /// Gets the policy type discriminator (e.g. <c>trace-sampling</c>).
     /// </summary>
-    /// <remarks>
-    /// The constructor rejects a blank type. <see langword="default"/> instances bypass
-    /// every constructor, so they report an empty value rather than <see langword="null"/>.
-    /// </remarks>
     public string PolicyType => this.policyType ?? string.Empty;
 
     /// <summary>
     /// Gets the opaque, provider-assigned policy identifier.
     /// </summary>
-    /// <remarks>
-    /// The constructor rejects a blank identifier. <see langword="default"/> instances
-    /// bypass every constructor, so they report an empty value rather than
-    /// <see langword="null"/>.
-    /// </remarks>
     public string PolicyId => this.policyId ?? string.Empty;
 
     /// <summary>

--- a/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Policies/PolicyKey.cs
@@ -17,10 +17,10 @@ namespace OpenTelemetry.DynamicControl.Internal.Policies;
 internal readonly struct PolicyKey : IEquatable<PolicyKey>
 {
     /// <summary>
-    /// A read-only instance of the <see cref="PolicyKey"/> structure whose values
+    /// A read-only instance of the <see cref="PolicyKey"/> structure whose field values
     /// are all <see langword="default"/>.
     /// </summary>
-    public static readonly PolicyKey None;
+    public static readonly PolicyKey Empty;
 
     private readonly string? policyType;
     private readonly string? policyId;

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceKind.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceKind.cs
@@ -13,8 +13,7 @@ namespace OpenTelemetry.DynamicControl.Internal.Sources;
 internal enum PolicySourceKind
 {
     /// <summary>
-    /// The kind is unspecified. This is the <see langword="default"/> value and is not a
-    /// valid kind for a configured source.
+    /// The kind is unspecified. This is not a valid kind for a configured source.
     /// </summary>
     Unknown = 0,
 
@@ -27,4 +26,15 @@ internal enum PolicySourceKind
     /// The source receives policies over OpAMP.
     /// </summary>
     OpAmp = 2,
+
+    /// <summary>
+    /// The source receives policies over HTTP.
+    /// </summary>
+    Http = 3,
+
+    /// <summary>
+    /// The source is a user-defined or third-party provider not covered by the
+    /// other named kinds.
+    /// </summary>
+    Custom = 4,
 }

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceKind.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceKind.cs
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.DynamicControl.Internal.Sources;
+
+/// <summary>
+/// Describes the transport or backing store that a configured policy source reads from.
+/// </summary>
+/// <remarks>
+/// The kind is diagnostic and grouping information only; it never identifies a source,
+/// because several sources of the same kind may be configured.
+/// </remarks>
+internal enum PolicySourceKind
+{
+    /// <summary>
+    /// The kind is unspecified. This is the <see langword="default"/> value and is not a
+    /// valid kind for a configured source.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The source reads policies from the local file system.
+    /// </summary>
+    File = 1,
+
+    /// <summary>
+    /// The source receives policies over OpAMP.
+    /// </summary>
+    OpAmp = 2,
+}

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
@@ -11,23 +11,16 @@ namespace OpenTelemetry.DynamicControl.Internal.Sources;
 /// </summary>
 internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
 {
-    /// <summary>
-    /// The precedence applied to a source that does not specify one.
-    /// </summary>
-    /// <remarks>
-    /// Because a lower value wins, the default is the lowest possible precedence
-    /// (<see cref="int.MaxValue"/>) rather than zero. A source that does not opt into
-    /// explicit ordering must not automatically outrank one that does. This constant only
-    /// applies when a constructor call omits the priority argument; a
-    /// <see langword="default"/> instance bypasses the constructor entirely and reports a
-    /// <see cref="Priority"/> of zero instead. See <see cref="Priority"/> for details.
-    /// </remarks>
-    public const int DefaultPriority = int.MaxValue;
+    // The precedence applied to a source that does not specify one.
+    // Lower values represent higher precedence, so a source that does not opt into
+    // explicit ordering is assigned the numerically highest value,
+    // ensuring it cannot outrank any explicitly prioritized source.
+    private const int DefaultPriority = int.MaxValue;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PolicySourceMetadata"/> struct.
     /// </summary>
-    /// <param name="registrationId">The identity of the configured source. Must not be <see langword="default"/>.</param>
+    /// <param name="registrationId">The identity of the configured source. Must not be <see cref="SourceRegistrationId.None"/>.</param>
     /// <param name="kind">The kind of source. Must not be <see cref="PolicySourceKind.Unknown"/>.</param>
     /// <param name="priority">
     /// The aggregation precedence. Lower values win, matching the provider-priority
@@ -35,7 +28,7 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
     /// non-negative.
     /// </param>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="registrationId"/> is <see langword="default"/>.
+    /// Thrown when <paramref name="registrationId"/> is <see cref="SourceRegistrationId.None"/>.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="kind"/> is <see cref="PolicySourceKind.Unknown"/> or is
@@ -78,10 +71,7 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
     /// A lower value takes precedence over a higher one, matching the provider-priority
     /// convention from the Telemetry Policy OTEP (e.g. OpAmp=1, Http=2, File=3). Aggregation
     /// resolves equal priorities deterministically rather than by update order; those rules
-    /// are defined with aggregation itself, not here. A constructor call that omits the
-    /// priority argument reports <see cref="DefaultPriority"/>; a <see langword="default"/>
-    /// instance bypasses every constructor, so it reports zero instead, the same as any
-    /// other field on a zero-initialized struct.
+    /// are defined with aggregation itself, not here.
     /// </remarks>
     public int Priority { get; }
 

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
@@ -20,7 +20,7 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
     /// <summary>
     /// Initializes a new instance of the <see cref="PolicySourceMetadata"/> struct.
     /// </summary>
-    /// <param name="registrationId">The identity of the configured source. Must not be <see cref="SourceRegistrationId.None"/>.</param>
+    /// <param name="registrationId">The identity of the configured source. Must not be <see cref="SourceRegistrationId.Empty"/>.</param>
     /// <param name="kind">The kind of source. Must not be <see cref="PolicySourceKind.Unknown"/>.</param>
     /// <param name="priority">
     /// The aggregation precedence. Lower values win, matching the provider-priority
@@ -28,7 +28,7 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
     /// non-negative.
     /// </param>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="registrationId"/> is <see cref="SourceRegistrationId.None"/>.
+    /// Thrown when <paramref name="registrationId"/> is <see cref="SourceRegistrationId.Empty"/>.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="kind"/> is <see cref="PolicySourceKind.Unknown"/> or is

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
@@ -1,0 +1,136 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.DynamicControl.Internal.Sources;
+
+/// <summary>
+/// Describes one configured policy source: its identity, its kind, and its precedence
+/// during aggregation.
+/// </summary>
+internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
+{
+    /// <summary>
+    /// The precedence applied to a source that does not specify one.
+    /// </summary>
+    /// <remarks>
+    /// Because a lower value wins, the default is the lowest possible precedence
+    /// (<see cref="int.MaxValue"/>) rather than zero. A source that does not opt into
+    /// explicit ordering must not automatically outrank one that does. This constant only
+    /// applies when a constructor call omits the priority argument; a
+    /// <see langword="default"/> instance bypasses the constructor entirely and reports a
+    /// <see cref="Priority"/> of zero instead. See <see cref="Priority"/> for details.
+    /// </remarks>
+    public const int DefaultPriority = int.MaxValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PolicySourceMetadata"/> struct.
+    /// </summary>
+    /// <param name="registrationId">The identity of the configured source. Must not be <see langword="default"/>.</param>
+    /// <param name="kind">The kind of source. Must not be <see cref="PolicySourceKind.Unknown"/>.</param>
+    /// <param name="priority">
+    /// The aggregation precedence. Lower values win, matching the provider-priority
+    /// convention from the Telemetry Policy OTEP (e.g. OpAmp=1, Http=2, File=3). Must be
+    /// non-negative.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="registrationId"/> is <see langword="default"/>, or when
+    /// <paramref name="kind"/> is <see cref="PolicySourceKind.Unknown"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="priority"/> is negative.
+    /// </exception>
+    public PolicySourceMetadata(
+        SourceRegistrationId registrationId,
+        PolicySourceKind kind,
+        int priority = DefaultPriority)
+    {
+        if (registrationId == default)
+        {
+            throw new ArgumentException("The source registration ID is required.", nameof(registrationId));
+        }
+
+        if (kind == PolicySourceKind.Unknown)
+        {
+            throw new ArgumentException("The source kind is required.", nameof(kind));
+        }
+
+        Guard.ThrowIfNegative(
+            priority,
+            "The priority must be non-negative. Per the Telemetry Policy OTEP, lower values represent higher precedence (e.g. OpAmp=1, Http=2, File=3).",
+            nameof(priority));
+
+        this.RegistrationId = registrationId;
+        this.Kind = kind;
+        this.Priority = priority;
+    }
+
+    /// <summary>
+    /// Gets the identity of the configured source.
+    /// </summary>
+    public SourceRegistrationId RegistrationId { get; }
+
+    /// <summary>
+    /// Gets the kind of source.
+    /// </summary>
+    public PolicySourceKind Kind { get; }
+
+    /// <summary>
+    /// Gets the precedence applied when several sources supply the same policy identity.
+    /// </summary>
+    /// <remarks>
+    /// A lower value takes precedence over a higher one, matching the provider-priority
+    /// convention from the Telemetry Policy OTEP (e.g. OpAmp=1, Http=2, File=3). Aggregation
+    /// resolves equal priorities deterministically rather than by update order; those rules
+    /// are defined with aggregation itself, not here. A constructor call that omits the
+    /// priority argument reports <see cref="DefaultPriority"/>; a <see langword="default"/>
+    /// instance bypasses every constructor, so it reports zero instead, the same as any
+    /// other field on a zero-initialized struct.
+    /// </remarks>
+    public int Priority { get; }
+
+    /// <summary>
+    /// Determines whether two <see cref="PolicySourceMetadata"/> instances describe the
+    /// same source in the same way.
+    /// </summary>
+    /// <param name="left">The first value to compare.</param>
+    /// <param name="right">The second value to compare.</param>
+    /// <returns><see langword="true"/> if the values are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(PolicySourceMetadata left, PolicySourceMetadata right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two <see cref="PolicySourceMetadata"/> instances differ.
+    /// </summary>
+    /// <param name="left">The first value to compare.</param>
+    /// <param name="right">The second value to compare.</param>
+    /// <returns><see langword="true"/> if the values are not equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(PolicySourceMetadata left, PolicySourceMetadata right) => !left.Equals(right);
+
+    /// <inheritdoc/>
+    public bool Equals(PolicySourceMetadata other)
+        => this.RegistrationId.Equals(other.RegistrationId)
+            && this.Kind == other.Kind
+            && this.Priority == other.Priority;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is PolicySourceMetadata other && this.Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = (17 * 31) + this.RegistrationId.GetHashCode();
+            hash = (hash * 31) + (int)this.Kind;
+            return (hash * 31) + this.Priority;
+        }
+    }
+
+    /// <summary>
+    /// Returns a diagnostic representation of the source metadata.
+    /// </summary>
+    /// <returns>The registration ID, kind, and priority, separated by forward slashes.</returns>
+    public override string ToString()
+        => this.RegistrationId.Value + "/" + this.Kind + "/" + this.Priority;
+}

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
@@ -35,26 +35,21 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
     /// non-negative.
     /// </param>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="registrationId"/> is <see langword="default"/>, or when
-    /// <paramref name="kind"/> is <see cref="PolicySourceKind.Unknown"/>.
+    /// Thrown when <paramref name="registrationId"/> is <see langword="default"/>.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="priority"/> is negative.
+    /// Thrown when <paramref name="kind"/> is <see cref="PolicySourceKind.Unknown"/> or is
+    /// not a defined <see cref="PolicySourceKind"/> value, or when <paramref name="priority"/>
+    /// is negative.
     /// </exception>
     public PolicySourceMetadata(
         SourceRegistrationId registrationId,
         PolicySourceKind kind,
         int priority = DefaultPriority)
     {
-        if (registrationId == default)
-        {
-            throw new ArgumentException("The source registration ID is required.", nameof(registrationId));
-        }
+        Guard.ThrowIfDefault(registrationId);
 
-        if (kind == PolicySourceKind.Unknown)
-        {
-            throw new ArgumentException("The source kind is required.", nameof(kind));
-        }
+        Guard.ThrowIfUndefinedOrDefault(kind);
 
         Guard.ThrowIfNegative(
             priority,
@@ -119,12 +114,16 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
     /// <inheritdoc/>
     public override int GetHashCode()
     {
+#if NET || NETSTANDARD2_1_OR_GREATER
+        return HashCode.Combine(this.RegistrationId, this.Kind, this.Priority);
+#else
         unchecked
         {
             var hash = (17 * 31) + this.RegistrationId.GetHashCode();
             hash = (hash * 31) + (int)this.Kind;
             return (hash * 31) + this.Priority;
         }
+#endif
     }
 
     /// <summary>

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/SourceRegistrationId.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/SourceRegistrationId.cs
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.DynamicControl.Internal.Sources;
+
+/// <summary>
+/// Identifies one configured policy source for the lifetime of the process.
+/// </summary>
+/// <remarks>
+/// The policy store retains one snapshot per source, so each configured source needs a
+/// stable identity. <see cref="PolicySourceKind"/> alone cannot serve as that identity
+/// because an application may configure several sources of the same kind.
+/// </remarks>
+internal readonly struct SourceRegistrationId : IEquatable<SourceRegistrationId>
+{
+    private readonly string? value;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SourceRegistrationId"/> struct.
+    /// </summary>
+    /// <param name="value">
+    /// The opaque registration value. Must not be null or whitespace, and must be unique
+    /// among the configured sources.
+    /// </param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="value"/> is null, empty, or whitespace.</exception>
+    public SourceRegistrationId(string value)
+    {
+        Guard.ThrowIfNullOrWhitespace(value, nameof(value));
+        this.value = value;
+    }
+
+    /// <summary>
+    /// Gets the opaque registration value.
+    /// </summary>
+    /// <remarks>
+    /// The constructor rejects a blank value. <see langword="default"/> instances bypass
+    /// every constructor, so they report an empty value rather than <see langword="null"/>.
+    /// </remarks>
+    public string Value => this.value ?? string.Empty;
+
+    /// <summary>
+    /// Determines whether two <see cref="SourceRegistrationId"/> instances identify the same source.
+    /// </summary>
+    /// <param name="left">The first identifier to compare.</param>
+    /// <param name="right">The second identifier to compare.</param>
+    /// <returns><see langword="true"/> if the identifiers are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(SourceRegistrationId left, SourceRegistrationId right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two <see cref="SourceRegistrationId"/> instances identify different sources.
+    /// </summary>
+    /// <param name="left">The first identifier to compare.</param>
+    /// <param name="right">The second identifier to compare.</param>
+    /// <returns><see langword="true"/> if the identifiers are not equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(SourceRegistrationId left, SourceRegistrationId right) => !left.Equals(right);
+
+    /// <inheritdoc/>
+    public bool Equals(SourceRegistrationId other)
+        => string.Equals(this.Value, other.Value, StringComparison.Ordinal);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is SourceRegistrationId other && this.Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(this.Value);
+
+    /// <inheritdoc/>
+    public override string ToString() => this.Value;
+}

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/SourceRegistrationId.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/SourceRegistrationId.cs
@@ -16,10 +16,10 @@ namespace OpenTelemetry.DynamicControl.Internal.Sources;
 internal readonly struct SourceRegistrationId : IEquatable<SourceRegistrationId>
 {
     /// <summary>
-    /// A read-only instance of the <see cref="SourceRegistrationId"/> structure whose values
-    /// are all <see langword="default"/>.
+    /// A read-only instance of the <see cref="SourceRegistrationId"/> structure whose field
+    /// values are all <see langword="default"/>.
     /// </summary>
-    public static readonly SourceRegistrationId None;
+    public static readonly SourceRegistrationId Empty;
 
     private readonly string? value;
 

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/SourceRegistrationId.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/SourceRegistrationId.cs
@@ -15,6 +15,12 @@ namespace OpenTelemetry.DynamicControl.Internal.Sources;
 /// </remarks>
 internal readonly struct SourceRegistrationId : IEquatable<SourceRegistrationId>
 {
+    /// <summary>
+    /// A read-only instance of the <see cref="SourceRegistrationId"/> structure whose values
+    /// are all <see langword="default"/>.
+    /// </summary>
+    public static readonly SourceRegistrationId None;
+
     private readonly string? value;
 
     /// <summary>
@@ -34,10 +40,6 @@ internal readonly struct SourceRegistrationId : IEquatable<SourceRegistrationId>
     /// <summary>
     /// Gets the opaque registration value.
     /// </summary>
-    /// <remarks>
-    /// The constructor rejects a blank value. <see langword="default"/> instances bypass
-    /// every constructor, so they report an empty value rather than <see langword="null"/>.
-    /// </remarks>
     public string Value => this.value ?? string.Empty;
 
     /// <summary>

--- a/src/OpenTelemetry.DynamicControl/OpenTelemetry.DynamicControl.csproj
+++ b/src/OpenTelemetry.DynamicControl/OpenTelemetry.DynamicControl.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
   </ItemGroup>
 

--- a/src/Shared/Guard.cs
+++ b/src/Shared/Guard.cs
@@ -195,6 +195,67 @@ namespace OpenTelemetry.Internal
         }
 
         /// <summary>
+        /// Throw an exception if the value equals <see langword="default"/>.
+        /// </summary>
+        /// <typeparam name="T">The value type to validate.</typeparam>
+        /// <param name="value">The value to check.</param>
+        /// <param name="paramName">The parameter name to use in the thrown exception.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfDefault<T>(T value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+            where T : struct, IEquatable<T>
+        {
+            if (value.Equals(default(T)))
+            {
+                throw new ArgumentException($"Must not be the default {typeof(T).Name} value.", paramName);
+            }
+        }
+
+        /// <summary>
+        /// Throw an exception if the enum value is not a defined member of
+        /// <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <typeparam name="TEnum">The enum type to validate.</typeparam>
+        /// <param name="value">The value to check.</param>
+        /// <param name="paramName">The parameter name to use in the thrown exception.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfUndefined<TEnum>(TEnum value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+            where TEnum : struct, Enum
+        {
+#if NET
+            if (!Enum.IsDefined(value))
+#else
+            if (!Enum.IsDefined(typeof(TEnum), value))
+#endif
+            {
+                throw new ArgumentOutOfRangeException(paramName, value, $"Must be a defined {typeof(TEnum).Name} value.");
+            }
+        }
+
+        /// <summary>
+        /// Throw an exception if the enum value is the default (zero) value or is not a
+        /// defined member of <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <typeparam name="TEnum">The enum type to validate.</typeparam>
+        /// <param name="value">The value to check.</param>
+        /// <param name="paramName">The parameter name to use in the thrown exception.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfUndefinedOrDefault<TEnum>(TEnum value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+            where TEnum : struct, Enum
+        {
+#if NET
+            if (value.Equals(default(TEnum)) || !Enum.IsDefined(value))
+#else
+            if (value.Equals(default(TEnum)) || !Enum.IsDefined(typeof(TEnum), value))
+#endif
+            {
+                throw new ArgumentOutOfRangeException(paramName, value, $"Must be a defined, non-default {typeof(TEnum).Name} value.");
+            }
+        }
+
+        /// <summary>
         /// Throw an exception if the value is not of the expected type.
         /// </summary>
         /// <param name="value">The value to check.</param>

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyKeyTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyKeyTests.cs
@@ -1,0 +1,218 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.DynamicControl.Internal.Policies;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+public class PolicyKeyTests
+{
+    [Fact]
+    public void Constructor_WithValidComponents_SetsComponents()
+    {
+        var key = new PolicyKey("trace-sampling", "policy-id");
+
+        Assert.Equal("trace-sampling", key.PolicyType);
+        Assert.Equal("policy-id", key.PolicyId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Constructor_WithBlankPolicyType_Throws(string? policyType) =>
+        Assert.ThrowsAny<ArgumentException>(() => _ = new PolicyKey(policyType!, "policy-id"));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Constructor_WithBlankPolicyId_Throws(string? policyId) =>
+        Assert.ThrowsAny<ArgumentException>(() => _ = new PolicyKey("trace-sampling", policyId!));
+
+    [Fact]
+    public void Equals_WithSameComponents_ReturnsTrue()
+    {
+        var left = new PolicyKey("trace-sampling", "policy-id");
+        var right = new PolicyKey("trace-sampling", "policy-id");
+
+        Assert.True(left.Equals(right), "Typed Equals should be true");
+        Assert.True(left.Equals((object)right), "Object Equals should be true");
+        Assert.True(left == right, "Equals (==) operator should be true");
+        Assert.False(left != right, "Not equals (!=) operator should be false");
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_WithSamePolicyIdButDifferentPolicyType_ReturnsFalse()
+    {
+        // Identity is the composite of both components, so the same identifier used by
+        // two policy types occupies two distinct slots.
+        var left = new PolicyKey("trace-sampling", "policy-id");
+        var right = new PolicyKey("log-level", "policy-id");
+
+        Assert.False(left.Equals(right), "Equals should be false");
+        Assert.True(left != right, "Not equals (!=) operator should be true");
+    }
+
+    [Fact]
+    public void Equals_WithSamePolicyTypeButDifferentPolicyId_ReturnsFalse()
+    {
+        var left = new PolicyKey("trace-sampling", "policy-id");
+        var right = new PolicyKey("trace-sampling", "other-policy-id");
+
+        Assert.False(left.Equals(right), "Equals should be false");
+        Assert.True(left != right, "Not equals (!=) operator should be true");
+    }
+
+    [Fact]
+    public void Equals_WithComponentsSwapped_ReturnsFalse()
+    {
+        var left = new PolicyKey("a", "b");
+        var right = new PolicyKey("b", "a");
+
+        Assert.False(left.Equals(right), "Equals should be false");
+    }
+
+    [Fact]
+    public void Equals_WithComponentsDifferingOnlyByCase_ReturnsFalse()
+    {
+        // Both components are compared ordinally; policy identity is not case-insensitive.
+        var left = new PolicyKey("trace-sampling", "policy-id");
+        var right = new PolicyKey("Trace-Sampling", "Policy-Id");
+
+        Assert.False(left.Equals(right), "Equals should be false");
+    }
+
+    [Fact]
+    public void Equals_WithOtherType_ReturnsFalse()
+    {
+        var key = new PolicyKey("trace-sampling", "policy-id");
+
+        Assert.False(key.Equals("trace-sampling/policy-id"), "Should not be equal to a string");
+        Assert.False(key.Equals(null), "Should not be equal to null");
+    }
+
+    [Fact]
+    public void Default_HasEmptyComponentsAndIsUsableWithoutThrowing()
+    {
+        var key = default(PolicyKey);
+
+        Assert.Equal(string.Empty, key.PolicyType);
+        Assert.Equal(string.Empty, key.PolicyId);
+        Assert.Equal(default, key);
+        Assert.Equal(default(PolicyKey).GetHashCode(), key.GetHashCode());
+        Assert.NotEqual(new PolicyKey("trace-sampling", "policy-id"), key);
+    }
+
+    [Fact]
+    public void CanBeUsedAsDictionaryKey()
+    {
+        var policies = new Dictionary<PolicyKey, string>
+        {
+            [new PolicyKey("trace-sampling", "policy-id")] = "first",
+            [new PolicyKey("log-level", "policy-id")] = "second",
+        };
+
+        // Overwrites rather than adds; an equal key must resolve to the same slot.
+        policies[new PolicyKey("trace-sampling", "policy-id")] = "replacement";
+
+        Assert.Equal(2, policies.Count);
+        Assert.Equal("replacement", policies[new PolicyKey("trace-sampling", "policy-id")]);
+        Assert.Equal("second", policies[new PolicyKey("log-level", "policy-id")]);
+    }
+
+    [Fact]
+    public void ToString_ReturnsPolicyTypeAndPolicyId()
+    {
+        var key = new PolicyKey("trace-sampling", "policy-id");
+
+        Assert.Equal("trace-sampling/policy-id", key.ToString());
+    }
+
+    [Fact]
+    public void FromPolicy_WithValidatedPolicy_ReturnsCompositeKey()
+    {
+        var policy = CreatePolicy("policy-id");
+
+        var key = PolicyKey.FromPolicy(policy);
+
+        Assert.Equal(TraceSamplingRatePolicy.PolicyTypeName, key.PolicyType);
+        Assert.Equal("policy-id", key.PolicyId);
+    }
+
+    [Fact]
+    public void FromPolicy_WithNullPolicy_Throws() =>
+        Assert.Throws<ArgumentNullException>("policy", () => _ = PolicyKey.FromPolicy(null!));
+
+    [Fact]
+    public void FromPolicy_WithSameIdAcrossPolicyTypes_ReturnsDistinctKeys()
+    {
+        // The reason identity is composite: one provider may reuse an identifier for
+        // policies of different types.
+        ITelemetryPolicy samplingPolicy = CreatePolicy("shared-id");
+        ITelemetryPolicy otherPolicy = new StubPolicy("shared-id", "Policy name", "log-level");
+
+        var samplingKey = PolicyKey.FromPolicy(samplingPolicy);
+        var otherKey = PolicyKey.FromPolicy(otherPolicy);
+
+        Assert.NotEqual(samplingKey, otherKey);
+        Assert.Equal(samplingKey.PolicyId, otherKey.PolicyId);
+    }
+
+    [Fact]
+    public void FromPolicy_IgnoresPolicyContent()
+    {
+        // A source replacing a policy value must land on the same slot, so the key must
+        // not vary with the policy's content.
+        var original = CreatePolicy("policy-id", 0.25);
+        var updated = CreatePolicy("policy-id", 0.75);
+
+        Assert.Equal(PolicyKey.FromPolicy(original), PolicyKey.FromPolicy(updated));
+
+        var policies = new Dictionary<PolicyKey, ITelemetryPolicy>
+        {
+            [PolicyKey.FromPolicy(original)] = original,
+        };
+
+        policies[PolicyKey.FromPolicy(updated)] = updated;
+
+        Assert.Single(policies);
+        Assert.Same(updated, policies[PolicyKey.FromPolicy(original)]);
+    }
+
+    [Theory]
+    [InlineData("", "trace-sampling")]
+    [InlineData(" ", "trace-sampling")]
+    [InlineData("policy-id", "")]
+    [InlineData("policy-id", " ")]
+    public void FromPolicy_WithBlankComponents_Throws(string id, string policyType)
+    {
+        // Validated policy models cannot report blank components, but the interface
+        // cannot enforce that for every implementation.
+        ITelemetryPolicy policy = new StubPolicy(id, "Policy name", policyType);
+
+        Assert.Throws<ArgumentException>(() => _ = PolicyKey.FromPolicy(policy));
+    }
+
+    private static TraceSamplingRatePolicy CreatePolicy(string id, double samplingProbability = 0.5)
+    {
+        Assert.True(TraceSamplingRatePolicy.TryCreate(
+            id,
+            "Policy name",
+            samplingProbability,
+            out var policy,
+            out _));
+
+        return policy;
+    }
+
+    private sealed class StubPolicy(string id, string name, string policyType) : ITelemetryPolicy
+    {
+        public string Id { get; } = id;
+
+        public string Name { get; } = name;
+
+        public string PolicyType { get; } = policyType;
+    }
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyKeyTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyKeyTests.cs
@@ -38,8 +38,10 @@ public class PolicyKeyTests
 
         Assert.True(left.Equals(right), "Typed Equals should be true");
         Assert.True(left.Equals((object)right), "Object Equals should be true");
-        Assert.True(left == right, "Equals (==) operator should be true");
-        Assert.False(left != right, "Not equals (!=) operator should be false");
+        Assert.True(left == right, "== operator should be true");
+        Assert.True(right == left, "== operator should be symmetric");
+        Assert.False(left != right, "!= operator should be false");
+        Assert.False(right != left, "!= operator should be symmetric");
         Assert.Equal(left.GetHashCode(), right.GetHashCode());
     }
 
@@ -101,6 +103,7 @@ public class PolicyKeyTests
         Assert.Equal(string.Empty, key.PolicyType);
         Assert.Equal(string.Empty, key.PolicyId);
         Assert.Equal(default, key);
+        Assert.Equal(PolicyKey.None, key);
         Assert.Equal(default(PolicyKey).GetHashCode(), key.GetHashCode());
         Assert.NotEqual(new PolicyKey("trace-sampling", "policy-id"), key);
     }

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyKeyTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyKeyTests.cs
@@ -103,7 +103,7 @@ public class PolicyKeyTests
         Assert.Equal(string.Empty, key.PolicyType);
         Assert.Equal(string.Empty, key.PolicyId);
         Assert.Equal(default, key);
-        Assert.Equal(PolicyKey.None, key);
+        Assert.Equal(PolicyKey.Empty, key);
         Assert.Equal(default(PolicyKey).GetHashCode(), key.GetHashCode());
         Assert.NotEqual(new PolicyKey("trace-sampling", "policy-id"), key);
     }

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
@@ -33,11 +33,13 @@ public class PolicySourceMetadataTests
             "registrationId",
             () => _ = new PolicySourceMetadata(default, PolicySourceKind.OpAmp));
 
-    [Fact]
-    public void Constructor_WithUnknownKind_Throws() =>
-        Assert.Throws<ArgumentException>(
+    [Theory]
+    [InlineData(0)] // The zero/default sentinel
+    [InlineData(99)] // undefined integer cast
+    public void Constructor_WithInvalidKind_Throws(int kindValue) =>
+        Assert.Throws<ArgumentOutOfRangeException>(
             "kind",
-            () => _ = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.Unknown));
+            () => _ = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), (PolicySourceKind)kindValue));
 
     [Theory]
     [InlineData(0)]

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.DynamicControl.Internal.Sources;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+public class PolicySourceMetadataTests
+{
+    [Fact]
+    public void Constructor_WithValidArguments_SetsProperties()
+    {
+        var registrationId = new SourceRegistrationId("opamp-1");
+
+        var metadata = new PolicySourceMetadata(registrationId, PolicySourceKind.OpAmp, 10);
+
+        Assert.Equal(registrationId, metadata.RegistrationId);
+        Assert.Equal(PolicySourceKind.OpAmp, metadata.Kind);
+        Assert.Equal(10, metadata.Priority);
+    }
+
+    [Fact]
+    public void Constructor_WithoutPriority_UsesDefaultPriority()
+    {
+        var metadata = new PolicySourceMetadata(new SourceRegistrationId("file-1"), PolicySourceKind.File);
+
+        Assert.Equal(PolicySourceMetadata.DefaultPriority, metadata.Priority);
+    }
+
+    [Fact]
+    public void Constructor_WithDefaultRegistrationId_Throws() =>
+        Assert.Throws<ArgumentException>(
+            "registrationId",
+            () => _ = new PolicySourceMetadata(default, PolicySourceKind.OpAmp));
+
+    [Fact]
+    public void Constructor_WithUnknownKind_Throws() =>
+        Assert.Throws<ArgumentException>(
+            "kind",
+            () => _ = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.Unknown));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void Constructor_WithNonNegativePriority_IsAllowed(int priority)
+    {
+        var metadata = new PolicySourceMetadata(new SourceRegistrationId("file-1"), PolicySourceKind.File, priority);
+
+        Assert.Equal(priority, metadata.Priority);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Constructor_WithNegativePriority_Throws(int priority) =>
+        Assert.Throws<ArgumentOutOfRangeException>(
+            nameof(priority),
+            () => _ = new PolicySourceMetadata(new SourceRegistrationId("file-1"), PolicySourceKind.File, priority));
+
+    [Fact]
+    public void Equals_WithSameValues_ReturnsTrue()
+    {
+        var left = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp, 10);
+        var right = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp, 10);
+
+        Assert.True(left.Equals(right), "Typed Equals should be true");
+        Assert.True(left.Equals((object)right), "Object Equals should be true");
+        Assert.True(left == right, "Equals (==) operator should be true");
+        Assert.False(left != right, "Not equals (!=) operator should be false");
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_WithDifferentRegistrationId_ReturnsFalse()
+    {
+        var left = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp, 10);
+        var right = new PolicySourceMetadata(new SourceRegistrationId("opamp-2"), PolicySourceKind.OpAmp, 10);
+
+        Assert.False(left.Equals(right), "Equals should be false");
+        Assert.True(left != right, "Not equals (!=) operator should be true");
+    }
+
+    [Fact]
+    public void Equals_WithDifferentKind_ReturnsFalse()
+    {
+        var left = new PolicySourceMetadata(new SourceRegistrationId("source-1"), PolicySourceKind.OpAmp, 10);
+        var right = new PolicySourceMetadata(new SourceRegistrationId("source-1"), PolicySourceKind.File, 10);
+
+        Assert.False(left.Equals(right), "Equals should be false");
+    }
+
+    [Fact]
+    public void Equals_WithDifferentPriority_ReturnsFalse()
+    {
+        var left = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp, 10);
+        var right = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp, 20);
+
+        Assert.False(left.Equals(right), "Equals should be false");
+    }
+
+    [Fact]
+    public void Equals_WithOtherType_ReturnsFalse()
+    {
+        var metadata = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp);
+
+        Assert.False(metadata.Equals(metadata.RegistrationId), "Should not be equal to a SourceRegistrationId");
+        Assert.False(metadata.Equals(null), "Should not be equal to null");
+    }
+
+    [Fact]
+    public void Priority_IsLowerForExplicitlyPrioritizedSource()
+    {
+        // Per the Telemetry Policy OTEP's provider-priority convention, a lower value wins
+        // (e.g. OpAmp=1 outranks a File source using the default, unprioritized value).
+        // Aggregation rules are defined with aggregation itself; this only pins the
+        // direction of the ordering that metadata expresses.
+        var opAmp = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp, 1);
+        var file = new PolicySourceMetadata(new SourceRegistrationId("file-1"), PolicySourceKind.File);
+
+        Assert.True(opAmp.Priority < file.Priority, "OpAmp source should have a lower (higher-precedence) priority value than the default-priority File source");
+    }
+
+    [Fact]
+    public void Default_HasEmptyRegistrationIdUnknownKindAndZeroPriority()
+    {
+        // default(PolicySourceMetadata) bypasses the constructor, so Priority is the
+        // zero-initialized struct value, not the DefaultPriority constant applied when a
+        // constructor call omits the priority argument.
+        var metadata = default(PolicySourceMetadata);
+
+        Assert.Equal(default, metadata.RegistrationId);
+        Assert.Equal(PolicySourceKind.Unknown, metadata.Kind);
+        Assert.Equal(0, metadata.Priority);
+        Assert.Equal(default(PolicySourceMetadata).GetHashCode(), metadata.GetHashCode());
+        Assert.NotEqual(
+            new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp),
+            metadata);
+    }
+
+    [Fact]
+    public void ToString_ReturnsRegistrationIdKindAndPriority()
+    {
+        var metadata = new PolicySourceMetadata(new SourceRegistrationId("opamp-1"), PolicySourceKind.OpAmp, 10);
+
+        Assert.Equal("opamp-1/OpAmp/10", metadata.ToString());
+    }
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
@@ -31,7 +31,7 @@ public class PolicySourceMetadataTests
     public void Constructor_WithDefaultRegistrationId_Throws() =>
         Assert.Throws<ArgumentException>(
             "registrationId",
-            () => _ = new PolicySourceMetadata(SourceRegistrationId.None, PolicySourceKind.OpAmp));
+            () => _ = new PolicySourceMetadata(SourceRegistrationId.Empty, PolicySourceKind.OpAmp));
 
     [Theory]
     [InlineData(0)] // The zero/default sentinel
@@ -131,7 +131,7 @@ public class PolicySourceMetadataTests
         var metadata = default(PolicySourceMetadata);
 
         Assert.Equal(default, metadata.RegistrationId);
-        Assert.Equal(SourceRegistrationId.None, metadata.RegistrationId);
+        Assert.Equal(SourceRegistrationId.Empty, metadata.RegistrationId);
         Assert.Equal(PolicySourceKind.Unknown, metadata.Kind);
         Assert.Equal(0, metadata.Priority);
         Assert.Equal(default(PolicySourceMetadata).GetHashCode(), metadata.GetHashCode());

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicySourceMetadataTests.cs
@@ -24,14 +24,14 @@ public class PolicySourceMetadataTests
     {
         var metadata = new PolicySourceMetadata(new SourceRegistrationId("file-1"), PolicySourceKind.File);
 
-        Assert.Equal(PolicySourceMetadata.DefaultPriority, metadata.Priority);
+        Assert.Equal(int.MaxValue, metadata.Priority);
     }
 
     [Fact]
     public void Constructor_WithDefaultRegistrationId_Throws() =>
         Assert.Throws<ArgumentException>(
             "registrationId",
-            () => _ = new PolicySourceMetadata(default, PolicySourceKind.OpAmp));
+            () => _ = new PolicySourceMetadata(SourceRegistrationId.None, PolicySourceKind.OpAmp));
 
     [Theory]
     [InlineData(0)] // The zero/default sentinel
@@ -69,7 +69,9 @@ public class PolicySourceMetadataTests
         Assert.True(left.Equals(right), "Typed Equals should be true");
         Assert.True(left.Equals((object)right), "Object Equals should be true");
         Assert.True(left == right, "Equals (==) operator should be true");
+        Assert.True(right == left, "Equals (==) operator should be true for swapped operands");
         Assert.False(left != right, "Not equals (!=) operator should be false");
+        Assert.False(right != left, "Not equals (!=) operator should be false for swapped operands");
         Assert.Equal(left.GetHashCode(), right.GetHashCode());
     }
 
@@ -126,12 +128,10 @@ public class PolicySourceMetadataTests
     [Fact]
     public void Default_HasEmptyRegistrationIdUnknownKindAndZeroPriority()
     {
-        // default(PolicySourceMetadata) bypasses the constructor, so Priority is the
-        // zero-initialized struct value, not the DefaultPriority constant applied when a
-        // constructor call omits the priority argument.
         var metadata = default(PolicySourceMetadata);
 
         Assert.Equal(default, metadata.RegistrationId);
+        Assert.Equal(SourceRegistrationId.None, metadata.RegistrationId);
         Assert.Equal(PolicySourceKind.Unknown, metadata.Kind);
         Assert.Equal(0, metadata.Priority);
         Assert.Equal(default(PolicySourceMetadata).GetHashCode(), metadata.GetHashCode());

--- a/test/OpenTelemetry.DynamicControl.Tests/SourceRegistrationIdTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/SourceRegistrationIdTests.cs
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.DynamicControl.Internal.Sources;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+public class SourceRegistrationIdTests
+{
+    [Fact]
+    public void Constructor_WithValidValue_SetsValue()
+    {
+        var id = new SourceRegistrationId("opamp-1");
+
+        Assert.Equal("opamp-1", id.Value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Constructor_WithBlankValue_Throws(string? value) =>
+        Assert.ThrowsAny<ArgumentException>(() => _ = new SourceRegistrationId(value!));
+
+    [Fact]
+    public void Equals_WithSameValue_ReturnsTrue()
+    {
+        var left = new SourceRegistrationId("opamp-1");
+        var right = new SourceRegistrationId("opamp-1");
+
+        Assert.True(left.Equals(right), "Typed Equals should be true");
+        Assert.True(left.Equals((object)right), "Object Equals should be true");
+        Assert.True(left == right, "Equals (==) operator should be true");
+        Assert.False(left != right, "Not equals (!=) operator should be false");
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_WithDifferentValue_ReturnsFalse()
+    {
+        var left = new SourceRegistrationId("opamp-1");
+        var right = new SourceRegistrationId("opamp-2");
+
+        Assert.False(left.Equals(right), "Typed Equals should be false");
+        Assert.True(left != right, "Not equals (!=) operator should be true");
+        Assert.False(left == right, "Equals (==) operator should be false");
+    }
+
+    [Fact]
+    public void Equals_WithValueDifferingOnlyByCase_ReturnsFalse()
+    {
+        var left = new SourceRegistrationId("opamp-1");
+        var right = new SourceRegistrationId("OpAmp-1");
+
+        Assert.False(left.Equals(right));
+    }
+
+    [Fact]
+    public void Equals_WithOtherType_ReturnsFalse()
+    {
+        var id = new SourceRegistrationId("opamp-1");
+
+        Assert.False(id.Equals("opamp-1"), "Should not be equal to a string");
+        Assert.False(id.Equals(null), "Should not be equal to null");
+    }
+
+    [Fact]
+    public void Default_HasEmptyValueAndIsUsableWithoutThrowing()
+    {
+        var id = default(SourceRegistrationId);
+
+        Assert.Equal(string.Empty, id.Value);
+        Assert.Equal(default, id);
+        Assert.Equal(default(SourceRegistrationId).GetHashCode(), id.GetHashCode());
+        Assert.NotEqual(new SourceRegistrationId("opamp-1"), id);
+    }
+
+    [Fact]
+    public void CanBeUsedAsDictionaryKey()
+    {
+        var snapshots = new Dictionary<SourceRegistrationId, string>
+        {
+            [new SourceRegistrationId("opamp-1")] = "first",
+            [new SourceRegistrationId("opamp-2")] = "second",
+        };
+
+        snapshots[new SourceRegistrationId("opamp-1")] = "replacement";
+
+        Assert.Equal(2, snapshots.Count);
+        Assert.Equal("replacement", snapshots[new SourceRegistrationId("opamp-1")]);
+        Assert.Equal("second", snapshots[new SourceRegistrationId("opamp-2")]);
+    }
+
+    [Fact]
+    public void ToString_ReturnsValue()
+    {
+        var id = new SourceRegistrationId("opamp-1");
+        Assert.Equal("opamp-1", id.ToString());
+    }
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/SourceRegistrationIdTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/SourceRegistrationIdTests.cs
@@ -31,7 +31,9 @@ public class SourceRegistrationIdTests
         Assert.True(left.Equals(right), "Typed Equals should be true");
         Assert.True(left.Equals((object)right), "Object Equals should be true");
         Assert.True(left == right, "Equals (==) operator should be true");
+        Assert.True(right == left, "Equals (==) operator should be true for swapped operands");
         Assert.False(left != right, "Not equals (!=) operator should be false");
+        Assert.False(right != left, "Not equals (!=) operator should be false for swapped operands");
         Assert.Equal(left.GetHashCode(), right.GetHashCode());
     }
 
@@ -71,6 +73,7 @@ public class SourceRegistrationIdTests
 
         Assert.Equal(string.Empty, id.Value);
         Assert.Equal(default, id);
+        Assert.Equal(SourceRegistrationId.None, id);
         Assert.Equal(default(SourceRegistrationId).GetHashCode(), id.GetHashCode());
         Assert.NotEqual(new SourceRegistrationId("opamp-1"), id);
     }

--- a/test/OpenTelemetry.DynamicControl.Tests/SourceRegistrationIdTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/SourceRegistrationIdTests.cs
@@ -73,7 +73,7 @@ public class SourceRegistrationIdTests
 
         Assert.Equal(string.Empty, id.Value);
         Assert.Equal(default, id);
-        Assert.Equal(SourceRegistrationId.None, id);
+        Assert.Equal(SourceRegistrationId.Empty, id);
         Assert.Equal(default(SourceRegistrationId).GetHashCode(), id.GetHashCode());
         Assert.NotEqual(new SourceRegistrationId("opamp-1"), id);
     }


### PR DESCRIPTION
Contributes to: #4742

## Changes

Adds `PolicyKey`, `SourceRegistrationId`, and `PolicySourceMetadata` identity types

Introduces internal identity types for keying policies and configured policy sources. This is intentially kept small for easier review before building on these types to introduce the `PolicyStore` in 3b.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~