### PR TITLE
[AWSLambda] Add EnrichWithInput to describe unrecognised triggers

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaInstrumentationOptions.EnrichWithInput.get -> System.Action<System.Diagnostics.Activity!, object?>?
+OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaInstrumentationOptions.EnrichWithInput.set -> void

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/.publicApi/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaInstrumentationOptions.EnrichWithInput.get -> System.Action<System.Diagnostics.Activity!, object?>?
+OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaInstrumentationOptions.EnrichWithInput.get -> System.Action<System.Diagnostics.Activity!, object?, Amazon.Lambda.Core.ILambdaContext!>?
 OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaInstrumentationOptions.EnrichWithInput.set -> void

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaInstrumentationOptions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Amazon.Lambda.Core;
 using OpenTelemetry.AWS;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda;
@@ -26,15 +27,16 @@ public class AWSLambdaInstrumentationOptions
     public bool SetParentFromBatch { get; set; }
 
     /// <summary>
-    /// Gets or sets an action to enrich the invocation Activity from the function input.
-    /// Use it to describe a trigger the instrumentation does not recognise, for example to set
-    /// <c>faas.trigger</c> and the <c>faas.document.*</c> attributes for an Amazon S3 event.
+    /// Gets or sets an action to enrich the invocation Activity from the function input and
+    /// the Lambda context. Use it to describe a trigger the instrumentation does not recognise,
+    /// for example to set <c>faas.trigger</c> and the <c>faas.document.*</c> attributes for an
+    /// Amazon S3 event.
     /// </summary>
     /// <remarks>
     /// The action runs after the activity is created, so values it sets are not seen by samplers,
     /// and it applies process-wide rather than per-provider.
     /// </remarks>
-    public Action<Activity, object?>? EnrichWithInput { get; set; }
+    public Action<Activity, object?, ILambdaContext>? EnrichWithInput { get; set; }
 
     /// <inheritdoc cref="AWSLambda.SemanticConventionVersion"/>
     public SemanticConventionVersion SemanticConventionVersion { get; set; } = AWSSemanticConventions.DefaultSemanticConventionVersion;

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaInstrumentationOptions.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using OpenTelemetry.AWS;
 
 namespace OpenTelemetry.Instrumentation.AWSLambda;
@@ -23,6 +24,17 @@ public class AWSLambdaInstrumentationOptions
     /// Currently, the only event type to which this applies is SQS.
     /// </remarks>
     public bool SetParentFromBatch { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action to enrich the invocation Activity from the function input.
+    /// Use it to describe a trigger the instrumentation does not recognise, for example to set
+    /// <c>faas.trigger</c> and the <c>faas.document.*</c> attributes for an Amazon S3 event.
+    /// </summary>
+    /// <remarks>
+    /// The action runs after the activity is created, so values it sets are not seen by samplers,
+    /// and it applies process-wide rather than per-provider.
+    /// </remarks>
+    public Action<Activity, object?>? EnrichWithInput { get; set; }
 
     /// <inheritdoc cref="AWSLambda.SemanticConventionVersion"/>
     public SemanticConventionVersion SemanticConventionVersion { get; set; } = AWSSemanticConventions.DefaultSemanticConventionVersion;

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
@@ -38,6 +38,8 @@ public static class AWSLambdaWrapper
 
     internal static AWSSemanticConventions AWSSemanticConventions { get; set; } = new();
 
+    internal static Action<Activity, object?>? EnrichWithInput { get; set; }
+
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 
     /// <summary>
@@ -183,6 +185,19 @@ public static class AWSLambdaWrapper
         // We assume that functionTags and httpTags have no intersection.
         var activityName = AWSLambdaUtils.GetFunctionName(context) ?? "AWS Lambda Invoke";
         var activity = AWSLambdaActivitySource.Value.StartActivity(activityName, ActivityKind.Server, parentContext, functionTags.Concat(httpTags)!, links);
+
+        if (activity is { IsAllDataRequested: true } && EnrichWithInput is { } enrich)
+        {
+            try
+            {
+                enrich(activity, input);
+            }
+            catch
+            {
+                // A failure in the caller's action must not fail the invocation. It is not
+                // reported, so the action should be defensive or handle its own errors.
+            }
+        }
 
         return activity;
     }

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaWrapper.cs
@@ -38,7 +38,7 @@ public static class AWSLambdaWrapper
 
     internal static AWSSemanticConventions AWSSemanticConventions { get; set; } = new();
 
-    internal static Action<Activity, object?>? EnrichWithInput { get; set; }
+    internal static Action<Activity, object?, ILambdaContext>? EnrichWithInput { get; set; }
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 
@@ -190,7 +190,7 @@ public static class AWSLambdaWrapper
         {
             try
             {
-                enrich(activity, input);
+                enrich(activity, input, context);
             }
             catch
             {

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Unreleased
 
+* The `faas.trigger` span attribute is now set to `pubsub` for functions
+  triggered by SQS or SNS events, instead of `other`.
+  ([#5146](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5146))
+
 * Added `AWSLambdaInstrumentationOptions.EnrichWithInput`, an action invoked with
   the invocation `Activity` and the function input. This allows a function to
   describe a trigger the instrumentation does not classify itself, such as setting
   `faas.trigger` and the `faas.document.*` attributes for an Amazon S3 or Amazon
   DynamoDB event.
   ([#5180](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5180))
-
-* The `faas.trigger` span attribute is now set to `pubsub` for functions
-  triggered by SQS or SNS events, instead of `other`.
-  ([#5146](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5146))
 
 ## 1.18.0
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -6,8 +6,7 @@
   the invocation `Activity` and the function input. This allows a function to
   describe a trigger the instrumentation does not classify itself, such as setting
   `faas.trigger` and the `faas.document.*` attributes for an Amazon S3 or Amazon
-  DynamoDB event, without this package taking a dependency on those event
-  packages.
+  DynamoDB event.
   ([#5180](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5180))
 
 * The `faas.trigger` span attribute is now set to `pubsub` for functions

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -7,10 +7,10 @@
   ([#5146](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5146))
 
 * Added `AWSLambdaInstrumentationOptions.EnrichWithInput`, an action invoked with
-  the invocation `Activity` and the function input. This allows a function to
-  describe a trigger the instrumentation does not classify itself, such as setting
-  `faas.trigger` and the `faas.document.*` attributes for an Amazon S3 or Amazon
-  DynamoDB event.
+  the invocation `Activity`, the function input and the `ILambdaContext`. This
+  allows a function to describe a trigger the instrumentation does not classify
+  itself, such as setting `faas.trigger` and the `faas.document.*` attributes for
+  an Amazon S3 or Amazon DynamoDB event.
   ([#5180](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5180))
 
 ## 1.18.0

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Added `AWSLambdaInstrumentationOptions.EnrichWithInput`, an action invoked with
+  the invocation `Activity` and the function input. This allows a function to
+  describe a trigger the instrumentation does not classify itself, such as setting
+  `faas.trigger` and the `faas.document.*` attributes for an Amazon S3 or Amazon
+  DynamoDB event, without this package taking a dependency on those event
+  packages.
+  ([#5180](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5180))
+
 * The `faas.trigger` span attribute is now set to `pubsub` for functions
   triggered by SQS or SNS events, instead of `other`.
   ([#5146](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/5146))

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
@@ -44,15 +44,15 @@ requests and to `pubsub` for SQS and SNS events. Other event sources report
 `other`.
 
 `EnrichWithInput` lets a function describe its own trigger. The action receives
-the invocation `Activity` and the function input, and runs after the activity is
-created. For example, for an S3 triggered function:
+the invocation `Activity`, the function input and the `ILambdaContext`, and runs
+after the activity is created. For example, for an S3 triggered function:
 
 ```csharp
 using System.Net;
 using Amazon.Lambda.S3Events;
 
 TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddAWSLambdaConfigurations(options => options.EnrichWithInput = (activity, input) =>
+    .AddAWSLambdaConfigurations(options => options.EnrichWithInput = (activity, input, context) =>
     {
         // S3 sends one event entry per notification.
         if (input is S3Event { Records.Count: 1 } s3Event)
@@ -67,6 +67,8 @@ TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
             activity.SetTag("faas.document.name", WebUtility.UrlDecode(record.S3.Object.Key));
             activity.SetTag("faas.document.time", record.EventTime.ToUniversalTime().ToString("o"));
         }
+
+        activity.SetTag("aws.lambda.log_stream", context.LogStreamName);
     })
     .Build();
 ```

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
@@ -35,6 +35,48 @@ AWS lambda instrumentation:
 
 * [`DisableAwsXRayContextExtraction`](/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaInstrumentationOptions.cs)
 * [`SetParentFromBatch`](/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaInstrumentationOptions.cs)
+* [`EnrichWithInput`](/src/OpenTelemetry.Instrumentation.AWSLambda/AWSLambdaInstrumentationOptions.cs)
+
+### Enriching the invocation span
+
+`faas.trigger` is set to `http` for API Gateway and Application Load Balancer
+requests and to `pubsub` for SQS and SNS events. Other event sources report
+`other`, because classifying them would require this package to depend on their
+event packages.
+
+`EnrichWithInput` lets a function describe its own trigger. The action receives
+the invocation `Activity` and the function input, and runs after the activity is
+created. For example, for an S3 triggered function:
+
+```csharp
+using System.Net;
+using Amazon.Lambda.S3Events;
+
+TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddAWSLambdaConfigurations(options => options.EnrichWithInput = (activity, input) =>
+    {
+        // S3 sends one event entry per notification.
+        if (input is S3Event { Records.Count: 1 } s3Event)
+        {
+            var record = s3Event.Records[0];
+
+            activity.SetTag("faas.trigger", "datasource");
+            activity.SetTag("faas.document.collection", record.S3.Bucket.Name);
+            activity.SetTag("faas.document.operation", "insert");
+
+            // S3 URL encodes the object key in the notification.
+            activity.SetTag("faas.document.name", WebUtility.UrlDecode(record.S3.Object.Key));
+            activity.SetTag("faas.document.time", record.EventTime.ToUniversalTime().ToString("o"));
+        }
+    })
+    .Build();
+```
+
+> [!NOTE]
+> The action runs after the activity is created, so attributes it sets are not
+> visible to samplers. Exceptions thrown by the action are caught so that they
+> cannot fail the invocation, and are not reported; keep the action defensive, or
+> handle errors within it if you need them logged.
 
 ### Query string redaction
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
@@ -41,8 +41,7 @@ AWS lambda instrumentation:
 
 `faas.trigger` is set to `http` for API Gateway and Application Load Balancer
 requests and to `pubsub` for SQS and SNS events. Other event sources report
-`other`, because classifying them would require this package to depend on their
-event packages.
+`other`.
 
 `EnrichWithInput` lets a function describe its own trigger. The action receives
 the invocation `Activity` and the function input, and runs after the activity is

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/README.md
@@ -73,9 +73,7 @@ TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 > [!NOTE]
 > The action runs after the activity is created, so attributes it sets are not
-> visible to samplers. Exceptions thrown by the action are caught so that they
-> cannot fail the invocation, and are not reported; keep the action defensive, or
-> handle errors within it if you need them logged.
+> visible to samplers.
 
 ### Query string redaction
 

--- a/src/OpenTelemetry.Instrumentation.AWSLambda/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWSLambda/TracerProviderBuilderExtensions.cs
@@ -42,6 +42,7 @@ public static class TracerProviderBuilderExtensions
         AWSLambdaWrapper.DisableAwsXRayContextExtraction = options.DisableAwsXRayContextExtraction;
         AWSLambdaWrapper.DisableUrlQueryRedaction = AWSLambdaWrapper.IsUrlQueryRedactionDisabledFromEnvironment();
         AWSMessagingUtils.SetParentFromMessageBatch = options.SetParentFromBatch;
+        AWSLambdaWrapper.EnrichWithInput = options.EnrichWithInput;
 
         builder.AddSource(AWSLambdaWrapper.ActivitySourceName);
         builder.ConfigureResource(x => x.AddDetector(new AWSLambdaResourceDetector(awsSemanticConventions)));

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Amazon.Lambda.Core;
 using Amazon.Lambda.SNSEvents;
 using Amazon.Lambda.SQSEvents;
 using OpenTelemetry.Resources;
@@ -404,6 +405,168 @@ public class AWSLambdaWrapperTests : IDisposable
 
         var item = Assert.Single(exportedItems);
         Assert.Equal("pubsub", item.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+    }
+
+    [Fact]
+    public void EnrichWithInputIsInvokedWithTheFunctionInput()
+    {
+        var exportedItems = new List<Activity>();
+        object? observedInput = null;
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                       opt.EnrichWithInput = (_, input) => observedInput = input;
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncInputAndNoReturn, "TestStream", this.sampleLambdaContext);
+        }
+
+        Assert.Single(exportedItems);
+        Assert.Equal("TestStream", observedInput);
+    }
+
+    [Fact]
+    public void EnrichWithInputCanAddAttributes()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                       opt.EnrichWithInput = (activity, _) => activity.SetTag("custom.attribute", "value");
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncInputAndNoReturn, "TestStream", this.sampleLambdaContext);
+        }
+
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("value", item.GetTagValue("custom.attribute"));
+    }
+
+    [Fact]
+    public void EnrichWithInputCanOverrideFaasTrigger()
+    {
+        // This is what the datasource trigger types need.
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                       opt.EnrichWithInput = (activity, _) =>
+                       {
+                           activity.SetTag(ExpectedSemanticConventions.AttributeFaasTrigger, "datasource");
+                           activity.SetTag("faas.document.collection", "my-bucket");
+                           activity.SetTag("faas.document.operation", "insert");
+                       };
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncInputAndNoReturn, "TestStream", this.sampleLambdaContext);
+        }
+
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("datasource", item.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+        Assert.Equal("my-bucket", item.GetTagValue("faas.document.collection"));
+        Assert.Equal("insert", item.GetTagValue("faas.document.operation"));
+    }
+
+    [Fact]
+    public void EnrichWithInputExceptionDoesNotFailTheInvocation()
+    {
+        var exportedItems = new List<Activity>();
+        var handlerRan = false;
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                       opt.EnrichWithInput = (_, _) => throw new InvalidOperationException("enrichment failure");
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(
+                tracerProvider,
+                (string _, ILambdaContext _) => handlerRan = true,
+                "TestStream",
+                this.sampleLambdaContext);
+        }
+
+        Assert.True(handlerRan);
+        var item = Assert.Single(exportedItems);
+        Assert.Equal(ActivityStatusCode.Unset, item.Status);
+    }
+
+    [Fact]
+    public async Task EnrichWithInputIsInvokedForAsyncHandlers()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                       opt.EnrichWithInput = (activity, _) => activity.SetTag("custom.attribute", "async");
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            await AWSLambdaWrapper.TraceAsync(tracerProvider, this.sampleHandlers.SampleHandlerAsyncInputAndNoReturn, "TestStream", this.sampleLambdaContext);
+        }
+
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("async", item.GetTagValue("custom.attribute"));
+    }
+
+    [Fact]
+    public void EnrichWithInputIsNotInvokedWhenTheActivityIsNotRecorded()
+    {
+        // Attributes on a non-recording activity are discarded, so the action is skipped.
+        var invoked = false;
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                       opt.EnrichWithInput = (_, _) => invoked = true;
+                   })
+                   .SetSampler(new AlwaysOffSampler())
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncInputAndNoReturn, "TestStream", this.sampleLambdaContext);
+        }
+
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void NoEnrichWithInputLeavesTheActivityUnchanged()
+    {
+        var exportedItems = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                   .AddAWSLambdaConfigurations(opt =>
+                   {
+                       opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
+                   })
+                   .AddInMemoryExporter(exportedItems)
+                   .Build()!)
+        {
+            AWSLambdaWrapper.Trace(tracerProvider, this.sampleHandlers.SampleHandlerSyncInputAndNoReturn, "TestStream", this.sampleLambdaContext);
+        }
+
+        var item = Assert.Single(exportedItems);
+        Assert.Equal("other", item.GetTagValue(ExpectedSemanticConventions.AttributeFaasTrigger));
+        Assert.Null(item.GetTagValue("custom.attribute"));
     }
 
     private static ActivityContext CreateParentContext()

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -453,7 +453,6 @@ public class AWSLambdaWrapperTests : IDisposable
     [Fact]
     public void EnrichWithInputCanOverrideFaasTrigger()
     {
-        // This is what the datasource trigger types need.
         var exportedItems = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -529,7 +529,6 @@ public class AWSLambdaWrapperTests : IDisposable
     [Fact]
     public void EnrichWithInputIsNotInvokedWhenTheActivityIsNotRecorded()
     {
-        // Attributes on a non-recording activity are discarded, so the action is skipped.
         var invoked = false;
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -483,12 +483,17 @@ public class AWSLambdaWrapperTests : IDisposable
     {
         var exportedItems = new List<Activity>();
         var handlerRan = false;
+        var enricherRan = false;
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
                    .AddAWSLambdaConfigurations(opt =>
                    {
                        opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
-                       opt.EnrichWithInput = (_, _) => throw new InvalidOperationException("enrichment failure");
+                       opt.EnrichWithInput = (_, _) =>
+                       {
+                           enricherRan = true;
+                           throw new InvalidOperationException("enrichment failure");
+                       };
                    })
                    .AddInMemoryExporter(exportedItems)
                    .Build()!)
@@ -500,6 +505,7 @@ public class AWSLambdaWrapperTests : IDisposable
                 this.sampleLambdaContext);
         }
 
+        Assert.True(enricherRan);
         Assert.True(handlerRan);
         var item = Assert.Single(exportedItems);
         Assert.Equal(ActivityStatusCode.Unset, item.Status);

--- a/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWSLambda.Tests/AWSLambdaWrapperTests.cs
@@ -408,16 +408,21 @@ public class AWSLambdaWrapperTests : IDisposable
     }
 
     [Fact]
-    public void EnrichWithInputIsInvokedWithTheFunctionInput()
+    public void EnrichWithInputIsInvokedWithTheFunctionInputAndLambdaContext()
     {
         var exportedItems = new List<Activity>();
         object? observedInput = null;
+        ILambdaContext? observedContext = null;
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
                    .AddAWSLambdaConfigurations(opt =>
                    {
                        opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
-                       opt.EnrichWithInput = (_, input) => observedInput = input;
+                       opt.EnrichWithInput = (_, input, context) =>
+                       {
+                           observedInput = input;
+                           observedContext = context;
+                       };
                    })
                    .AddInMemoryExporter(exportedItems)
                    .Build()!)
@@ -427,6 +432,7 @@ public class AWSLambdaWrapperTests : IDisposable
 
         Assert.Single(exportedItems);
         Assert.Equal("TestStream", observedInput);
+        Assert.Same(this.sampleLambdaContext, observedContext);
     }
 
     [Fact]
@@ -438,7 +444,7 @@ public class AWSLambdaWrapperTests : IDisposable
                    .AddAWSLambdaConfigurations(opt =>
                    {
                        opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
-                       opt.EnrichWithInput = (activity, _) => activity.SetTag("custom.attribute", "value");
+                       opt.EnrichWithInput = (activity, _, _) => activity.SetTag("custom.attribute", "value");
                    })
                    .AddInMemoryExporter(exportedItems)
                    .Build()!)
@@ -459,7 +465,7 @@ public class AWSLambdaWrapperTests : IDisposable
                    .AddAWSLambdaConfigurations(opt =>
                    {
                        opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
-                       opt.EnrichWithInput = (activity, _) =>
+                       opt.EnrichWithInput = (activity, _, _) =>
                        {
                            activity.SetTag(ExpectedSemanticConventions.AttributeFaasTrigger, "datasource");
                            activity.SetTag("faas.document.collection", "my-bucket");
@@ -489,7 +495,7 @@ public class AWSLambdaWrapperTests : IDisposable
                    .AddAWSLambdaConfigurations(opt =>
                    {
                        opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
-                       opt.EnrichWithInput = (_, _) =>
+                       opt.EnrichWithInput = (_, _, _) =>
                        {
                            enricherRan = true;
                            throw new InvalidOperationException("enrichment failure");
@@ -520,7 +526,7 @@ public class AWSLambdaWrapperTests : IDisposable
                    .AddAWSLambdaConfigurations(opt =>
                    {
                        opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
-                       opt.EnrichWithInput = (activity, _) => activity.SetTag("custom.attribute", "async");
+                       opt.EnrichWithInput = (activity, _, _) => activity.SetTag("custom.attribute", "async");
                    })
                    .AddInMemoryExporter(exportedItems)
                    .Build()!)
@@ -541,7 +547,7 @@ public class AWSLambdaWrapperTests : IDisposable
                    .AddAWSLambdaConfigurations(opt =>
                    {
                        opt.SemanticConventionVersion = SemanticConventionVersion.Latest;
-                       opt.EnrichWithInput = (_, _) => invoked = true;
+                       opt.EnrichWithInput = (_, _, _) => invoked = true;
                    })
                    .SetSampler(new AlwaysOffSampler())
                    .Build()!)


### PR DESCRIPTION
Fixes #
Design discussion issue #5178 

## Changes

`GetFaasTrigger` classifies API Gateway and Application Load Balancer requests as `http` and, since #5146, SQS and SNS events as `pubsub`. Every other event source reports `other`.

#5178 describe about supporting `datasource` for S3, and the answer there was to avoid new dependencies and instead make this achievable by the user for an arbitrary trigger. This adds that:

```csharp
public Action<Activity, object?, ILambdaContext>? EnrichWithInput { get; set; }
```
The action is invoked with the invocation Activity ,the function input and the ILambdaContext, so a function can describe its own trigger. This follows the EnrichWith* pattern already used by the AspNetCore, Http, GrpcNetClient and ElasticsearchClient instrumentations.

For the S3 case from #5178, the user references `Amazon.Lambda.S3Events` in their own function, where they already have it and this package takes no new dependency:

```
.AddAWSLambdaConfigurations(options => options.EnrichWithInput = (activity, input, context) =>
{
    if (input is S3Event { Records.Count: 1 } s3Event)
    {
        var record = s3Event.Records[0];
        activity.SetTag("faas.trigger", "datasource");
        activity.SetTag("faas.document.collection", record.S3.Bucket.Name);
        activity.SetTag("faas.document.operation", "insert");
        activity.SetTag("faas.document.name", WebUtility.UrlDecode(record.S3.Object.Key));
    }

    activity.SetTag("aws.lambda.log_stream", context.LogStreamName);
})
```
This also covers two cases a built-in classification could not:

- Event families with no well-known `faas.document.operation` value. S3 publishes eleven families; only `ObjectCreated` and `ObjectRemoved` map to insert/delete, and the conventions permit a custom value for the rest.
- Sources with no .NET event package. There is no `Amazon.Lambda.DocumentDBEvents`, so DocumentDB change streams are deserialised into user-defined types that no type-based detection in this library could classify.

Named EnrichWithInput to match the `EnrichWith* ` convention  used by the other instrumentations, and the `input `parameter name already in this package's public API. 
Happy to rename if you would prefer something else — it is unshipped.

### Verification
faas.trigger values, the trigger-override path, the URL-decoded object key,the ILambdaContext argument, the IsAllDataRequested gate, the async path, and the throwing-callback path are covered by unit tests. Each was checked by mutation — removing the invocation fails 4 tests,
removing the IsAllDataRequested guard fails 1, removing the try/catch fails 1.

The example above was also run as a real consumer: packed from this branch into a local NuGet feed and executed against the [S3 notification payload from the AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html), deserialised by DefaultLambdaJsonSerializer. The URL-encoded key S3 actually sends (`exports/2026-09-08+daily%3D1.csv`) is decoded to `exports/2026-09-08 daily=1.csv`, and faas.trigger carries a single datasource tag.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
