### PR TITLE
[Resources.Azure] Document env vars and log skipped detectors

### DIFF
--- a/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AppServiceResourceDetector.cs
@@ -67,6 +67,8 @@ internal sealed class AppServiceResourceDetector : IResourceDetector
                     attributeList,
                     Internal.SchemaUrls.Get(AzureResourceBuilderExtensions.SemanticConventionsVersion));
             }
+
+            AzureResourcesEventSource.Log.ResourceDetectorSkipped(nameof(AppServiceResourceDetector), ResourceAttributeConstants.AppServiceSiteNameEnvVar);
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
@@ -42,6 +42,10 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
                 AddBaseAttributes(attributeList, containerAppJobName);
                 AddResourceAttributes(attributeList, AzureContainerAppJobResourceAttributes);
             }
+            else
+            {
+                AzureResourcesEventSource.Log.ResourceDetectorSkipped(nameof(AzureContainerAppsResourceDetector), ResourceAttributeConstants.AzureContainerAppsNameEnvVar);
+            }
 
             return attributeList.Count == 0
                 ? Resource.Empty

--- a/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureContainerAppsResourceDetector.cs
@@ -44,7 +44,7 @@ internal sealed class AzureContainerAppsResourceDetector : IResourceDetector
             }
             else
             {
-                AzureResourcesEventSource.Log.ResourceDetectorSkipped(nameof(AzureContainerAppsResourceDetector), ResourceAttributeConstants.AzureContainerAppsNameEnvVar);
+                AzureResourcesEventSource.Log.ResourceDetectorSkipped(nameof(AzureContainerAppsResourceDetector), $"{ResourceAttributeConstants.AzureContainerAppsNameEnvVar} or {ResourceAttributeConstants.AzureContainerAppJobNameEnvVar}");
             }
 
             return attributeList.Count == 0

--- a/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
@@ -14,6 +14,7 @@ internal sealed class AzureResourcesEventSource : EventSource
     private const int EventIdFailedToDetectAppServiceResources = 1;
     private const int EventIdFailedToDetectAzureContainerAppResources = 2;
     private const int EventIdFailedToDetectAzureVMResources = 3;
+    private const int EventIdResourceDetectorSkipped = 5;
 
     [NonEvent]
     public void FailedToDetectAppServiceResources(Exception ex)
@@ -53,4 +54,8 @@ internal sealed class AzureResourcesEventSource : EventSource
     [Event(EventIdFailedToDetectAzureVMResources, Message = "Failed to detect Azure VM resources. Exception: {0}", Level = EventLevel.Warning)]
     public void FailedToDetectAzureVMResources(string exception)
         => this.WriteEvent(EventIdFailedToDetectAzureVMResources, exception);
+
+    [Event(EventIdResourceDetectorSkipped, Message = "Resource detector '{0}' did not detect any attributes because the environment variable '{1}' is not set.", Level = EventLevel.Verbose)]
+    public void ResourceDetectorSkipped(string detector, string environmentVariable)
+        => this.WriteEvent(EventIdResourceDetectorSkipped, detector, environmentVariable);
 }

--- a/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
@@ -14,7 +14,7 @@ internal sealed class AzureResourcesEventSource : EventSource
     private const int EventIdFailedToDetectAppServiceResources = 1;
     private const int EventIdFailedToDetectAzureContainerAppResources = 2;
     private const int EventIdFailedToDetectAzureVMResources = 3;
-    private const int EventIdResourceDetectorSkipped = 5;
+    private const int EventIdResourceDetectorSkipped = 4;
 
     [NonEvent]
     public void FailedToDetectAppServiceResources(Exception ex)

--- a/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
+++ b/src/OpenTelemetry.Resources.Azure/AzureResourcesEventSource.cs
@@ -55,7 +55,7 @@ internal sealed class AzureResourcesEventSource : EventSource
     public void FailedToDetectAzureVMResources(string exception)
         => this.WriteEvent(EventIdFailedToDetectAzureVMResources, exception);
 
-    [Event(EventIdResourceDetectorSkipped, Message = "Resource detector '{0}' did not detect any attributes because the environment variable '{1}' is not set.", Level = EventLevel.Verbose)]
+    [Event(EventIdResourceDetectorSkipped, Message = "Resource detector '{0}' did not detect any attributes because no environment variable named {1} is set.", Level = EventLevel.Verbose)]
     public void ResourceDetectorSkipped(string detector, string environmentVariable)
         => this.WriteEvent(EventIdResourceDetectorSkipped, detector, environmentVariable);
 }

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -13,6 +13,10 @@
   * `azure_vm` to `azure.vm`
   ([#5143](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5143))
 
+* Log an event when a resource detector does not detect any attributes because
+  the environment variable that identifies the platform is not set.
+  ([#5169](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5169))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -14,7 +14,7 @@
   ([#5143](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5143))
 
 * Log an event when a resource detector does not detect any attributes because
-  none of the environment variables that identify the platform is set.
+  none of the environment variables that identify the platform are set.
   ([#5169](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5169))
 
 ## 1.18.0-beta.1

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -14,7 +14,7 @@
   ([#5143](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5143))
 
 * Log an event when a resource detector does not detect any attributes because
-  the environment variable that identifies the platform is not set.
+  none of the environment variables that identify the platform is set.
   ([#5169](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5169))
 
 ## 1.18.0-beta.1

--- a/src/OpenTelemetry.Resources.Azure/README.md
+++ b/src/OpenTelemetry.Resources.Azure/README.md
@@ -48,19 +48,19 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 });
 ```
 
-| Attribute                   | Description                                                                                                                                                                                               |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| azure.app.service.stamp     | The specific "stamp" cluster within Azure where the App Service is running, e.g., "waws-prod-sn1-001".                                                                                                    |
-| azure.resource_group.name   | The Azure resource group from `WEBSITE_RESOURCE_GROUP`. Emitted when the environment variable is non-empty.                                                                                               |
-| cloud.account.id            | The Azure subscription ID parsed from `WEBSITE_OWNER_NAME`. Emitted when the environment variable is non-empty.                                                                                           |
-| cloud.platform              | The cloud platform. Here, it's always "azure.app_service".                                                                                                                                                |
-| cloud.provider              | The cloud service provider. In this context, it's always "azure".                                                                                                                                         |
-| cloud.resource_id           | The Azure Resource Manager URI uniquely identifying the Azure App Service. Typically in the format "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Web/sites/{siteName}". |
-| cloud.region                | The Azure region where the App Service is hosted, e.g., "East US", "West Europe", etc.                                                                                                                    |
-| deployment.environment.name | The deployment slot where the Azure App Service is running, such as "staging", "production", etc.                                                                                                         |
-| host.id                     | The primary hostname for the app, excluding any custom hostnames.                                                                                                                                         |
-| service.instance.id         | The specific instance of the Azure App Service, useful in a scaled-out configuration.                                                                                                                     |
-| service.name                | The name of the Azure App Service.                                                                                                                                                                        |
+| Attribute                   | Description                                                                                                                                                                                                                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| azure.app.service.stamp     | The specific "stamp" cluster within Azure where the App Service is running, from `WEBSITE_HOME_STAMPNAME`, e.g., "waws-prod-sn1-001".                                                                                                                                                        |
+| azure.resource_group.name   | The Azure resource group from `WEBSITE_RESOURCE_GROUP`. Emitted when the environment variable is non-empty.                                                                                                                                                                                  |
+| cloud.account.id            | The Azure subscription ID parsed from `WEBSITE_OWNER_NAME`. Emitted when the environment variable is non-empty.                                                                                                                                                                              |
+| cloud.platform              | The cloud platform. Here, it's always "azure.app_service".                                                                                                                                                                                                                                   |
+| cloud.provider              | The cloud service provider. In this context, it's always "azure".                                                                                                                                                                                                                            |
+| cloud.resource_id           | The Azure Resource Manager URI uniquely identifying the Azure App Service, built from `WEBSITE_SITE_NAME`, `WEBSITE_RESOURCE_GROUP` and `WEBSITE_OWNER_NAME`. Typically in the format "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Web/sites/{siteName}". |
+| cloud.region                | The Azure region where the App Service is hosted, from `REGION_NAME`, e.g., "East US", "West Europe", etc.                                                                                                                                                                                   |
+| deployment.environment.name | The deployment slot where the Azure App Service is running, from `WEBSITE_SLOT_NAME`, such as "staging", "production", etc.                                                                                                                                                                  |
+| host.id                     | The primary hostname for the app from `WEBSITE_HOSTNAME`, excluding any custom hostnames.                                                                                                                                                                                                    |
+| service.instance.id         | The specific instance of the Azure App Service from `WEBSITE_INSTANCE_ID`, useful in a scaled-out configuration.                                                                                                                                                                             |
+| service.name                | The name of the Azure App Service from `WEBSITE_SITE_NAME`.                                                                                                                                                                                                                                  |
 
 ## VM Resource Detector
 
@@ -82,6 +82,11 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     // other configurations
     .Build();
 ```
+
+Unlike the other detectors in this package, the VM detector reads these values
+from the [Azure Instance Metadata
+Service](https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service)
+rather than from environment variables.
 
 | Attribute              | Description                                                                                                                                                                                                                         |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -118,10 +123,23 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .Build();
 ```
 
-| Attribute           | Description                                                                                                                 |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| cloud.platform      | The cloud platform. Here, it's always "azure.container_apps".                                                               |
-| cloud.provider      | The cloud service provider. In this context, it's always "azure".                                                           |
-| service.instance.id | Represents the specific instance ID of Azure Container Apps, useful in scaled-out configurations.                           |
-| service.name        | The name of the Azure Container Apps or Azure Container Apps job.                                                           |
-| service.version     | The current revision or version of Azure Container Apps, or in case of a Azure Container Apps job - the job execution name. |
+| Attribute           | Description                                                                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cloud.platform      | The cloud platform. Here, it's always "azure.container_apps".                                                                                                                                               |
+| cloud.provider      | The cloud service provider. In this context, it's always "azure".                                                                                                                                           |
+| service.instance.id | Represents the specific instance ID of Azure Container Apps from `CONTAINER_APP_REPLICA_NAME`, useful in scaled-out configurations.                                                                         |
+| service.name        | The name of the Azure Container Apps from `CONTAINER_APP_NAME`, or of the Azure Container Apps job from `CONTAINER_APP_JOB_NAME`.                                                                           |
+| service.version     | The current revision or version of Azure Container Apps from `CONTAINER_APP_REVISION`, or in case of a Azure Container Apps job - the job execution name from `CONTAINER_APP_JOB_EXECUTION_NAME`.           |
+
+## Troubleshooting
+
+This component uses an
+[EventSource](https://docs.microsoft.com/dotnet/api/system.diagnostics.tracing.eventsource)
+with the name "OpenTelemetry-Resources-Azure" for its internal logging.
+Please refer to [SDK
+troubleshooting](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/README.md#troubleshooting)
+for instructions on seeing these internal logs.
+
+A detector writes a `Verbose` event naming itself and the environment variable
+it looked for when that variable is absent and it therefore contributes no
+attributes.

--- a/src/OpenTelemetry.Resources.Azure/README.md
+++ b/src/OpenTelemetry.Resources.Azure/README.md
@@ -141,4 +141,4 @@ troubleshooting](https://github.com/open-telemetry/opentelemetry-dotnet/blob/mai
 for instructions on seeing these internal logs.
 
 A detector writes a `Verbose` event naming itself and the environment variables
-it looked for when none is set and it therefore contributes no attributes.
+it looked for when none are set and it therefore contributes no attributes.

--- a/src/OpenTelemetry.Resources.Azure/README.md
+++ b/src/OpenTelemetry.Resources.Azure/README.md
@@ -140,6 +140,5 @@ Please refer to [SDK
 troubleshooting](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/README.md#troubleshooting)
 for instructions on seeing these internal logs.
 
-A detector writes a `Verbose` event naming itself and the environment variable
-it looked for when that variable is absent and it therefore contributes no
-attributes.
+A detector writes a `Verbose` event naming itself and the environment variables
+it looked for when none is set and it therefore contributes no attributes.

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -1,10 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Tracing;
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
 
+using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Resources.Azure.Tests;
@@ -318,6 +320,104 @@ public class AzureResourceDetectorTests
                 resource.Attributes);
         }
     }
+
+    [Fact]
+    public void AppServiceResourceDetectorLogsSkippedEventWhenSiteNameIsNotSet()
+    {
+        using var listener = new InMemoryEventListener(AzureResourcesEventSource.Log);
+
+        var environment = new Dictionary<string, string?>
+        {
+            [ResourceAttributeConstants.AppServiceSiteNameEnvVar] = null,
+        };
+
+        using (EnvironmentVariableScope.Create(environment))
+        {
+            var resource = ResourceBuilder.CreateEmpty().AddAzureAppServiceDetector().Build();
+
+            Assert.Empty(resource.Attributes);
+            Assert.Null(resource.SchemaUrl);
+        }
+
+        var skipped = Assert.Single(listener.Events, e => e.EventName == nameof(AzureResourcesEventSource.ResourceDetectorSkipped));
+
+        Assert.Equal(EventLevel.Verbose, skipped.Level);
+        Assert.Contains(nameof(AppServiceResourceDetector), GetPayloadText(skipped), StringComparison.Ordinal);
+        Assert.Contains(ResourceAttributeConstants.AppServiceSiteNameEnvVar, GetPayloadText(skipped), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AppServiceResourceDetectorDoesNotLogSkippedEventWhenSiteNameIsSet()
+    {
+        using var listener = new InMemoryEventListener(AzureResourcesEventSource.Log);
+
+        var environment = new Dictionary<string, string?>
+        {
+            [ResourceAttributeConstants.AppServiceSiteNameEnvVar] = "sitename",
+        };
+
+        using (EnvironmentVariableScope.Create(environment))
+        {
+            var resource = ResourceBuilder.CreateEmpty().AddAzureAppServiceDetector().Build();
+
+            Assert.NotEmpty(resource.Attributes);
+        }
+
+        Assert.DoesNotContain(listener.Events, e => e.EventName == nameof(AzureResourcesEventSource.ResourceDetectorSkipped));
+    }
+
+    [Fact]
+    public void AzureContainerAppsResourceDetectorLogsSkippedEventWhenNoContainerAppVariableIsSet()
+    {
+        using var listener = new InMemoryEventListener(AzureResourcesEventSource.Log);
+
+        var environment = new Dictionary<string, string?>
+        {
+            [ResourceAttributeConstants.AzureContainerAppsNameEnvVar] = null,
+            [ResourceAttributeConstants.AzureContainerAppJobNameEnvVar] = null,
+        };
+
+        using (EnvironmentVariableScope.Create(environment))
+        {
+            var resource = ResourceBuilder.CreateEmpty().AddAzureContainerAppsDetector().Build();
+
+            Assert.Empty(resource.Attributes);
+            Assert.Null(resource.SchemaUrl);
+        }
+
+        var skipped = Assert.Single(listener.Events, e => e.EventName == nameof(AzureResourcesEventSource.ResourceDetectorSkipped));
+
+        Assert.Equal(EventLevel.Verbose, skipped.Level);
+        Assert.Contains(nameof(AzureContainerAppsResourceDetector), GetPayloadText(skipped), StringComparison.Ordinal);
+        Assert.Contains(ResourceAttributeConstants.AzureContainerAppsNameEnvVar, GetPayloadText(skipped), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(ResourceAttributeConstants.AzureContainerAppsNameEnvVar, "containerAppName")]
+    [InlineData(ResourceAttributeConstants.AzureContainerAppJobNameEnvVar, "containerAppJobName")]
+    public void AzureContainerAppsResourceDetectorDoesNotLogSkippedEventWhenDetectionSucceeds(string environmentVariableName, string environmentVariableValue)
+    {
+        using var listener = new InMemoryEventListener(AzureResourcesEventSource.Log);
+
+        var environment = new Dictionary<string, string?>
+        {
+            [ResourceAttributeConstants.AzureContainerAppsNameEnvVar] = null,
+            [ResourceAttributeConstants.AzureContainerAppJobNameEnvVar] = null,
+            [environmentVariableName] = environmentVariableValue,
+        };
+
+        using (EnvironmentVariableScope.Create(environment))
+        {
+            var resource = ResourceBuilder.CreateEmpty().AddAzureContainerAppsDetector().Build();
+
+            Assert.NotEmpty(resource.Attributes);
+        }
+
+        Assert.DoesNotContain(listener.Events, e => e.EventName == nameof(AzureResourcesEventSource.ResourceDetectorSkipped));
+    }
+
+    private static string GetPayloadText(EventWrittenEventArgs eventData)
+        => string.Join(" ", eventData.Payload!);
 
     private static Resource DetectAppServiceResource(string? websiteOwnerName, string? websiteResourceGroup)
     {

--- a/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Azure.Tests/AzureResourceDetectorTests.cs
@@ -390,6 +390,7 @@ public class AzureResourceDetectorTests
         Assert.Equal(EventLevel.Verbose, skipped.Level);
         Assert.Contains(nameof(AzureContainerAppsResourceDetector), GetPayloadText(skipped), StringComparison.Ordinal);
         Assert.Contains(ResourceAttributeConstants.AzureContainerAppsNameEnvVar, GetPayloadText(skipped), StringComparison.Ordinal);
+        Assert.Contains(ResourceAttributeConstants.AzureContainerAppJobNameEnvVar, GetPayloadText(skipped), StringComparison.Ordinal);
     }
 
     [Theory]

--- a/test/OpenTelemetry.Resources.Azure.Tests/OpenTelemetry.Resources.Azure.Tests.csproj
+++ b/test/OpenTelemetry.Resources.Azure.Tests/OpenTelemetry.Resources.Azure.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Shared\EnvironmentVariableScope.cs" Link="Includes\EnvironmentVariableScope.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\Shared\InMemoryEventListener.cs" Link="Includes\InMemoryEventListener.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #1568

## Changes

App Service and Container Apps tables in the README now have the source environment variable in the description of every attribute that has one. Added troubleshooting sections containing `OpenTelemetry-Resources-Azure` EventSource.

`AppServiceResourceDetector` and `AzureContainerAppsResourceDetector` now write a Verbose event when they bail out because their environment variable is not present.

ResourceDetectorSkipped is logged with EventIdResourceDetectorSkipped taking ID 5. The reason for this is #5165 PR that declares `EventIdFailedToDetectAzureFunctionsResources` with ID 4.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
