### PR TITLE
[Resources.Host] Add host.ip and host.mac resource attributes

### DIFF
--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Added the `host.ip` and `host.mac` resource attributes, emitted when
+  `OTEL_DOTNET_EXPERIMENTAL_HOST_RESOURCE_ENABLE_NETWORK_ADDRESSES` is `true`.
+  ([#5172](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5172))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -6,6 +6,10 @@
   `OTEL_DOTNET_EXPERIMENTAL_HOST_RESOURCE_ENABLE_NETWORK_ADDRESSES` is `true`.
   ([#5172](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5172))
 
+* Updated semantic conventions to
+  [v1.44.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/resource/host.md).
+  ([#5172](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5172))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Resources.Host/HostDetector.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetector.cs
@@ -6,6 +6,9 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 #endif
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using Microsoft.Win32;
 using OpenTelemetry.Internal;
 
@@ -16,6 +19,8 @@ namespace OpenTelemetry.Resources.Host;
 /// </summary>
 internal sealed class HostDetector : IResourceDetector
 {
+    internal const string EnableNetworkAddressesEnvVarName = "OTEL_DOTNET_EXPERIMENTAL_HOST_RESOURCE_ENABLE_NETWORK_ADDRESSES";
+
 #if !NETFRAMEWORK
     private const string ETCMACHINEID = "/etc/machine-id";
     private const string ETCVARDBUSMACHINEID = "/var/lib/dbus/machine-id";
@@ -113,7 +118,9 @@ internal sealed class HostDetector : IResourceDetector
     {
         try
         {
-            var attributes = new List<KeyValuePair<string, object>>(3)
+            var networkAddressesEnabled = IsNetworkAddressesEnabled();
+
+            var attributes = new List<KeyValuePair<string, object>>(networkAddressesEnabled ? 5 : 3)
             {
                 new(HostSemanticConventions.AttributeHostName, Environment.MachineName),
             };
@@ -136,6 +143,11 @@ internal sealed class HostDetector : IResourceDetector
 #error Architecture is available in .NET Framework 4.7.1+, enable it when we move to that as minimum supported version
 #endif
 
+            if (networkAddressesEnabled)
+            {
+                AddNetworkAddresses(attributes);
+            }
+
             return new Resource(attributes, SchemaUrls.Get(SemanticConventionsVersion));
         }
         catch (InvalidOperationException ex)
@@ -145,6 +157,35 @@ internal sealed class HostDetector : IResourceDetector
         }
 
         return Resource.Empty;
+    }
+
+    internal static bool ShouldIncludeNetworkInterface(OperationalStatus operationalStatus, NetworkInterfaceType networkInterfaceType) =>
+        operationalStatus == OperationalStatus.Up && networkInterfaceType != NetworkInterfaceType.Loopback;
+
+    internal static bool ShouldIncludeIpAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address) || address.IsIPv6LinkLocal)
+        {
+            return false;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            // 169.254.0.0/16 has no BCL predicate, unlike its IPv6 counterpart.
+            var addressBytes = address.GetAddressBytes();
+            return addressBytes[0] != 169 || addressBytes[1] != 254;
+        }
+
+        return true;
+    }
+
+    internal static string? FormatPhysicalAddress(PhysicalAddress physicalAddress)
+    {
+        var addressBytes = physicalAddress.GetAddressBytes();
+
+        // BitConverter renders the IEEE RA format the specification requires, which
+        // PhysicalAddress.ToString does not.
+        return addressBytes.Length == 0 ? null : BitConverter.ToString(addressBytes);
     }
 
 #if !NETFRAMEWORK
@@ -183,6 +224,55 @@ internal sealed class HostDetector : IResourceDetector
         yield return ETCVARDBUSMACHINEID;
     }
 #endif
+
+    private static bool IsNetworkAddressesEnabled() =>
+        bool.TryParse(Environment.GetEnvironmentVariable(EnableNetworkAddressesEnvVarName), out var enabled) && enabled;
+
+    private static void AddNetworkAddresses(List<KeyValuePair<string, object>> attributes)
+    {
+        var ipAddresses = new List<string>();
+        var macAddresses = new List<string>();
+
+        try
+        {
+            foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (!ShouldIncludeNetworkInterface(networkInterface.OperationalStatus, networkInterface.NetworkInterfaceType))
+                {
+                    continue;
+                }
+
+                foreach (var unicastAddress in networkInterface.GetIPProperties().UnicastAddresses)
+                {
+                    if (ShouldIncludeIpAddress(unicastAddress.Address))
+                    {
+                        ipAddresses.Add(unicastAddress.Address.ToString());
+                    }
+                }
+
+                var macAddress = FormatPhysicalAddress(networkInterface.GetPhysicalAddress());
+                if (macAddress != null)
+                {
+                    macAddresses.Add(macAddress);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            HostResourceEventSource.Log.ResourceAttributesExtractException(nameof(HostDetector), ex);
+            return;
+        }
+
+        if (ipAddresses.Count > 0)
+        {
+            attributes.Add(new(HostSemanticConventions.AttributeHostIp, ipAddresses.ToArray()));
+        }
+
+        if (macAddresses.Count > 0)
+        {
+            attributes.Add(new(HostSemanticConventions.AttributeHostMac, macAddresses.ToArray()));
+        }
+    }
 
 #if !NETFRAMEWORK
     private static string? GetMachineIdMacOs()

--- a/src/OpenTelemetry.Resources.Host/HostDetector.cs
+++ b/src/OpenTelemetry.Resources.Host/HostDetector.cs
@@ -26,7 +26,7 @@ internal sealed class HostDetector : IResourceDetector
     private const string ETCVARDBUSMACHINEID = "/var/lib/dbus/machine-id";
 #endif
 
-    private static readonly Version SemanticConventionsVersion = new(1, 43, 0);
+    private static readonly Version SemanticConventionsVersion = new(1, 44, 0);
 
 #if !NETFRAMEWORK
     private readonly Func<OSPlatform, bool> isOsPlatform;

--- a/src/OpenTelemetry.Resources.Host/HostSemanticConventions.cs
+++ b/src/OpenTelemetry.Resources.Host/HostSemanticConventions.cs
@@ -8,4 +8,6 @@ internal static class HostSemanticConventions
     public const string AttributeHostName = "host.name";
     public const string AttributeHostId = "host.id";
     public const string AttributeHostArch = "host.arch";
+    public const string AttributeHostIp = "host.ip";
+    public const string AttributeHostMac = "host.mac";
 }

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -10,7 +10,7 @@
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib/branch/main/graphs/badge.svg?flag=unittests-Resources.Host)](https://app.codecov.io/gh/open-telemetry/opentelemetry-dotnet-contrib?flags[0]=unittests-Resources.Host)
 
 > [!IMPORTANT]
-> Resources detected by this packages are defined by [experimental semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/resource/host.md).
+> Resources detected by this packages are defined by [experimental semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/resource/host.md).
 > These resources can be changed without prior notification.
 
 ## Getting Started
@@ -57,7 +57,29 @@ your application is running:
 - **HostDetector**:
   - `host.arch` (supported only on .NET),
   - `host.id` (when running on non-containerized systems),
+  - `host.ip` and `host.mac` (opt-in, see
+    [Network addresses](#network-addresses)),
   - `host.name`.
+
+## Experimental features
+
+> [!NOTE]
+> Experimental features are off by default and are turned on through
+> environment variables. They may change or be removed in a future release.
+
+### Network addresses
+
+`host.ip` and `host.mac` are
+[opt-in](https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/resource/host.md)
+attributes and identify the machine, so they are not emitted by default. Set
+`OTEL_DOTNET_EXPERIMENTAL_HOST_RESOURCE_ENABLE_NETWORK_ADDRESSES` to `true` to
+emit them.
+
+Both attributes are read from network interfaces that are up, skipping
+loopback interfaces. `host.ip` also leaves out link-local addresses, and
+`host.mac` only includes interfaces that have a physical address. The values
+are captured once, when the resource is built, so addresses assigned after
+startup are not picked up.
 
 ## References
 

--- a/src/OpenTelemetry.Resources.Host/README.md
+++ b/src/OpenTelemetry.Resources.Host/README.md
@@ -78,8 +78,8 @@ emit them.
 Both attributes are read from network interfaces that are up, skipping
 loopback interfaces. `host.ip` also leaves out link-local addresses, and
 `host.mac` only includes interfaces that have a physical address. The values
-are captured once, when the resource is built, so addresses assigned after
-startup are not picked up.
+are read when the resource is built, so addresses assigned afterwards are
+only picked up if the resource is built again.
 
 ## References
 

--- a/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
+++ b/test/OpenTelemetry.Resources.Host.Tests/HostDetectorTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Net;
+using System.Net.NetworkInformation;
 #if NET
 using System.Runtime.InteropServices;
 #endif
@@ -9,6 +11,8 @@ namespace OpenTelemetry.Resources.Host.Tests;
 
 public class HostDetectorTests
 {
+    private const string EnableNetworkAddressesEnvVarName = "OTEL_DOTNET_EXPERIMENTAL_HOST_RESOURCE_ENABLE_NETWORK_ADDRESSES";
+
 #if !NETFRAMEWORK
     private const string MacOSMachineIdOutput = @"+-o J293AP  <class IOPlatformExpertDevice, id 0x100000227, registered, matched,$
         {
@@ -48,6 +52,8 @@ public class HostDetectorTests
     [Fact]
     public void TestHostAttributes()
     {
+        using var environment = EnvironmentVariableScope.Create(EnableNetworkAddressesEnvVarName, null);
+
         var resource = ResourceBuilder.CreateEmpty().AddHostDetector().Build();
 
         Assert.NotNull(resource);
@@ -231,4 +237,74 @@ public class HostDetectorTests
         }
     }
 #endif
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("True")]
+    [InlineData("TRUE")]
+    public void TestHostNetworkAddressesEnabled(string value)
+    {
+        using var environment = EnvironmentVariableScope.Create(EnableNetworkAddressesEnvVarName, value);
+
+        var resource = ResourceBuilder.CreateEmpty().AddHostDetector().Build();
+
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
+
+        Assert.True(resourceAttributes.ContainsKey("host.ip"), "host.ip should be detected when the flag is set and the host has an eligible network interface.");
+        Assert.True(resourceAttributes.ContainsKey("host.mac"), "host.mac should be detected when the flag is set and the host has an eligible network interface.");
+
+        Assert.NotEmpty(Assert.IsType<string[]>(resourceAttributes["host.ip"]));
+        Assert.NotEmpty(Assert.IsType<string[]>(resourceAttributes["host.mac"]));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(" ")]
+    [InlineData("false")]
+    [InlineData("1")]
+    public void TestHostNetworkAddressesNotEnabled(string? value)
+    {
+        using var environment = EnvironmentVariableScope.Create(EnableNetworkAddressesEnvVarName, value);
+
+        var resource = ResourceBuilder.CreateEmpty().AddHostDetector().Build();
+
+        var resourceAttributes = resource.Attributes.ToDictionary(x => x.Key, x => x.Value);
+
+        Assert.False(resourceAttributes.ContainsKey("host.ip"), "host.ip should not be detected when the flag is not set.");
+        Assert.False(resourceAttributes.ContainsKey("host.mac"), "host.mac should not be detected when the flag is not set.");
+    }
+
+    [Theory]
+    [InlineData(OperationalStatus.Up, NetworkInterfaceType.Ethernet, true)]
+    [InlineData(OperationalStatus.Up, NetworkInterfaceType.Wireless80211, true)]
+    [InlineData(OperationalStatus.Up, NetworkInterfaceType.Unknown, true)]
+    [InlineData(OperationalStatus.Up, NetworkInterfaceType.Tunnel, true)]
+    [InlineData(OperationalStatus.Up, NetworkInterfaceType.Loopback, false)]
+    [InlineData(OperationalStatus.Down, NetworkInterfaceType.Ethernet, false)]
+    [InlineData(OperationalStatus.Dormant, NetworkInterfaceType.Ethernet, false)]
+    public void TestShouldIncludeNetworkInterface(OperationalStatus operationalStatus, NetworkInterfaceType networkInterfaceType, bool expected) =>
+        Assert.Equal(expected, HostDetector.ShouldIncludeNetworkInterface(operationalStatus, networkInterfaceType));
+
+    [Theory]
+    [InlineData("192.0.2.1", true)]
+    [InlineData("2001:db8::1", true)]
+    [InlineData("10.0.0.4", true)]
+    [InlineData("169.255.0.1", true)]
+    [InlineData("127.0.0.1", false)]
+    [InlineData("::1", false)]
+    [InlineData("169.254.0.1", false)]
+    [InlineData("fe80::1", false)]
+    public void TestShouldIncludeIpAddress(string address, bool expected) =>
+        Assert.Equal(expected, HostDetector.ShouldIncludeIpAddress(IPAddress.Parse(address)));
+
+    [Theory]
+    [InlineData(new byte[] { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF }, "AA-BB-CC-DD-EE-FF")]
+    [InlineData(new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0xFF }, "00-11-22-33-44-FF")]
+    [InlineData(new byte[] { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11 }, "AA-BB-CC-DD-EE-FF-00-11")]
+    public void TestFormatPhysicalAddress(byte[] address, string expected) =>
+        Assert.Equal(expected, HostDetector.FormatPhysicalAddress(new PhysicalAddress(address)));
+
+    [Fact]
+    public void TestFormatPhysicalAddressWithEmptyAddress() =>
+        Assert.Null(HostDetector.FormatPhysicalAddress(PhysicalAddress.None));
 }

--- a/test/OpenTelemetry.Resources.Host.Tests/OpenTelemetry.Resources.Host.Tests.csproj
+++ b/test/OpenTelemetry.Resources.Host.Tests/OpenTelemetry.Resources.Host.Tests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\test\Shared\EnvironmentVariableScope.cs" Link="Includes\EnvironmentVariableScope.cs" />
     <Compile Include="$(RepoRoot)\test\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Design discussion issue #1516.

First of the three proposed points there.

## Changes

`host.ip` and `host.mac` are emitted when `OTEL_DOTNET_EXPERIMENTAL_HOST_RESOURCE_ENABLE_NETWORK_ADDRESSES` is set to true. Both are opt_in in semconv, so they are off by default, meaning existing users are not affected.

Implementation follows the OpenTelemetry Collector's [system detector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.160.0/internal/metadataproviders/system/metadata.go#L274-L322) (interfaces that are Up and not loopback, skipping loopback addresses). There are 2 differences:
- An interface with an empty physical address contributes no MAC
- Duplicate values are removed from both attributes, first occurrence is kept

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
