### PR TITLE
[Owin] Normalize `network.protocol.version` values

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
@@ -112,7 +112,9 @@ internal sealed class DiagnosticsMiddleware : OwinMiddleware
                 RequestDataHelper.SetHttpMethodTag(activity, request.Method);
                 activity.SetTag(SemanticConventions.AttributeServerAddress, request.Uri.Host);
                 activity.SetTag(SemanticConventions.AttributeServerPort, request.Uri.Port);
-                activity.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, request.Protocol);
+                activity.SetTag(
+                    SemanticConventions.AttributeNetworkProtocolVersion,
+                    RequestDataHelper.GetHttpProtocolVersion(request.Protocol));
 
                 activity.SetTag(SemanticConventions.AttributeUrlPath, request.Uri.AbsolutePath);
                 activity.SetTag(SemanticConventions.AttributeUrlQuery, queryString);

--- a/src/Shared/RequestDataHelper.cs
+++ b/src/Shared/RequestDataHelper.cs
@@ -162,6 +162,7 @@ internal sealed class RequestDataHelper
 
     internal static string GetHttpProtocolVersion(string protocol) => protocol switch
     {
+        "HTTP/1.0" => "1.0",
         "HTTP/1.1" => "1.1",
         "HTTP/2" => "2",
         "HTTP/3" => "3",

--- a/test/OpenTelemetry.Contrib.Shared.Tests/RequestDataHelperTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/RequestDataHelperTests.cs
@@ -118,6 +118,7 @@ public class RequestDataHelperTests
 #endif
 
     [Theory]
+    [InlineData("HTTP/1.0", "1.0")]
     [InlineData("HTTP/1.1", "1.1")]
     [InlineData("HTTP/2", "2")]
     [InlineData("HTTP/3", "3")]

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/RequestDataHelperExtensionsTests.cs
@@ -10,6 +10,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests;
 public class RequestDataHelperExtensionsTests
 {
     [InlineData("1.1", "HTTP/1.1")]
+    [InlineData("1.0", "HTTP/1.0")]
     [InlineData("2", "2")]
     [InlineData("3", "3")]
     [InlineData("NotKnownVersion", "NotKnownVersion")]

--- a/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Owin.Tests/DiagnosticsMiddlewareTests.cs
@@ -199,6 +199,7 @@ public class DiagnosticsMiddlewareTests : IDisposable
                 Assert.Equal(requestUri.Host, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeServerAddress).Value);
                 Assert.Equal(requestUri.Port, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeServerPort).Value);
                 Assert.Equal("GET", activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeHttpRequestMethod).Value);
+                Assert.Equal("1.1", activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeNetworkProtocolVersion).Value);
                 Assert.Equal(requestUri.AbsolutePath, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeUrlPath).Value);
                 Assert.Equal(generateRemoteException ? 500 : 200, activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeHttpResponseStatusCode).Value);
                 Assert.Equal("company.client/1.2.3", activity.TagObjects.FirstOrDefault(t => t.Key == SemanticConventions.AttributeUserAgentOriginal).Value);


### PR DESCRIPTION
## Changes

Fixed `network.protocol.version` value to match semconv formatting. Previously it recorded the raw request protocol (e.g. HTTP/1.1) and now normalizes the value (HTTP/1.1 => 1.1).

HTTP protocol helper also now handles HTTP/1.0 as 1.0. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
