### PR TITLE
[AWSLambda] Set faas.trigger to pubsub for SQS and SNS triggered functions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* The `faas.trigger` span attribute is now set to `pubsub` for functions
+  triggered by SQS or SNS events, instead of `other`.
+  ([#5146](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5146))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
@@ -255,8 +255,6 @@ internal class AWSLambdaUtils
     private static bool IsHttpRequest<TInput>(TInput input) =>
         input is APIGatewayProxyRequest or APIGatewayHttpApiV2ProxyRequest or ApplicationLoadBalancerRequest;
 
-    // SQS and SNS deliver messages published to a queue or topic, which the
-    // semantic conventions describe as the "pubsub" trigger type.
     private static bool IsPubSubRequest<TInput>(TInput input) =>
         input is SQSEvent or SQSEvent.SQSMessage or SNSEvent or SNSEvent.SNSRecord;
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/Implementation/AWSLambdaUtils.cs
@@ -242,11 +242,23 @@ internal class AWSLambdaUtils
         return faasId;
     }
 
-    private static string GetFaasTrigger<TInput>(TInput input) =>
-        IsHttpRequest(input) ? "http" : "other";
+    private static string GetFaasTrigger<TInput>(TInput input)
+    {
+        if (IsHttpRequest(input))
+        {
+            return "http";
+        }
+
+        return IsPubSubRequest(input) ? "pubsub" : "other";
+    }
 
     private static bool IsHttpRequest<TInput>(TInput input) =>
         input is APIGatewayProxyRequest or APIGatewayHttpApiV2ProxyRequest or ApplicationLoadBalancerRequest;
+
+    // SQS and SNS deliver messages published to a queue or topic, which the
+    // semantic conventions describe as the "pubsub" trigger type.
+    private static bool IsPubSubRequest<TInput>(TInput input) =>
+        input is SQSEvent or SQSEvent.SQSMessage or SNSEvent or SNSEvent.SNSRecord;
 
     private static ActivityContext ParseXRayTraceHeader(string rawHeader)
     {

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -342,8 +342,8 @@ public class AWSLambdaWrapperTests : IDisposable
             AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSqsEvent, new SQSEvent(), this.sampleLambdaContext);
         }
 
-        Assert.Single(exportedItems);
-        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("pubsub", item.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
     }
 
     [Fact]
@@ -362,8 +362,8 @@ public class AWSLambdaWrapperTests : IDisposable
             AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSnsEvent, new SNSEvent(), this.sampleLambdaContext);
         }
 
-        Assert.Single(exportedItems);
-        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("pubsub", item.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
     }
 
     [Fact]
@@ -382,8 +382,8 @@ public class AWSLambdaWrapperTests : IDisposable
             AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSqsMessage, new SQSEvent.SQSMessage(), this.sampleLambdaContext);
         }
 
-        Assert.Single(exportedItems);
-        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("pubsub", item.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
     }
 
     [Fact]
@@ -402,8 +402,8 @@ public class AWSLambdaWrapperTests : IDisposable
             AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSnsRecord, new SNSEvent.SNSRecord(), this.sampleLambdaContext);
         }
 
-        Assert.Single(exportedItems);
-        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("pubsub", item.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
     }
 
     private static ActivityContext CreateParentContext()

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Amazon.Lambda.SNSEvents;
+using Amazon.Lambda.SQSEvents;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -322,6 +324,86 @@ public class AWSLambdaWrapperTests : IDisposable
 
         Assert.True(attrs.TryGetValue("env", out actual), "Resource attribute 'env' is missing");
         Assert.Equal("prod", actual);
+    }
+
+    [Fact]
+    public void TraceSyncSqsEventSetsPubSubTrigger()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSqsEvent, new SQSEvent(), this.sampleLambdaContext);
+        }
+
+        Assert.Single(exportedItems);
+        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+    }
+
+    [Fact]
+    public void TraceSyncSnsEventSetsPubSubTrigger()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSnsEvent, new SNSEvent(), this.sampleLambdaContext);
+        }
+
+        Assert.Single(exportedItems);
+        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+    }
+
+    [Fact]
+    public void TraceSyncSqsMessageSetsPubSubTrigger()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSqsMessage, new SQSEvent.SQSMessage(), this.sampleLambdaContext);
+        }
+
+        Assert.Single(exportedItems);
+        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+    }
+
+    [Fact]
+    public void TraceSyncSnsRecordSetsPubSubTrigger()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncSnsRecord, new SNSEvent.SNSRecord(), this.sampleLambdaContext);
+        }
+
+        Assert.Single(exportedItems);
+        Assert.Equal("pubsub", exportedItems[0].GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
     }
 
     private static ActivityContext CreateParentContext()

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleHandlers.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/SampleHandlers.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Amazon.Lambda.Core;
+using Amazon.Lambda.SNSEvents;
+using Amazon.Lambda.SQSEvents;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda.Tests;
 
@@ -17,6 +19,26 @@ internal class SampleHandlers
     public string SampleHandlerSyncInputAndReturn(string str, ILambdaContext _2)
     {
         return str;
+    }
+
+    // Action<TInput, ILambdaContext> for an SQS event source.
+    public void SampleHandlerSyncSqsEvent(SQSEvent _1, ILambdaContext _2)
+    {
+    }
+
+    // Action<TInput, ILambdaContext> for a single SQS message.
+    public void SampleHandlerSyncSqsMessage(SQSEvent.SQSMessage _1, ILambdaContext _2)
+    {
+    }
+
+    // Action<TInput, ILambdaContext> for an SNS event source.
+    public void SampleHandlerSyncSnsEvent(SNSEvent _1, ILambdaContext _2)
+    {
+    }
+
+    // Action<TInput, ILambdaContext> for a single SNS record.
+    public void SampleHandlerSyncSnsRecord(SNSEvent.SNSRecord _1, ILambdaContext _2)
+    {
     }
 
     // Func<TInput, ILambdaContext, Task>


### PR DESCRIPTION
Fixes #5145

## Changes

GetFaasTrigger in AWSLambdaUtils only distinguishes HTTP request types, so every non-HTTP event source falls through to "other". Functions triggered by SQS or SNS are message-driven, and both the general FaaS conventions and the AWS Lambda conventions require faas.trigger to be pubsub for these sources:

[FaaS spans — PubSub](https://opentelemetry.io/docs/specs/semconv/faas/faas-spans/#pubsub)
[AWS Lambda — SQS event](https://opentelemetry.io/docs/specs/semconv/faas/aws-lambda/#sqs-event):
"faas.trigger MUST be set to pubsub."
[AWS Lambda — SQS message](https://opentelemetry.io/docs/specs/semconv/faas/aws-lambda/#sqs-message):
"faas.trigger MUST be set to pubsub."


This adds an IsPubSubRequest check, mirroring the existing IsHttpRequest, so faas.trigger is pubsub for SQSEvent, SQSEvent.SQSMessage, SNSEvent and SNSEvent.SNSRecord.

The record-level types are included because ExtractParentContext already treats them as message-driven sources in order to extract parent context from them, while GetFaasTrigger did not classify them. Both are called with the same input in OnFunctionStart, so passing an individual message previously produced correct trace linkage but a trigger type of other.

Behaviour is unchanged for all other inputs: HTTP request types still report http, and plain payloads from a direct invocation still report other.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
