### PR TITLE
[Infra] Avoid boxing for port numbers

### DIFF
--- a/opentelemetry-dotnet-contrib.slnx
+++ b/opentelemetry-dotnet-contrib.slnx
@@ -203,6 +203,7 @@
     <File Path="src/Shared/MeterFactory.cs" />
     <File Path="src/Shared/MultiTypePropertyFetcher.cs" />
     <File Path="src/Shared/NullableAttributes.cs" />
+    <File Path="src/Shared/PortTelemetryHelper.cs" />
     <File Path="src/Shared/PropertyFetcher.cs" />
     <File Path="src/Shared/RedactionHelper.cs" />
     <File Path="src/Shared/RequestDataHelper.cs" />

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -106,7 +106,7 @@ internal class AWSLambdaHttpUtils
 
         if (hostPort is { } port)
         {
-            var boxedHostPort = PortTelemetryHelper.GetBoxedPort(port);
+            var boxedHostPort = PortTelemetryHelper.GetBoxedPort(port, cacheValue: true);
             tags.AddAttributeNetHostPort(boxedHostPort);
             tags.AddAttributeServerPort(boxedHostPort);
         }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaHttpUtils.cs
@@ -104,8 +104,12 @@ internal class AWSLambdaHttpUtils
             tags.AddAttributeServerAddress(hostName, addIfEmpty: true);
         }
 
-        tags.AddAttributeNetHostPort(hostPort);
-        tags.AddAttributeServerPort(hostPort);
+        if (hostPort is { } port)
+        {
+            var boxedHostPort = PortTelemetryHelper.GetBoxedPort(port);
+            tags.AddAttributeNetHostPort(boxedHostPort);
+            tags.AddAttributeServerPort(boxedHostPort);
+        }
 
         return tags.Build();
     }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/OpenTelemetry.Instrumentation.AWSLambda.csproj
@@ -37,6 +37,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AWS\*.cs" Link="Includes\AWS\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -72,7 +72,7 @@ internal sealed class HttpInListener : IDisposable
         if (options.EnableServerAttributesForRequestDuration)
         {
             tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
-            tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(url.Port));
+            tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(url.Port, cacheValue: true));
         }
 
         var protocolVersion = RequestDataHelperExtensions.GetHttpProtocolVersion(request);
@@ -137,7 +137,7 @@ internal sealed class HttpInListener : IDisposable
 
         var url = request.Url;
         tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
-        tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(url.Port));
+        tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(url.Port, cacheValue: true));
         tags.Add(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
         if (context.Request.Unvalidated?.Path is string path)

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -72,7 +72,7 @@ internal sealed class HttpInListener : IDisposable
         if (options.EnableServerAttributesForRequestDuration)
         {
             tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
-            tags.Add(SemanticConventions.AttributeServerPort, url.Port);
+            tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(url.Port));
         }
 
         var protocolVersion = RequestDataHelperExtensions.GetHttpProtocolVersion(request);
@@ -137,7 +137,7 @@ internal sealed class HttpInListener : IDisposable
 
         var url = request.Url;
         tags.Add(SemanticConventions.AttributeServerAddress, url.Host);
-        tags.Add(SemanticConventions.AttributeServerPort, url.Port);
+        tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(url.Port));
         tags.Add(SemanticConventions.AttributeUrlScheme, url.Scheme);
 
         if (context.Request.Unvalidated?.Path is string path)

--- a/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -242,7 +242,7 @@ internal class HttpInListener : ListenerHandler
 
                     if (request.Host.Port is { } port)
                     {
-                        activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port));
+                        activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port, cacheValue: true));
                     }
                 }
 
@@ -482,7 +482,9 @@ internal class HttpInListener : ListenerHandler
             activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, context.Connection.RemoteIpAddress.ToString());
         }
 
-        activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(context.Connection.RemotePort));
+        // Intentionally not using PortTelemetryHelper here: this is the client's ephemeral
+        // TCP source port, which is different on essentially every connection.
+        activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, context.Connection.RemotePort);
 
         var spanStatus = ActivityStatusCode.Unset;
         if (validStatusCode)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -484,7 +484,7 @@ internal class HttpInListener : ListenerHandler
 
         // Intentionally not using PortTelemetryHelper here: this is the client's ephemeral
         // TCP source port, which is different on essentially every connection.
-        activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, context.Connection.RemotePort);
+        activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(context.Connection.RemotePort));
 
         var spanStatus = ActivityStatusCode.Unset;
         if (validStatusCode)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -242,7 +242,7 @@ internal class HttpInListener : ListenerHandler
 
                     if (request.Host.Port is { } port)
                     {
-                        activity.SetTag(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(port));
+                        activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port));
                     }
                 }
 
@@ -482,7 +482,7 @@ internal class HttpInListener : ListenerHandler
             activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, context.Connection.RemoteIpAddress.ToString());
         }
 
-        activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, context.Connection.RemotePort);
+        activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(context.Connection.RemotePort));
 
         var spanStatus = ActivityStatusCode.Unset;
         if (validStatusCode)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -482,7 +482,7 @@ internal class HttpInListener : ListenerHandler
             activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, context.Connection.RemoteIpAddress.ToString());
         }
 
-        // Intentionally not using PortTelemetryHelper here: this is the client's ephemeral
+        // Intentionally not caching the port value here: this is the client's ephemeral
         // TCP source port, which is different on essentially every connection.
         activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(context.Connection.RemotePort));
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
@@ -10,52 +10,8 @@ internal static class TelemetryHelper
     public static readonly object[] BoxedStatusCodes = InitializeBoxedStatusCodes();
     internal static readonly RequestDataHelper RequestDataHelper = new(configureByHttpKnownMethodsEnvironmentalVariable: false);
 
-    // Boxed values for the most common ASP.NET Core server ports to avoid boxing server.port per request.
-    private static readonly object Port80 = 80;
-    private static readonly object Port443 = 443;
-    private static readonly object Port8080 = 8080;
-    private static readonly object Port5000 = 5000;
-    private static readonly object Port5001 = 5001;
-
-    // Single-value cache for any other (e.g. dynamically-assigned) port. The server's listening
-    // port is effectively constant for the lifetime of the process, so this avoids boxing on the
-    // common path. The Host header is client-controlled, so the cache is intentionally limited to
-    // a single entry; a miss simply boxes the value again. Reads/writes of a reference are atomic
-    // and a race only causes an occasional extra allocation, so no locking is required.
-    private static object? lastBoxedPort;
-
     public static object GetBoxedStatusCode(int statusCode) =>
         statusCode is >= 100 and < 600 ? BoxedStatusCodes[statusCode - 100] : statusCode;
-
-    public static object GetBoxedPort(int port)
-    {
-        // Reuse pre-boxed instances for the most common ports to avoid allocating.
-        var common = port switch
-        {
-            80 => Port80,
-            443 => Port443,
-            8080 => Port8080,
-            5000 => Port5000,
-            5001 => Port5001,
-            _ => null,
-        };
-
-        if (common is not null)
-        {
-            return common;
-        }
-
-        var last = lastBoxedPort;
-        if (last is not null && (int)last == port)
-        {
-            return last;
-        }
-
-        object boxed = port;
-        lastBoxedPort = boxed;
-
-        return boxed;
-    }
 
     private static object[] InitializeBoxedStatusCodes()
     {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
@@ -226,7 +226,7 @@ internal partial class ElasticsearchRequestPipelineDiagnosticListener : Listener
 
             if (uri.Port > 0)
             {
-                activity.SetTag(SemanticConventions.AttributeNetPeerPort, uri.Port);
+                activity.SetTag(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(uri.Port));
             }
 
             if (method != null)

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/Implementation/ElasticsearchRequestPipelineDiagnosticListener.cs
@@ -226,7 +226,7 @@ internal partial class ElasticsearchRequestPipelineDiagnosticListener : Listener
 
             if (uri.Port > 0)
             {
-                activity.SetTag(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(uri.Port));
+                activity.SetTag(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(uri.Port, cacheValue: true));
             }
 
             if (method != null)

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/OpenTelemetry.Instrumentation.ElasticsearchClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/OpenTelemetry.Instrumentation.ElasticsearchClient.csproj
@@ -35,6 +35,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MultiTypePropertyFetcher.cs" Link="Includes\MultiTypePropertyFetcher.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SpanHelper.cs" Link="Includes\SpanHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\UriHelper.cs" Link="Includes\UriHelper.cs" />

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\GrpcStatusCanonicalCode.cs" Link="Includes\GrpcStatusCanonicalCode.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -196,7 +196,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
 
         if (!uri.IsDefaultPort)
         {
-            activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(uri.Port));
+            activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(uri.Port, cacheValue: true));
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -196,7 +196,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
 
         if (!uri.IsDefaultPort)
         {
-            activity.SetTag(SemanticConventions.AttributeServerPort, GrpcTagHelper.GetBoxedPort(uri.Port));
+            activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(uri.Port));
         }
     }
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -116,7 +116,7 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
             if (requestUri != null)
             {
                 activity.SetTag(SemanticConventions.AttributeServerAddress, requestUri.Host);
-                var boxedPort = PortTelemetryHelper.GetBoxedPort(requestUri.Port);
+                var boxedPort = PortTelemetryHelper.GetBoxedPort(requestUri.Port, cacheValue: true);
                 activity.SetTag(SemanticConventions.AttributeServerPort, boxedPort);
 
                 var uriHostNameType = Uri.CheckHostName(requestUri.Host);
@@ -193,7 +193,7 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
                 if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                 {
                     activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, requestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(requestUri.Port));
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(requestUri.Port, cacheValue: true));
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -116,7 +116,7 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
             if (requestUri != null)
             {
                 activity.SetTag(SemanticConventions.AttributeServerAddress, requestUri.Host);
-                var boxedPort = GrpcTagHelper.GetBoxedPort(requestUri.Port);
+                var boxedPort = PortTelemetryHelper.GetBoxedPort(requestUri.Port);
                 activity.SetTag(SemanticConventions.AttributeServerPort, boxedPort);
 
                 var uriHostNameType = Uri.CheckHostName(requestUri.Host);
@@ -193,7 +193,7 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
                 if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                 {
                     activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, requestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, GrpcTagHelper.GetBoxedPort(requestUri.Port));
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(requestUri.Port));
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
@@ -32,6 +32,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ListenerHandler.cs" Link="Includes\ListenerHandler.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -143,7 +143,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 if (request.RequestUri != null)
                 {
                     activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port));
+                    activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port, cacheValue: true));
                     activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, this.options.DisableUrlQueryRedaction));
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -143,7 +143,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 if (request.RequestUri != null)
                 {
                     activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
-                    activity.SetTag(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port));
+                    activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port));
                     activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, this.options.DisableUrlQueryRedaction));
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -55,7 +55,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 
                 if (!request.RequestUri.IsDefaultPort)
                 {
-                    tags.Add(new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port)));
+                    tags.Add(new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port, cacheValue: true)));
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -55,7 +55,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 
                 if (!request.RequestUri.IsDefaultPort)
                 {
-                    tags.Add(new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port)));
+                    tags.Add(new KeyValuePair<string, object?>(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port)));
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -77,7 +77,7 @@ internal static class HttpWebRequestActivitySource
             HttpTagHelper.RequestDataHelper.SetHttpMethodTag(activity, request.Method);
 
             activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
-            activity.SetTag(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port));
+            activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port));
 
             activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, TracingOptions.DisableUrlQueryRedaction));
 
@@ -422,7 +422,7 @@ internal static class HttpWebRequestActivitySource
 
             if (!request.RequestUri.IsDefaultPort)
             {
-                tags.Add(SemanticConventions.AttributeServerPort, TelemetryHelper.GetBoxedPort(request.RequestUri.Port));
+                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port));
             }
 
             if (httpStatusCode is { } statusCode)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -77,7 +77,7 @@ internal static class HttpWebRequestActivitySource
             HttpTagHelper.RequestDataHelper.SetHttpMethodTag(activity, request.Method);
 
             activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
-            activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port));
+            activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port, cacheValue: true));
 
             activity.SetTag(SemanticConventions.AttributeUrlFull, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri, TracingOptions.DisableUrlQueryRedaction));
 
@@ -422,7 +422,7 @@ internal static class HttpWebRequestActivitySource
 
             if (!request.RequestUri.IsDefaultPort)
             {
-                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port));
+                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.RequestUri.Port, cacheValue: true));
             }
 
             if (httpStatusCode is { } statusCode)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/TelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/TelemetryHelper.cs
@@ -10,12 +10,6 @@ internal static class TelemetryHelper
 {
     public static readonly (object, string)[] BoxedStatusCodes = InitializeBoxedStatusCodes();
 
-    private static readonly object Port80 = 80;
-    private static readonly object Port443 = 443;
-    private static readonly object Port8080 = 8080;
-
-    private static object? lastBoxedPort;
-
     public static object GetBoxedStatusCode(HttpStatusCode statusCode)
     {
         var intStatusCode = (int)statusCode;
@@ -26,33 +20,6 @@ internal static class TelemetryHelper
     {
         var intStatusCode = (int)statusCode;
         return intStatusCode is >= 100 and < 600 ? BoxedStatusCodes[intStatusCode - 100].Item2 : statusCode.ToString();
-    }
-
-    public static object GetBoxedPort(int port)
-    {
-        var common = port switch
-        {
-            80 => Port80,
-            443 => Port443,
-            8080 => Port8080,
-            _ => null,
-        };
-
-        if (common is not null)
-        {
-            return common;
-        }
-
-        var last = lastBoxedPort;
-        if (last is not null && (int)last == port)
-        {
-            return last;
-        }
-
-        object boxed = port;
-        lastBoxedPort = boxed;
-
-        return boxed;
     }
 
     private static (object, string)[] InitializeBoxedStatusCodes()

--- a/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
+++ b/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />

--- a/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
@@ -165,7 +165,7 @@ internal sealed class KustoTraceRecordListener : KustoUtils.ITraceListener
 
             if (result.ServerPort is { } serverPort)
             {
-                var boxedServerPort = PortTelemetryHelper.GetBoxedPort(serverPort);
+                var boxedServerPort = PortTelemetryHelper.GetBoxedPort(serverPort, cacheValue: true);
                 activity?.AddTag(SemanticConventions.AttributeServerPort, boxedServerPort);
                 context.AddMeterTag(SemanticConventions.AttributeServerPort, boxedServerPort);
             }

--- a/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Kusto/Implementation/KustoTraceRecordListener.cs
@@ -163,10 +163,11 @@ internal sealed class KustoTraceRecordListener : KustoUtils.ITraceListener
                 context.AddMeterTag(SemanticConventions.AttributeServerAddress, result.ServerAddress);
             }
 
-            if (result.ServerPort is not null)
+            if (result.ServerPort is { } serverPort)
             {
-                activity?.AddTag(SemanticConventions.AttributeServerPort, result.ServerPort.Value);
-                context.AddMeterTag(SemanticConventions.AttributeServerPort, result.ServerPort.Value);
+                var boxedServerPort = PortTelemetryHelper.GetBoxedPort(serverPort);
+                activity?.AddTag(SemanticConventions.AttributeServerPort, boxedServerPort);
+                context.AddMeterTag(SemanticConventions.AttributeServerPort, boxedServerPort);
             }
 
             if (!result.Database.IsEmpty)

--- a/src/OpenTelemetry.Instrumentation.Kusto/OpenTelemetry.Instrumentation.Kusto.csproj
+++ b/src/OpenTelemetry.Instrumentation.Kusto/OpenTelemetry.Instrumentation.Kusto.csproj
@@ -41,6 +41,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
@@ -111,7 +111,7 @@ internal sealed class DiagnosticsMiddleware : OwinMiddleware
 
                 RequestDataHelper.SetHttpMethodTag(activity, request.Method);
                 activity.SetTag(SemanticConventions.AttributeServerAddress, request.Uri.Host);
-                activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.Uri.Port));
+                activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.Uri.Port, cacheValue: true));
                 activity.SetTag(
                     SemanticConventions.AttributeNetworkProtocolVersion,
                     RequestDataHelper.GetHttpProtocolVersion(request.Protocol));

--- a/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
+++ b/src/OpenTelemetry.Instrumentation.Owin/Implementation/DiagnosticsMiddleware.cs
@@ -111,7 +111,7 @@ internal sealed class DiagnosticsMiddleware : OwinMiddleware
 
                 RequestDataHelper.SetHttpMethodTag(activity, request.Method);
                 activity.SetTag(SemanticConventions.AttributeServerAddress, request.Uri.Host);
-                activity.SetTag(SemanticConventions.AttributeServerPort, request.Uri.Port);
+                activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(request.Uri.Port));
                 activity.SetTag(
                     SemanticConventions.AttributeNetworkProtocolVersion,
                     RequestDataHelper.GetHttpProtocolVersion(request.Protocol));

--- a/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
+++ b/src/OpenTelemetry.Instrumentation.Owin/OpenTelemetry.Instrumentation.Owin.csproj
@@ -23,6 +23,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MeterFactory.cs" Link="Includes\MeterFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RedactionHelper.cs" Link="Includes\RedactionHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RequestDataHelper.cs" Link="Includes\RequestDataHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs"/>

--- a/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
+++ b/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
@@ -298,7 +298,7 @@ internal sealed class TelemetryDynamicSink : IDynamicMessageSink
             tags.Add(SemanticConventions.AttributeServerAddress, host);
             if (port.HasValue)
             {
-                tags.Add(SemanticConventions.AttributeServerPort, port.Value);
+                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port.Value));
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
+++ b/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
@@ -298,7 +298,9 @@ internal sealed class TelemetryDynamicSink : IDynamicMessageSink
             tags.Add(SemanticConventions.AttributeServerAddress, host);
             if (port.HasValue)
             {
-                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port.Value, cacheValue: true));
+                // Not opting into the single-value cache: this is the target remote object's port,
+                // which can vary per call for a client that talks to multiple remote endpoints.
+                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port.Value));
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
+++ b/src/OpenTelemetry.Instrumentation.Remoting/Implementation/TelemetryDynamicSink.cs
@@ -298,7 +298,7 @@ internal sealed class TelemetryDynamicSink : IDynamicMessageSink
             tags.Add(SemanticConventions.AttributeServerAddress, host);
             if (port.HasValue)
             {
-                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port.Value));
+                tags.Add(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(port.Value, cacheValue: true));
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.Remoting/OpenTelemetry.Instrumentation.Remoting.csproj
+++ b/src/OpenTelemetry.Instrumentation.Remoting/OpenTelemetry.Instrumentation.Remoting.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -187,15 +187,16 @@ internal static class RedisProfilerEntryToActivityConverter
                 if (command.EndPoint is IPEndPoint ipEndPoint)
                 {
                     var address = ipEndPoint.Address.ToString();
+                    var port = PortTelemetryHelper.GetBoxedPort(ipEndPoint.Port);
                     activity.SetTag(SemanticConventions.AttributeServerAddress, address);
-                    activity.SetTag(SemanticConventions.AttributeServerPort, ipEndPoint.Port);
+                    activity.SetTag(SemanticConventions.AttributeServerPort, port);
                     activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, address);
-                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, ipEndPoint.Port);
+                    activity.SetTag(SemanticConventions.AttributeNetworkPeerPort, port);
                 }
                 else if (command.EndPoint is DnsEndPoint dnsEndPoint)
                 {
                     activity.SetTag(SemanticConventions.AttributeServerAddress, dnsEndPoint.Host);
-                    activity.SetTag(SemanticConventions.AttributeServerPort, dnsEndPoint.Port);
+                    activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(dnsEndPoint.Port));
                 }
 #if NET
                 else if (command.EndPoint is UnixDomainSocketEndPoint unixDomainSocketEndPoint)

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -187,7 +187,7 @@ internal static class RedisProfilerEntryToActivityConverter
                 if (command.EndPoint is IPEndPoint ipEndPoint)
                 {
                     var address = ipEndPoint.Address.ToString();
-                    var port = PortTelemetryHelper.GetBoxedPort(ipEndPoint.Port);
+                    var port = PortTelemetryHelper.GetBoxedPort(ipEndPoint.Port, cacheValue: true);
                     activity.SetTag(SemanticConventions.AttributeServerAddress, address);
                     activity.SetTag(SemanticConventions.AttributeServerPort, port);
                     activity.SetTag(SemanticConventions.AttributeNetworkPeerAddress, address);
@@ -196,7 +196,7 @@ internal static class RedisProfilerEntryToActivityConverter
                 else if (command.EndPoint is DnsEndPoint dnsEndPoint)
                 {
                     activity.SetTag(SemanticConventions.AttributeServerAddress, dnsEndPoint.Host);
-                    activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(dnsEndPoint.Port));
+                    activity.SetTag(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(dnsEndPoint.Port, cacheValue: true));
                 }
 #if NET
                 else if (command.EndPoint is UnixDomainSocketEndPoint unixDomainSocketEndPoint)

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
@@ -166,13 +166,13 @@ internal static class ClientChannelInstrumentation
             if (options?.EmitOldRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeNetPeerName, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeNetPeerPort, remoteAddressUri.Port));
+                tags.Add(new(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
             }
 
             if (options?.EmitNewRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeServerAddress, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeServerPort, remoteAddressUri.Port));
+                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
 
                 if (remoteAddressUri.Host is { Length: > 0 } host)
                 {
@@ -181,7 +181,7 @@ internal static class ClientChannelInstrumentation
                     if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                     {
                         tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, host));
-                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, remoteAddressUri.Port));
+                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
                     }
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
@@ -161,18 +161,20 @@ internal static class ClientChannelInstrumentation
             tags.Add(new(SemanticConventions.AttributeRpcSystemName, WcfInstrumentationConstants.WcfSystemValue));
         }
 
+        // Not opting into the single-value cache for remoteAddressUri.Port below: this is the target
+        // WCF service's port, which can vary per call for a client that talks to multiple downstream services.
         if (remoteAddressUri != null)
         {
             if (options?.EmitOldRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeNetPeerName, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port, cacheValue: true)));
+                tags.Add(new(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
             }
 
             if (options?.EmitNewRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeServerAddress, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port, cacheValue: true)));
+                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
 
                 if (remoteAddressUri.Host is { Length: > 0 } host)
                 {
@@ -181,7 +183,7 @@ internal static class ClientChannelInstrumentation
                     if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                     {
                         tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, host));
-                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port, cacheValue: true)));
+                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
                     }
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
@@ -161,20 +161,22 @@ internal static class ClientChannelInstrumentation
             tags.Add(new(SemanticConventions.AttributeRpcSystemName, WcfInstrumentationConstants.WcfSystemValue));
         }
 
-        // Not opting into the single-value cache for remoteAddressUri.Port below: this is the target
-        // WCF service's port, which can vary per call for a client that talks to multiple downstream services.
         if (remoteAddressUri != null)
         {
+            // Not opting into the single-value cache: this is the target WCF service's port,
+            // which can vary per call for a client that talks to multiple downstream services.
+            var port = PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port);
+
             if (options?.EmitOldRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeNetPeerName, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
+                tags.Add(new(SemanticConventions.AttributeNetPeerPort, port));
             }
 
             if (options?.EmitNewRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeServerAddress, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
+                tags.Add(new(SemanticConventions.AttributeServerPort, port));
 
                 if (remoteAddressUri.Host is { Length: > 0 } host)
                 {
@@ -183,7 +185,7 @@ internal static class ClientChannelInstrumentation
                     if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                     {
                         tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, host));
-                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
+                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, port));
                     }
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/ClientChannelInstrumentation.cs
@@ -166,13 +166,13 @@ internal static class ClientChannelInstrumentation
             if (options?.EmitOldRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeNetPeerName, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
+                tags.Add(new(SemanticConventions.AttributeNetPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port, cacheValue: true)));
             }
 
             if (options?.EmitNewRpcAttributes is true)
             {
                 tags.Add(new(SemanticConventions.AttributeServerAddress, remoteAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
+                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port, cacheValue: true)));
 
                 if (remoteAddressUri.Host is { Length: > 0 } host)
                 {
@@ -181,7 +181,7 @@ internal static class ClientChannelInstrumentation
                     if (uriHostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
                     {
                         tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, host));
-                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port)));
+                        tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteAddressUri.Port, cacheValue: true)));
                     }
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
@@ -211,13 +211,13 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
             if (options.EmitOldRpcAttributes)
             {
                 tags.Add(new(SemanticConventions.AttributeNetHostName, localAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeNetHostPort, localAddressUri.Port));
+                tags.Add(new(SemanticConventions.AttributeNetHostPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port)));
             }
 
             if (options.EmitNewRpcAttributes)
             {
                 tags.Add(new(SemanticConventions.AttributeServerAddress, localAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeServerPort, localAddressUri.Port));
+                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port)));
             }
 
             tags.Add(new(WcfInstrumentationConstants.AttributeWcfChannelScheme, localAddressUri.Scheme));
@@ -232,7 +232,7 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
             !string.IsNullOrEmpty(remoteEndpoint.Address))
         {
             tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, remoteEndpoint.Address));
-            tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, remoteEndpoint.Port));
+            tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteEndpoint.Port)));
         }
 
         return tags;

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
@@ -211,13 +211,13 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
             if (options.EmitOldRpcAttributes)
             {
                 tags.Add(new(SemanticConventions.AttributeNetHostName, localAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeNetHostPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port)));
+                tags.Add(new(SemanticConventions.AttributeNetHostPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port, cacheValue: true)));
             }
 
             if (options.EmitNewRpcAttributes)
             {
                 tags.Add(new(SemanticConventions.AttributeServerAddress, localAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port)));
+                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port, cacheValue: true)));
             }
 
             tags.Add(new(WcfInstrumentationConstants.AttributeWcfChannelScheme, localAddressUri.Scheme));
@@ -232,7 +232,7 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
             !string.IsNullOrEmpty(remoteEndpoint.Address))
         {
             tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, remoteEndpoint.Address));
-            tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteEndpoint.Port)));
+            tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteEndpoint.Port, cacheValue: true)));
         }
 
         return tags;

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
@@ -208,16 +208,18 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
         var localAddressUri = channel.LocalAddress?.Uri;
         if (localAddressUri != null)
         {
+            var port = PortTelemetryHelper.GetBoxedPort(localAddressUri.Port, cacheValue: true);
+
             if (options.EmitOldRpcAttributes)
             {
                 tags.Add(new(SemanticConventions.AttributeNetHostName, localAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeNetHostPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port, cacheValue: true)));
+                tags.Add(new(SemanticConventions.AttributeNetHostPort, port));
             }
 
             if (options.EmitNewRpcAttributes)
             {
                 tags.Add(new(SemanticConventions.AttributeServerAddress, localAddressUri.Host));
-                tags.Add(new(SemanticConventions.AttributeServerPort, PortTelemetryHelper.GetBoxedPort(localAddressUri.Port, cacheValue: true)));
+                tags.Add(new(SemanticConventions.AttributeServerPort, port));
             }
 
             tags.Add(new(WcfInstrumentationConstants.AttributeWcfChannelScheme, localAddressUri.Scheme));
@@ -233,7 +235,7 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
         {
             tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, remoteEndpoint.Address));
 
-            // Intentionally not using PortTelemetryHelper here: this is the client's
+            // Intentionally not caching the port value here: this is the client's
             // ephemeral source port, which is different on essentially every connection.
             tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteEndpoint.Port)));
         }

--- a/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
+++ b/src/OpenTelemetry.Instrumentation.Wcf/Implementation/TelemetryDispatchMessageInspector.cs
@@ -232,7 +232,10 @@ internal class TelemetryDispatchMessageInspector : IDispatchMessageInspector
             !string.IsNullOrEmpty(remoteEndpoint.Address))
         {
             tags.Add(new(SemanticConventions.AttributeNetworkPeerAddress, remoteEndpoint.Address));
-            tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteEndpoint.Port, cacheValue: true)));
+
+            // Intentionally not using PortTelemetryHelper here: this is the client's
+            // ephemeral source port, which is different on essentially every connection.
+            tags.Add(new(SemanticConventions.AttributeNetworkPeerPort, PortTelemetryHelper.GetBoxedPort(remoteEndpoint.Port)));
         }
 
         return tags;

--- a/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
+++ b/src/OpenTelemetry.Instrumentation.Wcf/OpenTelemetry.Instrumentation.Wcf.csproj
@@ -39,6 +39,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\PortTelemetryHelper.cs" Link="Includes\PortTelemetryHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\RpcSemanticConventionHelper.cs" Link="Includes\RpcSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SchemaUrls.cs" Link="Includes\SchemaUrls.cs" />

--- a/src/Shared/GrpcTagHelper.cs
+++ b/src/Shared/GrpcTagHelper.cs
@@ -29,39 +29,6 @@ internal static class GrpcTagHelper
     public const string GrpcStatusCodeTagName = "grpc.status_code";
     public const string GrpcTargetTagName = "grpc.target";
 
-    private static readonly object Port80 = 80;
-    private static readonly object Port443 = 443;
-    private static readonly object Port8080 = 8080;
-
-    private static object? lastBoxedPort;
-
-    public static object GetBoxedPort(int port)
-    {
-        var common = port switch
-        {
-            80 => Port80,
-            443 => Port443,
-            8080 => Port8080,
-            _ => null,
-        };
-
-        if (common is not null)
-        {
-            return common;
-        }
-
-        var last = lastBoxedPort;
-        if (last is not null && (int)last == port)
-        {
-            return last;
-        }
-
-        object boxed = port;
-        lastBoxedPort = boxed;
-
-        return boxed;
-    }
-
     public static string? GetGrpcMethodFromActivity(Activity activity)
         => activity.GetTagValue(GrpcMethodTagName) as string;
 

--- a/src/Shared/PortTelemetryHelper.cs
+++ b/src/Shared/PortTelemetryHelper.cs
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Instrumentation;
+
+/// <summary>
+/// Helper class for caching boxed port numbers to avoid boxing allocations when setting
+/// port-valued tags (e.g. <c>server.port</c>, <c>network.peer.port</c>) on a hot request path.
+/// </summary>
+internal static class PortTelemetryHelper
+{
+    private static readonly object Port80 = 80;
+    private static readonly object Port443 = 443;
+    private static readonly object Port8080 = 8080;
+    private static readonly object Port5000 = 5000;
+    private static readonly object Port5001 = 5001;
+
+    // Single-value cache for any other (e.g. dynamically-assigned) port. A server/client's port is
+    // effectively constant for the lifetime of the process, so this avoids boxing on the common path.
+    // Reads/writes of a reference are atomic and a race only causes an occasional extra allocation,
+    // so no locking is required.
+    private static object? lastBoxedPort;
+
+    public static object GetBoxedPort(int port)
+    {
+        // Reuse pre-boxed instances for the most common ports to avoid allocating.
+        var common = port switch
+        {
+            80 => Port80,
+            443 => Port443,
+            8080 => Port8080,
+            5000 => Port5000,
+            5001 => Port5001,
+            _ => null,
+        };
+
+        if (common is not null)
+        {
+            return common;
+        }
+
+        var last = lastBoxedPort;
+        if (last is not null && (int)last == port)
+        {
+            return last;
+        }
+
+        object boxed = port;
+        lastBoxedPort = boxed;
+
+        return boxed;
+    }
+}

--- a/src/Shared/PortTelemetryHelper.cs
+++ b/src/Shared/PortTelemetryHelper.cs
@@ -15,13 +15,24 @@ internal static class PortTelemetryHelper
     private static readonly object Port5000 = 5000;
     private static readonly object Port5001 = 5001;
 
-    // Single-value cache for any other (e.g. dynamically-assigned) port. A server/client's port is
-    // effectively constant for the lifetime of the process, so this avoids boxing on the common path.
-    // Reads/writes of a reference are atomic and a race only causes an occasional extra allocation,
-    // so no locking is required.
+    // Single-value cache for any other (e.g. dynamically-assigned) port. Only useful when the caller's
+    // port is effectively constant for the lifetime of the process (e.g. a server's own listening
+    // port) so that this avoids boxing on the common path. Reads/writes of a reference are atomic and
+    // a race only causes an occasional extra allocation, so no locking is required. Callers whose port
+    // varies per call (e.g. a client targeting many different remote ports) should not opt in.
     private static object? lastBoxedPort;
 
-    public static object GetBoxedPort(int port)
+    /// <summary>
+    /// Gets a boxed instance of <paramref name="port"/>, avoiding a fresh boxing allocation where possible.
+    /// </summary>
+    /// <param name="port">The port number to box.</param>
+    /// <param name="cacheValue">
+    /// Whether to fall back to the single-value cache when <paramref name="port"/> is not one of the
+    /// common, pre-boxed ports. Only pass <see langword="true"/> when the port is expected to be
+    /// effectively constant for the process's lifetime; otherwise the cache will rarely hit.
+    /// </param>
+    /// <returns>A boxed <see cref="int"/> equal to <paramref name="port"/>.</returns>
+    public static object GetBoxedPort(int port, bool cacheValue = false)
     {
         // Reuse pre-boxed instances for the most common ports to avoid allocating.
         var common = port switch
@@ -37,6 +48,11 @@ internal static class PortTelemetryHelper
         if (common is not null)
         {
             return common;
+        }
+
+        if (!cacheValue)
+        {
+            return port;
         }
 
         var last = lastBoxedPort;

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -112,6 +112,40 @@ public partial class GrpcTests(WeaverFixture weaver, ITestOutputHelper outputHel
     }
 
     [Fact]
+    public void GrpcClientCallToIpLiteralSetsNetworkPeerTagsOnStop()
+    {
+        var uri = new UriBuilder("http://127.0.0.1") { Port = 1234 }.Uri;
+
+        using var httpClient = ClientTestHelpers.CreateTestClient(async request =>
+        {
+            var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply());
+            var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: global::Grpc.Core.StatusCode.OK);
+            response.RequestMessage = request;
+            return response;
+        });
+
+        var exportedItems = new List<Activity>();
+
+        using (Sdk.CreateTracerProviderBuilder()
+                .SetSampler(new AlwaysOnSampler())
+                .AddGrpcClientInstrumentation()
+                .AddInMemoryExporter(exportedItems)
+                .Build())
+        {
+            var channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions
+            {
+                HttpClient = httpClient,
+            });
+            var client = new Greeter.GreeterClient(channel);
+            _ = client.SayHello(new HelloRequest());
+        }
+
+        var activity = Assert.Single(exportedItems);
+        Assert.Equal("127.0.0.1", activity.GetTagValue(SemanticConventions.AttributeNetworkPeerAddress));
+        Assert.Equal(1234, activity.GetTagValue(SemanticConventions.AttributeNetworkPeerPort));
+    }
+
+    [Fact]
     public void GrpcClientCancelledCallIsRecordedAsErrorPerSemanticConventions()
     {
         // The gRPC semantic conventions specify that, for client spans, all status codes

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -120,7 +120,7 @@ public partial class GrpcTests(WeaverFixture weaver, ITestOutputHelper outputHel
         {
             var streamContent = await ClientTestHelpers.CreateResponseContent(new HelloReply());
             var response = ResponseUtils.CreateResponse(HttpStatusCode.OK, streamContent, grpcStatusCode: global::Grpc.Core.StatusCode.OK);
-            response.RequestMessage = request;
+            response.RequestMessage!.RequestUri = request.RequestUri;
             return response;
         });
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpHandlerMetricsDiagnosticListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpHandlerMetricsDiagnosticListenerTests.cs
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+using OpenTelemetry.Instrumentation.Http.Implementation;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.Http.Tests;
+
+public class HttpHandlerMetricsDiagnosticListenerTests
+{
+    [Fact]
+    public void OnStopEventWrittenSetsServerPortTagForNonDefaultPort()
+    {
+        var metricItems = new List<Metric>();
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(HttpHandlerMetricsDiagnosticListener.Meter.Name)
+            .AddInMemoryExporter(metricItems)
+            .Build();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://example.com:8080/"));
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Version = new Version(1, 1) };
+
+        using var activity = new Activity("test").Start();
+
+        var listener = new HttpHandlerMetricsDiagnosticListener("HttpHandlerDiagnosticListener");
+        listener.OnEventWritten(HttpHandlerMetricsDiagnosticListener.OnStopEvent, new { Request = request, Response = response });
+
+        meterProvider.Dispose();
+
+        var metric = Assert.Single(metricItems, m => m.Name == "http.client.request.duration");
+
+        var metricPoints = new List<MetricPoint>();
+        foreach (var point in metric.GetMetricPoints())
+        {
+            metricPoints.Add(point);
+        }
+
+        var metricPoint = Assert.Single(metricPoints);
+
+        var attributes = new Dictionary<string, object?>();
+        foreach (var tag in metricPoint.Tags)
+        {
+            attributes[tag.Key] = tag.Value;
+        }
+
+        Assert.Equal(8080, attributes[SemanticConventions.AttributeServerPort]);
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
@@ -1,7 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections;
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.Remoting.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -159,6 +161,29 @@ public class RemotingInstrumentationTests
         Assert.Equal(expectedServiceName, TelemetryDynamicSinkProvider.ExtractServiceName(typeName));
 
     [Fact]
+    public void TelemetryDynamicSink_SetsServerAddressAndPortWhenUriIsAbsoluteWithNonDefaultPort()
+    {
+        var activities = new List<Activity>();
+        using var provider = new TelemetryDynamicSinkProvider(
+            new TestOptionsMonitor<RemotingInstrumentationOptions>(new RemotingInstrumentationOptions()));
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(TelemetryDynamicSinkProvider.ActivitySourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        var sink = provider.GetDynamicSink();
+        var message = new FakeMethodMessage("tcp://remote-host:8080/RemoteObject.rem", typeof(RemoteObject).AssemblyQualifiedName!, "DoStuff");
+
+        sink.ProcessMessageStart(message, bCliSide: true, bAsync: false);
+        sink.ProcessMessageFinish(message, bCliSide: true, bAsync: false);
+
+        var activity = Assert.Single(activities);
+        Assert.Equal("remote-host", activity.GetTagItem(SemanticConventions.AttributeServerAddress));
+        Assert.Equal(8080, activity.GetTagItem(SemanticConventions.AttributeServerPort));
+    }
+
+    [Fact]
     public void TelemetryDynamicSinkProvider_BoundsServiceNameCache()
     {
         using var provider = new TelemetryDynamicSinkProvider(
@@ -207,6 +232,45 @@ public class RemotingInstrumentationTests
                 throw new Exception(exceptionMessage);
             }
         }
+    }
+
+    private sealed class FakeMethodMessage : IMethodMessage
+    {
+        public FakeMethodMessage(string uri, string typeName, string methodName)
+        {
+            this.Uri = uri;
+            this.TypeName = typeName;
+            this.MethodName = methodName;
+
+            // LogicalCallContext has no accessible constructor; the runtime only ever hands out
+            // instances it creates itself, so one is created reflectively for this fake message.
+            this.LogicalCallContext = (LogicalCallContext)Activator.CreateInstance(typeof(LogicalCallContext), nonPublic: true)!;
+            this.Properties = new Hashtable { ["__CallContext"] = this.LogicalCallContext };
+        }
+
+        public string Uri { get; }
+
+        public string MethodName { get; }
+
+        public string TypeName { get; }
+
+        public object MethodSignature => Array.Empty<Type>();
+
+        public MethodBase MethodBase => null!;
+
+        public int ArgCount => 0;
+
+        public object[] Args => [];
+
+        public bool HasVarArgs => false;
+
+        public LogicalCallContext LogicalCallContext { get; }
+
+        public IDictionary Properties { get; }
+
+        public object GetArg(int argNum) => throw new NotSupportedException();
+
+        public string GetArgName(int index) => throw new NotSupportedException();
     }
 
     private sealed class TestOptionsMonitor<TOptions> : IOptionsMonitor<TOptions>

--- a/test/OpenTelemetry.Instrumentation.Wcf.Tests/ClientChannelInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Wcf.Tests/ClientChannelInstrumentationTests.cs
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.ServiceModel.Channels;
+using OpenTelemetry.Instrumentation.Wcf.Implementation;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.Wcf.Tests;
+
+[Collection("WCF")]
+public class ClientChannelInstrumentationTests
+{
+    [Fact]
+    public void BeforeSendRequestSetsNetworkPeerTagsForIpLiteralRemoteAddress()
+    {
+        var stoppedActivities = new List<Activity>();
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = stoppedActivities.Add,
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        WcfInstrumentationActivitySource.Options = new WcfInstrumentationOptions { EmitNewRpcAttributes = true };
+
+        try
+        {
+            using var message = Message.CreateMessage(MessageVersion.Default, "http://opentelemetry.io/Service/Execute");
+
+            var state = ClientChannelInstrumentation.BeforeSendRequest(message, new Uri("http://127.0.0.1:8080/Service"));
+            state.Activity?.Stop();
+            state.SuppressionScope?.Dispose();
+
+            var activity = Assert.Single(stoppedActivities);
+            Assert.Equal("127.0.0.1", activity.GetTagItem(SemanticConventions.AttributeNetworkPeerAddress));
+            Assert.Equal(8080, activity.GetTagItem(SemanticConventions.AttributeNetworkPeerPort));
+        }
+        finally
+        {
+            WcfInstrumentationActivitySource.Options = null;
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Avoid boxing port numbers in instrumentation.
- Remove duplicated code for avoiding port boxing and centralise into one helper.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
