### PR TITLE
[Infra] Fix hanging tests

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -143,6 +143,7 @@ jobs:
     - name: dotnet test ${{ steps.resolve-project.outputs.title }}
       if: inputs.run-tests && (!inputs.test-require-elevated || matrix.os == 'windows-2025')
       shell: pwsh
+      timeout-minutes: 20
       env:
         DISABLE_APP_DOMAIN: ${{ matrix.version == 'net462' && 'false' || 'true' }}
         PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
@@ -151,7 +152,9 @@ jobs:
       run: |
         dotnet test ${env:PROJECT_PATH} `
           --collect:"Code Coverage" `
+          --diag:"TestResults/diag/log.txt;tracelevel=info"
           --results-directory:TestResults `
+          --settings:"${env:GITHUB_WORKSPACE}/build/CodeCoverage.runsettings"
           --framework ${env:TARGET_FRAMEWORK} `
           --configuration Release `
           --no-restore `
@@ -159,11 +162,14 @@ jobs:
           --logger:"GitHubActions;report-warnings=false" `
           --logger:"junit;LogFilePath=${env:GITHUB_WORKSPACE}/TestResults/junit.xml" `
           --filter "${env:TEST_FILTER}" `
-          -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
+          -- `
+          RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN} `
+          RunConfiguration.TestSessionTimeout=900000
 
     - name: dotnet test ${{ steps.resolve-project.outputs.title }} (elevated)
       if: inputs.run-tests && inputs.test-require-elevated && matrix.os != 'windows-2025'
       shell: pwsh
+      timeout-minutes: 20
       env:
         DISABLE_APP_DOMAIN: ${{ matrix.version == 'net462' && 'false' || 'true' }}
         PROJECT_PATH: ${{ steps.resolve-project.outputs.project }}
@@ -172,7 +178,9 @@ jobs:
       run: |
         sudo -E dotnet test ${env:PROJECT_PATH} `
           --collect:"Code Coverage" `
+          --diag:"TestResults/diag/log.txt;tracelevel=info"
           --results-directory:TestResults `
+          --settings:"${env:GITHUB_WORKSPACE}/build/CodeCoverage.runsettings"
           --framework ${env:TARGET_FRAMEWORK} `
           --configuration Release `
           --no-restore `
@@ -180,8 +188,22 @@ jobs:
           --logger:"GitHubActions;report-warnings=false" `
           --logger:"junit;LogFilePath=${env:GITHUB_WORKSPACE}/TestResults/junit.xml" `
           --filter "${env:TEST_FILTER}" `
-          -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
+          -- `
+          RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN} `
+          RunConfiguration.TestSessionTimeout=900000
         sudo chmod a+rw ./TestResults
+
+    - name: Upload hang dumps and test platform logs
+      if: ${{ failure() || cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        if-no-files-found: ignore
+        name: hang-dumps-${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}-${{ matrix.os }}-${{ matrix.version }}-attempt-${{ github.run_attempt }}
+        retention-days: 7
+        path: |
+          **/TestResults/**/*hangdump*.dmp
+          **/TestResults/**/Sequence_*.xml
+          **/TestResults/diag/*
 
     - name: dotnet pack ${{ steps.resolve-project.outputs.title }}
       if: matrix.os == 'windows-2025' && inputs.pack

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -152,9 +152,9 @@ jobs:
       run: |
         dotnet test ${env:PROJECT_PATH} `
           --collect:"Code Coverage" `
-          --diag:"TestResults/diag/log.txt;tracelevel=info"
+          --diag:"TestResults/diag/log.txt;tracelevel=info" `
           --results-directory:TestResults `
-          --settings:"${env:GITHUB_WORKSPACE}/build/CodeCoverage.runsettings"
+          --settings:"${env:GITHUB_WORKSPACE}/build/CodeCoverage.runsettings" `
           --framework ${env:TARGET_FRAMEWORK} `
           --configuration Release `
           --no-restore `
@@ -178,9 +178,9 @@ jobs:
       run: |
         sudo -E dotnet test ${env:PROJECT_PATH} `
           --collect:"Code Coverage" `
-          --diag:"TestResults/diag/log.txt;tracelevel=info"
+          --diag:"TestResults/diag/log.txt;tracelevel=info" `
           --results-directory:TestResults `
-          --settings:"${env:GITHUB_WORKSPACE}/build/CodeCoverage.runsettings"
+          --settings:"${env:GITHUB_WORKSPACE}/build/CodeCoverage.runsettings" `
           --framework ${env:TARGET_FRAMEWORK} `
           --configuration Release `
           --no-restore `

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -132,6 +132,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.3.3" />
     <PackageVersion Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.7.37220.1" />
     <PackageVersion Include="Microsoft.Web.Xdt" Version="3.2.11" />
     <PackageVersion Include="MinVer" Version="7.0.0" />

--- a/build/CodeCoverage.runsettings
+++ b/build/CodeCoverage.runsettings
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage">
+        <Configuration>
+          <CodeCoverage>
+            <ModulePaths>
+              <Exclude>
+                <ModulePath>.*[\\/]GitHubActionsTestLogger\.dll$</ModulePath>
+                <ModulePath>.*[\\/]Microsoft\.VisualStudio\.TestPlatform\.Extension\.JUnit\.Xml\.TestLogger\.dll$</ModulePath>
+                <ModulePath>.*[\\/]Spekt\.TestLogger\.dll$</ModulePath>
+              </Exclude>
+            </ModulePaths>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -28,6 +28,7 @@
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="JunitXml.TestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Platform" Condition="'$(EnableMSTestRunner)' != 'true'" ExcludeAssets="build;buildMultiTargeting;buildTransitive" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
## Changes

Copy changes from open-telemetry/opentelemetry-dotnet#7615 to:

- Increase `VSTEST_CONNECTION_TIMEOUT` to allow for additional time required to instrument the GAC for code coverage when targeting net462.
- Exclude test loggers from code coverage as they could cause the VSTest process to hang.
- Collect hang dumps from tests.
- Add a timeout to the test step and the test session.

Hopefully this makes some of the random flakes and timeouts ([example](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/runs/33079786667/job/98543587057#step:9:30)) reduce or stop.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
