### PR TITLE
[Infra] Fix code analysis warnings

### DIFF
--- a/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/FrameProcessor.cs
@@ -176,7 +176,7 @@ internal sealed class FrameProcessor
             return true;
         }
 
-        result = Array.Empty<object>();
+        result = [];
         return false;
     }
 }

--- a/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpPipe.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/OpAmpPipe.cs
@@ -197,7 +197,7 @@ internal sealed class OpAmpPipe : IDisposable
 
         var cancellationCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var registration = token.Register(
-            static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true),
+            static state => ((TaskCompletionSource<bool>?)state)?.TrySetResult(true),
             cancellationCompletion);
 
         if (await Task.WhenAny(flushTask, cancellationCompletion.Task).ConfigureAwait(false) == cancellationCompletion.Task)

--- a/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
+++ b/src/OpenTelemetry.OpAmp.Client/Internal/Services/Heartbeat/HeartbeatService.cs
@@ -104,9 +104,9 @@ internal sealed class HeartbeatService : IBackgroundService, IOpAmpListener<Conn
         }
     }
 
-    private void HeartbeatTick(object? state) => _ = this.HeartbeatTickAsync();
+    private void HeartbeatTick(object? state) => this.HeartbeatTick();
 
-    private async Task HeartbeatTickAsync()
+    private void HeartbeatTick()
     {
         if (this.cts.IsCancellationRequested)
         {

--- a/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Geneva.Tests/OtlpProtobufMetricExporterTests.cs
@@ -1014,8 +1014,8 @@ public abstract class OtlpProtobufMetricExporterTests
         var expectedBucketCounts = new ulong[boundaryCount + 1];
         expectedBucketCounts[boundaryCount / 2] = 1;
 
-        Assert.Equal(boundaries, dataPoint.ExplicitBounds.ToArray());
-        Assert.Equal(expectedBucketCounts, dataPoint.BucketCounts.ToArray());
+        Assert.Equal(boundaries, dataPoint.ExplicitBounds.ToList());
+        Assert.Equal(expectedBucketCounts, dataPoint.BucketCounts.ToList());
     }
 
     [Theory]

--- a/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Remoting.Tests/RemotingInstrumentationTests.cs
@@ -244,7 +244,7 @@ public class RemotingInstrumentationTests
 
             // LogicalCallContext has no accessible constructor; the runtime only ever hands out
             // instances it creates itself, so one is created reflectively for this fake message.
-            this.LogicalCallContext = (LogicalCallContext)Activator.CreateInstance(typeof(LogicalCallContext), nonPublic: true)!;
+            this.LogicalCallContext = (LogicalCallContext)Activator.CreateInstance(typeof(LogicalCallContext), nonPublic: true);
             this.Properties = new Hashtable { ["__CallContext"] = this.LogicalCallContext };
         }
 

--- a/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockControlledTransport.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/Mocks/MockControlledTransport.cs
@@ -13,7 +13,7 @@ internal abstract class MockControlledTransport : IOpAmpTransport, IDisposable
 {
     private readonly ConcurrentQueue<AgentToServer> messages = [];
     private readonly ConcurrentQueue<TaskCompletionSource<bool>> sendCompletions = [];
-    private readonly object syncRoot = new();
+    private readonly Lock syncRoot = new();
     private Action? firstSendCallback;
 
     private int waitTarget;

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpPipeTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpPipeTests.cs
@@ -221,6 +221,8 @@ public abstract class OpAmpPipeTests
         {
             await pipe.FlushAsync();
         });
+
+        await Task.CompletedTask;
 #endif
 
         Assert.Empty(transport.Messages);

--- a/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpWsPipeTests.cs
+++ b/test/OpenTelemetry.OpAmp.Client.Tests/OpAmpWsPipeTests.cs
@@ -50,7 +50,7 @@ public class OpAmpWsPipeTests : OpAmpPipeTests
         // Hold the first send while the queue fills; every later send completes synchronously.
         private readonly TaskCompletionSource<bool> firstSendCompletion = new();
         private readonly ManualResetEventSlim firstSendStarted = new();
-        private readonly object stackDepthLock = new();
+        private readonly Lock stackDepthLock = new();
         private int maximumStackDepth;
         private int minimumStackDepth = int.MaxValue;
         private int sendCount;


### PR DESCRIPTION
## Changes

Fix new .NET 11 code analysis warnings surfaced in #3867.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
