### PR TITLE
[Extensions.Enrichment.AspNetCore] Add Enrichment instructions

### DIFF
--- a/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-* Documented the "Steps to enable" section of the README, covering enricher
-  class creation and registration.
-  ([#5114](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5114))
-
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Documented the "Steps to enable" section of the README, covering enricher
+  class creation and registration.
+  ([#TODO-PR-NUMBER](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO-PR-NUMBER))
+
 ## 1.17.0-beta.1
 
 Released 2026-Jul-17

--- a/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Documented the "Steps to enable" section of the README, covering enricher
   class creation and registration.
-  ([#TODO-PR-NUMBER](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO-PR-NUMBER))
+  ([#5114](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5114))
 
 ## 1.17.0-beta.1
 

--- a/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/README.md
@@ -126,6 +126,6 @@ app.Run();
 ### Step 4: Usage
 
 Once registered, the enrichment methods of your class are called automatically
-for every incoming HTTP request handled by ASP.NET Core — no additional code is
+for every incoming HTTP request handled by ASP.NET Core - no additional code is
 required at the request-handling site. Run your application and issue a request;
 the tags added in your enricher will appear on the resulting `Activity`.

--- a/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/README.md
@@ -51,9 +51,7 @@ class and override one or more of the following virtual methods, as needed:
 
 Each method receives a `TraceEnrichmentBag`, the same lightweight `readonly struct`
 used by `OpenTelemetry.Extensions.Enrichment`, which exposes a single
-`Add(string key, object? value)` method for adding tags. All three methods have
-a default no-op implementation, so you only need to override the ones relevant
-to your scenario.
+`Add(string key, object? value)` method for adding tags.
 
 ```csharp
 internal sealed class MyAspNetCoreTraceEnricher : AspNetCoreTraceEnricher
@@ -83,37 +81,47 @@ for an example).
 ### Step 3: Register enricher class
 
 Add your custom enricher class to the `TracerProviderBuilder` by calling the
-`TryAddAspNetCoreTraceEnricher<T>()` method, alongside ASP.NET Core instrumentation
-and an exporter as usual:
+`TryAddAspNetCoreTraceEnricher<T>()` method:
 
 ```csharp
-services.AddOpenTelemetry()
-    .WithTracing(builder => builder
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
         .AddAspNetCoreInstrumentation()
         .TryAddAspNetCoreTraceEnricher<MyAspNetCoreTraceEnricher>()
         .AddConsoleExporter());
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello OpenTelemetry!");
+
+app.Run();
 ```
 
 Alternatively, you can add your custom enricher to the `IServiceCollection`
-directly, typically inside the
-[ConfigureServices()](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.hosting.startupbase.configureservices)
-method:
+directly:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    services.TryAddAspNetCoreTraceEnricher<MyAspNetCoreTraceEnricher>();
+var builder = WebApplication.CreateBuilder(args);
 
-    services.AddOpenTelemetry()
-        .WithTracing(builder => builder
-            .AddAspNetCoreInstrumentation()
-            .AddConsoleExporter());
-}
+builder.Services.TryAddAspNetCoreTraceEnricher<MyAspNetCoreTraceEnricher>();
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddConsoleExporter());
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello OpenTelemetry!");
+
+app.Run();
 ```
 
 > [!NOTE]
 > The `TryAddAspNetCoreTraceEnricher()` call should be done *before* exporter
-related Activity processors are added.
+> related Activity processors are added.
 
 ### Step 4: Usage
 

--- a/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/README.md
+++ b/src/OpenTelemetry.Extensions.Enrichment.AspNetCore/README.md
@@ -32,4 +32,92 @@ Currently this package supports trace enrichment only.
 
 ### Steps to enable OpenTelemetry.Extensions.Enrichment.AspNetCore
 
-TBD
+### Step 1: Install package
+
+Download the `OpenTelemetry.Extensions.Enrichment.AspNetCore` package:
+
+```shell
+dotnet add package OpenTelemetry.Extensions.Enrichment.AspNetCore --prerelease
+```
+
+### Step 2: Create enricher class
+
+Create your custom enricher class that inherits from the `AspNetCoreTraceEnricher`
+class and override one or more of the following virtual methods, as needed:
+
+* `EnrichWithHttpRequest(in TraceEnrichmentBag bag, HttpRequest request)`
+* `EnrichWithHttpResponse(in TraceEnrichmentBag bag, HttpResponse response)`
+* `EnrichWithException(in TraceEnrichmentBag bag, Exception exception)`
+
+Each method receives a `TraceEnrichmentBag`, the same lightweight `readonly struct`
+used by `OpenTelemetry.Extensions.Enrichment`, which exposes a single
+`Add(string key, object? value)` method for adding tags. All three methods have
+a default no-op implementation, so you only need to override the ones relevant
+to your scenario.
+
+```csharp
+internal sealed class MyAspNetCoreTraceEnricher : AspNetCoreTraceEnricher
+{
+    public override void EnrichWithHttpRequest(in TraceEnrichmentBag bag, HttpRequest request)
+    {
+        bag.Add("http.request.header.x-my-custom-header", request.Headers["x-my-custom-header"].ToString());
+    }
+
+    public override void EnrichWithHttpResponse(in TraceEnrichmentBag bag, HttpResponse response)
+    {
+        bag.Add("http.response.content-length", response.ContentLength);
+    }
+
+    public override void EnrichWithException(in TraceEnrichmentBag bag, Exception exception)
+    {
+        bag.Add("exception.source", exception.Source);
+    }
+}
+```
+
+Optionally, inject other services your enricher class depends on via its constructor,
+the same way you would with `TraceEnricher` (see the
+[OpenTelemetry.Extensions.Enrichment README](../OpenTelemetry.Extensions.Enrichment/README.md#step-2-create-enricher-class)
+for an example).
+
+### Step 3: Register enricher class
+
+Add your custom enricher class to the `TracerProviderBuilder` by calling the
+`TryAddAspNetCoreTraceEnricher<T>()` method, alongside ASP.NET Core instrumentation
+and an exporter as usual:
+
+```csharp
+services.AddOpenTelemetry()
+    .WithTracing(builder => builder
+        .AddAspNetCoreInstrumentation()
+        .TryAddAspNetCoreTraceEnricher<MyAspNetCoreTraceEnricher>()
+        .AddConsoleExporter());
+```
+
+Alternatively, you can add your custom enricher to the `IServiceCollection`
+directly, typically inside the
+[ConfigureServices()](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.hosting.startupbase.configureservices)
+method:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.TryAddAspNetCoreTraceEnricher<MyAspNetCoreTraceEnricher>();
+
+    services.AddOpenTelemetry()
+        .WithTracing(builder => builder
+            .AddAspNetCoreInstrumentation()
+            .AddConsoleExporter());
+}
+```
+
+> [!NOTE]
+> The `TryAddAspNetCoreTraceEnricher()` call should be done *before* exporter
+related Activity processors are added.
+
+### Step 4: Usage
+
+Once registered, the enrichment methods of your class are called automatically
+for every incoming HTTP request handled by ASP.NET Core — no additional code is
+required at the request-handling site. Run your application and issue a request;
+the tags added in your enricher will appear on the resulting `Activity`.


### PR DESCRIPTION
Contributes to #5113

## Changes
Adds the "Steps to enable" section to the
`OpenTelemetry.Extensions.Enrichment.AspNetCore` README, which previously
just said "TBD". Covers installing the package, creating a custom enricher
class inherited from `AspNetCoreTraceEnricher` (overriding
`EnrichWithHttpRequest`, `EnrichWithHttpResponse`, `EnrichWithException`),
registering it via `TryAddAspNetCoreTraceEnricher<T>()`, and the note that
registration must happen before exporter processors are added. Structure
mirrors the existing completed "Steps to enable" section in the base
`OpenTelemetry.Extensions.Enrichment` package README.

Docs-only change — no source or public API changes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)

## AI Disclosure

AI helped organize the “Steps to enable” section, but everything in the README comes directly from the public API. I double checked the class names, method names, and DI extension signatures against the actual source (AspNetCoreTraceEnrichmentServiceCollectionExtensions.cs, AspNetCoreTraceEnricher.cs) before including them. I also ran the code and tests locally to make sure the examples were correct before opening the PR.