### PR TITLE
[Dynamic Control] Phase 4: Add ordered, coalesced PolicyStore subscriptions

### DIFF
--- a/src/OpenTelemetry.DynamicControl/CHANGELOG.md
+++ b/src/OpenTelemetry.DynamicControl/CHANGELOG.md
@@ -17,4 +17,8 @@
   policy/source ordering via `PolicyKeyComparer`.
   ([#5017](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5017))
 
+* Added ordered, store-change subscriptions to the internal `PolicyStore` via a
+  new `PolicyChangeNotifier`/`PolicyChangeSubscription` pair.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 For more details, please refer to the [README](README.md).

--- a/src/OpenTelemetry.DynamicControl/CHANGELOG.md
+++ b/src/OpenTelemetry.DynamicControl/CHANGELOG.md
@@ -19,6 +19,6 @@
 
 * Added ordered, store-change subscriptions to the internal `PolicyStore` via a
   new `PolicyChangeNotifier`/`PolicyChangeSubscription` pair.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#5135](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5135))
 
 For more details, please refer to the [README](README.md).

--- a/src/OpenTelemetry.DynamicControl/Internal/Diagnostics/DynamicControlEventSource.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Diagnostics/DynamicControlEventSource.cs
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Tracing;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.DynamicControl.Internal.Diagnostics;
+
+/// <summary>
+/// The <see cref="EventSource"/> for this component's internal diagnostics.
+/// </summary>
+[EventSource(Name = "OpenTelemetry-DynamicControl")]
+internal sealed class DynamicControlEventSource : EventSource
+{
+    public static readonly DynamicControlEventSource Log = new();
+
+    private const int EventIdPolicyChangeSubscriberFailure = 1;
+
+    /// <summary>
+    /// Records that a policy change subscriber's callback threw an exception. The
+    /// exception is isolated to the subscription that raised it; it does not affect the
+    /// store, other subscribers, or the commit that triggered the notification.
+    /// </summary>
+    /// <param name="ex">The exception thrown by the subscriber callback.</param>
+    [NonEvent]
+    public void PolicyChangeSubscriberException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.PolicyChangeSubscriberFailure(ex.ToInvariantString());
+        }
+    }
+
+    [Event(EventIdPolicyChangeSubscriberFailure, Message = "Policy change subscriber callback failed: {0}", Level = EventLevel.Warning)]
+    public void PolicyChangeSubscriberFailure(string exception)
+    {
+        this.WriteEvent(EventIdPolicyChangeSubscriberFailure, exception);
+    }
+}

--- a/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeNotifier.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeNotifier.cs
@@ -69,7 +69,7 @@ internal sealed class PolicyChangeNotifier : IDisposable
             var current = this.subscribers;
             var updated = new PolicyChangeSubscription[current.Length + 1];
             Array.Copy(current, updated, current.Length);
-            updated[current.Length] = subscription;
+            updated[updated.Length - 1] = subscription;
             Volatile.Write(ref this.subscribers, updated);
 
             return subscription;
@@ -77,7 +77,7 @@ internal sealed class PolicyChangeNotifier : IDisposable
     }
 
     /// <summary>
-    /// Removes a subscription. Called by <see cref="PolicyChangeSubscription.Dispose"/>.
+    /// Removes a subscription.
     /// </summary>
     /// <param name="subscription">The subscription to remove.</param>
     internal void Remove(PolicyChangeSubscription subscription)

--- a/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeNotifier.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeNotifier.cs
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.DynamicControl.Internal.Store;
+
+/// <summary>
+/// Owns the set of subscriptions registered against a <see cref="PolicyStore"/> and
+/// dispatches published snapshots to them.
+/// </summary>
+internal sealed class PolicyChangeNotifier : IDisposable
+{
+    private static readonly PolicyChangeSubscription[] EmptySubscribers = [];
+
+    private readonly Lock registrationLock = new();
+
+    // The subscriber list is a copy-on-write array.
+    private PolicyChangeSubscription[] subscribers = EmptySubscribers;
+    private bool disposed;
+
+    /// <summary>
+    /// Gets a read-only view of the currently registered subscriptions.
+    /// </summary>
+    internal ReadOnlySpan<PolicyChangeSubscription> Subscribers =>
+        Volatile.Read(ref this.subscribers); // The array is copy-on-write, so it is safe to read without a lock.
+
+    /// <summary>
+    /// Disposes every currently registered subscription.
+    /// </summary>
+    public void Dispose()
+    {
+        PolicyChangeSubscription[] current;
+
+        lock (this.registrationLock)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            current = this.subscribers;
+            Volatile.Write(ref this.subscribers, EmptySubscribers);
+        }
+
+        foreach (var subscription in current)
+        {
+            subscription.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Registers a new subscription.
+    /// </summary>
+    /// <param name="onChanged">The callback to invoke with each delivered snapshot.</param>
+    /// <returns>The new subscription. Disposing it stops future delivery and removes it from this notifier.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="onChanged"/> is null.</exception>
+    /// <exception cref="ObjectDisposedException">The notifier has been disposed.</exception>
+    internal PolicyChangeSubscription Add(Action<PolicyStoreSnapshot> onChanged)
+    {
+        Guard.ThrowIfNull(onChanged);
+
+        lock (this.registrationLock)
+        {
+            this.ThrowIfDisposed();
+
+            var subscription = new PolicyChangeSubscription(onChanged, this);
+            var current = this.subscribers;
+            var updated = new PolicyChangeSubscription[current.Length + 1];
+            Array.Copy(current, updated, current.Length);
+            updated[current.Length] = subscription;
+            Volatile.Write(ref this.subscribers, updated);
+
+            return subscription;
+        }
+    }
+
+    /// <summary>
+    /// Removes a subscription. Called by <see cref="PolicyChangeSubscription.Dispose"/>.
+    /// </summary>
+    /// <param name="subscription">The subscription to remove.</param>
+    internal void Remove(PolicyChangeSubscription subscription)
+    {
+        lock (this.registrationLock)
+        {
+            var current = this.subscribers;
+            var index = Array.IndexOf(current, subscription);
+            if (index < 0)
+            {
+                return;
+            }
+
+            if (current.Length == 1)
+            {
+                Volatile.Write(ref this.subscribers, EmptySubscribers);
+                return;
+            }
+
+            var updated = new PolicyChangeSubscription[current.Length - 1];
+            Array.Copy(current, updated, index);
+            Array.Copy(current, index + 1, updated, index, current.Length - index - 1);
+            Volatile.Write(ref this.subscribers, updated);
+        }
+    }
+
+#if NET
+    private void ThrowIfDisposed() =>
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+#else
+    private void ThrowIfDisposed()
+    {
+        if (this.disposed)
+        {
+            throw new ObjectDisposedException(nameof(PolicyChangeNotifier));
+        }
+    }
+#endif
+}

--- a/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeSubscription.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeSubscription.cs
@@ -72,6 +72,10 @@ internal sealed class PolicyChangeSubscription : IDisposable
             }
 
             this.lastSeenRevision = snapshot.Revision;
+
+            // Coalesce rather than queue every revision or block the committer: the
+            // telemetry-policy OTEP requires async, fail-open updates, so dropping a
+            // superseded revision here is intentional, not a bug.
             this.pending = snapshot;
 
             if (this.dispatching)

--- a/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeSubscription.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeSubscription.cs
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.DynamicControl.Internal.Diagnostics;
+
+namespace OpenTelemetry.DynamicControl.Internal.Store;
+
+/// <summary>
+/// Represents a subscription to policy changes.
+/// </summary>
+/// <remarks>
+/// Callbacks are asynchronous and serialized per subscription. Delivered revisions never
+/// decrease, but pending notifications may be coalesced to the newest snapshot. Changes
+/// triggered by a callback are delivered after that callback completes. Callback exceptions
+/// are reported through <see cref="DynamicControlEventSource"/> and do not stop subsequent
+/// delivery.
+/// </remarks>
+internal sealed class PolicyChangeSubscription : IDisposable
+{
+    private readonly Lock gate = new();
+
+    private Action<PolicyStoreSnapshot>? onChanged;
+    private PolicyChangeNotifier? owner;
+    private PolicyStoreSnapshot? pending;
+    private long lastSeenRevision = -1;
+    private bool dispatching;
+    private bool disposed;
+
+    internal PolicyChangeSubscription(Action<PolicyStoreSnapshot> onChanged, PolicyChangeNotifier owner)
+    {
+        this.onChanged = onChanged;
+        this.owner = owner;
+    }
+
+    /// <summary>
+    /// Unregisters the subscription and discards pending delivery. A callback already in
+    /// progress may complete.
+    /// </summary>
+    public void Dispose()
+    {
+        PolicyChangeNotifier? owner;
+
+        lock (this.gate)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.pending = null;
+            this.onChanged = null;
+            owner = this.owner;
+            this.owner = null;
+        }
+
+        owner?.Remove(this);
+    }
+
+    /// <summary>
+    /// Queues a snapshot for delivery. A newer snapshot may replace one that is still pending.
+    /// </summary>
+    /// <param name="snapshot">The snapshot to deliver.</param>
+    internal void Enqueue(PolicyStoreSnapshot snapshot)
+    {
+        lock (this.gate)
+        {
+            // Concurrent notifications can arrive out of order; never deliver an older revision.
+            if (this.disposed || snapshot.Revision <= this.lastSeenRevision)
+            {
+                return;
+            }
+
+            this.lastSeenRevision = snapshot.Revision;
+            this.pending = snapshot;
+
+            if (this.dispatching)
+            {
+                return;
+            }
+
+            this.dispatching = true;
+        }
+
+        ThreadPool.UnsafeQueueUserWorkItem(static state => ((PolicyChangeSubscription)state!).Drain(), this);
+    }
+
+    private void Drain()
+    {
+        while (true)
+        {
+            PolicyStoreSnapshot? snapshot;
+            Action<PolicyStoreSnapshot>? onChanged;
+
+            lock (this.gate)
+            {
+                onChanged = this.onChanged;
+                if (this.disposed || this.pending is null || onChanged is null)
+                {
+                    this.dispatching = false;
+                    return;
+                }
+
+                snapshot = this.pending;
+                this.pending = null;
+            }
+
+            try
+            {
+                onChanged(snapshot);
+            }
+            catch (Exception ex)
+            {
+                DynamicControlEventSource.Log.PolicyChangeSubscriberException(ex);
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyStore.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyStore.cs
@@ -7,51 +7,76 @@ using OpenTelemetry.Internal;
 namespace OpenTelemetry.DynamicControl.Internal.Store;
 
 /// <summary>
-/// A copy-on-write holder for the complete set of per-source policy snapshots.
+/// Stores the current set of per-source policy snapshots.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Reads are lock-free: <see cref="Current"/> reads via <see cref="Volatile.Read{T}"/>
-/// and returns a point-in-time value. Callers must capture <see cref="Current"/> once
+/// Reads are lock-free. Callers must capture <see cref="Current"/> once
 /// and work from that instance; re-reading mid-operation can observe a newer revision
 /// and produce incorrect results.
 /// </para>
 /// <para>
 /// Updates are serialized under a single lock. Each accepted change builds and publishes
-/// a new <see cref="PolicyStoreSnapshot"/>, reusing unchanged
-/// <see cref="PolicySourceSnapshot"/> instances by reference. The cost of a commit is
-/// proportional to the number of sources, not the number of policies.
+/// a new <see cref="PolicyStoreSnapshot"/>.
 /// </para>
 /// </remarks>
-internal sealed class PolicyStore
+internal sealed class PolicyStore : IDisposable
 {
     private readonly Lock updateLock = new();
 
-    // Mutable working set.
     private readonly Dictionary<SourceRegistrationId, PolicySourceSnapshot> sources = [];
 
-    // Maximum sequence seen per source. Governs staleness for both Applied and
-    // SuppressedUnchangedVersion outcomes. Separate from the snapshot so suppression
-    // can advance the sequence without altering the published state.
+    // Suppressed submissions still advance the sequence used for staleness checks.
     private readonly Dictionary<SourceRegistrationId, long> maxSequence = [];
 
-    // The currently published snapshot.
+    private readonly PolicyChangeNotifier notifier = new();
+
     private PolicyStoreSnapshot current = PolicyStoreSnapshot.Empty;
 
     /// <summary>
     /// Gets the current store snapshot.
     /// </summary>
     /// <remarks>
-    /// This is a point-in-time value. Capture it once and work from that instance;
-    /// re-reading this property mid-operation can observe a newer revision published
-    /// by a concurrent update and produce incorrect results.
+    /// Capture the snapshot once per operation to avoid mixing revisions.
     /// </remarks>
     public PolicyStoreSnapshot Current => Volatile.Read(ref this.current);
 
     /// <summary>
+    /// Subscribes to policy changes, starting with the current snapshot.
+    /// </summary>
+    /// <remarks>
+    /// Registration does not miss concurrent updates. Delivery follows the guarantees
+    /// documented by <see cref="PolicyChangeSubscription"/>.
+    /// </remarks>
+    /// <param name="onChanged">The callback to invoke with each delivered snapshot.</param>
+    /// <returns>A handle that stops delivery when disposed.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="onChanged"/> is null.</exception>
+    /// <exception cref="ObjectDisposedException">The store has been disposed.</exception>
+    public IDisposable Subscribe(Action<PolicyStoreSnapshot> onChanged)
+    {
+        Guard.ThrowIfNull(onChanged);
+
+        PolicyChangeSubscription subscription;
+        PolicyStoreSnapshot initialSnapshot;
+
+        lock (this.updateLock)
+        {
+            // Registration and snapshot capture must be atomic with respect to publication.
+            subscription = this.notifier.Add(onChanged);
+            initialSnapshot = this.current;
+        }
+
+        subscription.Enqueue(initialSnapshot);
+        return subscription;
+    }
+
+    /// <summary>
+    /// Stops all subscriptions without waiting for callbacks already in progress.
+    /// </summary>
+    public void Dispose() => this.notifier.Dispose();
+
+    /// <summary>
     /// Replaces the policy set for the source described by <paramref name="snapshot"/>.
-    /// The submission is evaluated against metadata consistency, sequence staleness, and
-    /// version suppression gates before being applied.
     /// </summary>
     /// <param name="snapshot">The new snapshot to commit.</param>
     /// <returns>The outcome of the submission and the current (resulting or unchanged) snapshot.</returns>
@@ -61,45 +86,43 @@ internal sealed class PolicyStore
         Guard.ThrowIfNull(snapshot);
 
         var id = snapshot.RegistrationId;
+        PolicyStoreSnapshot newSnapshot;
+        ReadOnlySpan<PolicyChangeSubscription> subscribers;
 
         lock (this.updateLock)
         {
-            // Gate 1: metadata mismatch. Checked before staleness so a configuration
-            // defect surfaces even when the offending submission is also stale.
             if (this.sources.TryGetValue(id, out var existing)
                 && !existing.Metadata.Equals(snapshot.Metadata))
             {
                 return new PolicyStoreUpdateResult(PolicyStoreUpdateStatus.RejectedMetadataMismatch, this.current);
             }
 
-            // Gate 2: staleness.
             if (this.maxSequence.TryGetValue(id, out var maxSeq)
                 && snapshot.Sequence <= maxSeq)
             {
                 return new PolicyStoreUpdateResult(PolicyStoreUpdateStatus.RejectedStaleSequence, this.current);
             }
 
-            // Gate 3: version suppression. Advance the maximum sequence even on
-            // suppression to prevent a lower-sequence later submission from winning.
             if (!snapshot.Version.IsEmpty
                 && existing != null
                 && snapshot.Version.Equals(existing.Version))
             {
-                // Gate 2 above guarantees snapshot.Sequence > maxSeq; this assignment always increases the value.
                 this.maxSequence[id] = snapshot.Sequence;
                 return new PolicyStoreUpdateResult(PolicyStoreUpdateStatus.SuppressedUnchangedVersion, this.current);
             }
 
-            // Apply: replace the source entry, advance the maximum sequence, and
-            // publish a new snapshot.
             this.sources[id] = snapshot;
             this.maxSequence[id] = snapshot.Sequence;
 
-            var newSnapshot = new PolicyStoreSnapshot(this.current.Revision + 1, this.sources);
+            newSnapshot = new PolicyStoreSnapshot(this.current.Revision + 1, this.sources);
             Volatile.Write(ref this.current, newSnapshot);
 
-            return new PolicyStoreUpdateResult(PolicyStoreUpdateStatus.Applied, newSnapshot);
+            subscribers = this.notifier.Subscribers;
         }
+
+        Notify(subscribers, newSnapshot);
+
+        return new PolicyStoreUpdateResult(PolicyStoreUpdateStatus.Applied, newSnapshot);
     }
 
     /// <summary>
@@ -125,6 +148,9 @@ internal sealed class PolicyStore
     {
         Guard.ThrowIfDefault(registrationId);
 
+        PolicyStoreSnapshot newSnapshot;
+        ReadOnlySpan<PolicyChangeSubscription> subscribers;
+
         lock (this.updateLock)
         {
             if (!this.sources.Remove(registrationId))
@@ -134,10 +160,22 @@ internal sealed class PolicyStore
 
             this.maxSequence.Remove(registrationId);
 
-            var newSnapshot = new PolicyStoreSnapshot(this.current.Revision + 1, this.sources);
+            newSnapshot = new PolicyStoreSnapshot(this.current.Revision + 1, this.sources);
             Volatile.Write(ref this.current, newSnapshot);
 
-            return new PolicyStoreUpdateResult(PolicyStoreUpdateStatus.Applied, newSnapshot);
+            subscribers = this.notifier.Subscribers;
+        }
+
+        Notify(subscribers, newSnapshot);
+
+        return new PolicyStoreUpdateResult(PolicyStoreUpdateStatus.Applied, newSnapshot);
+    }
+
+    private static void Notify(ReadOnlySpan<PolicyChangeSubscription> subscribers, PolicyStoreSnapshot snapshot)
+    {
+        foreach (var subscription in subscribers)
+        {
+            subscription.Enqueue(snapshot);
         }
     }
 }

--- a/src/OpenTelemetry.DynamicControl/OpenTelemetry.DynamicControl.csproj
+++ b/src/OpenTelemetry.DynamicControl/OpenTelemetry.DynamicControl.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Lock.cs" Link="Includes\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -22,6 +22,7 @@
       When adding projects here please also update the verify-aot-compat job in
       .github\workflows\ci.yml so that it runs for the project(s) being added.
     -->
+    <TrimmerRootAssembly Include="OpenTelemetry.DynamicControl" />
     <TrimmerRootAssembly Include="OpenTelemetry.Exporter.Geneva" />
     <TrimmerRootAssembly Include="OpenTelemetry.Exporter.OneCollector" />
     <TrimmerRootAssembly Include="OpenTelemetry.Extensions" />

--- a/test/OpenTelemetry.DynamicControl.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/EventSourceTests.cs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.DynamicControl.Internal.Diagnostics;
+using OpenTelemetry.Tests;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+public class EventSourceTests
+{
+    [Fact]
+    public void EventSourceTests_DynamicControlEventSource()
+        => EventSourceTestHelper.ValidateEventSourceIds<DynamicControlEventSource>();
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/OpenTelemetry.DynamicControl.Tests.csproj
+++ b/test/OpenTelemetry.DynamicControl.Tests/OpenTelemetry.DynamicControl.Tests.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework'">

--- a/test/OpenTelemetry.DynamicControl.Tests/OpenTelemetry.DynamicControl.Tests.csproj
+++ b/test/OpenTelemetry.DynamicControl.Tests/OpenTelemetry.DynamicControl.Tests.csproj
@@ -10,6 +10,10 @@
     <ProjectReference Include="..\..\src\OpenTelemetry.DynamicControl\OpenTelemetry.DynamicControl.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework'">
     <PackageReference Include="System.Memory" VersionOverride="4.6.3" />
   </ItemGroup>

--- a/test/OpenTelemetry.DynamicControl.Tests/OpenTelemetry.DynamicControl.Tests.csproj
+++ b/test/OpenTelemetry.DynamicControl.Tests/OpenTelemetry.DynamicControl.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETFramework'">

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeNotifierTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeNotifierTests.cs
@@ -1,0 +1,128 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.DynamicControl.Internal.Store;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+public class PolicyChangeNotifierTests
+{
+    [Fact]
+    public void Add_ReturnsSubscription_IncludedInSubscribers()
+    {
+        var notifier = new PolicyChangeNotifier();
+
+        var subscription = notifier.Add(_ => { });
+
+        Assert.Same(subscription, notifier.Subscribers[0]);
+    }
+
+    [Fact]
+    public void Add_NullCallback_Throws()
+    {
+        var notifier = new PolicyChangeNotifier();
+
+        Assert.Throws<ArgumentNullException>(() => notifier.Add(null!));
+    }
+
+    [Fact]
+    public void Add_MultipleSubscriptions_AllIncluded()
+    {
+        var notifier = new PolicyChangeNotifier();
+
+        var first = notifier.Add(_ => { });
+        var second = notifier.Add(_ => { });
+
+        Assert.Equal(2, notifier.Subscribers.Length);
+        Assert.Same(first, notifier.Subscribers[0]);
+        Assert.Same(second, notifier.Subscribers[1]);
+    }
+
+    [Fact]
+    public void Remove_ViaDispose_NoLongerInSubscribers()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var kept = notifier.Add(_ => { });
+        var removed = notifier.Add(_ => { });
+
+        removed.Dispose();
+
+        Assert.Equal(1, notifier.Subscribers.Length);
+        Assert.Same(kept, notifier.Subscribers[0]);
+    }
+
+    [Fact]
+    public void Remove_NotRegistered_NoOp()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var other = new PolicyChangeNotifier().Add(_ => { });
+
+        // Removing a subscription that was never added to this notifier must not throw
+        // or otherwise disturb this notifier's own subscriber list.
+        notifier.Remove(other);
+
+        Assert.True(notifier.Subscribers.IsEmpty);
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllSubscriptions_SubscribersEmpty()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var deliveries = new List<PolicyStoreSnapshot>();
+        notifier.Add(s => deliveries.Add(s));
+        notifier.Add(s => deliveries.Add(s));
+
+        notifier.Dispose();
+
+        Assert.True(notifier.Subscribers.IsEmpty);
+    }
+
+    [Fact]
+    public void Add_AfterDispose_Throws()
+    {
+        var notifier = new PolicyChangeNotifier();
+        notifier.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => notifier.Add(_ => { }));
+        Assert.True(notifier.Subscribers.IsEmpty);
+    }
+
+    [Fact]
+    public void Dispose_MultipleTimes_NoOp()
+    {
+        var notifier = new PolicyChangeNotifier();
+        notifier.Add(_ => { });
+
+        notifier.Dispose();
+        notifier.Dispose();
+
+        Assert.True(notifier.Subscribers.IsEmpty);
+    }
+
+    [Fact]
+    public async Task Add_ConcurrentWithRemove_SubscribersNeverTorn()
+    {
+        const int operationCount = 500;
+        var notifier = new PolicyChangeNotifier();
+        var errors = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        var addTasks = Enumerable.Range(0, operationCount).Select(_ => Task.Run(() => notifier.Add(_ => { })));
+
+        var readTasks = Enumerable.Range(0, operationCount).Select(_ => Task.Run(() =>
+        {
+            var subscribers = notifier.Subscribers;
+            for (var i = 0; i < subscribers.Length; i++)
+            {
+                if (subscribers[i] is null)
+                {
+                    errors.Add("Null entry observed in subscriber array");
+                }
+            }
+        }));
+
+        await Task.WhenAll(addTasks.Concat(readTasks));
+
+        Assert.Empty(errors);
+        Assert.Equal(operationCount, notifier.Subscribers.Length);
+    }
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeNotifierTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeNotifierTests.cs
@@ -99,6 +99,27 @@ public class PolicyChangeNotifierTests
         Assert.True(notifier.Subscribers.IsEmpty);
     }
 
+    [Theory]
+    [InlineData(2, 0)] // 2 elements, remove first
+    [InlineData(2, 1)] // 2 elements, remove last
+    [InlineData(3, 0)] // 3 elements, remove first
+    [InlineData(3, 1)] // 3 elements, remove middle
+    [InlineData(3, 2)] // 3 elements, remove last
+    public void Remove_BoundaryIndex_KeepsRemainingInOrder(int subscriberCount, int indexToRemove)
+    {
+        var notifier = new PolicyChangeNotifier();
+        var subscriptions = new PolicyChangeSubscription[subscriberCount];
+        for (var i = 0; i < subscriberCount; i++)
+        {
+            subscriptions[i] = notifier.Add(_ => { });
+        }
+
+        subscriptions[indexToRemove].Dispose();
+
+        var expected = subscriptions.Where((_, i) => i != indexToRemove).ToArray();
+        Assert.Equal(expected, notifier.Subscribers.ToArray());
+    }
+
     [Fact]
     public async Task Add_ConcurrentWithRemove_SubscribersNeverTorn()
     {

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeSubscriptionTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeSubscriptionTests.cs
@@ -1,0 +1,217 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Tracing;
+using OpenTelemetry.DynamicControl.Internal.Diagnostics;
+using OpenTelemetry.DynamicControl.Internal.Store;
+using OpenTelemetry.Tests;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+public class PolicyChangeSubscriptionTests
+{
+    [Fact]
+    public async Task Enqueue_SingleSnapshot_Delivered()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+        var subscription = notifier.Add(s => delivered.Enqueue(s));
+
+        subscription.Enqueue(SnapshotAtRevision(1));
+
+        await WaitUntil(() => delivered.Count == 1);
+        Assert.Equal(1, delivered.Single().Revision);
+    }
+
+    [Fact]
+    public async Task Enqueue_WhileDispatching_CoalescesToLatest()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+        using var callbackStarted = new SemaphoreSlim(0);
+        using var releaseCallback = new SemaphoreSlim(0);
+        var firstCallback = true;
+
+        var subscription = notifier.Add(s =>
+        {
+            if (firstCallback)
+            {
+                firstCallback = false;
+                callbackStarted.Release();
+                releaseCallback.Wait(TimeSpan.FromSeconds(10));
+            }
+
+            delivered.Enqueue(s);
+        });
+
+        subscription.Enqueue(SnapshotAtRevision(1));
+        await callbackStarted.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Enqueue several more snapshots while the first callback is still blocked.
+        // Only the newest should ever be delivered next.
+        subscription.Enqueue(SnapshotAtRevision(2));
+        subscription.Enqueue(SnapshotAtRevision(3));
+        subscription.Enqueue(SnapshotAtRevision(4));
+
+        releaseCallback.Release();
+
+        await WaitUntil(() => delivered.Count == 2);
+
+        var results = delivered.ToArray();
+        Assert.Equal(1, results[0].Revision);
+        Assert.Equal(4, results[1].Revision);
+    }
+
+    [Fact]
+    public async Task Enqueue_NeverOverlapsCallbackInvocations()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var overlapDetected = false;
+        var concurrentCount = 0;
+
+        var subscription = notifier.Add(_ =>
+        {
+            if (Interlocked.Increment(ref concurrentCount) > 1)
+            {
+                overlapDetected = true;
+            }
+
+            Thread.Sleep(1);
+            Interlocked.Decrement(ref concurrentCount);
+        });
+
+        for (var i = 1; i <= 50; i++)
+        {
+            subscription.Enqueue(SnapshotAtRevision(i));
+        }
+
+        await WaitUntil(() => Volatile.Read(ref concurrentCount) == 0, 5000);
+        Assert.False(overlapDetected, "Callback invocations for one subscription must never overlap");
+    }
+
+    [Fact]
+    public async Task Enqueue_CallbackThrows_ExceptionIsolated_SubsequentDeliverySucceeds()
+    {
+        using var listener = new InMemoryEventListener(DynamicControlEventSource.Log, EventLevel.Warning);
+        var notifier = new PolicyChangeNotifier();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+
+        var subscription = notifier.Add(s =>
+        {
+            if (s.Revision == 1)
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            delivered.Enqueue(s);
+        });
+
+        subscription.Enqueue(SnapshotAtRevision(1));
+        await WaitUntil(() => listener.Events.Any(e => e.EventId == 1));
+
+        subscription.Enqueue(SnapshotAtRevision(2));
+        await WaitUntil(() => delivered.Count == 1);
+
+        Assert.Equal(2, delivered.Single().Revision);
+        Assert.Contains(listener.Events, e => e.EventId == 1 && e.Payload!.Single() is string message && message.Contains("boom"));
+    }
+
+    [Fact]
+    public async Task Dispose_StopsFutureDelivery()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+        var subscription = notifier.Add(s => delivered.Enqueue(s));
+
+        subscription.Enqueue(SnapshotAtRevision(1));
+        await WaitUntil(() => delivered.Count == 1);
+
+        subscription.Dispose();
+        subscription.Enqueue(SnapshotAtRevision(2));
+
+        await Task.Delay(50);
+        Assert.Single(delivered);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotWaitForInFlightCallback()
+    {
+        var notifier = new PolicyChangeNotifier();
+        using var callbackStarted = new SemaphoreSlim(0);
+        using var releaseCallback = new SemaphoreSlim(0);
+
+        var subscription = notifier.Add(_ =>
+        {
+            callbackStarted.Release();
+            releaseCallback.Wait(TimeSpan.FromSeconds(10));
+        });
+
+        subscription.Enqueue(SnapshotAtRevision(1));
+        Assert.True(callbackStarted.Wait(TimeSpan.FromSeconds(10)));
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        subscription.Dispose();
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds < 1000, "Dispose must not block on an in-flight callback");
+        releaseCallback.Release();
+    }
+
+    [Fact]
+    public async Task Dispose_WhileCallbackInProgress_DropsPendingDelivery()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<long>();
+        using var callbackStarted = new SemaphoreSlim(0);
+        using var releaseCallback = new SemaphoreSlim(0);
+
+        var subscription = notifier.Add(snapshot =>
+        {
+            callbackStarted.Release();
+            releaseCallback.Wait(TimeSpan.FromSeconds(10));
+            delivered.Enqueue(snapshot.Revision);
+        });
+
+        subscription.Enqueue(SnapshotAtRevision(1));
+        await callbackStarted.WaitAsync(TimeSpan.FromSeconds(10));
+
+        subscription.Enqueue(SnapshotAtRevision(2));
+        subscription.Dispose();
+        releaseCallback.Release();
+
+        await WaitUntil(() => delivered.Count == 1);
+        await Task.Delay(50);
+
+        Assert.Equal([1], delivered);
+        Assert.True(notifier.Subscribers.IsEmpty);
+    }
+
+    [Fact]
+    public void Dispose_MultipleTimes_NoOp()
+    {
+        var notifier = new PolicyChangeNotifier();
+        var subscription = notifier.Add(_ => { });
+
+        subscription.Dispose();
+        subscription.Dispose();
+
+        Assert.True(notifier.Subscribers.IsEmpty);
+    }
+
+    private static PolicyStoreSnapshot SnapshotAtRevision(long revision)
+        => new(revision, []);
+
+    private static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 5000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (sw.ElapsedMilliseconds > timeoutMilliseconds)
+            {
+                Assert.Fail("Timed out waiting for condition.");
+            }
+
+            await Task.Delay(5);
+        }
+    }
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeSubscriptionTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeSubscriptionTests.cs
@@ -19,7 +19,7 @@ public class PolicyChangeSubscriptionTests
 
         subscription.Enqueue(SnapshotAtRevision(1));
 
-        await WaitUntil(() => delivered.Count == 1);
+        await WaitHelper.WaitUntil(() => delivered.Count == 1);
         Assert.Equal(1, delivered.Single().Revision);
     }
 
@@ -55,7 +55,7 @@ public class PolicyChangeSubscriptionTests
 
         releaseCallback.Release();
 
-        await WaitUntil(() => delivered.Count == 2);
+        await WaitHelper.WaitUntil(() => delivered.Count == 2);
 
         var results = delivered.ToArray();
         Assert.Equal(1, results[0].Revision);
@@ -85,7 +85,7 @@ public class PolicyChangeSubscriptionTests
             subscription.Enqueue(SnapshotAtRevision(i));
         }
 
-        await WaitUntil(() => Volatile.Read(ref concurrentCount) == 0, 5000);
+        await WaitHelper.WaitUntil(() => Volatile.Read(ref concurrentCount) == 0, 5000);
         Assert.False(overlapDetected, "Callback invocations for one subscription must never overlap");
     }
 
@@ -107,10 +107,10 @@ public class PolicyChangeSubscriptionTests
         });
 
         subscription.Enqueue(SnapshotAtRevision(1));
-        await WaitUntil(() => listener.Events.Any(e => e.EventId == 1));
+        await WaitHelper.WaitUntil(() => listener.Events.Any(e => e.EventId == 1));
 
         subscription.Enqueue(SnapshotAtRevision(2));
-        await WaitUntil(() => delivered.Count == 1);
+        await WaitHelper.WaitUntil(() => delivered.Count == 1);
 
         Assert.Equal(2, delivered.Single().Revision);
         Assert.Contains(listener.Events, e => e.EventId == 1 && e.Payload!.Single() is string message && message.Contains("boom"));
@@ -124,7 +124,7 @@ public class PolicyChangeSubscriptionTests
         var subscription = notifier.Add(s => delivered.Enqueue(s));
 
         subscription.Enqueue(SnapshotAtRevision(1));
-        await WaitUntil(() => delivered.Count == 1);
+        await WaitHelper.WaitUntil(() => delivered.Count == 1);
 
         subscription.Dispose();
         subscription.Enqueue(SnapshotAtRevision(2));
@@ -179,7 +179,7 @@ public class PolicyChangeSubscriptionTests
         subscription.Dispose();
         releaseCallback.Release();
 
-        await WaitUntil(() => delivered.Count == 1);
+        await WaitHelper.WaitUntil(() => delivered.Count == 1);
         await Task.Delay(50);
 
         Assert.Equal([1], delivered);
@@ -200,18 +200,4 @@ public class PolicyChangeSubscriptionTests
 
     private static PolicyStoreSnapshot SnapshotAtRevision(long revision)
         => new(revision, []);
-
-    private static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 5000)
-    {
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (!condition())
-        {
-            if (sw.ElapsedMilliseconds > timeoutMilliseconds)
-            {
-                Assert.Fail("Timed out waiting for condition.");
-            }
-
-            await Task.Delay(5);
-        }
-    }
 }

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
@@ -1,0 +1,165 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using OpenTelemetry.DynamicControl.Internal.Sources;
+using OpenTelemetry.DynamicControl.Internal.Store;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+/// <summary>
+/// Bounded, multi-thread tests for the store-subscription guarantees, following the
+/// repo's existing thread-safety test precedent.
+/// </summary>
+public class PolicyStoreConcurrencyTests
+{
+    [Fact]
+    public async Task Subscribe_ConcurrentWithCommit_DoesNotMissCommittedSnapshot()
+    {
+        const int attemptCount = 100;
+
+        for (var attempt = 0; attempt < attemptCount; attempt++)
+        {
+            var store = new PolicyStore();
+            var delivered = new ConcurrentQueue<long>();
+            var meta = new PolicySourceMetadata(new SourceRegistrationId($"source-{attempt}"), PolicySourceKind.File);
+            using var start = new ManualResetEventSlim();
+            IDisposable? subscription = null;
+
+            var subscribeTask = Task.Run(() =>
+            {
+                start.Wait();
+                subscription = store.Subscribe(snapshot => delivered.Enqueue(snapshot.Revision));
+            });
+
+            var commitTask = Task.Run(() =>
+            {
+                start.Wait();
+                PolicySourceSnapshot.TryCreate(meta, sequence: 1, PolicySourceVersion.Empty, [], out var snapshot, out _);
+                store.ReplaceSource(snapshot!);
+            });
+
+            start.Set();
+            await Task.WhenAll(subscribeTask, commitTask);
+
+            Assert.NotNull(subscription);
+            using (subscription)
+            {
+                await WaitUntil(() => !delivered.IsEmpty && delivered.Last() == store.Current.Revision);
+                Assert.Equal(1, store.Current.Revision);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Subscribe_ManyConcurrentCommits_DeliveredRevisionsNeverDecrease_ConvergeToFinal()
+    {
+        const int producerCount = 6;
+        const int commitsPerProducer = 500;
+        var store = new PolicyStore();
+
+        var deliveredA = new ConcurrentQueue<long>();
+        var deliveredB = new ConcurrentQueue<long>();
+        var reentrancyA = 0;
+        var reentrancyB = 0;
+        var overlapDetected = false;
+
+        using var subscriptionA = store.Subscribe(s =>
+        {
+            if (Interlocked.Increment(ref reentrancyA) > 1)
+            {
+                overlapDetected = true;
+            }
+
+            deliveredA.Enqueue(s.Revision);
+            Interlocked.Decrement(ref reentrancyA);
+        });
+
+        using var subscriptionB = store.Subscribe(s =>
+        {
+            if (Interlocked.Increment(ref reentrancyB) > 1)
+            {
+                overlapDetected = true;
+            }
+
+            deliveredB.Enqueue(s.Revision);
+            Interlocked.Decrement(ref reentrancyB);
+        });
+
+        var producers = Enumerable.Range(0, producerCount).Select(p => Task.Run(() =>
+        {
+            var meta = new PolicySourceMetadata(new SourceRegistrationId($"source-{p}"), PolicySourceKind.File);
+            for (var seq = 1L; seq <= commitsPerProducer; seq++)
+            {
+                PolicySourceSnapshot.TryCreate(meta, seq, PolicySourceVersion.Empty, [], out var snapshot, out _);
+                store.ReplaceSource(snapshot!);
+            }
+        }));
+
+        await Task.WhenAll(producers);
+
+        var finalRevision = store.Current.Revision;
+        Assert.Equal(producerCount * commitsPerProducer, finalRevision);
+
+        await WaitUntil(() => !deliveredA.IsEmpty && deliveredA.Last() == finalRevision);
+        await WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == finalRevision);
+
+        Assert.False(overlapDetected, "Callback invocations for one subscription must never overlap");
+        AssertNonDecreasing(deliveredA.ToArray());
+        AssertNonDecreasing(deliveredB.ToArray());
+    }
+
+    [Fact]
+    public async Task Subscribe_DisposeMidRun_StopsRecordingFurtherRevisions()
+    {
+        const int commitCount = 500;
+        var store = new PolicyStore();
+        var delivered = new ConcurrentQueue<long>();
+        var subscription = store.Subscribe(s => delivered.Enqueue(s.Revision));
+        var meta = new PolicySourceMetadata(new SourceRegistrationId("source-a"), PolicySourceKind.File);
+
+        var producer = Task.Run(() =>
+        {
+            for (var seq = 1L; seq <= commitCount; seq++)
+            {
+                PolicySourceSnapshot.TryCreate(meta, seq, PolicySourceVersion.Empty, [], out var snapshot, out _);
+                store.ReplaceSource(snapshot!);
+
+                if (seq == commitCount / 2)
+                {
+                    subscription.Dispose();
+                }
+            }
+        });
+
+        await producer;
+        await Task.Delay(50); // allow any in-flight delivery to finish
+
+        var countAfterDisposal = delivered.Count;
+        await Task.Delay(50);
+
+        Assert.Equal(countAfterDisposal, delivered.Count);
+    }
+
+    private static void AssertNonDecreasing(long[] revisions)
+    {
+        for (var i = 1; i < revisions.Length; i++)
+        {
+            Assert.True(revisions[i] >= revisions[i - 1], "Delivered revisions must never run backwards");
+        }
+    }
+
+    private static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 10_000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (sw.ElapsedMilliseconds > timeoutMilliseconds)
+            {
+                Assert.Fail("Timed out waiting for condition.");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
@@ -22,7 +22,7 @@ public class PolicyStoreConcurrencyTests
         {
             var store = new PolicyStore();
             var delivered = new ConcurrentQueue<long>();
-            var meta = new PolicySourceMetadata(new SourceRegistrationId($"source-{attempt}"), PolicySourceKind.File);
+            var sourceId = $"source-{attempt}";
             using var start = new ManualResetEventSlim();
             IDisposable? subscription = null;
 
@@ -35,8 +35,7 @@ public class PolicyStoreConcurrencyTests
             var commitTask = Task.Run(() =>
             {
                 start.Wait();
-                PolicySourceSnapshot.TryCreate(meta, sequence: 1, PolicySourceVersion.Empty, [], out var snapshot, out _);
-                store.ReplaceSource(snapshot!);
+                store.ReplaceSource(CreateSnapshot(sourceId, sequence: 1));
             });
 
             start.Set();
@@ -88,11 +87,10 @@ public class PolicyStoreConcurrencyTests
 
         var producers = Enumerable.Range(0, producerCount).Select(p => Task.Run(() =>
         {
-            var meta = new PolicySourceMetadata(new SourceRegistrationId($"source-{p}"), PolicySourceKind.File);
+            var sourceId = $"source-{p}";
             for (var seq = 1L; seq <= commitsPerProducer; seq++)
             {
-                PolicySourceSnapshot.TryCreate(meta, seq, PolicySourceVersion.Empty, [], out var snapshot, out _);
-                store.ReplaceSource(snapshot!);
+                store.ReplaceSource(CreateSnapshot(sourceId, seq));
             }
         }));
 
@@ -116,14 +114,13 @@ public class PolicyStoreConcurrencyTests
         var store = new PolicyStore();
         var delivered = new ConcurrentQueue<long>();
         var subscription = store.Subscribe(s => delivered.Enqueue(s.Revision));
-        var meta = new PolicySourceMetadata(new SourceRegistrationId("source-a"), PolicySourceKind.File);
+        var sourceId = "source-a";
 
         var producer = Task.Run(() =>
         {
             for (var seq = 1L; seq <= commitCount; seq++)
             {
-                PolicySourceSnapshot.TryCreate(meta, seq, PolicySourceVersion.Empty, [], out var snapshot, out _);
-                store.ReplaceSource(snapshot!);
+                store.ReplaceSource(CreateSnapshot(sourceId, seq));
 
                 if (seq == commitCount / 2)
                 {
@@ -139,6 +136,13 @@ public class PolicyStoreConcurrencyTests
         await Task.Delay(50);
 
         Assert.Equal(countAfterDisposal, delivered.Count);
+    }
+
+    private static PolicySourceSnapshot CreateSnapshot(string sourceId, long sequence)
+    {
+        var meta = new PolicySourceMetadata(new SourceRegistrationId(sourceId), PolicySourceKind.File);
+        PolicySourceSnapshot.TryCreate(meta, sequence, PolicySourceVersion.Empty, [], out var snapshot, out _);
+        return snapshot!;
     }
 
     private static void AssertNonDecreasing(long[] revisions)

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
@@ -44,7 +44,7 @@ public class PolicyStoreConcurrencyTests
             Assert.NotNull(subscription);
             using (subscription)
             {
-                await WaitUntil(() => !delivered.IsEmpty && delivered.Last() == store.Current.Revision);
+                await WaitHelper.WaitUntil(() => !delivered.IsEmpty && delivered.Last() == store.Current.Revision);
                 Assert.Equal(1, store.Current.Revision);
             }
         }
@@ -99,8 +99,8 @@ public class PolicyStoreConcurrencyTests
         var finalRevision = store.Current.Revision;
         Assert.Equal(producerCount * commitsPerProducer, finalRevision);
 
-        await WaitUntil(() => !deliveredA.IsEmpty && deliveredA.Last() == finalRevision);
-        await WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == finalRevision);
+        await WaitHelper.WaitUntil(() => !deliveredA.IsEmpty && deliveredA.Last() == finalRevision);
+        await WaitHelper.WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == finalRevision);
 
         Assert.False(overlapDetected, "Callback invocations for one subscription must never overlap");
         AssertNonDecreasing(deliveredA.ToArray());
@@ -150,20 +150,6 @@ public class PolicyStoreConcurrencyTests
         for (var i = 1; i < revisions.Length; i++)
         {
             Assert.True(revisions[i] >= revisions[i - 1], "Delivered revisions must never run backwards");
-        }
-    }
-
-    private static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 10_000)
-    {
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (!condition())
-        {
-            if (sw.ElapsedMilliseconds > timeoutMilliseconds)
-            {
-                Assert.Fail("Timed out waiting for condition.");
-            }
-
-            await Task.Delay(10);
         }
     }
 }

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSubscriptionTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSubscriptionTests.cs
@@ -1,0 +1,131 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.DynamicControl.Internal.Sources;
+using OpenTelemetry.DynamicControl.Internal.Store;
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+public class PolicyStoreSubscriptionTests
+{
+    [Fact]
+    public async Task Subscribe_OnEmptyStore_ReplaysEmptySnapshot()
+    {
+        var store = new PolicyStore();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+
+        using var subscription = store.Subscribe(s => delivered.Enqueue(s));
+
+        await WaitUntil(() => !delivered.IsEmpty);
+        Assert.Same(PolicyStoreSnapshot.Empty, delivered.Single());
+    }
+
+    [Fact]
+    public async Task Subscribe_AfterCommits_ReplaysCurrentSnapshot_NotEarlierOnes()
+    {
+        var store = new PolicyStore();
+        Replace(store, "source-a", sequence: 1);
+        Replace(store, "source-a", sequence: 2);
+        var expected = store.Current;
+
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+        using var subscription = store.Subscribe(s => delivered.Enqueue(s));
+
+        await WaitUntil(() => !delivered.IsEmpty);
+        Assert.Same(expected, delivered.First());
+    }
+
+    [Fact]
+    public async Task Subscribe_ThenCommit_DeliversNewSnapshot()
+    {
+        var store = new PolicyStore();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+        using var subscription = store.Subscribe(s => delivered.Enqueue(s));
+        await WaitUntil(() => !delivered.IsEmpty); // initial replay
+
+        Replace(store, "source-a", sequence: 1);
+
+        await WaitUntil(() => delivered.Count >= 2);
+        Assert.Equal(store.Current.Revision, delivered.Last().Revision);
+    }
+
+    [Fact]
+    public async Task Subscribe_MultipleIndependentSubscriptions_EachReceivesOwnOrderedStream()
+    {
+        var store = new PolicyStore();
+        var deliveredA = new System.Collections.Concurrent.ConcurrentQueue<long>();
+        var deliveredB = new System.Collections.Concurrent.ConcurrentQueue<long>();
+
+        using var subscriptionA = store.Subscribe(s => deliveredA.Enqueue(s.Revision));
+        using var subscriptionB = store.Subscribe(s => deliveredB.Enqueue(s.Revision));
+
+        for (var i = 1; i <= 5; i++)
+        {
+            Replace(store, "source-a", sequence: i);
+        }
+
+        await WaitUntil(() => !deliveredA.IsEmpty && deliveredA.Last() == 5);
+        await WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == 5);
+
+        AssertNonDecreasing(deliveredA.ToArray());
+        AssertNonDecreasing(deliveredB.ToArray());
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllLiveSubscriptions()
+    {
+        var store = new PolicyStore();
+        var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
+        var subscription = store.Subscribe(s => delivered.Enqueue(s));
+
+        store.Dispose();
+
+        // Further commits after disposal must not deliver to the now-disposed subscription.
+        Replace(store, "source-a", sequence: 1);
+    }
+
+    [Fact]
+    public void Subscribe_NullCallback_Throws()
+    {
+        var store = new PolicyStore();
+        Assert.Throws<ArgumentNullException>(() => store.Subscribe(null!));
+    }
+
+    [Fact]
+    public void Subscribe_AfterDispose_Throws()
+    {
+        var store = new PolicyStore();
+        store.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => store.Subscribe(_ => { }));
+    }
+
+    private static void AssertNonDecreasing(long[] revisions)
+    {
+        for (var i = 1; i < revisions.Length; i++)
+        {
+            Assert.True(revisions[i] >= revisions[i - 1], "Delivered revisions must never run backwards");
+        }
+    }
+
+    private static void Replace(PolicyStore store, string idValue, long sequence)
+    {
+        var meta = new PolicySourceMetadata(new SourceRegistrationId(idValue), PolicySourceKind.File);
+        PolicySourceSnapshot.TryCreate(meta, sequence, PolicySourceVersion.Empty, [], out var snapshot, out _);
+        store.ReplaceSource(snapshot!);
+    }
+
+    private static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 5000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (sw.ElapsedMilliseconds > timeoutMilliseconds)
+            {
+                Assert.Fail("Timed out waiting for condition.");
+            }
+
+            await Task.Delay(5);
+        }
+    }
+}

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSubscriptionTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSubscriptionTests.cs
@@ -16,7 +16,7 @@ public class PolicyStoreSubscriptionTests
 
         using var subscription = store.Subscribe(s => delivered.Enqueue(s));
 
-        await WaitUntil(() => !delivered.IsEmpty);
+        await WaitHelper.WaitUntil(() => !delivered.IsEmpty);
         Assert.Same(PolicyStoreSnapshot.Empty, delivered.Single());
     }
 
@@ -31,7 +31,7 @@ public class PolicyStoreSubscriptionTests
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
         using var subscription = store.Subscribe(s => delivered.Enqueue(s));
 
-        await WaitUntil(() => !delivered.IsEmpty);
+        await WaitHelper.WaitUntil(() => !delivered.IsEmpty);
         Assert.Same(expected, delivered.First());
     }
 
@@ -41,11 +41,11 @@ public class PolicyStoreSubscriptionTests
         var store = new PolicyStore();
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
         using var subscription = store.Subscribe(s => delivered.Enqueue(s));
-        await WaitUntil(() => !delivered.IsEmpty); // initial replay
+        await WaitHelper.WaitUntil(() => !delivered.IsEmpty); // initial replay
 
         Replace(store, "source-a", sequence: 1);
 
-        await WaitUntil(() => delivered.Count >= 2);
+        await WaitHelper.WaitUntil(() => delivered.Count >= 2);
         Assert.Equal(store.Current.Revision, delivered.Last().Revision);
     }
 
@@ -64,8 +64,8 @@ public class PolicyStoreSubscriptionTests
             Replace(store, "source-a", sequence: i);
         }
 
-        await WaitUntil(() => !deliveredA.IsEmpty && deliveredA.Last() == 5);
-        await WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == 5);
+        await WaitHelper.WaitUntil(() => !deliveredA.IsEmpty && deliveredA.Last() == 5);
+        await WaitHelper.WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == 5);
 
         AssertNonDecreasing(deliveredA.ToArray());
         AssertNonDecreasing(deliveredB.ToArray());
@@ -113,19 +113,5 @@ public class PolicyStoreSubscriptionTests
         var meta = new PolicySourceMetadata(new SourceRegistrationId(idValue), PolicySourceKind.File);
         PolicySourceSnapshot.TryCreate(meta, sequence, PolicySourceVersion.Empty, [], out var snapshot, out _);
         store.ReplaceSource(snapshot!);
-    }
-
-    private static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 5000)
-    {
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (!condition())
-        {
-            if (sw.ElapsedMilliseconds > timeoutMilliseconds)
-            {
-                Assert.Fail("Timed out waiting for condition.");
-            }
-
-            await Task.Delay(5);
-        }
     }
 }

--- a/test/OpenTelemetry.DynamicControl.Tests/WaitHelper.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/WaitHelper.cs
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.DynamicControl.Tests;
+
+internal static class WaitHelper
+{
+    public static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 10_000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (sw.ElapsedMilliseconds > timeoutMilliseconds)
+            {
+                Assert.Fail("Timed out waiting for condition.");
+            }
+
+            await Task.Delay(5);
+        }
+    }
+}


### PR DESCRIPTION
Contributes to: #4742

## Changes

Adds PolicyChangeNotifier/PolicyChangeSubscription so that a subscriber can register with PolicyStore.Subscribe and receive an atomic replay of the current snapshot followed by every subsequent commit, coalesced to the latest revision and never delivered out of order or overlapping. Subscriber callback failures are isolated per-subscription and reported via a new DynamicControlEventSource rather than propagating to the committing thread.

PolicyStore is now IDisposable to release its subscriptions.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~