### PR TITLE
[WCF] Fix multiple source registrations

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fixed `AddWcfInstrumentation` so it no longer throws `NotSupportedException`
+  when called again after any previously created `TracerProvider` has been
+  disposed of.
+  ([#5109](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5109))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Instrumentation.Wcf/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/TracerProviderBuilderExtensions.cs
@@ -43,6 +43,18 @@ public static class TracerProviderBuilderExtensions
         Instrumentation.Wcf.Implementation.AspNetParentSpanCorrector.Register();
 #endif
 
+        builder.AddInstrumentation(() => new WcfInstrumentation());
+
         return builder.AddSource(WcfInstrumentationActivitySource.ActivitySource.Name);
+    }
+
+    /// <summary>
+    /// Tracks the lifetime of a WCF instrumentation registration so that the
+    /// static <see cref="WcfInstrumentationActivitySource.Options"/> can be
+    /// cleared when the owning <see cref="TracerProvider"/> is disposed.
+    /// </summary>
+    private sealed class WcfInstrumentation : IDisposable
+    {
+        public void Dispose() => WcfInstrumentationActivitySource.Options = null;
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TracerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TracerProviderBuilderExtensionsTests.cs
@@ -5,6 +5,7 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Wcf.Tests;
 
+[Collection("WCF")]
 public class TracerProviderBuilderExtensionsTests
 {
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/TracerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/TracerProviderBuilderExtensionsTests.cs
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Tests;
+
+public class TracerProviderBuilderExtensionsTests
+{
+    [Fact]
+    public void AddWcfInstrumentation_CalledTwiceWhileFirstProviderIsActive_Throws()
+    {
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddWcfInstrumentation()
+            .Build();
+
+        Assert.Throws<NotSupportedException>(() =>
+            Sdk.CreateTracerProviderBuilder()
+                .AddWcfInstrumentation()
+                .Build());
+    }
+
+    [Fact]
+    public void AddWcfInstrumentation_CalledAgainAfterProviderDisposed_DoesNotThrow()
+    {
+        using (Sdk.CreateTracerProviderBuilder()
+            .AddWcfInstrumentation()
+            .Build())
+        {
+            // First usage scope
+        }
+
+        var exception = Record.Exception(() =>
+        {
+            // Second usage scope
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddWcfInstrumentation()
+                .Build();
+        });
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
Fixes #1592

## Changes

Allow sequential WCF trace instrumentation registrations (e.g. in tests) by resetting the options when the tracer is disposed of.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
