### PR TITLE
[Resources.Container] Add container.runtime.name

### DIFF
--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added the `container.runtime.name` attribute, detected from the Docker
   (`/.dockerenv`) or Podman (`/run/.containerenv`) marker files.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+  ([#5144](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5144))
 
 ## 1.18.0-beta.1
 

--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Added the `container.runtime.name` attribute, detected from the Docker
+  (`/.dockerenv`) or Podman (`/run/.containerenv`) marker files.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/TODO))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
+++ b/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
@@ -41,13 +41,11 @@ internal sealed partial class ContainerDetector : IResourceDetector
     /// <returns>Resource with key-value pairs of resource attributes.</returns>
     public Resource Detect()
     {
-        var cGroupBuild = this.BuildResource(Filepath, ParseMode.V1);
-        if (cGroupBuild == Resource.Empty)
-        {
-            cGroupBuild = this.BuildResource(FilepathV2, ParseMode.V2);
-        }
+        var containerId =
+            this.ExtractContainerId(Filepath, ParseMode.V1) ??
+            this.ExtractContainerId(FilepathV2, ParseMode.V2);
 
-        return cGroupBuild;
+        return BuildResource(containerId, DetectContainerRuntimeName());
     }
 
     /// <summary>
@@ -64,22 +62,39 @@ internal sealed partial class ContainerDetector : IResourceDetector
     /// </summary>
     /// <param name="path">File path where container id exists.</param>
     /// <param name="cgroupVersion">CGroup Version of file to parse from.</param>
-    /// <returns>Returns Resource with list of key-value pairs of container resource attributes if container id exists else empty resource.</returns>
-    internal Resource BuildResource(string path, ParseMode cgroupVersion)
+    /// <param name="dockerEnvPath">Path to the Docker marker file. Overridable for testing.</param>
+    /// <param name="podmanEnvPath">Path to the Podman marker file. Overridable for testing.</param>
+    /// <returns>Returns Resource with list of key-value pairs of container resource attributes if a container id or runtime is detected, else empty resource.</returns>
+    internal Resource BuildResource(string path, ParseMode cgroupVersion, string dockerEnvPath = DockerEnvFilePath, string podmanEnvPath = PodmanEnvFilePath)
     {
         var containerId = this.ExtractContainerId(path, cgroupVersion);
+        var runtimeName = DetectContainerRuntimeName(dockerEnvPath, podmanEnvPath);
 
-        if (containerId is not { Length: > 0 })
+        return BuildResource(containerId, runtimeName);
+    }
+
+    /// <summary>
+    /// Builds the resource attributes from an already-detected container id and/or runtime name.
+    /// </summary>
+    /// <param name="containerId">The detected container id, or <see langword="null"/> if not detected.</param>
+    /// <param name="runtimeName">The detected container runtime name, or <see langword="null"/> if not detected.</param>
+    /// <returns>Returns Resource with list of key-value pairs of container resource attributes if a container id or runtime is detected, else empty resource.</returns>
+    private static Resource BuildResource(string? containerId, string? runtimeName)
+    {
+        var hasContainerId = containerId is { Length: > 0 };
+        if (!hasContainerId && runtimeName is null)
         {
             return Resource.Empty;
         }
 
-        var attributeList = new List<KeyValuePair<string, object>>
-        {
-            new(ContainerSemanticConventions.AttributeContainerId, containerId),
-        };
+        var attributeList = new List<KeyValuePair<string, object>>(2);
 
-        if (DetectContainerRuntimeName() is { } runtimeName)
+        if (hasContainerId)
+        {
+            attributeList.Add(new(ContainerSemanticConventions.AttributeContainerId, containerId!));
+        }
+
+        if (runtimeName is not null)
         {
             attributeList.Add(new(ContainerSemanticConventions.AttributeContainerRuntimeName, runtimeName));
         }

--- a/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
+++ b/src/OpenTelemetry.Resources.Container/ContainerDetector.cs
@@ -14,6 +14,8 @@ internal sealed partial class ContainerDetector : IResourceDetector
     private const string Filepath = "/proc/self/cgroup";
     private const string FilepathV2 = "/proc/self/mountinfo";
     private const string Hostname = "hostname";
+    private const string DockerEnvFilePath = "/.dockerenv";
+    private const string PodmanEnvFilePath = "/run/.containerenv";
 
     private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
 
@@ -49,6 +51,15 @@ internal sealed partial class ContainerDetector : IResourceDetector
     }
 
     /// <summary>
+    /// Detects the container runtime from well-known marker files created by the runtime itself.
+    /// </summary>
+    /// <param name="dockerEnvPath">Path to the Docker marker file. Overridable for testing.</param>
+    /// <param name="podmanEnvPath">Path to the Podman marker file. Overridable for testing.</param>
+    /// <returns>The detected runtime name, or <see langword="null"/> if no known marker file is present.</returns>
+    internal static string? DetectContainerRuntimeName(string dockerEnvPath = DockerEnvFilePath, string podmanEnvPath = PodmanEnvFilePath)
+        => File.Exists(dockerEnvPath) ? "docker" : File.Exists(podmanEnvPath) ? "podman" : null;
+
+    /// <summary>
     /// Builds the resource attributes from Container Id in file path.
     /// </summary>
     /// <param name="path">File path where container id exists.</param>
@@ -58,9 +69,22 @@ internal sealed partial class ContainerDetector : IResourceDetector
     {
         var containerId = this.ExtractContainerId(path, cgroupVersion);
 
-        return containerId is { Length: > 0 } ?
-            new Resource([new(ContainerSemanticConventions.AttributeContainerId, containerId)], Internal.SchemaUrls.Get(SemanticConventionsVersion)) :
-            Resource.Empty;
+        if (containerId is not { Length: > 0 })
+        {
+            return Resource.Empty;
+        }
+
+        var attributeList = new List<KeyValuePair<string, object>>
+        {
+            new(ContainerSemanticConventions.AttributeContainerId, containerId),
+        };
+
+        if (DetectContainerRuntimeName() is { } runtimeName)
+        {
+            attributeList.Add(new(ContainerSemanticConventions.AttributeContainerRuntimeName, runtimeName));
+        }
+
+        return new Resource(attributeList, Internal.SchemaUrls.Get(SemanticConventionsVersion));
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Resources.Container/ContainerSemanticConventions.cs
+++ b/src/OpenTelemetry.Resources.Container/ContainerSemanticConventions.cs
@@ -6,4 +6,5 @@ namespace OpenTelemetry.Resources.Container;
 internal static class ContainerSemanticConventions
 {
     public const string AttributeContainerId = "container.id";
+    public const string AttributeContainerRuntimeName = "container.runtime.name";
 }

--- a/src/OpenTelemetry.Resources.Container/README.md
+++ b/src/OpenTelemetry.Resources.Container/README.md
@@ -51,8 +51,8 @@ The resource detectors will record the following metadata based on where
 your application is running:
 
 - **ContainerDetector**:
-    - `container.id`
-    - `container.runtime.name` (when the container runtime is Docker or Podman).
+  - `container.id`
+  - `container.runtime.name` (when the container runtime is Docker or Podman).
 
 ## References
 

--- a/src/OpenTelemetry.Resources.Container/README.md
+++ b/src/OpenTelemetry.Resources.Container/README.md
@@ -50,7 +50,9 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 The resource detectors will record the following metadata based on where
 your application is running:
 
-- **ContainerDetector**: container.id.
+- **ContainerDetector**:
+    - `container.id`
+    - `container.runtime.name` (when the container runtime is Docker or Podman).
 
 ## References
 

--- a/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
@@ -111,6 +111,8 @@ public class ContainerDetectorTests
     public void TestInvalidContainer()
     {
         var containerDetector = new ContainerDetector();
+        var missingDockerEnvPath = GetNonExistentFilePath();
+        var missingPodmanEnvPath = GetNonExistentFilePath();
 
         // Valid in cgroupv1 is not valid in cgroupv2
         foreach (var testCase in this.testValidCasesV1)
@@ -118,7 +120,7 @@ public class ContainerDetectorTests
             using var tempFile = new TempFile();
             tempFile.Write(testCase.Line);
             Assert.Equal(
-                containerDetector.BuildResource(tempFile.FilePath, ContainerDetector.ParseMode.V2),
+                containerDetector.BuildResource(tempFile.FilePath, ContainerDetector.ParseMode.V2, missingDockerEnvPath, missingPodmanEnvPath),
                 Resource.Empty);
         }
 
@@ -128,7 +130,7 @@ public class ContainerDetectorTests
             using var tempFile = new TempFile();
             tempFile.Write(testCase.Line);
             Assert.Equal(
-                containerDetector.BuildResource(tempFile.FilePath, ContainerDetector.ParseMode.V1),
+                containerDetector.BuildResource(tempFile.FilePath, ContainerDetector.ParseMode.V1, missingDockerEnvPath, missingPodmanEnvPath),
                 Resource.Empty);
         }
 
@@ -137,12 +139,58 @@ public class ContainerDetectorTests
         {
             using var tempFile = new TempFile();
             tempFile.Write(testCase.Line);
-            Assert.Equal(containerDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion), Resource.Empty);
+            Assert.Equal(containerDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion, missingDockerEnvPath, missingPodmanEnvPath), Resource.Empty);
         }
 
         // test invalid file
-        Assert.Equal(containerDetector.BuildResource(Path.GetTempPath(), ContainerDetector.ParseMode.V1), Resource.Empty);
-        Assert.Equal(containerDetector.BuildResource(Path.GetTempPath(), ContainerDetector.ParseMode.V2), Resource.Empty);
+        Assert.Equal(containerDetector.BuildResource(Path.GetTempPath(), ContainerDetector.ParseMode.V1, missingDockerEnvPath, missingPodmanEnvPath), Resource.Empty);
+        Assert.Equal(containerDetector.BuildResource(Path.GetTempPath(), ContainerDetector.ParseMode.V2, missingDockerEnvPath, missingPodmanEnvPath), Resource.Empty);
+    }
+
+    [Fact]
+    public void BuildResourceIncludesRuntimeNameWhenContainerIdIsExtractable()
+    {
+        var containerDetector = new ContainerDetector();
+        var testCase = this.testValidCasesV1[0];
+        using var tempFile = new TempFile();
+        tempFile.Write(testCase.Line);
+        using var dockerEnvFile = new TempFile();
+        var missingPodmanEnvPath = GetNonExistentFilePath();
+
+        var resource = containerDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion, dockerEnvFile.FilePath, missingPodmanEnvPath);
+
+        Assert.NotEqual(Resource.Empty, resource);
+        Assert.Equal(testCase.ExpectedContainerId, GetContainerId(resource));
+        Assert.Equal("docker", GetContainerRuntimeName(resource));
+    }
+
+    [Fact]
+    public void BuildResourceIncludesRuntimeNameWhenContainerIdIsNotExtractable()
+    {
+        var containerDetector = new ContainerDetector();
+        var testCase = this.testInvalidCases[0];
+        using var tempFile = new TempFile();
+        tempFile.Write(testCase.Line);
+        using var podmanEnvFile = new TempFile();
+        var missingDockerEnvPath = GetNonExistentFilePath();
+
+        var resource = containerDetector.BuildResource(tempFile.FilePath, testCase.CgroupVersion, missingDockerEnvPath, podmanEnvFile.FilePath);
+
+        Assert.NotEqual(Resource.Empty, resource);
+        Assert.DoesNotContain(resource.Attributes, x => x.Key == ContainerSemanticConventions.AttributeContainerId);
+        Assert.Equal("podman", GetContainerRuntimeName(resource));
+    }
+
+    [Fact]
+    public void BuildResourceReturnsEmptyWhenNoContainerIdOrRuntimeIsDetected()
+    {
+        var containerDetector = new ContainerDetector();
+        var missingDockerEnvPath = GetNonExistentFilePath();
+        var missingPodmanEnvPath = GetNonExistentFilePath();
+
+        var resource = containerDetector.BuildResource(Path.GetTempPath(), ContainerDetector.ParseMode.V1, missingDockerEnvPath, missingPodmanEnvPath);
+
+        Assert.Equal(Resource.Empty, resource);
     }
 
     [Fact]
@@ -195,6 +243,12 @@ public class ContainerDetectorTests
     {
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
         return resourceAttributes[ContainerSemanticConventions.AttributeContainerId].ToString()!;
+    }
+
+    private static string GetContainerRuntimeName(Resource resource)
+    {
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
+        return resourceAttributes[ContainerSemanticConventions.AttributeContainerRuntimeName].ToString()!;
     }
 
     private sealed class TestCase

--- a/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Container.Tests/ContainerDetectorTests.cs
@@ -156,6 +156,41 @@ public class ContainerDetectorTests
         Assert.Null(resource.SchemaUrl);
     }
 
+    [Fact]
+    public void DetectContainerRuntimeNamePrefersDockerOverPodman()
+    {
+        using var dockerEnvFile = new TempFile();
+        using var podmanEnvFile = new TempFile();
+
+        var runtimeName = ContainerDetector.DetectContainerRuntimeName(dockerEnvFile.FilePath, podmanEnvFile.FilePath);
+
+        Assert.Equal("docker", runtimeName);
+    }
+
+    [Fact]
+    public void DetectContainerRuntimeNameReturnsPodmanWhenOnlyPodmanEnvFileExists()
+    {
+        var missingDockerEnvPath = GetNonExistentFilePath();
+        using var podmanEnvFile = new TempFile();
+
+        var runtimeName = ContainerDetector.DetectContainerRuntimeName(missingDockerEnvPath, podmanEnvFile.FilePath);
+
+        Assert.Equal("podman", runtimeName);
+    }
+
+    [Fact]
+    public void DetectContainerRuntimeNameReturnsNullWhenNoMarkerFilesExist()
+    {
+        var missingDockerEnvPath = GetNonExistentFilePath();
+        var missingPodmanEnvPath = GetNonExistentFilePath();
+
+        var runtimeName = ContainerDetector.DetectContainerRuntimeName(missingDockerEnvPath, missingPodmanEnvPath);
+
+        Assert.Null(runtimeName);
+    }
+
+    private static string GetNonExistentFilePath() => Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
     private static string GetContainerId(Resource resource)
     {
         var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);


### PR DESCRIPTION
## Changes

Add the [`container.runtime.name`](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/registry/attributes/container.md#container-runtime-name) attribute when running in Docker or Podman.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
