### PR TITLE
[Geneva Exporter] Preserve null metric dimensions in OTLP protobuf encoding

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed OTLP protobuf metric serialization to export dimensions with `null`
+  values as empty strings, matching TLV serialization.
+  Fixes issue: ([#5020](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/5020)).
+
 ## 1.18.0-beta.2
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/Metrics/OtlpProtobuf/OtlpProtobufSerializer.cs
@@ -285,6 +285,14 @@ internal sealed class OtlpProtobufSerializer
         // TODO: Serialize schema_url field.
     }
 
+    private static void SerializeMetricPointTags(byte[] buffer, ref int cursor, ReadOnlyTagCollection tags, int fieldNumber)
+    {
+        foreach (var tag in tags)
+        {
+            SerializeTag(buffer, ref cursor, tag.Key, tag.Value ?? string.Empty, fieldNumber);
+        }
+    }
+
     private static void SerializeExemplar<T>(byte[] buffer, ref int cursor, in Exemplar exemplar, T value, int fieldNumber)
     {
         var exemplarTagAndLengthIndex = cursor;
@@ -519,7 +527,7 @@ internal sealed class OtlpProtobufSerializer
                             var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
                             ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.HistogramDataPoint_time_unix_nano, endTime);
 
-                            SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.HistogramDataPoint_attributes);
+                            SerializeMetricPointTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.HistogramDataPoint_attributes);
 
                             if (this.prepopulatedHistogramDataPointAttributes != null)
                             {
@@ -601,7 +609,7 @@ internal sealed class OtlpProtobufSerializer
                             var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
                             ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.ExponentialHistogramDataPoint_time_unix_nano, endTime);
 
-                            SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.ExponentialHistogramDataPoint_attributes);
+                            SerializeMetricPointTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.ExponentialHistogramDataPoint_attributes);
 
                             if (this.prepopulatedExponentialHistogramDataPointAttributes != null)
                             {
@@ -694,7 +702,7 @@ internal sealed class OtlpProtobufSerializer
         var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
         ProtobufSerializerHelper.WriteFixed64WithTag(buffer, ref cursor, FieldNumberConstants.NumberDataPoint_time_unix_nano, endTime);
 
-        SerializeTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.NumberDataPoint_attributes);
+        SerializeMetricPointTags(buffer, ref cursor, metricPoint.Tags, FieldNumberConstants.NumberDataPoint_attributes);
 
         if (this.prepopulatedNumberDataPointAttributes != null)
         {

--- a/src/OpenTelemetry.Exporter.Geneva/README.md
+++ b/src/OpenTelemetry.Exporter.Geneva/README.md
@@ -304,6 +304,10 @@ A feature flag is available to opt-into changing the underlying
 serialization format to binary protobuf following the schema defined in [OTLP
 specification](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.1.0/opentelemetry/proto/metrics/v1/metrics.proto).
 
+Metric dimensions with `null` values are exported as empty strings, matching
+the TLV serialization behavior. Geneva Metrics (MDM) records these dimension
+values as `__Empty`.
+
 When using OTLP protobuf encoding `Account` and `Namespace` are **NOT** required
 to be set on the `ConnectionString`. The recommended approach is to use
 OpenTelemetry Resource instead:

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -1605,6 +1605,92 @@ public abstract class OtlpProtobufMetricExporterTests
         }
     }
 
+    [Theory]
+    [InlineData("Counter")]
+    [InlineData("Histogram")]
+    [InlineData("ExponentialHistogram")]
+    public void NullMetricDimensionIsSerializedAsEmptyString(string metricType)
+    {
+        using var meter = new Meter(nameof(this.NullMetricDimensionIsSerializedAsEmptyString), "0.0.1");
+
+        var exportedItems = new List<Metric>();
+        using var inMemoryReader = new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems))
+        {
+            TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+        };
+
+        var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(nameof(this.NullMetricDimensionIsSerializedAsEmptyString))
+            .AddReader(inMemoryReader);
+
+        if (metricType == "ExponentialHistogram")
+        {
+            meterProviderBuilder.AddView(
+                "TestMetric",
+                new Base2ExponentialBucketHistogramConfiguration());
+        }
+
+        using var meterProvider = meterProviderBuilder.Build();
+
+        var tags = new TagList
+        {
+            { "emptyKey", string.Empty },
+            { "nullKey", null },
+            { "presentKey", "presentValue" },
+        };
+
+        switch (metricType)
+        {
+            case "Counter":
+                meter.CreateCounter<long>("TestMetric").Add(1, tags);
+                break;
+            case "Histogram":
+            case "ExponentialHistogram":
+                meter.CreateHistogram<double>("TestMetric").Record(1.5, tags);
+                break;
+            default:
+                throw new InvalidOperationException($"Unexpected metric type: {metricType}");
+        }
+
+        meterProvider.ForceFlush();
+
+        var testTransport = new TestTransport();
+        var otlpProtobufSerializer = new OtlpProtobufSerializer(
+            testTransport,
+            null,
+            null,
+            null,
+            prefixBufferWithUInt32LittleEndianLength: this.PrefixBufferWithUInt32LittleEndianLength);
+
+        otlpProtobufSerializer.SerializeAndSendMetrics(
+            new byte[65360],
+            meterProvider.GetResource(),
+            new Batch<Metric>([.. exportedItems], exportedItems.Count));
+
+        Assert.Single(testTransport.ExportedItems);
+
+        var metric = this.AssertAndConvertExportedBlobToRequest(testTransport.ExportedItems[0])
+            .ResourceMetrics[0]
+            .ScopeMetrics[0]
+            .Metrics[0];
+
+        var attributes = metricType switch
+        {
+            "Counter" => metric.Sum.DataPoints[0].Attributes,
+            "Histogram" => metric.Histogram.DataPoints[0].Attributes,
+            "ExponentialHistogram" => metric.ExponentialHistogram.DataPoints[0].Attributes,
+            _ => throw new InvalidOperationException($"Unexpected metric type: {metricType}"),
+        };
+
+        AssertOtlpAttributes(
+            [
+                new KeyValuePair<string, object>("emptyKey", string.Empty),
+                new KeyValuePair<string, object>("nullKey", string.Empty),
+                new KeyValuePair<string, object>("presentKey", "presentValue"),
+            ],
+            attributes);
+    }
+
     internal static void AssertOtlpAttributes(
         IEnumerable<KeyValuePair<string, object>> expected,
         RepeatedField<OtlpCommon.KeyValue> actual)


### PR DESCRIPTION
Serialize null-valued OTLP metric point dimensions as empty strings to match the TLV encoding and retain the dimension name for pre-aggregates.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #
[Issue 5020](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/5020)