### PR TITLE
[OpAMP] Make custom message queue limits configurable

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.OpAmp.Client/.publicApi/PublicAPI.Unshipped.txt
@@ -124,6 +124,10 @@ OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Identification.get -> Op
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.Identification.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.InstanceUid.get -> System.Guid
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.InstanceUid.set -> void
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.MaxPendingCustomMessageBytes.get -> int
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.MaxPendingCustomMessageBytes.set -> void
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.MaxPendingCustomMessages.get -> int
+OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.MaxPendingCustomMessages.set -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.OpAmpClientSettings() -> void
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.RemoteConfiguration.get -> OpenTelemetry.OpAmp.Client.Settings.RemoteConfigSettings!
 OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings.RemoteConfiguration.set -> void

--- a/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
+++ b/src/OpenTelemetry.OpAmp.Client/CHANGELOG.md
@@ -13,6 +13,10 @@
   is reached.
   ([#5161](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5161))
 
+* Make the custom message queue count and aggregate payload-byte limits
+  configurable through `OpAmpClientSettings`.
+  ([#5171](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5171))
+
 ## 0.6.0-alpha.1
 
 Released 2026-Jul-07

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientDefaults.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpClientDefaults.cs
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.OpAmp.Client.Internal;
+
+internal static class OpAmpClientDefaults
+{
+    internal const int MaxPendingCustomMessages = 2048;
+    internal const int MaxPendingCustomMessageBytes = 64 * 1024 * 1024;
+}

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpPipe.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpPipe.cs
@@ -13,11 +13,10 @@ namespace OpenTelemetry.OpAmp.Client.Internal;
 
 internal sealed class OpAmpPipe : IDisposable
 {
-    internal const int MaxPendingCustomMessages = 2048;
-    internal const int MaxPendingCustomMessageBytes = 64 * 1024 * 1024;
-
     private readonly IOpAmpTransport transport;
     private readonly FrameProcessor processor;
+    private readonly int maxPendingCustomMessages;
+    private readonly int maxPendingCustomMessageBytes;
     private readonly Lock frameLock = new();
     private readonly CancellationTokenSource tokenSource = new();
     private readonly ServerFrameHandler? frameHandler;
@@ -42,6 +41,8 @@ internal sealed class OpAmpPipe : IDisposable
         this.processor = processor;
         this.transport = transport;
         this.currentFrame = new FrameBuilder(settings);
+        this.maxPendingCustomMessages = settings.MaxPendingCustomMessages;
+        this.maxPendingCustomMessageBytes = settings.MaxPendingCustomMessageBytes;
 
         if (transport.RequiresResponseBeforeNextSend)
         {
@@ -124,17 +125,17 @@ internal sealed class OpAmpPipe : IDisposable
                 return; // Discard any new messages
             }
 
-            if (this.pendingFrames.Count >= MaxPendingCustomMessages)
+            if (this.pendingFrames.Count >= this.maxPendingCustomMessages)
             {
                 throw new InvalidOperationException(
-                    $"The custom message queue has reached its limit of {MaxPendingCustomMessages} pending messages.");
+                    $"The custom message queue has reached its limit of {this.maxPendingCustomMessages} pending messages.");
             }
 
-            if (data.Length > MaxPendingCustomMessageBytes - this.pendingCustomMessageBytes)
+            if (data.Length > this.maxPendingCustomMessageBytes - this.pendingCustomMessageBytes)
             {
                 throw new InvalidOperationException(
                     $"The custom message queue would exceed its limit of " +
-                    $"{MaxPendingCustomMessageBytes} pending payload bytes.");
+                    $"{this.maxPendingCustomMessageBytes} pending payload bytes.");
             }
 
             MessageBuilderHelper.AppendCustomMessage(this.currentFrame, capability, type, data);

--- a/src/OpenTelemetry.OpAmp.Client/README.md
+++ b/src/OpenTelemetry.OpAmp.Client/README.md
@@ -96,8 +96,10 @@ Use `SendCustomCapabilities()` to advertise custom capability names
 supported by the client. Use `SendCustomMessage()` to send a typed payload
 for one of those capabilities.
 
-The client retains up to 2,048 custom messages with up to 64 MiB of aggregate
-payload data while another message is being sent. `SendCustomMessage()` throws
+By default, the client retains up to 2,048 custom messages with up to 64 MiB of
+aggregate payload data while another message is being sent. Configure these
+limits with `OpAmpClientSettings.MaxPendingCustomMessages` and
+`OpAmpClientSettings.MaxPendingCustomMessageBytes`. `SendCustomMessage()` throws
 `InvalidOperationException` when either queue limit would be exceeded. Await
 `FlushAsync()` before retrying the rejected message.
 

--- a/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.WebSockets;
 
 using OpenTelemetry.Internal;
+using OpenTelemetry.OpAmp.Client.Internal;
 
 namespace OpenTelemetry.OpAmp.Client.Settings;
 
@@ -17,6 +18,9 @@ public sealed class OpAmpClientSettings
 {
     private static readonly Func<ClientWebSocket> DefaultClientWebSocketFactory = static () => new();
     private static readonly Func<HttpClient> DefaultHttpClientFactory = static () => new();
+
+    private int maxPendingCustomMessages = OpAmpClientDefaults.MaxPendingCustomMessages;
+    private int maxPendingCustomMessageBytes = OpAmpClientDefaults.MaxPendingCustomMessageBytes;
 
     /// <summary>
     /// Gets or sets the unique identifier for the current client instance.
@@ -77,6 +81,45 @@ public sealed class OpAmpClientSettings
             _ => throw new InvalidOperationException("Unknown connection type"),
         };
         set;
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum number of custom messages that may wait to be sent.
+    /// </summary>
+    /// <value>
+    /// The maximum number of pending custom messages. The default is <c>2,048</c>.
+    /// </value>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when the value is less than <c>1</c>.
+    /// </exception>
+    public int MaxPendingCustomMessages
+    {
+        get => this.maxPendingCustomMessages;
+        set
+        {
+            Guard.ThrowIfOutOfRange(value, min: 1);
+            this.maxPendingCustomMessages = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum aggregate payload size of custom messages that may wait to be sent.
+    /// </summary>
+    /// <value>
+    /// The maximum aggregate size, in bytes, of the <c>Data</c> payloads of pending
+    /// custom messages. The default is 64 MiB (<c>67,108,864</c> bytes).
+    /// </value>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when the value is less than <c>1</c>.
+    /// </exception>
+    public int MaxPendingCustomMessageBytes
+    {
+        get => this.maxPendingCustomMessageBytes;
+        set
+        {
+            Guard.ThrowIfOutOfRange(value, min: 1);
+            this.maxPendingCustomMessageBytes = value;
+        }
     }
 
     /// <summary>

--- a/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Settings/OpAmpClientSettings.cs
@@ -85,10 +85,8 @@ public sealed class OpAmpClientSettings
 
     /// <summary>
     /// Gets or sets the maximum number of custom messages that may wait to be sent.
+    /// The default is <c>2,048</c>.
     /// </summary>
-    /// <value>
-    /// The maximum number of pending custom messages. The default is <c>2,048</c>.
-    /// </value>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when the value is less than <c>1</c>.
     /// </exception>
@@ -103,12 +101,10 @@ public sealed class OpAmpClientSettings
     }
 
     /// <summary>
-    /// Gets or sets the maximum aggregate payload size of custom messages that may wait to be sent.
+    /// Gets or sets the maximum aggregate size, in bytes, of the <c>Data</c>
+    /// payloads of custom messages that may wait to be sent. The default is
+    /// 64 MiB (<c>67,108,864</c> bytes).
     /// </summary>
-    /// <value>
-    /// The maximum aggregate size, in bytes, of the <c>Data</c> payloads of pending
-    /// custom messages. The default is 64 MiB (<c>67,108,864</c> bytes).
-    /// </value>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when the value is less than <c>1</c>.
     /// </exception>

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientSettingsTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientSettingsTests.cs
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.OpAmp.Client.Settings;
+
+namespace OpenTelemetry.OpAmp.Client.Tests;
+
+public class OpAmpClientSettingsTests
+{
+    [Fact]
+    public void CustomMessageQueueLimits_HaveExpectedDefaults()
+    {
+        var settings = new OpAmpClientSettings();
+
+        Assert.Equal(2048, settings.MaxPendingCustomMessages);
+        Assert.Equal(64 * 1024 * 1024, settings.MaxPendingCustomMessageBytes);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public void MaxPendingCustomMessages_RejectsNonPositiveValue(int value)
+    {
+        var settings = new OpAmpClientSettings();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => settings.MaxPendingCustomMessages = value);
+
+        Assert.Equal(nameof(value), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public void MaxPendingCustomMessageBytes_RejectsNonPositiveValue(int value)
+    {
+        var settings = new OpAmpClientSettings();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => settings.MaxPendingCustomMessageBytes = value);
+
+        Assert.Equal(nameof(value), exception.ParamName);
+    }
+}

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientSettingsTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpClientSettingsTests.cs
@@ -23,10 +23,9 @@ public class OpAmpClientSettingsTests
     {
         var settings = new OpAmpClientSettings();
 
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+        Assert.Throws<ArgumentOutOfRangeException>(
+            nameof(value),
             () => settings.MaxPendingCustomMessages = value);
-
-        Assert.Equal(nameof(value), exception.ParamName);
     }
 
     [Theory]
@@ -36,9 +35,8 @@ public class OpAmpClientSettingsTests
     {
         var settings = new OpAmpClientSettings();
 
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+        Assert.Throws<ArgumentOutOfRangeException>(
+            nameof(value),
             () => settings.MaxPendingCustomMessageBytes = value);
-
-        Assert.Equal(nameof(value), exception.ParamName);
     }
 }

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpPipeTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpPipeTests.cs
@@ -113,8 +113,13 @@ public abstract class OpAmpPipeTests
     [Fact]
     public async Task OpAmpPipe_RejectsCustomMessagesBeyondQueueLimit()
     {
+        const int maxPendingCustomMessages = 2;
+
         using var transport = this.GetTransport();
-        var settings = new OpAmpClientSettings();
+        var settings = new OpAmpClientSettings
+        {
+            MaxPendingCustomMessages = maxPendingCustomMessages,
+        };
         var processor = new FrameProcessor();
         using var pipe = new OpAmpPipe(settings, processor, transport);
         var serverFrame = new ServerToAgent().ToByteArray();
@@ -122,15 +127,15 @@ public abstract class OpAmpPipeTests
         AppendIdentification(pipe);
         await transport.WaitForMessagesAsync(1);
 
-        for (var i = 0; i < OpAmpPipe.MaxPendingCustomMessages; i++)
+        for (var i = 0; i < maxPendingCustomMessages; i++)
         {
             AppendCustomMessage(pipe, i);
         }
 
         var exception = Assert.Throws<InvalidOperationException>(
-            () => AppendCustomMessage(pipe, OpAmpPipe.MaxPendingCustomMessages));
+            () => AppendCustomMessage(pipe, maxPendingCustomMessages));
 
-        Assert.Contains(OpAmpPipe.MaxPendingCustomMessages.ToString(), exception.Message);
+        Assert.Contains(maxPendingCustomMessages.ToString(), exception.Message);
         Assert.Single(transport.Messages);
 
         transport.CompleteNextSend();
@@ -138,17 +143,21 @@ public abstract class OpAmpPipeTests
         await transport.WaitForMessagesAsync(2);
 
         // Dequeueing a pending frame must make capacity available immediately.
-        AppendCustomMessage(pipe, OpAmpPipe.MaxPendingCustomMessages);
+        AppendCustomMessage(pipe, maxPendingCustomMessages);
     }
 
     [Fact]
     public async Task OpAmpPipe_RejectsCustomMessagesBeyondQueuePayloadByteLimit()
     {
-        const int payloadSize = 1024 * 1024;
-        const int messagesAtLimit = OpAmpPipe.MaxPendingCustomMessageBytes / payloadSize;
+        const int payloadSize = 4;
+        const int maxPendingCustomMessageBytes = 8;
+        const int messagesAtLimit = maxPendingCustomMessageBytes / payloadSize;
 
         using var transport = this.GetTransport();
-        var settings = new OpAmpClientSettings();
+        var settings = new OpAmpClientSettings
+        {
+            MaxPendingCustomMessageBytes = maxPendingCustomMessageBytes,
+        };
         var processor = new FrameProcessor();
         using var pipe = new OpAmpPipe(settings, processor, transport);
         var serverFrame = new ServerToAgent().ToByteArray();
@@ -164,7 +173,7 @@ public abstract class OpAmpPipeTests
 
         var fullQueueException = Assert.Throws<InvalidOperationException>(
             () => AppendCustomMessage(pipe, messagesAtLimit, new byte[1]));
-        Assert.Contains(OpAmpPipe.MaxPendingCustomMessageBytes.ToString(), fullQueueException.Message);
+        Assert.Contains(maxPendingCustomMessageBytes.ToString(), fullQueueException.Message);
         Assert.Single(transport.Messages);
 
         transport.CompleteNextSend();


### PR DESCRIPTION
## Changes

This PR makes the custom message queue limits introduced in #5161 configurable through `OpAmpClientSettings`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
