### PR TITLE
[Geneva] Add NullDimensionExportMode to control how null metric dimensions are exported

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Geneva/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.NullDimensionExportMode.get -> OpenTelemetry.Exporter.Geneva.NullDimensionExportMode
+OpenTelemetry.Exporter.Geneva.GenevaMetricExporterOptions.NullDimensionExportMode.set -> void
+OpenTelemetry.Exporter.Geneva.NullDimensionExportMode
+OpenTelemetry.Exporter.Geneva.NullDimensionExportMode.Drop = 0 -> OpenTelemetry.Exporter.Geneva.NullDimensionExportMode
+OpenTelemetry.Exporter.Geneva.NullDimensionExportMode.ExportAsEmptyString = 1 -> OpenTelemetry.Exporter.Geneva.NullDimensionExportMode

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Added `NullDimensionExportMode` option to `GenevaMetricExporterOptions` for
+  controlling how metric dimensions with a `null` value are exported when OTLP
+  protobuf encoding is used. The default (`Drop`) keeps the existing behavior of
+  omitting the dimension. Setting `ExportAsEmptyString` exports the dimension
+  with an empty string value, matching the TLV encoding, so that Geneva Metrics
+  (MDM) pre-aggregates which include optional dimensions keep working when
+  migrating from TLV to OTLP protobuf encoding.
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-10

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporter.cs
@@ -91,7 +91,8 @@ public partial class GenevaMetricExporter : BaseExporter<Metric>
                 transport,
                 metricsAccount,
                 metricsNamespace,
-                options.PrepopulatedMetricDimensions);
+                options.PrepopulatedMetricDimensions,
+                options.NullDimensionExportMode);
 
             this.exportMetrics = otlpProtobufExporter.Export;
 

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/GenevaMetricExporterOptions.cs
@@ -36,6 +36,17 @@ public class GenevaMetricExporterOptions
     }
 
     /// <summary>
+    /// Gets or sets the mode used to export metric dimensions whose value is <see langword="null"/>.
+    /// The default value is <see cref="NullDimensionExportMode.Drop"/>.
+    /// </summary>
+    /// <remarks>
+    /// This setting only applies when OTLP protobuf encoding is enabled via the
+    /// <c>EnableOtlpProtobufEncoding=true</c> connection string switch. The TLV encoding
+    /// always exports <see langword="null"/> dimension values as an empty string.
+    /// </remarks>
+    public NullDimensionExportMode NullDimensionExportMode { get; set; }
+
+    /// <summary>
     /// Gets or sets the pre-populated dimensions for all the metrics exported by the exporter.
     /// </summary>
     public IReadOnlyDictionary<string, object>? PrepopulatedMetricDimensions

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/NullDimensionExportMode.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/NullDimensionExportMode.cs
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter.Geneva;
+
+/// <summary>
+/// Defines modes for exporting metric dimensions whose value is <see langword="null"/>.
+/// Currently applicable only to the Metrics signal when OTLP protobuf encoding is used.
+/// </summary>
+public enum NullDimensionExportMode
+{
+    /// <summary>
+    /// Dimensions with a <see langword="null"/> value are dropped and not exported.
+    /// </summary>
+    /// <remarks>
+    /// This is the default. Because the dimension name is omitted entirely, any
+    /// Geneva Metrics (MDM) pre-aggregate which includes that dimension will not
+    /// match the emitted time series.
+    /// </remarks>
+    Drop,
+
+    /// <summary>
+    /// Dimensions with a <see langword="null"/> value are exported with an empty string value.
+    /// </summary>
+    /// <remarks>
+    /// This matches the behavior of the TLV encoding, which converts a <see langword="null"/>
+    /// dimension value to an empty string, and causes Geneva Metrics (MDM) to record the
+    /// dimension as <c>__Empty</c>. Use this mode to keep pre-aggregates which include
+    /// optional dimensions working when moving from the TLV encoding to OTLP protobuf encoding.
+    /// </remarks>
+    ExportAsEmptyString,
+}

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufMetricExporter.cs
@@ -19,7 +19,8 @@ internal sealed class OtlpProtobufMetricExporter : IDisposable
         IMetricDataTransport transport,
         string? metricsAccount,
         string? metricsNamespace,
-        IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions)
+        IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions,
+        NullDimensionExportMode nullDimensionExportMode = NullDimensionExportMode.Drop)
     {
         this.getResource = getResource;
 
@@ -28,7 +29,8 @@ internal sealed class OtlpProtobufMetricExporter : IDisposable
             metricsAccount,
             metricsNamespace,
             prepopulatedMetricDimensions,
-            prefixBufferWithUInt32LittleEndianLength: transport is MetricUnixDomainSocketDataTransport);
+            prefixBufferWithUInt32LittleEndianLength: transport is MetricUnixDomainSocketDataTransport,
+            nullDimensionExportMode: nullDimensionExportMode);
     }
 
     public ExportResult Export(in Batch<Metric> batch)

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
@@ -19,6 +19,7 @@ internal sealed class OtlpProtobufSerializer
     private readonly string? metricNamespace;
     private readonly string? metricAccount;
     private readonly bool prefixBufferWithUInt32LittleEndianLength;
+    private readonly bool exportNullDimensionsAsEmptyString;
     private readonly byte[]? prepopulatedNumberDataPointAttributes;
     private readonly int prepopulatedNumberDataPointAttributesLength;
     private readonly byte[]? prepopulatedHistogramDataPointAttributes;
@@ -42,7 +43,8 @@ internal sealed class OtlpProtobufSerializer
         string? metricsAccount,
         string? metricsNamespace,
         IReadOnlyDictionary<string, object>? prepopulatedMetricDimensions,
-        bool prefixBufferWithUInt32LittleEndianLength = false)
+        bool prefixBufferWithUInt32LittleEndianLength = false,
+        NullDimensionExportMode nullDimensionExportMode = NullDimensionExportMode.Drop)
     {
         Debug.Assert(metricDataTransport != null, "metricDataTransport was null");
 
@@ -50,6 +52,7 @@ internal sealed class OtlpProtobufSerializer
         this.metricAccount = metricsAccount;
         this.metricNamespace = metricsNamespace;
         this.prefixBufferWithUInt32LittleEndianLength = prefixBufferWithUInt32LittleEndianLength;
+        this.exportNullDimensionsAsEmptyString = nullDimensionExportMode == NullDimensionExportMode.ExportAsEmptyString;
 
         // Taking a arbitrary number here for writing attributes.
         var temp = new byte[20000];
@@ -110,13 +113,17 @@ internal sealed class OtlpProtobufSerializer
         ProtobufSerializerHelper.WriteTagAndLengthPrefix(buffer, ref tagAndLengthIndex, cursor - valueIndex, FieldNumberConstants.ScopeMetrics_scope, WireType.LEN);
     }
 
-    internal static void SerializeTags(byte[] buffer, ref int cursor, ReadOnlyTagCollection tags, int fieldNumber)
+    internal static void SerializeTags(byte[] buffer, ref int cursor, ReadOnlyTagCollection tags, int fieldNumber, bool exportNullDimensionsAsEmptyString = false)
     {
         foreach (var tag in tags)
         {
             if (tag.Value != null)
             {
                 SerializeTag(buffer, ref cursor, tag.Key, tag.Value, fieldNumber);
+            }
+            else if (exportNullDimensionsAsEmptyString)
+            {
+                SerializeTag(buffer, ref cursor, tag.Key, string.Empty, fieldNumber);
             }
         }
     }
@@ -333,7 +340,7 @@ internal sealed class OtlpProtobufSerializer
         }
     }
 
-    private static void SerializeTags(byte[] buffer, ref int cursor, IEnumerable<KeyValuePair<string, object?>>? attributes, int fieldNumber)
+    private static void SerializeTags(byte[] buffer, ref int cursor, IEnumerable<KeyValuePair<string, object?>>? attributes, int fieldNumber, bool exportNullDimensionsAsEmptyString = false)
     {
         if (attributes != null)
         {
@@ -342,6 +349,10 @@ internal sealed class OtlpProtobufSerializer
                 if (tag.Value != null)
                 {
                     SerializeTag(buffer, ref cursor, tag.Key, tag.Value, fieldNumber);
+                }
+                else if (exportNullDimensionsAsEmptyString)
+                {
+                    SerializeTag(buffer, ref cursor, tag.Key, string.Empty, fieldNumber);
                 }
             }
         }
@@ -519,7 +530,7 @@ internal sealed class OtlpProtobufSerializer
                             var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
                             ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.HistogramDataPoint_time_unix_nano, endTime);
 
-                            SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.HistogramDataPoint_attributes);
+                            SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.HistogramDataPoint_attributes, this.exportNullDimensionsAsEmptyString);
 
                             if (this.prepopulatedHistogramDataPointAttributes != null)
                             {
@@ -601,7 +612,7 @@ internal sealed class OtlpProtobufSerializer
                             var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
                             ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.ExponentialHistogramDataPoint_time_unix_nano, endTime);
 
-                            SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.ExponentialHistogramDataPoint_attributes);
+                            SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.ExponentialHistogramDataPoint_attributes, this.exportNullDimensionsAsEmptyString);
 
                             if (this.prepopulatedExponentialHistogramDataPointAttributes != null)
                             {
@@ -694,7 +705,7 @@ internal sealed class OtlpProtobufSerializer
         var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
         ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.NumberDataPoint_time_unix_nano, endTime);
 
-        SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.NumberDataPoint_attributes);
+        SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.NumberDataPoint_attributes, this.exportNullDimensionsAsEmptyString);
 
         if (this.prepopulatedNumberDataPointAttributes != null)
         {

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -372,6 +372,30 @@ the `ConnectionString`.
 Set the exporter's periodic time interval to export Metrics. The default value
 is 60000 milliseconds.
 
+#### `NullDimensionExportMode` (optional)
+
+Controls how metric dimensions whose value is `null` are exported. This applies
+only when OTLP protobuf encoding is enabled; the TLV encoding always exports a
+`null` dimension value as an empty string.
+
+| Value | Behavior |
+| ----- | -------- |
+| `Drop` (default) | The dimension is omitted from the exported data point. |
+| `ExportAsEmptyString` | The dimension is exported with an empty string value, matching the TLV encoding. Geneva Metrics (MDM) records it as `__Empty`. |
+
+Because `Drop` omits the dimension name entirely, any MDM pre-aggregate which
+includes that dimension will not match the emitted time series. Set
+`ExportAsEmptyString` to keep such pre-aggregates working when migrating from
+the TLV encoding to OTLP protobuf encoding:
+
+```csharp
+.AddGenevaMetricExporter(options =>
+{
+    options.ConnectionString = "EnableOtlpProtobufEncoding=true";
+    options.NullDimensionExportMode = NullDimensionExportMode.ExportAsEmptyString;
+})
+```
+
 #### `PrepopulatedMetricDimensions` (optional)
 
 This is a collection of the dimensions that will be applied to _every_ metric

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/GenevaMetricExporterOptionsTests.cs
@@ -76,4 +76,12 @@ public class GenevaMetricExporterOptionsTests
 
         Assert.Null(exception);
     }
+
+    [Fact]
+    public void NullDimensionExportModeDefaultsToDrop()
+    {
+        var exporterOptions = new GenevaMetricExporterOptions();
+
+        Assert.Equal(NullDimensionExportMode.Drop, exporterOptions.NullDimensionExportMode);
+    }
 }

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -1605,6 +1605,148 @@ public abstract class OtlpProtobufMetricExporterTests
         }
     }
 
+    [Theory]
+    [InlineData(NullDimensionExportMode.Drop)]
+    [InlineData(NullDimensionExportMode.ExportAsEmptyString)]
+    [InlineData(null)]
+    public void CounterSerializationWithNullDimensionValue(NullDimensionExportMode? nullDimensionExportMode)
+    {
+        using var meter = new Meter(nameof(this.CounterSerializationWithNullDimensionValue), "0.0.1");
+
+        var exportedItems = new List<Metric>();
+        using var inMemoryReader = new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems))
+        {
+            TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+        };
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(nameof(this.CounterSerializationWithNullDimensionValue))
+            .AddReader(inMemoryReader)
+            .Build();
+
+        var tags = new TagList
+        {
+            { "presentKey", "presentValue" },
+            { "nullKey", null },
+        };
+
+        meter.CreateCounter<long>("TestCounter").Add(18, tags);
+
+        meterProvider.ForceFlush();
+
+        var buffer = new byte[65360];
+
+        var testTransport = new TestTransport();
+
+        // Omitting the argument must behave exactly like Drop so that upgrading does
+        // not silently change the emitted payload.
+        var otlpProtobufSerializer = nullDimensionExportMode == null
+            ? new OtlpProtobufSerializer(
+                testTransport,
+                null,
+                null,
+                null,
+                prefixBufferWithUInt32LittleEndianLength: this.PrefixBufferWithUInt32LittleEndianLength)
+            : new OtlpProtobufSerializer(
+                testTransport,
+                null,
+                null,
+                null,
+                prefixBufferWithUInt32LittleEndianLength: this.PrefixBufferWithUInt32LittleEndianLength,
+                nullDimensionExportMode: nullDimensionExportMode.Value);
+
+        otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>([.. exportedItems], exportedItems.Count));
+
+        Assert.Single(testTransport.ExportedItems);
+
+        var request = this.AssertAndConvertExportedBlobToRequest(testTransport.ExportedItems[0]);
+
+        var dataPoint = request.ResourceMetrics[0].ScopeMetrics[0].Metrics[0].Sum.DataPoints[0];
+
+        if (nullDimensionExportMode == NullDimensionExportMode.ExportAsEmptyString)
+        {
+            // Note: the SDK sorts tag keys, so "nullKey" is emitted before "presentKey".
+            AssertOtlpAttributes(
+                [
+                    new KeyValuePair<string, object>("nullKey", string.Empty),
+                    new KeyValuePair<string, object>("presentKey", "presentValue"),
+                ],
+                dataPoint.Attributes);
+        }
+        else
+        {
+            AssertOtlpAttributes(
+                [new KeyValuePair<string, object>("presentKey", "presentValue")],
+                dataPoint.Attributes);
+        }
+    }
+
+    [Theory]
+    [InlineData(NullDimensionExportMode.Drop)]
+    [InlineData(NullDimensionExportMode.ExportAsEmptyString)]
+    public void HistogramSerializationWithNullDimensionValue(NullDimensionExportMode nullDimensionExportMode)
+    {
+        using var meter = new Meter(nameof(this.HistogramSerializationWithNullDimensionValue), "0.0.1");
+
+        var exportedItems = new List<Metric>();
+        using var inMemoryReader = new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems))
+        {
+            TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+        };
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(nameof(this.HistogramSerializationWithNullDimensionValue))
+            .AddReader(inMemoryReader)
+            .Build();
+
+        var tags = new TagList
+        {
+            { "presentKey", "presentValue" },
+            { "nullKey", null },
+        };
+
+        meter.CreateHistogram<double>("TestHistogram").Record(1.5, tags);
+
+        meterProvider.ForceFlush();
+
+        var buffer = new byte[65360];
+
+        var testTransport = new TestTransport();
+
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(
+            testTransport,
+            null,
+            null,
+            null,
+            prefixBufferWithUInt32LittleEndianLength: this.PrefixBufferWithUInt32LittleEndianLength,
+            nullDimensionExportMode: nullDimensionExportMode);
+
+        otlpProtobufSerializer.SerializeAndSendMetrics(buffer, meterProvider.GetResource(), new Batch<Metric>([.. exportedItems], exportedItems.Count));
+
+        Assert.Single(testTransport.ExportedItems);
+
+        var request = this.AssertAndConvertExportedBlobToRequest(testTransport.ExportedItems[0]);
+
+        var dataPoint = request.ResourceMetrics[0].ScopeMetrics[0].Metrics[0].Histogram.DataPoints[0];
+
+        if (nullDimensionExportMode == NullDimensionExportMode.ExportAsEmptyString)
+        {
+            // Note: the SDK sorts tag keys, so "nullKey" is emitted before "presentKey".
+            AssertOtlpAttributes(
+                [
+                    new KeyValuePair<string, object>("nullKey", string.Empty),
+                    new KeyValuePair<string, object>("presentKey", "presentValue"),
+                ],
+                dataPoint.Attributes);
+        }
+        else
+        {
+            AssertOtlpAttributes(
+                [new KeyValuePair<string, object>("presentKey", "presentValue")],
+                dataPoint.Attributes);
+        }
+    }
+
     internal static void AssertOtlpAttributes(
         IEnumerable<KeyValuePair<string, object>> expected,
         RepeatedField<OtlpCommon.KeyValue> actual)


### PR DESCRIPTION
## Problem

The TLV and OTLP protobuf metric encodings disagree on how a dimension with a `null`
value is exported.

`TlvMetricExporter` converts every tag value with `Convert.ToString(value, CultureInfo.InvariantCulture)`,
which turns `null` into an empty string, so the dimension **name is always emitted**.

`OtlpProtobufSerializer.SerializeTags` instead skips the tag entirely:

```csharp
foreach (var tag in tags)
{
    if (tag.Value != null)
    {
        SerializeTag(buffer, ref cursor, tag.Key, tag.Value, fieldNumber);
    }
}
```

so the dimension **name disappears** from the data point.

This is a silent, hard-to-diagnose behavior change when moving a metric from the TLV
encoding to OTLP protobuf encoding: any Geneva Metrics (MDM) pre-aggregate that includes
an optional dimension stops matching the emitted time series and returns no data. There is
no error and no log, and the metric itself keeps flowing — only the pre-aggregates that
reference the omitted dimension go empty.

Concretely, for a counter emitted with dimensions
`{ icmTeam, result, reason, source, subSource, severity, flow, channel, isTerminal }`
where `reason`, `subSource`, `severity` and `channel` are optional (`string?`):

* a pre-aggregate over only the always-present dimensions keeps working;
* a pre-aggregate that also includes `subSource` and `channel` silently returns no data
  after the switch to OTLP protobuf encoding.

## Change

Adds a `NullDimensionExportMode` option to `GenevaMetricExporterOptions`:

| Value | Behavior |
| --- | --- |
| `Drop` (default) | Dimension is omitted from the data point. Existing behavior, unchanged. |
| `ExportAsEmptyString` | Dimension is exported with an empty string value, matching the TLV encoding. MDM records it as `__Empty`. |

The option is applied only to metric point tags (the dimensions), at the three
`metricPoint.Tags` call sites — number data points, histogram data points and exponential
histogram data points. Prepopulated dimensions, instrumentation scope attributes, resource
attributes and exemplar filtered tags are intentionally left alone, matching the option's
documented scope. (`PrepopulatedMetricDimensions` already rejects `null` values in its
setter, so it cannot be affected.)

`Drop` is the default and is the zero value of the enum, so behavior is byte-for-byte
unchanged unless the option is explicitly set.

### Why an option rather than changing the default

Changing the default would alter the emitted payload — and therefore the time series
identity as MDM sees it — for every existing user of the OTLP protobuf encoding. This is
opt-in, for users who need TLV-compatible behavior.

### Why an options property rather than a connection string flag

The connection string carries transport and destination concerns (`Endpoint`,
`EtwSession`, `Account`, `Namespace`, `TimeoutMilliseconds`) plus flags that select a
transport or encoding. This setting instead controls how a single value is represented
inside the payload, which matches the existing `ExceptionStackExportMode`
(`Drop` / `ExportAsString` / `ExportAsStackTraceString`) and `EventNameExportMode`
options on `GenevaExporterOptions`. The naming follows that established
`<Thing>ExportMode` convention.

## Testing

Added:

* `GenevaMetricExporterOptionsTests.NullDimensionExportModeDefaultsToDrop` — asserts the default.
* `OtlpProtobufMetricExporterTests.CounterSerializationWithNullDimensionValue` — theory over
  `Drop`, `ExportAsEmptyString`, and the argument being omitted entirely (which must behave
  like `Drop`).
* `OtlpProtobufMetricExporterTests.HistogramSerializationWithNullDimensionValue` — theory over
  both modes.

Both serialization tests live on the abstract base class, so they run under both the
`WithPrefix` and `WithoutPrefix` subclasses.

The change was additionally verified out of band by serializing real metrics through
`OtlpProtobufSerializer` with a capturing transport and inspecting the emitted bytes, for
counters, histograms, exponential histograms and observable gauges. With
`ExportAsEmptyString` the null dimension is emitted as
`0x12 0x82 0x80 0x00 0x0A 0x00` — `KeyValue.value` → `AnyValue.string_value` of length 0,
i.e. a genuine empty string. With `Drop`, and with the argument omitted, the dimension is
absent.

## Notes

Opened as a **draft**: the exporter project builds for net8.0, netstandard2.0 and net462,
but I have not yet been able to execute the xUnit test project in my environment. I will
mark this ready for review once the test run is green. Review of the approach is very
welcome in the meantime.

## Checklist

- [x] CHANGELOG.md updated
- [x] `PublicAPI.Unshipped.txt` updated
- [x] README.md updated
- [ ] Test suite executed
