### PR TITLE
[Extensions.Enrichment] Document DI lifetime for enrichers

### DIFF
--- a/src/OpenTelemetry.Extensions.Enrichment/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/README.md
@@ -114,6 +114,12 @@ Add your custom enricher class to the `TracerProviderBuilder` by calling the
 `TryAddTraceEnricher<T>()` method. Configure other services via
 `ConfigureServices()`, add `ActivitySource` and an exporter as usual:
 
+When using dependency injection, `TraceEnricher` instances are registered as
+singletons. A single instance of each enricher is created per service provider
+and reused for all activities. This means you should inject only singleton or
+transient services into your enricher constructor. Injecting scoped services
+into a singleton enricher may cause issues with service lifetime management.
+
 ```csharp
 using var MyActivitySource = new ActivitySource("MyCompany.MyProduct.MyLibrary");
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()


### PR DESCRIPTION
Add documentation clarifying that TraceEnricher instances are registered as
singletons when using dependency injection. This helps users understand the
lifetime semantics and which services can be safely injected into enrichers.

Fixes #2551