### PR TITLE
[Instrumentation.AspNetCore] README TODO clean up

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -249,12 +249,11 @@ This instrumentation can be configured to change the default behavior by using
 `AspNetCoreTraceInstrumentationOptions`, which allows adding [`Filter`](#filter),
 [`Enrich`](#enrich) as explained below.
 
-// TODO: This section could be refined.
 When used with
 [`OpenTelemetry.Extensions.Hosting`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Extensions.Hosting/README.md),
-all configurations to `AspNetCoreTraceInstrumentationOptions` can be done in the
-`ConfigureServices`
-method of you applications `Startup` class as shown below.
+all configuration of `AspNetCoreTraceInstrumentationOptions` can be done in
+the `ConfigureServices` method of your application's `Startup` class, as
+shown below.
 
 ```csharp
 // Configure


### PR DESCRIPTION

## Changes

Removes a stray `// TODO: This section could be refined.` line that has been rendering in the `OpenTelemetry.Instrumentation.AspNetCore` README

- fixes the typo "method of you applications `Startup` class"
- tightens the sentence and fixes the awkward line wrapping

Docs-only. No source or public API changes. Documented pattern is unchanged

## Merge requirement checklist

- [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
[ ] Unit tests added/updated
[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
[ ] Changes in public API reviewed (if applicable)

## AI Disclosure

AI helped spot the stray TODO and draft the replacement wording. I reviewed the final text and confirmed the section's guidance is unchanged before opening the PR.
