### PR TITLE
[DynamicControl] Fix code analysis warnings

### DIFF
--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/LogLevelPolicyReader.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/LogLevelPolicyReader.cs
@@ -57,6 +57,7 @@ internal sealed class LogLevelPolicyReader : PolicyReader
                     PolicyRejectionReason.SchemaMismatch,
                     "The log level object declares 'level' more than once."),
 
+                JsonMemberLookup.Unspecified => throw JsonValueReader.UnhandledLookup(JsonMemberLookup.Unspecified),
                 var lookup => throw JsonValueReader.UnhandledLookup(lookup),
             };
 

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/PolicySourceMetadata.cs
@@ -101,16 +101,20 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
     /// <inheritdoc/>
     public override int GetHashCode()
     {
+        int hash;
+
 #if NET || NETSTANDARD2_1_OR_GREATER
-        return HashCode.Combine(this.RegistrationId, this.Kind, this.Priority);
+        hash = HashCode.Combine(this.RegistrationId, this.Kind, this.Priority);
 #else
         unchecked
         {
-            var hash = (17 * 31) + this.RegistrationId.GetHashCode();
+            hash = (17 * 31) + this.RegistrationId.GetHashCode();
             hash = (hash * 31) + (int)this.Kind;
-            return (hash * 31) + this.Priority;
+            hash = (hash * 31) + this.Priority;
         }
 #endif
+
+        return hash;
     }
 
     /// <summary>
@@ -126,7 +130,7 @@ internal readonly struct PolicySourceMetadata : IEquatable<PolicySourceMetadata>
         PolicySourceKind.Http => 2,
         PolicySourceKind.File => 3,
         PolicySourceKind.Custom => 1000,
-        _ =>
+        PolicySourceKind.Unknown or _ =>
 #if NET
             throw new System.Diagnostics.UnreachableException($"Unhandled {nameof(PolicySourceKind)}: {kind}"),
 #else

--- a/src/OpenTelemetry.DynamicControl/Internal/Sources/TraceSamplingRatePolicyReader.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Sources/TraceSamplingRatePolicyReader.cs
@@ -61,6 +61,7 @@ internal sealed class TraceSamplingRatePolicyReader : PolicyReader
                     PolicyRejectionReason.SchemaMismatch,
                     "The sampling rate object declares 'probability' more than once."),
 
+                JsonMemberLookup.Unspecified => throw JsonValueReader.UnhandledLookup(JsonMemberLookup.Unspecified),
                 var lookup => throw JsonValueReader.UnhandledLookup(lookup),
             };
 

--- a/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeSubscription.cs
+++ b/src/OpenTelemetry.DynamicControl/Internal/Store/PolicyChangeSubscription.cs
@@ -86,7 +86,7 @@ internal sealed class PolicyChangeSubscription : IDisposable
             this.dispatching = true;
         }
 
-        ThreadPool.UnsafeQueueUserWorkItem(static state => ((PolicyChangeSubscription)state!).Drain(), this);
+        ThreadPool.UnsafeQueueUserWorkItem(static state => ((PolicyChangeSubscription?)state!).Drain(), this);
     }
 
     private void Drain()

--- a/test/OpenTelemetry.DynamicControl.FuzzTests/FuzzInput.cs
+++ b/test/OpenTelemetry.DynamicControl.FuzzTests/FuzzInput.cs
@@ -12,12 +12,12 @@ internal static class FuzzInput
 
     public static string MapIntoNumericPool(string? text)
     {
-        if (string.IsNullOrEmpty(text))
+        if (text is not { Length: > 0 })
         {
             return string.Empty;
         }
 
-        var chars = new char[text!.Length];
+        var chars = new char[text.Length];
 
         for (var i = 0; i < text.Length; i++)
         {

--- a/test/OpenTelemetry.DynamicControl.FuzzTests/PolicyReaderTests.cs
+++ b/test/OpenTelemetry.DynamicControl.FuzzTests/PolicyReaderTests.cs
@@ -25,7 +25,7 @@ public static class PolicyReaderTests
 
         foreach (var reader in Readers)
         {
-            AssertWellFormed(reader, document.RootElement, json);
+            AssertWellFormed(reader, document.RootElement);
         }
     }
 
@@ -38,7 +38,7 @@ public static class PolicyReaderTests
 
         using var document = JsonDocument.Parse(json);
 
-        var policy = AssertWellFormed(TraceSamplingRatePolicyReader.Instance, document.RootElement, json);
+        var policy = AssertWellFormed(TraceSamplingRatePolicyReader.Instance, document.RootElement);
 
         Assert.NotNull(policy);
         Assert.Equal(probability, Assert.IsType<TraceSamplingRatePolicy>(policy).SamplingProbability);
@@ -51,13 +51,13 @@ public static class PolicyReaderTests
 
         using var document = JsonDocument.Parse(json);
 
-        var policy = AssertWellFormed(LogLevelPolicyReader.Instance, document.RootElement, json);
+        var policy = AssertWellFormed(LogLevelPolicyReader.Instance, document.RootElement);
 
         Assert.NotNull(policy);
         Assert.NotEqual(DiagnosticLogLevel.Unspecified, Assert.IsType<LogLevelPolicy>(policy).MinimumLevel);
     }
 
-    private static TelemetryPolicy? AssertWellFormed(PolicyReader reader, in JsonElement value, string json)
+    private static TelemetryPolicy? AssertWellFormed(PolicyReader reader, in JsonElement value)
     {
         var result = reader.Read(value);
 

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeNotifierTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeNotifierTests.cs
@@ -69,8 +69,8 @@ public class PolicyChangeNotifierTests
     {
         var notifier = new PolicyChangeNotifier();
         var deliveries = new List<PolicyStoreSnapshot>();
-        notifier.Add(s => deliveries.Add(s));
-        notifier.Add(s => deliveries.Add(s));
+        notifier.Add(deliveries.Add);
+        notifier.Add(deliveries.Add);
 
         notifier.Dispose();
 

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeSubscriptionTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyChangeSubscriptionTests.cs
@@ -15,7 +15,7 @@ public class PolicyChangeSubscriptionTests
     {
         var notifier = new PolicyChangeNotifier();
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
-        var subscription = notifier.Add(s => delivered.Enqueue(s));
+        var subscription = notifier.Add(delivered.Enqueue);
 
         subscription.Enqueue(SnapshotAtRevision(1));
 
@@ -121,7 +121,7 @@ public class PolicyChangeSubscriptionTests
     {
         var notifier = new PolicyChangeNotifier();
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
-        var subscription = notifier.Add(s => delivered.Enqueue(s));
+        var subscription = notifier.Add(delivered.Enqueue);
 
         subscription.Enqueue(SnapshotAtRevision(1));
         await WaitHelper.WaitUntil(() => delivered.Count == 1);

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyIdentityValueTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyIdentityValueTests.cs
@@ -56,7 +56,7 @@ public class PolicyIdentityValueTests
 
         Assert.True(first.Equals((object)equal));
         Assert.False(first.Equals((object)new PolicyType("other")));
-        Assert.False(first.Equals((object?)null));
+        Assert.False(first.Equals(null));
         Assert.False(first.Equals("trace-sampling"));
     }
 
@@ -109,7 +109,7 @@ public class PolicyIdentityValueTests
 
         Assert.True(first.Equals((object)equal));
         Assert.False(first.Equals((object)new PolicyId("policy-2")));
-        Assert.False(first.Equals((object?)null));
+        Assert.False(first.Equals(null));
         Assert.False(first.Equals("policy-1"));
     }
 }

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicySourceSnapshotTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicySourceSnapshotTests.cs
@@ -206,13 +206,13 @@ public class PolicySourceSnapshotTests
         var policy = new StubPolicy("trace-sampling", "a");
         TryCreate(DefaultMetadata, 1, [policy], out var snapshot, out _);
 
-        var asList = Assert.IsAssignableFrom<IList<TelemetryPolicy>>(snapshot!.Policies);
+        var asList = Assert.IsType<IList<TelemetryPolicy>>(snapshot!.Policies, exactMatch: false);
 
         Assert.True(asList.IsReadOnly, "Policies list must be read-only");
         Assert.Throws<NotSupportedException>(() => { asList[0] = new StubPolicy("trace-sampling", "b"); });
         Assert.Throws<NotSupportedException>(() => asList.Add(new StubPolicy("trace-sampling", "c")));
         Assert.Throws<NotSupportedException>(() => asList.RemoveAt(0));
-        Assert.Throws<NotSupportedException>(() => asList.Clear());
+        Assert.Throws<NotSupportedException>(asList.Clear);
         Assert.Same(policy, snapshot.Policies[0]);
     }
 

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreConcurrencyTests.cs
@@ -103,8 +103,8 @@ public class PolicyStoreConcurrencyTests
         await WaitHelper.WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == finalRevision);
 
         Assert.False(overlapDetected, "Callback invocations for one subscription must never overlap");
-        AssertNonDecreasing(deliveredA.ToArray());
-        AssertNonDecreasing(deliveredB.ToArray());
+        AssertNonDecreasing([.. deliveredA]);
+        AssertNonDecreasing([.. deliveredB]);
     }
 
     [Fact]

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSnapshotTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSnapshotTests.cs
@@ -76,7 +76,7 @@ public class PolicyStoreSnapshotTests
         Assert.True(asList.IsReadOnly, "Sources list must be read-only");
         Assert.Throws<NotSupportedException>(() => { asList[0] = snapshot.Sources[1]; });
         Assert.Throws<NotSupportedException>(() => asList.RemoveAt(0));
-        Assert.Throws<NotSupportedException>(() => asList.Clear());
+        Assert.Throws<NotSupportedException>(asList.Clear);
         Assert.Same(first, snapshot.Sources[0]);
     }
 

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSubscriptionTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreSubscriptionTests.cs
@@ -14,7 +14,7 @@ public class PolicyStoreSubscriptionTests
         var store = new PolicyStore();
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
 
-        using var subscription = store.Subscribe(s => delivered.Enqueue(s));
+        using var subscription = store.Subscribe(delivered.Enqueue);
 
         await WaitHelper.WaitUntil(() => !delivered.IsEmpty);
         Assert.Same(PolicyStoreSnapshot.Empty, delivered.Single());
@@ -29,7 +29,7 @@ public class PolicyStoreSubscriptionTests
         var expected = store.Current;
 
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
-        using var subscription = store.Subscribe(s => delivered.Enqueue(s));
+        using var subscription = store.Subscribe(delivered.Enqueue);
 
         await WaitHelper.WaitUntil(() => !delivered.IsEmpty);
         Assert.Same(expected, delivered.First());
@@ -40,7 +40,7 @@ public class PolicyStoreSubscriptionTests
     {
         var store = new PolicyStore();
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
-        using var subscription = store.Subscribe(s => delivered.Enqueue(s));
+        using var subscription = store.Subscribe(delivered.Enqueue);
         await WaitHelper.WaitUntil(() => !delivered.IsEmpty); // initial replay
 
         Replace(store, "source-a", sequence: 1);
@@ -67,8 +67,8 @@ public class PolicyStoreSubscriptionTests
         await WaitHelper.WaitUntil(() => !deliveredA.IsEmpty && deliveredA.Last() == 5);
         await WaitHelper.WaitUntil(() => !deliveredB.IsEmpty && deliveredB.Last() == 5);
 
-        AssertNonDecreasing(deliveredA.ToArray());
-        AssertNonDecreasing(deliveredB.ToArray());
+        AssertNonDecreasing([.. deliveredA]);
+        AssertNonDecreasing([.. deliveredB]);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class PolicyStoreSubscriptionTests
     {
         var store = new PolicyStore();
         var delivered = new System.Collections.Concurrent.ConcurrentQueue<PolicyStoreSnapshot>();
-        var subscription = store.Subscribe(s => delivered.Enqueue(s));
+        var subscription = store.Subscribe(delivered.Enqueue);
 
         store.Dispose();
 

--- a/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreTests.cs
+++ b/test/OpenTelemetry.DynamicControl.Tests/PolicyStoreTests.cs
@@ -195,7 +195,7 @@ public class PolicyStoreTests
         var id = new SourceRegistrationId("source-a");
         var meta1 = new PolicySourceMetadata(id, PolicySourceKind.File, 5);
         var meta2 = new PolicySourceMetadata(id, PolicySourceKind.File, 99);
-        var before = store.Current;
+        _ = store.Current;
 
         ReplaceEmpty(store, meta1, sequence: 1);
         var result = ReplaceEmpty(store, meta2, sequence: 2);


### PR DESCRIPTION
## Changes

Cherry-pick new code analysis fixes from #3867.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
