### PR TITLE
[gRPC] Add client request filter

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/.publicApi/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions
+OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions.Filter.get -> System.Func<System.Net.Http.HttpRequestMessage!, bool>?
+OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions.EnrichWithHttpRequestMessage.get -> System.Action<System.Diagnostics.Activity!, System.Net.Http.HttpRequestMessage!>?
 OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions.EnrichWithHttpRequestMessage.set -> void
 OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions.EnrichWithHttpResponseMessage.get -> System.Action<System.Diagnostics.Activity!, System.Net.Http.HttpResponseMessage!>?

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add a `Filter` option to exclude gRPC client requests from instrumentation.
+  ([#5112](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5112))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcClientTraceInstrumentationOptions.cs
@@ -11,6 +11,19 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient;
 public class GrpcClientTraceInstrumentationOptions
 {
     /// <summary>
+    /// Gets or sets a filter function that determines whether or not to
+    /// collect telemetry on a per request basis.
+    /// </summary>
+    /// <remarks>
+    /// <para>The return value for the filter function is interpreted as:</para>
+    /// <list type="bullet">
+    /// <item>If the filter returns <see langword="true" />, the request is collected.</item>
+    /// <item>If the filter returns <see langword="false" /> or throws an exception, the request is not collected.</item>
+    /// </list>
+    /// </remarks>
+    public Func<HttpRequestMessage, bool>? Filter { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether down stream instrumentation is suppressed (disabled).
     /// </summary>
     public bool SuppressDownstreamInstrumentation { get; set; }

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -105,6 +105,25 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
 
         if (activity.IsAllDataRequested)
         {
+            if (this.options.Filter is { } filter)
+            {
+                try
+                {
+                    if (!filter(request))
+                    {
+                        GrpcInstrumentationEventSource.Log.RequestIsFilteredOut(nameof(GrpcClientDiagnosticListener), nameof(this.OnStartActivity), activity.OperationName);
+                        DisableActivity(activity);
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    GrpcInstrumentationEventSource.Log.RequestFilterException(nameof(GrpcClientDiagnosticListener), nameof(this.OnStartActivity), activity.OperationName, ex);
+                    DisableActivity(activity);
+                    return;
+                }
+            }
+
             ActivityInstrumentationHelper.SetActivitySourceProperty(activity, ActivitySource);
             ActivityInstrumentationHelper.SetKindProperty(activity, ActivityKind.Client);
 
@@ -139,6 +158,12 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
                     GrpcInstrumentationEventSource.Log.EnrichmentException(ex);
                 }
             }
+        }
+
+        static void DisableActivity(Activity activity)
+        {
+            activity.IsAllDataRequested = false;
+            activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
         }
 
         // See https://github.com/grpc/grpc-dotnet/blob/ff1a07b90c498f259e6d9f4a50cdad7c89ecd3c0/src/Grpc.Net.Client/Internal/GrpcCall.cs#L1180-L1183

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
@@ -49,4 +49,25 @@ internal sealed class GrpcInstrumentationEventSource : EventSource
     {
         this.WriteEvent(3, handlerName, eventName, ex);
     }
+
+    [Event(4, Message = "Request is filtered out. HandlerName: '{0}', EventName: '{1}', OperationName: '{2}'.", Level = EventLevel.Verbose)]
+    public void RequestIsFilteredOut(string handlerName, string eventName, string operationName)
+    {
+        this.WriteEvent(4, handlerName, eventName, operationName);
+    }
+
+    [Event(5, Message = "Filter threw exception, request will not be collected. HandlerName: '{0}', EventName: '{1}', OperationName: '{2}', Exception: {3}.", Level = EventLevel.Error)]
+    public void RequestFilterException(string handlerName, string eventName, string operationName, string exception)
+    {
+        this.WriteEvent(5, handlerName, eventName, operationName, exception);
+    }
+
+    [NonEvent]
+    public void RequestFilterException(string handlerName, string eventName, string operationName, Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.RequestFilterException(handlerName, eventName, operationName, ex.ToInvariantString());
+        }
+    }
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
@@ -83,6 +83,22 @@ the `ConfigureServices` of your `Startup` class. Refer to documentation for
 This instrumentation can be configured to change the default behavior by using
 `GrpcClientInstrumentationOptions`.
 
+### Filter
+
+The `Filter` option can be used to exclude gRPC client requests from
+instrumentation. The filter receives the underlying `HttpRequestMessage` and
+returns `true` to collect the request or `false` to exclude it. Requests are
+excluded when the filter throws an exception.
+
+```csharp
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddGrpcClientInstrumentation(options =>
+    {
+        options.Filter = request => request.RequestUri?.Host != "internal.example.com";
+    })
+    .Build();
+```
+
 ### SuppressDownstreamInstrumentation
 
 > [!CAUTION]

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -111,6 +111,83 @@ public partial class GrpcTests(WeaverFixture weaver, ITestOutputHelper outputHel
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GrpcClientFilterControlsCollection(bool filterResult)
+    {
+        var filterCalled = false;
+        var uri = new UriBuilder("http://localhost") { Port = 1234 }.Uri;
+
+        using var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+        {
+            var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply());
+            return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: global::Grpc.Core.StatusCode.OK);
+        });
+
+        var exportedItems = new List<Activity>();
+
+        using (Sdk.CreateTracerProviderBuilder()
+            .SetSampler(new AlwaysOnSampler())
+            .AddGrpcClientInstrumentation(options => options.Filter = request =>
+            {
+                filterCalled = true;
+                Assert.Equal(uri.Host, request.RequestUri?.Host);
+                Assert.Equal(uri.Port, request.RequestUri?.Port);
+                return filterResult;
+            })
+            .AddInMemoryExporter(exportedItems)
+            .Build())
+        {
+            var channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions
+            {
+                HttpClient = httpClient,
+            });
+            var client = new Greeter.GreeterClient(channel);
+            _ = client.SayHello(new HelloRequest());
+        }
+
+        Assert.True(filterCalled);
+        if (filterResult)
+        {
+            Assert.Single(exportedItems);
+        }
+        else
+        {
+            Assert.Empty(exportedItems);
+        }
+    }
+
+    [Fact]
+    public void GrpcClientFilterExceptionsPreventCollection()
+    {
+        var uri = new UriBuilder("http://localhost") { Port = 1234 }.Uri;
+
+        using var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+        {
+            var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply());
+            return ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: global::Grpc.Core.StatusCode.OK);
+        });
+
+        var exportedItems = new List<Activity>();
+
+        using (Sdk.CreateTracerProviderBuilder()
+            .SetSampler(new AlwaysOnSampler())
+            .AddGrpcClientInstrumentation(options => options.Filter = _ => throw new InvalidOperationException("filter failure"))
+            .AddInMemoryExporter(exportedItems)
+            .Build())
+        {
+            var channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions
+            {
+                HttpClient = httpClient,
+            });
+            var client = new Greeter.GreeterClient(channel);
+            _ = client.SayHello(new HelloRequest());
+        }
+
+        Assert.Empty(exportedItems);
+    }
+
     [Fact]
     public void GrpcClientCancelledCallIsRecordedAsErrorPerSemanticConventions()
     {


### PR DESCRIPTION
Fixes #1781
Design discussion issue #1781

## Changes

Add a request-level `Filter` option to gRPC client tracing. Returning `false` suppresses recording, and filter exceptions are logged and suppress recording without interrupting the request.

The change includes public API tracking, documentation, changelog coverage, and tests for true, false, and exception paths.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)

Validation: gRPC client tests passed (`30 passed`, `1 skipped`); Release build passed for all targeted frameworks; `dotnet format --verify-no-changes` passed.
