### PR TITLE
[SemanticConventions] Update to v1.44.0

### DIFF
--- a/src/OpenTelemetry.SemanticConventions/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.SemanticConventions/.publicApi/PublicAPI.Unshipped.txt
@@ -201,6 +201,27 @@ const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserDocume
 const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserLanguage = "browser.language" -> string!
 const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserMobile = "browser.mobile" -> string!
 const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserPlatform = "browser.platform" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserWebVitalDelta = "browser.web_vital.delta" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserWebVitalId = "browser.web_vital.id" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserWebVitalName = "browser.web_vital.name" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserWebVitalNavigationType = "browser.web_vital.navigation_type" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserWebVitalRating = "browser.web_vital.rating" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.AttributeBrowserWebVitalValue = "browser.web_vital.value" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNameValues.Cls = "cls" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNameValues.Fcp = "fcp" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNameValues.Fid = "fid" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNameValues.Inp = "inp" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNameValues.Lcp = "lcp" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNameValues.Ttfb = "ttfb" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNavigationTypeValues.BackForward = "back-forward" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNavigationTypeValues.BackForwardCache = "back-forward-cache" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNavigationTypeValues.Navigate = "navigate" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNavigationTypeValues.Prerender = "prerender" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNavigationTypeValues.Reload = "reload" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNavigationTypeValues.Restore = "restore" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalRatingValues.Good = "good" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalRatingValues.NeedsImprovement = "needs-improvement" -> string!
+const OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalRatingValues.Poor = "poor" -> string!
 const OpenTelemetry.SemanticConventions.CassandraAttributes.AttributeCassandraConsistencyLevel = "cassandra.consistency.level" -> string!
 const OpenTelemetry.SemanticConventions.CassandraAttributes.AttributeCassandraCoordinatorDc = "cassandra.coordinator.dc" -> string!
 const OpenTelemetry.SemanticConventions.CassandraAttributes.AttributeCassandraCoordinatorId = "cassandra.coordinator.id" -> string!
@@ -296,6 +317,7 @@ const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.Hetz
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.IbmCloudOpenshift = "ibm_cloud_openshift" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.OracleCloudCompute = "oracle_cloud_compute" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.OracleCloudOke = "oracle_cloud_oke" -> string!
+const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.ScalewayCloudCompute = "scaleway_cloud_compute" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.TencentCloudCvm = "tencent_cloud_cvm" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.TencentCloudEks = "tencent_cloud_eks" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudPlatformValues.TencentCloudScf = "tencent_cloud_scf" -> string!
@@ -309,6 +331,7 @@ const OpenTelemetry.SemanticConventions.CloudAttributes.CloudProviderValues.Hero
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudProviderValues.Hetzner = "hetzner" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudProviderValues.IbmCloud = "ibm_cloud" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudProviderValues.OracleCloud = "oracle_cloud" -> string!
+const OpenTelemetry.SemanticConventions.CloudAttributes.CloudProviderValues.ScalewayCloud = "scaleway_cloud" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudProviderValues.TencentCloud = "tencent_cloud" -> string!
 const OpenTelemetry.SemanticConventions.CloudAttributes.CloudProviderValues.Vultr = "vultr" -> string!
 const OpenTelemetry.SemanticConventions.CloudeventsAttributes.AttributeCloudeventsEventId = "cloudevents.event_id" -> string!
@@ -1262,6 +1285,7 @@ const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingGc
 const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingGcpPubsubMessageAckId = "messaging.gcp_pubsub.message.ack_id" -> string!
 const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingGcpPubsubMessageDeliveryAttempt = "messaging.gcp_pubsub.message.delivery_attempt" -> string!
 const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingGcpPubsubMessageOrderingKey = "messaging.gcp_pubsub.message.ordering_key" -> string!
+const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingKafkaClusterId = "messaging.kafka.cluster.id" -> string!
 const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer.group" -> string!
 const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition" -> string!
 const OpenTelemetry.SemanticConventions.MessagingAttributes.AttributeMessagingKafkaMessageKey = "messaging.kafka.message.key" -> string!
@@ -1914,6 +1938,9 @@ OpenTelemetry.SemanticConventions.AzureAttributes
 OpenTelemetry.SemanticConventions.AzureAttributes.AzureCosmosdbConnectionModeValues
 OpenTelemetry.SemanticConventions.AzureAttributes.AzureCosmosdbConsistencyLevelValues
 OpenTelemetry.SemanticConventions.BrowserAttributes
+OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNameValues
+OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalNavigationTypeValues
+OpenTelemetry.SemanticConventions.BrowserAttributes.BrowserWebVitalRatingValues
 OpenTelemetry.SemanticConventions.CassandraAttributes
 OpenTelemetry.SemanticConventions.CassandraAttributes.CassandraConsistencyLevelValues
 OpenTelemetry.SemanticConventions.CicdAttributes

--- a/src/OpenTelemetry.SemanticConventions/Attributes/AndroidAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/AndroidAttributes.cs
@@ -23,7 +23,7 @@ public static class AndroidAttributes
     public const string AttributeAndroidAppState = "android.app.state";
 
     /// <summary>
-    /// Uniquely identifies the framework API revision offered by a version (<c>os.version</c>) of the android operating system. More information can be found in the <a href="https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels">Android API levels documentation</a>.
+    /// Uniquely identifies the framework API revision offered by a version (<c>os.version</c>) of the Android operating system. More information can be found in the <a href="https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels">Android API levels documentation</a>.
     /// </summary>
     public const string AttributeAndroidOsApiLevel = "android.os.api_level";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/AppAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/AppAttributes.cs
@@ -20,7 +20,7 @@ public static class AppAttributes
     public const string AttributeAppBuildId = "app.build_id";
 
     /// <summary>
-    /// A unique identifier representing an instance of an end-user facing app crash.
+    /// A unique identifier representing an instance of an end user facing app crash.
     /// </summary>
     /// <remarks>
     /// Its value MAY be meaningful and be used as a reference for telemetry and metadata recorded by

--- a/src/OpenTelemetry.SemanticConventions/Attributes/ArtifactAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/ArtifactAttributes.cs
@@ -25,15 +25,15 @@ public static class ArtifactAttributes
     public const string AttributeArtifactAttestationHash = "artifact.attestation.hash";
 
     /// <summary>
-    /// The id of the build <a href="https://slsa.dev/attestation-model">software attestation</a>.
+    /// The ID of the build <a href="https://slsa.dev/attestation-model">software attestation</a>.
     /// </summary>
     public const string AttributeArtifactAttestationId = "artifact.attestation.id";
 
     /// <summary>
-    /// The human readable file name of the artifact, typically generated during build and release processes. Often includes the package name and version in the file name.
+    /// The human readable filename of the artifact, typically generated during build and release processes. Often includes the package name and version in the filename.
     /// </summary>
     /// <remarks>
-    /// This file name can also act as the <a href="https://slsa.dev/spec/v1.0/terminology#package-model">Package Name</a>
+    /// This filename can also act as the <a href="https://slsa.dev/spec/v1.0/terminology#package-model">Package Name</a>
     /// in cases where the package ecosystem maps accordingly.
     /// Additionally, the artifact <a href="https://slsa.dev/spec/v1.0/terminology#software-supply-chain">can be published</a>
     /// for others, but that is not a guarantee.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/AspnetcoreAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/AspnetcoreAttributes.cs
@@ -369,7 +369,7 @@ public static class AspnetcoreAttributes
         public const string Update = "update";
 
         /// <summary>
-        /// Identity user name updated.
+        /// Identity username updated.
         /// </summary>
         public const string UserName = "user_name";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/BrowserAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/BrowserAttributes.cs
@@ -51,4 +51,128 @@ public static class BrowserAttributes
     /// The list of possible values is defined in the <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform">W3C User-Agent Client Hints specification</a>. Note that some (but not all) of these values can overlap with values in the <a href="./os.md"><c>os.type</c> and <c>os.name</c> attributes</a>. However, for consistency, the values in the <c>browser.platform</c> attribute should capture the exact value that the user agent provides.
     /// </remarks>
     public const string AttributeBrowserPlatform = "browser.platform";
+
+    /// <summary>
+    /// The delta between the current value and the last-reported value. See <a href="https://github.com/GoogleChrome/web-vitals?tab=readme-ov-file#report-only-the-delta-of-changes">delta</a>.
+    /// </summary>
+    public const string AttributeBrowserWebVitalDelta = "browser.web_vital.delta";
+
+    /// <summary>
+    /// A unique ID representing this particular metric instance.
+    /// </summary>
+    public const string AttributeBrowserWebVitalId = "browser.web_vital.id";
+
+    /// <summary>
+    /// Name of the web vital.
+    /// </summary>
+    public const string AttributeBrowserWebVitalName = "browser.web_vital.name";
+
+    /// <summary>
+    /// The type of navigation, as reported by the <a href="https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming/type">Navigation Timing API</a>, with additional values reported by the web-vitals library.
+    /// </summary>
+    public const string AttributeBrowserWebVitalNavigationType = "browser.web_vital.navigation_type";
+
+    /// <summary>
+    /// The rating of the web vital value against the "good", "needs improvement", and "poor" thresholds defined for the metric.
+    /// </summary>
+    public const string AttributeBrowserWebVitalRating = "browser.web_vital.rating";
+
+    /// <summary>
+    /// Value of the web vital.
+    /// </summary>
+    public const string AttributeBrowserWebVitalValue = "browser.web_vital.value";
+
+    /// <summary>
+    /// Name of the web vital.
+    /// </summary>
+    public static class BrowserWebVitalNameValues
+    {
+        /// <summary>
+        /// Cumulative Layout Shift. See <a href="https://web.dev/articles/cls">cls</a>.
+        /// </summary>
+        public const string Cls = "cls";
+
+        /// <summary>
+        /// Largest Contentful Paint. See <a href="https://web.dev/articles/lcp">lcp</a>.
+        /// </summary>
+        public const string Lcp = "lcp";
+
+        /// <summary>
+        /// First Contentful Paint. See <a href="https://web.dev/articles/fcp">fcp</a>.
+        /// </summary>
+        public const string Fcp = "fcp";
+
+        /// <summary>
+        /// Interaction to Next Paint. See <a href="https://web.dev/articles/inp">inp</a>.
+        /// </summary>
+        public const string Inp = "inp";
+
+        /// <summary>
+        /// Time to First Byte. See <a href="https://web.dev/articles/ttfb">ttfb</a>.
+        /// </summary>
+        public const string Ttfb = "ttfb";
+
+        /// <summary>
+        /// First Input Delay. See <a href="https://web.dev/articles/fid">fid</a>.
+        /// </summary>
+        [Obsolete("Replaced by Interaction to Next Paint (<c>inp</c>), which became a Core Web Vital in March 2024. See inp (https://web.dev/articles/inp).")]
+        public const string Fid = "fid";
+    }
+
+    /// <summary>
+    /// The type of navigation, as reported by the <a href="https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming/type">Navigation Timing API</a>, with additional values reported by the web-vitals library.
+    /// </summary>
+    public static class BrowserWebVitalNavigationTypeValues
+    {
+        /// <summary>
+        /// Navigation started by clicking a link, entering a URL, form submission, or a script operation.
+        /// </summary>
+        public const string Navigate = "navigate";
+
+        /// <summary>
+        /// Navigation through a reload operation or a <c>Location.reload()</c> call.
+        /// </summary>
+        public const string Reload = "reload";
+
+        /// <summary>
+        /// Navigation through the browser's history traversal (e.g. back/forward buttons).
+        /// </summary>
+        public const string BackForward = "back-forward";
+
+        /// <summary>
+        /// Navigation restoring a page from the back/forward cache (bfcache).
+        /// </summary>
+        public const string BackForwardCache = "back-forward-cache";
+
+        /// <summary>
+        /// Navigation to a page that was prerendered.
+        /// </summary>
+        public const string Prerender = "prerender";
+
+        /// <summary>
+        /// Navigation restoring a page that was previously discarded by the browser.
+        /// </summary>
+        public const string Restore = "restore";
+    }
+
+    /// <summary>
+    /// The rating of the web vital value against the "good", "needs improvement", and "poor" thresholds defined for the metric.
+    /// </summary>
+    public static class BrowserWebVitalRatingValues
+    {
+        /// <summary>
+        /// The metric value is within the "good" threshold.
+        /// </summary>
+        public const string Good = "good";
+
+        /// <summary>
+        /// The metric value is within the "needs improvement" threshold.
+        /// </summary>
+        public const string NeedsImprovement = "needs-improvement";
+
+        /// <summary>
+        /// The metric value is within the "poor" threshold.
+        /// </summary>
+        public const string Poor = "poor";
+    }
 }

--- a/src/OpenTelemetry.SemanticConventions/Attributes/ClientAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/ClientAttributes.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.SemanticConventions;
 public static class ClientAttributes
 {
     /// <summary>
-    /// Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+    /// Client address - domain name if available without reverse DNS lookup; otherwise, IP address or UNIX domain socket name.
     /// </summary>
     /// <remarks>
     /// When observed from the server side, and when communicating through an intermediary, <c>client.address</c> SHOULD represent the client address behind any intermediaries,  for example proxies, if it's available.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/CloudAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/CloudAttributes.cs
@@ -232,6 +232,11 @@ public static class CloudAttributes
         public const string OracleCloudOke = "oracle_cloud_oke";
 
         /// <summary>
+        /// Compute on Scaleway Cloud.
+        /// </summary>
+        public const string ScalewayCloudCompute = "scaleway_cloud_compute";
+
+        /// <summary>
         /// Tencent Cloud Cloud Virtual Machine (CVM).
         /// </summary>
         public const string TencentCloudCvm = "tencent_cloud_cvm";
@@ -301,6 +306,11 @@ public static class CloudAttributes
         /// Oracle Cloud Infrastructure (OCI).
         /// </summary>
         public const string OracleCloud = "oracle_cloud";
+
+        /// <summary>
+        /// Scaleway Cloud.
+        /// </summary>
+        public const string ScalewayCloud = "scaleway_cloud";
 
         /// <summary>
         /// Tencent Cloud.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/CloudfoundryAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/CloudfoundryAttributes.cs
@@ -131,7 +131,7 @@ public static class CloudfoundryAttributes
     /// <remarks>
     /// CloudFoundry defines the <c>instance_id</c> in the <a href="https://github.com/cloudfoundry/loggregator-api#v2-envelope">Loggregator v2 envelope</a>.
     /// It is used for logs and metrics emitted by CloudFoundry. It is
-    /// supposed to contain the vm id for CloudFoundry components.
+    /// supposed to contain the vm ID for CloudFoundry components.
     /// <p>
     /// When system components are instrumented, values from the
     /// <a href="https://bosh.io/docs/jobs/#properties-spec">Bosh spec</a>

--- a/src/OpenTelemetry.SemanticConventions/Attributes/CodeAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/CodeAttributes.cs
@@ -26,7 +26,7 @@ public static class CodeAttributes
     public const string AttributeCodeColumnNumber = "code.column.number";
 
     /// <summary>
-    /// The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path). This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Function'. This constraint is imposed to prevent redundancy and maintain data integrity.
+    /// The source code filename that identifies the code unit as uniquely as possible (preferably an absolute file path). This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Function'. This constraint is imposed to prevent redundancy and maintain data integrity.
     /// </summary>
     public const string AttributeCodeFilePath = "code.file.path";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/ContainerAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/ContainerAttributes.cs
@@ -63,7 +63,7 @@ public static class ContainerAttributes
     /// Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
     /// </summary>
     /// <remarks>
-    /// Docker defines a sha256 of the image id; <c>container.image.id</c> corresponds to the <c>Image</c> field from the Docker container inspect <a href="https://docs.docker.com/reference/api/engine/version/v1.52/#tag/Container/operation/ContainerInspect">API</a> endpoint.
+    /// Docker defines a sha256 of the image ID; <c>container.image.id</c> corresponds to the <c>Image</c> field from the Docker container inspect <a href="https://docs.docker.com/reference/api/engine/version/v1.52/#tag/Container/operation/ContainerInspect">API</a> endpoint.
     /// K8s defines a link to the container registry repository with digest <c>"imageID": "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"</c>.
     /// The ID is assigned by the container runtime and can vary in different environments. Consider using <c>oci.manifest.digest</c> if it is important to identify the same image in different environments/runtimes.
     /// </remarks>
@@ -75,7 +75,7 @@ public static class ContainerAttributes
     public const string AttributeContainerImageName = "container.image.name";
 
     /// <summary>
-    /// Repo digests of the container image as provided by the container runtime.
+    /// Repository digests of the container image as provided by the container runtime.
     /// </summary>
     /// <remarks>
     /// <a href="https://docs.docker.com/reference/api/engine/version/v1.52/#tag/Image/operation/ImageInspect">Docker</a> and <a href="https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238">CRI</a> report those under the <c>RepoDigests</c> field.
@@ -91,7 +91,7 @@ public static class ContainerAttributes
     /// Container labels, <c><key></c> being the label name, the value being the label value.
     /// </summary>
     /// <remarks>
-    /// For example, a docker container label <c>app</c> with value <c>nginx</c> SHOULD be recorded as the <c>container.label.app</c> attribute with value <c>"nginx"</c>.
+    /// For example, a Docker container label <c>app</c> with value <c>nginx</c> SHOULD be recorded as the <c>container.label.app</c> attribute with value <c>"nginx"</c>.
     /// </remarks>
     public const string AttributeContainerLabelTemplate = "container.label";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/DbAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/DbAttributes.cs
@@ -297,7 +297,12 @@ public static class DbAttributes
     /// up with the parameterized placeholders present in <c>db.query.text</c>.
     /// <p>
     /// It is RECOMMENDED to capture the value as provided by the application
-    /// without attempting to do any case normalization.
+    /// without attempting to do any case normalization or sanitization.
+    /// <p>
+    /// Instrumentations SHOULD NOT capture <c>db.query.parameter.<key></c> by default
+    /// since values may contain PII or sensitive details.
+    /// Application operators are expected to enable specific keys depending
+    /// on their privacy and security considerations.
     /// <p>
     /// <c>db.query.parameter.<key></c> SHOULD NOT be captured on batch operations.
     /// <p>
@@ -345,7 +350,7 @@ public static class DbAttributes
     /// <summary>
     /// Deprecated, use <c>db.namespace</c> instead.
     /// </summary>
-    [Obsolete("Uncategorized.")]
+    [Obsolete("Replaced by <c>db.namespace</c> (string).")]
     public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
 
     /// <summary>

--- a/src/OpenTelemetry.SemanticConventions/Attributes/DeploymentAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/DeploymentAttributes.cs
@@ -36,7 +36,7 @@ public static class DeploymentAttributes
     public const string AttributeDeploymentEnvironmentName = "deployment.environment.name";
 
     /// <summary>
-    /// The id of the deployment.
+    /// The ID of the deployment.
     /// </summary>
     public const string AttributeDeploymentId = "deployment.id";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/DestinationAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/DestinationAttributes.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.SemanticConventions;
 public static class DestinationAttributes
 {
     /// <summary>
-    /// Destination address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+    /// Destination address - domain name if available without reverse DNS lookup; otherwise, IP address or UNIX domain socket name.
     /// </summary>
     /// <remarks>
     /// When observed from the source side, and when communicating through an intermediary, <c>destination.address</c> SHOULD represent the destination address behind any intermediaries, for example proxies, if it's available.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/FileAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/FileAttributes.cs
@@ -55,7 +55,7 @@ public static class FileAttributes
     /// File extension, excluding the leading dot.
     /// </summary>
     /// <remarks>
-    /// When the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz").
+    /// When the filename has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz").
     /// </remarks>
     public const string AttributeFileExtension = "file.extension";
 
@@ -64,7 +64,7 @@ public static class FileAttributes
     /// </summary>
     /// <remarks>
     /// On Linux, a resource fork is used to store additional data with a filesystem object. A file always has at least one fork for the data portion, and additional forks may exist.
-    /// On NTFS, this is analogous to an Alternate Data Stream (ADS), and the default data stream for a file is just called $DATA. Zone.Identifier is commonly used by Windows to track contents downloaded from the Internet. An ADS is typically of the form: C:\path\to\filename.extension:some_fork_name, and some_fork_name is the value that should populate <c>fork_name</c>. <c>filename.extension</c> should populate <c>file.name</c>, and <c>extension</c> should populate <c>file.extension</c>. The full path, <c>file.path</c>, will include the fork name.
+    /// On NTFS, this is analogous to an Alternate Data Stream (ADS), and the default data stream for a file is just called $DATA. Zone.Identifier is commonly used by Windows to track contents downloaded from the internet. An ADS is typically of the form: C:\path\to\filename.extension:some_fork_name, and some_fork_name is the value that should populate <c>fork_name</c>. <c>filename.extension</c> should populate <c>file.name</c>, and <c>extension</c> should populate <c>file.extension</c>. The full path, <c>file.path</c>, will include the fork name.
     /// </remarks>
     public const string AttributeFileForkName = "file.fork_name";
 
@@ -124,7 +124,7 @@ public static class FileAttributes
     public const string AttributeFileOwnerName = "file.owner.name";
 
     /// <summary>
-    /// Full path to the file, including the file name. It should include the drive letter, when appropriate.
+    /// Full path to the file, including the filename. It should include the drive letter, when appropriate.
     /// </summary>
     public const string AttributeFilePath = "file.path";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/HostAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/HostAttributes.cs
@@ -89,7 +89,7 @@ public static class HostAttributes
     public const string AttributeHostMac = "host.mac";
 
     /// <summary>
-    /// Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
+    /// Name of the host. On UNIX systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
     /// </summary>
     public const string AttributeHostName = "host.name";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/LogAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/LogAttributes.cs
@@ -51,8 +51,8 @@ public static class LogAttributes
     /// A unique identifier for the Log Record.
     /// </summary>
     /// <remarks>
-    /// If an id is provided, other log records with the same id will be considered duplicates and can be removed safely. This means, that two distinguishable log records MUST have different values.
-    /// The id MAY be an <a href="https://github.com/ulid/spec">Universally Unique Lexicographically Sortable Identifier (ULID)</a>, but other identifiers (e.g. UUID) may be used as needed.
+    /// If an ID is provided, other log records with the same ID will be considered duplicates and can be removed safely. This means, that two distinguishable log records MUST have different values.
+    /// The ID MAY be an <a href="https://github.com/ulid/spec">Universally Unique Lexicographically Sortable Identifier (ULID)</a>, but other identifiers (e.g. UUID) may be used as needed.
     /// </remarks>
     public const string AttributeLogRecordUid = "log.record.uid";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/McpAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/McpAttributes.cs
@@ -27,7 +27,7 @@ public static class McpAttributes
     public const string AttributeMcpProtocolVersion = "mcp.protocol.version";
 
     /// <summary>
-    /// The value of the resource uri.
+    /// The value of the resource URI.
     /// </summary>
     /// <remarks>
     /// This is a URI of the resource provided in the following requests or notifications: <c>resources/read</c>, <c>resources/subscribe</c>, <c>resources/unsubscribe</c>, or <c>notifications/resources/updated</c>.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/MessagingAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/MessagingAttributes.cs
@@ -44,8 +44,8 @@ public static class MessagingAttributes
     /// The message destination name.
     /// </summary>
     /// <remarks>
-    /// Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
-    /// the broker doesn't have such notion, the destination name SHOULD uniquely identify the broker.
+    /// SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
+    /// the broker doesn't have such notion, it SHOULD uniquely identify the broker.
     /// </remarks>
     public const string AttributeMessagingDestinationName = "messaging.destination.name";
 
@@ -66,7 +66,7 @@ public static class MessagingAttributes
     /// Low cardinality representation of the messaging destination name.
     /// </summary>
     /// <remarks>
-    /// Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
+    /// Destination names could be constructed from templates. An example would be a destination name involving a username or product ID. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
     /// </remarks>
     public const string AttributeMessagingDestinationTemplate = "messaging.destination.template";
 
@@ -104,7 +104,7 @@ public static class MessagingAttributes
     public const string AttributeMessagingGcpPubsubMessageAckDeadline = "messaging.gcp_pubsub.message.ack_deadline";
 
     /// <summary>
-    /// The ack id for a given message.
+    /// The ack ID for a given message.
     /// </summary>
     public const string AttributeMessagingGcpPubsubMessageAckId = "messaging.gcp_pubsub.message.ack_id";
 
@@ -119,6 +119,14 @@ public static class MessagingAttributes
     public const string AttributeMessagingGcpPubsubMessageOrderingKey = "messaging.gcp_pubsub.message.ordering_key";
 
     /// <summary>
+    /// The Kafka cluster ID, obtained from the broker metadata exposed through the Kafka client (or AdminClient) API.
+    /// </summary>
+    /// <remarks>
+    /// The cluster ID is a unique identifier reported by the Kafka broker. It identifies the cluster independently of the individual brokers the client is configured to connect to, and remains stable even if broker hostnames, IP addresses, or ports change.
+    /// </remarks>
+    public const string AttributeMessagingKafkaClusterId = "messaging.kafka.cluster.id";
+
+    /// <summary>
     /// Deprecated, use <c>messaging.consumer.group.name</c> instead.
     /// </summary>
     [Obsolete("Replaced by <c>messaging.consumer.group.name</c>.")]
@@ -127,7 +135,7 @@ public static class MessagingAttributes
     /// <summary>
     /// Deprecated, use <c>messaging.destination.partition.id</c> instead.
     /// </summary>
-    [Obsolete("Record string representation of the partition id in <c>messaging.destination.partition.id</c> attribute.")]
+    [Obsolete("Record string representation of the partition ID in <c>messaging.destination.partition.id</c> attribute.")]
     public const string AttributeMessagingKafkaDestinationPartition = "messaging.kafka.destination.partition";
 
     /// <summary>
@@ -238,7 +246,7 @@ public static class MessagingAttributes
     public const string AttributeMessagingRocketmqMessageGroup = "messaging.rocketmq.message.group";
 
     /// <summary>
-    /// Key(s) of message, another way to mark message besides message id.
+    /// Key(s) of message, another way to mark message besides message ID.
     /// </summary>
     public const string AttributeMessagingRocketmqMessageKeys = "messaging.rocketmq.message.keys";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/NetAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/NetAttributes.cs
@@ -121,7 +121,7 @@ public static class NetAttributes
         public const string Inet6 = "inet6";
 
         /// <summary>
-        /// Unix domain socket path.
+        /// UNIX domain socket path.
         /// </summary>
         public const string Unix = "unix";
     }

--- a/src/OpenTelemetry.SemanticConventions/Attributes/NetworkAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/NetworkAttributes.cs
@@ -43,7 +43,7 @@ public static class NetworkAttributes
     public const string AttributeNetworkConnectionState = "network.connection.state";
 
     /// <summary>
-    /// This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+    /// This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a Wi-Fi connection.
     /// </summary>
     public const string AttributeNetworkConnectionSubtype = "network.connection.subtype";
 
@@ -63,7 +63,7 @@ public static class NetworkAttributes
     public const string AttributeNetworkIoDirection = "network.io.direction";
 
     /// <summary>
-    /// Local address of the network connection - IP address or Unix domain socket name.
+    /// Local address of the network connection - IP address or UNIX domain socket name.
     /// </summary>
     public const string AttributeNetworkLocalAddress = "network.local.address";
 
@@ -73,7 +73,7 @@ public static class NetworkAttributes
     public const string AttributeNetworkLocalPort = "network.local.port";
 
     /// <summary>
-    /// Peer address of the network connection - IP address or Unix domain socket name.
+    /// Peer address of the network connection - IP address or UNIX domain socket name.
     /// </summary>
     public const string AttributeNetworkPeerAddress = "network.peer.address";
 
@@ -180,7 +180,7 @@ public static class NetworkAttributes
     }
 
     /// <summary>
-    /// This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+    /// This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a Wi-Fi connection.
     /// </summary>
     public static class NetworkConnectionSubtypeValues
     {
@@ -296,7 +296,7 @@ public static class NetworkAttributes
     public static class NetworkConnectionTypeValues
     {
         /// <summary>
-        /// wifi.
+        /// Wi-Fi.
         /// </summary>
         public const string Wifi = "wifi";
 
@@ -358,7 +358,7 @@ public static class NetworkAttributes
         public const string Pipe = "pipe";
 
         /// <summary>
-        /// Unix domain socket.
+        /// UNIX domain socket.
         /// </summary>
         public const string Unix = "unix";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/OracleAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/OracleAttributes.cs
@@ -60,7 +60,7 @@ public static class OracleAttributes
     /// </summary>
     /// <remarks>
     /// The effective service name for a connection can change during its lifetime,
-    /// for example after executing sql, <c>ALTER SESSION</c>. If an instrumentation cannot reliably
+    /// for example after executing SQL, <c>ALTER SESSION</c>. If an instrumentation cannot reliably
     /// obtain the current service name for each operation without issuing an additional
     /// query (such as <c>SELECT SYS_CONTEXT</c>), it is RECOMMENDED to fall back to the
     /// service name originally provided at connection establishment.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/OsAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/OsAttributes.cs
@@ -80,7 +80,7 @@ public static class OsAttributes
         public const string Dragonflybsd = "dragonflybsd";
 
         /// <summary>
-        /// HP-UX (Hewlett Packard Unix).
+        /// HP-UX (Hewlett Packard UNIX).
         /// </summary>
         public const string Hpux = "hpux";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/OtelAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/OtelAttributes.cs
@@ -92,22 +92,22 @@ public static class OtelAttributes
     public static class OtelComponentTypeValues
     {
         /// <summary>
-        /// The builtin SDK batching span processor.
+        /// The built-in SDK batching span processor.
         /// </summary>
         public const string BatchingSpanProcessor = "batching_span_processor";
 
         /// <summary>
-        /// The builtin SDK simple span processor.
+        /// The built-in SDK simple span processor.
         /// </summary>
         public const string SimpleSpanProcessor = "simple_span_processor";
 
         /// <summary>
-        /// The builtin SDK batching log record processor.
+        /// The built-in SDK batching log record processor.
         /// </summary>
         public const string BatchingLogProcessor = "batching_log_processor";
 
         /// <summary>
-        /// The builtin SDK simple log record processor.
+        /// The built-in SDK simple log record processor.
         /// </summary>
         public const string SimpleLogProcessor = "simple_log_processor";
 
@@ -147,7 +147,7 @@ public static class OtelAttributes
         public const string OtlpHttpJsonLogExporter = "otlp_http_json_log_exporter";
 
         /// <summary>
-        /// The builtin SDK periodically exporting metric reader.
+        /// The built-in SDK periodically exporting metric reader.
         /// </summary>
         public const string PeriodicMetricReader = "periodic_metric_reader";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/PprofAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/PprofAttributes.cs
@@ -53,12 +53,12 @@ public static class PprofAttributes
     public const string AttributePprofProfileDocUrl = "pprof.profile.doc_url";
 
     /// <summary>
-    /// Frames with Function.function_name fully matching the regexp will be dropped from the samples, along with their successors.
+    /// Frames with Function.function_name fully matching the regular expression will be dropped from the samples, along with their successors.
     /// </summary>
     public const string AttributePprofProfileDropFrames = "pprof.profile.drop_frames";
 
     /// <summary>
-    /// Frames with Function.function_name fully matching the regexp will be kept, even if it matches drop_frames.
+    /// Frames with Function.function_name fully matching the regular expression will be kept, even if it matches drop_frames.
     /// </summary>
     public const string AttributePprofProfileKeepFrames = "pprof.profile.keep_frames";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/RpcAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/RpcAttributes.cs
@@ -115,9 +115,7 @@ public static class RpcAttributes
     /// When the method is not recognized, for example, when the server receives
     /// a request for a method that is not predefined on the server, or when
     /// instrumentation is not able to reliably detect if the method is predefined,
-    /// the attribute MUST be set to <c>_OTHER</c>. In such cases, tracing
-    /// instrumentations MUST also set <c>rpc.method_original</c> attribute to
-    /// the original method value.
+    /// the attribute MUST be set to <c>_OTHER</c>.
     /// <p>
     /// If the RPC instrumentation could end up converting valid RPC methods to
     /// <c>_OTHER</c>, then it SHOULD provide a way to configure the list of recognized

--- a/src/OpenTelemetry.SemanticConventions/Attributes/ServerAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/ServerAttributes.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.SemanticConventions;
 public static class ServerAttributes
 {
     /// <summary>
-    /// Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+    /// Server domain name if available without reverse DNS lookup; otherwise, IP address or UNIX domain socket name.
     /// </summary>
     /// <remarks>
     /// When observed from the client side, and when communicating through an intermediary, <c>server.address</c> SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/SessionAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/SessionAttributes.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.SemanticConventions;
 public static class SessionAttributes
 {
     /// <summary>
-    /// A unique id to identify a session.
+    /// A unique ID to identify a session.
     /// </summary>
     public const string AttributeSessionId = "session.id";
 

--- a/src/OpenTelemetry.SemanticConventions/Attributes/SourceAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/SourceAttributes.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.SemanticConventions;
 public static class SourceAttributes
 {
     /// <summary>
-    /// Source address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+    /// Source address - domain name if available without reverse DNS lookup; otherwise, IP address or UNIX domain socket name.
     /// </summary>
     /// <remarks>
     /// When observed from the destination side, and when communicating through an intermediary, <c>source.address</c> SHOULD represent the source address behind any intermediaries, for example proxies, if it's available.

--- a/src/OpenTelemetry.SemanticConventions/Attributes/TelemetryAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/TelemetryAttributes.cs
@@ -57,67 +57,67 @@ public static class TelemetryAttributes
     public static class TelemetrySdkLanguageValues
     {
         /// <summary>
-        /// cpp.
+        /// <a href="https://opentelemetry.io/docs/languages/cpp/">C++</a>.
         /// </summary>
         public const string Cpp = "cpp";
 
         /// <summary>
-        /// dotnet.
+        /// <a href="https://opentelemetry.io/docs/languages/dotnet/">.NET</a>.
         /// </summary>
         public const string Dotnet = "dotnet";
 
         /// <summary>
-        /// erlang.
+        /// <a href="https://opentelemetry.io/docs/languages/erlang/">Erlang/Elixir</a>.
         /// </summary>
         public const string Erlang = "erlang";
 
         /// <summary>
-        /// go.
+        /// <a href="https://opentelemetry.io/docs/languages/go/">Go</a>.
         /// </summary>
         public const string Go = "go";
 
         /// <summary>
-        /// java.
+        /// <a href="https://opentelemetry.io/docs/languages/java/">Java</a>.
         /// </summary>
         public const string Java = "java";
 
         /// <summary>
-        /// kotlin.
+        /// <a href="https://opentelemetry.io/docs/languages/kotlin/">Kotlin</a>.
         /// </summary>
         public const string Kotlin = "kotlin";
 
         /// <summary>
-        /// nodejs.
+        /// <a href="https://opentelemetry.io/docs/languages/js/">Node.js</a>.
         /// </summary>
         public const string Nodejs = "nodejs";
 
         /// <summary>
-        /// php.
+        /// <a href="https://opentelemetry.io/docs/languages/php/">PHP</a>.
         /// </summary>
         public const string Php = "php";
 
         /// <summary>
-        /// python.
+        /// <a href="https://opentelemetry.io/docs/languages/python/">Python</a>.
         /// </summary>
         public const string Python = "python";
 
         /// <summary>
-        /// ruby.
+        /// <a href="https://opentelemetry.io/docs/languages/ruby/">Ruby</a>.
         /// </summary>
         public const string Ruby = "ruby";
 
         /// <summary>
-        /// rust.
+        /// <a href="https://opentelemetry.io/docs/languages/rust/">Rust</a>.
         /// </summary>
         public const string Rust = "rust";
 
         /// <summary>
-        /// swift.
+        /// <a href="https://opentelemetry.io/docs/languages/swift/">Swift</a>.
         /// </summary>
         public const string Swift = "swift";
 
         /// <summary>
-        /// webjs.
+        /// <a href="https://opentelemetry.io/docs/languages/js/">Browser</a>.
         /// </summary>
         public const string Webjs = "webjs";
     }

--- a/src/OpenTelemetry.SemanticConventions/Attributes/TlsAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/TlsAttributes.cs
@@ -169,12 +169,12 @@ public static class TlsAttributes
     public static class TlsProtocolNameValues
     {
         /// <summary>
-        /// ssl.
+        /// SSL.
         /// </summary>
         public const string Ssl = "ssl";
 
         /// <summary>
-        /// tls.
+        /// TLS.
         /// </summary>
         public const string Tls = "tls";
     }

--- a/src/OpenTelemetry.SemanticConventions/Attributes/UrlAttributes.cs
+++ b/src/OpenTelemetry.SemanticConventions/Attributes/UrlAttributes.cs
@@ -26,7 +26,7 @@ public static class UrlAttributes
     /// The file extension extracted from the <c>url.full</c>, excluding the leading dot.
     /// </summary>
     /// <remarks>
-    /// The file extension is only set if it exists, as not every url has a file extension. When the file name has multiple extensions <c>example.tar.gz</c>, only the last one should be captured <c>gz</c>, not <c>tar.gz</c>.
+    /// The file extension is only set if it exists, as not every URL has a file extension. When the filename has multiple extensions <c>example.tar.gz</c>, only the last one should be captured <c>gz</c>, not <c>tar.gz</c>.
     /// </remarks>
     public const string AttributeUrlExtension = "url.extension";
 
@@ -132,7 +132,7 @@ public static class UrlAttributes
     public const string AttributeUrlQuery = "url.query";
 
     /// <summary>
-    /// The highest registered url domain, stripped of the subdomain.
+    /// The highest registered URL domain, stripped of the subdomain.
     /// </summary>
     /// <remarks>
     /// This value can be determined precisely with the <a href="https://publicsuffix.org/">public suffix list</a>. For example, the registered domain for <c>foo.example.com</c> is <c>example.com</c>. Trying to approximate this by simply taking the last two labels will not work well for TLDs such as <c>co.uk</c>.
@@ -145,7 +145,7 @@ public static class UrlAttributes
     public const string AttributeUrlScheme = "url.scheme";
 
     /// <summary>
-    /// The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain. In a partially qualified domain, or if the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+    /// The subdomain portion of a fully qualified domain name includes all of the names except the hostname under the registered_domain. In a partially qualified domain, or if the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
     /// </summary>
     /// <remarks>
     /// The subdomain portion of <c>www.east.mydomain.co.uk</c> is <c>east</c>. If the domain has multiple levels of subdomain, such as <c>sub2.sub1.example.com</c>, the subdomain field should contain <c>sub2.sub1</c>, with no trailing period.

--- a/src/OpenTelemetry.SemanticConventions/CHANGELOG.md
+++ b/src/OpenTelemetry.SemanticConventions/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated to `v1.44.0` release of OpenTelemetry Semantic Conventions.
+  ([#5121](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5121))
+
 * Updated to `v1.43.0` release of OpenTelemetry Semantic Conventions.
   ([#4772](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4772))
 

--- a/src/OpenTelemetry.SemanticConventions/scripts/generate.ps1
+++ b/src/OpenTelemetry.SemanticConventions/scripts/generate.ps1
@@ -2,8 +2,8 @@ $SCRIPT_DIR = $PSScriptRoot
 $ROOT_DIR = "${SCRIPT_DIR}/../"
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-$SEMCONV_VERSION="1.43.0"
-$GENERATOR_VERSION="v0.24.2"
+$SEMCONV_VERSION="1.44.0"
+$GENERATOR_VERSION="v0.25.1"
 
 Set-Location $SCRIPT_DIR
 

--- a/src/OpenTelemetry.SemanticConventions/scripts/generate.sh
+++ b/src/OpenTelemetry.SemanticConventions/scripts/generate.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/../"
 
 # freeze the spec version to make SemanticAttributes generation reproducible
-SEMCONV_VERSION="1.41.0"
-GENERATOR_VERSION="v0.23.0"
+SEMCONV_VERSION="1.44.0"
+GENERATOR_VERSION="v0.25.1"
 
 cd ${SCRIPT_DIR}
 


### PR DESCRIPTION
## Changes

- Update Semantic Conventions to [v1.44.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.44.0) and regenerate code.
- Update weaver to v0.25.1.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
